### PR TITLE
Compiler error fixes for `cppcheck` and `clang-tidy`

### DIFF
--- a/cmake/StaticAnalysisHelpers.cmake
+++ b/cmake/StaticAnalysisHelpers.cmake
@@ -65,8 +65,9 @@ function(configure_cppcheck _target_name)
   )
   if(CPPCHECK_EXE)
     message(STATUS "Found cppcheck for static analysis: ${CPPCHECK_EXE}")
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles/cppcheck)
     execute_process(
-      COMMAND     ${CMAKE_COMMAND} -E echo_append "*:${CMAKE_BINARY_DIR}/_deps/*"
+      COMMAND     ${CMAKE_COMMAND} -E echo "*:${CMAKE_BINARY_DIR}/_deps/*"
       OUTPUT_FILE ${CMAKE_BINARY_DIR}/CMakeFiles/cppcheck/suppressions.txt
     )
     set(CPPCHECK_COMMAND

--- a/cmake/StaticAnalysisHelpers.cmake
+++ b/cmake/StaticAnalysisHelpers.cmake
@@ -45,8 +45,13 @@ function(configure_clang_tidy _target_name)
         endif()
       endif()
       if(MPI_CXX_INCLUDE_DIRS)
+        set(CLANG_TIDY_EXTRA_ARG)
+        foreach(INCLUDE_DIR IN LISTS MPI_CXX_INCLUDE_DIRS)
+          set(CLANG_TIDY_EXTRA_ARG "${CLANG_TIDY_EXTRA_ARG} -I${INCLUDE_DIR}")
+        endforeach()
+        string(STRIP "${CLANG_TIDY_EXTRA_ARG}" CLANG_TIDY_EXTRA_ARG)
         list(APPEND CLANG_TIDY_COMMAND
-          "-extra-arg=-I${MPI_CXX_INCLUDE_DIRS}"
+          "-extra-arg=${CLANG_TIDY_EXTRA_ARG}"
         )
       endif()
     endif()


### PR DESCRIPTION
Resolves #11 and #13.