### PR TITLE
Fix typos in cavity and convergence examples

### DIFF
--- a/examples/cavity/cavity.jl
+++ b/examples/cavity/cavity.jl
@@ -155,10 +155,10 @@ l, in GHz
 
 # Arguments
 
-  - n - mode number in the circumfrential direction
+  - n - mode number in the circumferential direction
   - m - mode number in the radial direction
   - l - mode number in the z direction
-  - ϵᵣ - relative electric permitivity
+  - ϵᵣ - relative electric permittivity
   - μᵣ - relative magnetic permeability
   - a - radius of cavity in centimeters
   - d - height of cavity in centimeters

--- a/examples/cavity/convergence_study.jl
+++ b/examples/cavity/convergence_study.jl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #=
-    This script performs a converence study of the cavity resonator problem
+    This script performs a convergence study of the cavity resonator problem
 
     Loops over mesh refinement level and order
         a) Generates a mesh that corresponds, by calling `mesh.jl`,


### PR DESCRIPTION
First of all, very exciting package! I noticed a couple of typos while looking at the examples, so thought to make a PR fixing them.

*Description of changes:*
Fixes couple of typos in Julia examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
