### PR TITLE
Updates to Julia code for `examples/` and `scripts`

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,12 @@
+[deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Gmsh = "705231aa-382f-11e9-3f0c-b7cb4346fdeb"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/examples/cavity/cavity.jl
+++ b/examples/cavity/cavity.jl
@@ -259,7 +259,9 @@ function generate_cavity_convergence_data(;
         push!(dof, eltype(dof)())
         push!(f_TM_010, eltype(f_TM_010)())
         push!(f_TE_111, eltype(f_TE_111)())
-        for ref = (p == 1 && mesh_type == 2 ? 1 : ref_min):(p > 3 ? 3 : ref_max)
+        ref_lower = (p == 1 && mesh_type == 2) ? max(1, ref_min) : ref_min
+        ref_upper = (p > 3) ? min(3, ref_max) : ref_max
+        for ref = ref_lower:ref_upper
             print("p = ", p, ", ref = ", ref, ": ")
             results = solve_cavity_resonator(
                 params,

--- a/examples/cavity/cavity.jl
+++ b/examples/cavity/cavity.jl
@@ -259,7 +259,7 @@ function generate_cavity_convergence_data(;
         push!(dof, eltype(dof)())
         push!(f_TM_010, eltype(f_TM_010)())
         push!(f_TE_111, eltype(f_TE_111)())
-        for ref = ref_min:(p > 3 ? 3 : ref_max)
+        for ref = (p == 1 && mesh_type == 2 ? 1 : ref_min):(p > 3 ? 3 : ref_max)
             print("p = ", p, ", ref = ", ref, ": ")
             results = solve_cavity_resonator(
                 params,

--- a/examples/cavity/convergence_study.jl
+++ b/examples/cavity/convergence_study.jl
@@ -48,9 +48,9 @@ markers = [
 
 # Compute the convergence data
 p_min = 1
-p_max = 2
+p_max = 3
 ref_min = 0
-ref_max = 1
+ref_max = 3
 for mesh_type ∈ [0, 1, 2]
     if mesh_type == 0
         mesh_name = "Tetrahedra"

--- a/examples/cavity/convergence_study.jl
+++ b/examples/cavity/convergence_study.jl
@@ -13,6 +13,7 @@
     Once these are generated, plots DOF^(-1/3) against error.
 =#
 
+using DelimitedFiles
 using Measures
 using Plots
 using PyPlot: matplotlib
@@ -47,9 +48,9 @@ markers = [
 
 # Compute the convergence data
 p_min = 1
-p_max = 3
+p_max = 2
 ref_min = 0
-ref_max = 3
+ref_max = 1
 for mesh_type ∈ [0, 1, 2]
     if mesh_type == 0
         mesh_name = "Tetrahedra"

--- a/palace/linalg/arpack.cpp
+++ b/palace/linalg/arpack.cpp
@@ -549,9 +549,12 @@ void ArpackEPSSolver::SetOperators(const petsc::PetscParMatrix &K,
   {
     normK = opK->Norm2();
     normM = opM->Norm2();
-    MFEM_VERIFY(normK > 0.0 && normM > 0.0, "Invalid matrix norms for EPS scaling!");
-    gamma = normK / normM;  // Store γ² for linear problem
-    delta = 2.0 / normK;
+    MFEM_VERIFY(normK >= 0.0 && normM >= 0.0, "Invalid matrix norms for EPS scaling!");
+    if (normK > 0 && normM > 0.0)
+    {
+      gamma = normK / normM;  // Store γ² for linear problem
+      delta = 2.0 / normK;
+    }
   }
 
   // Set up workspace.
@@ -714,10 +717,13 @@ void ArpackPEPSolver::SetOperators(const petsc::PetscParMatrix &K,
     normK = opK->Norm2();
     normC = opC->Norm2();
     normM = opM->Norm2();
-    MFEM_VERIFY(normK > 0.0 && normC > 0.0 && normM > 0.0,
+    MFEM_VERIFY(normK >= 0.0 && normC >= 0.0 && normM >= 0.0,
                 "Invalid matrix norms for PEP scaling!");
-    gamma = std::sqrt(normK / normM);
-    delta = 2.0 / (normK + gamma * normC);
+    if (normK > 0 && normC > 0.0 && normM > 0.0)
+    {
+      gamma = std::sqrt(normK / normM);
+      delta = 2.0 / (normK + gamma * normC);
+    }
   }
 
   // Set up workspace.

--- a/palace/linalg/slepc.cpp
+++ b/palace/linalg/slepc.cpp
@@ -595,9 +595,12 @@ void SlepcEPSSolver::SetOperators(const petsc::PetscParMatrix &K,
   {
     normK = opK->Norm2();
     normM = opM->Norm2();
-    MFEM_VERIFY(normK > 0.0 && normM > 0.0, "Invalid matrix norms for EPS scaling!");
-    gamma = normK / normM;  // Store γ² for linear problem
-    delta = 2.0 / normK;
+    MFEM_VERIFY(normK >= 0.0 && normM >= 0.0, "Invalid matrix norms for EPS scaling!");
+    if (normK > 0 && normM > 0.0)
+    {
+      gamma = normK / normM;  // Store γ² for linear problem
+      delta = 2.0 / normK;
+    }
   }
 
   // Set up workspace.
@@ -700,10 +703,13 @@ void SlepcPEPLinearSolver::SetOperators(const petsc::PetscParMatrix &K,
     normK = opK->Norm2();
     normC = opC->Norm2();
     normM = opM->Norm2();
-    MFEM_VERIFY(normK > 0.0 && normC > 0.0 && normM > 0.0,
+    MFEM_VERIFY(normK >= 0.0 && normC >= 0.0 && normM >= 0.0,
                 "Invalid matrix norms for PEP scaling!");
-    gamma = std::sqrt(normK / normM);
-    delta = 2.0 / (normK + gamma * normC);
+    if (normK > 0 && normC > 0.0 && normM > 0.0)
+    {
+      gamma = std::sqrt(normK / normM);
+      delta = 2.0 / (normK + gamma * normC);
+    }
   }
 
   // Set up workspace.
@@ -1165,10 +1171,13 @@ void SlepcPEPSolver::SetOperators(const petsc::PetscParMatrix &K,
     normK = opK->Norm2();
     normC = opC->Norm2();
     normM = opM->Norm2();
-    MFEM_VERIFY(normK > 0.0 && normC > 0.0 && normM > 0.0,
+    MFEM_VERIFY(normK >= 0.0 && normC >= 0.0 && normM >= 0.0,
                 "Invalid matrix norms for PEP scaling!");
-    gamma = std::sqrt(normK / normM);
-    delta = 2.0 / (normK + gamma * normC);
+    if (normK > 0 && normC > 0.0 && normM > 0.0)
+    {
+      gamma = std::sqrt(normK / normM);
+      delta = 2.0 / (normK + gamma * normC);
+    }
   }
 
   // Set up workspace.

--- a/scripts/format-source
+++ b/scripts/format-source
@@ -99,8 +99,13 @@ if $FORMAT_JL; then
     FORMAT_JL_FILES="$(find $SOURCE_DIR -maxdepth 1 \
                            -type f -iname \*.md -exec echo -n '"{}", ' \;)$FORMAT_JL_FILES"
     echo "
-using Pkg; Pkg.add(\"JuliaFormatter\")
-using JuliaFormatter
+try
+    @eval using JuliaFormatter
+catch
+    using Pkg; Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
+    Pkg.activate(; temp=true); Pkg.add(\"JuliaFormatter\")
+    @eval using JuliaFormatter
+end
 format([$FORMAT_JL_FILES], $FORMAT_JL_ARGS)
 " | $JULIA
 fi

--- a/scripts/schema/ValidateConfig.jl
+++ b/scripts/schema/ValidateConfig.jl
@@ -11,7 +11,7 @@ export validate_config_file
 """
     validate_config_file(; config_file::AbstractString, schema_file::AbstractString)
 
-Validate the provided configuration file against the provided JSON schema
+Validate the provided configuration file against the provided JSON Schema
 """
 function validate_config_file(; config_file::AbstractString, schema_file::AbstractString)
     # Resolve relative paths in schema by running parsefile in its directory

--- a/scripts/validate-config
+++ b/scripts/validate-config
@@ -7,7 +7,7 @@ help()
 {
     echo "Usage: validate-config [OPTIONS] CONFIG_FILE
 
-Validate the provided Palace configuration file against the JSON schema
+Validate the provided Palace configuration file against the provided JSON Schema
 
 Options:
   -h, --help                       Show this help message and exit
@@ -50,7 +50,7 @@ else
     CONFIG="$@"
 fi
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+SCRIPT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 if ! command -v $JULIA &> /dev/null; then
     echo "Error: Could not locate $JULIA executable"
@@ -58,7 +58,13 @@ if ! command -v $JULIA &> /dev/null; then
 fi
 
 echo "
-using Pkg; Pkg.add([\"JSON\", \"JSONSchema\"])
+try
+    using JSON
+    using JSONSchema
+catch
+    using Pkg; Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
+    Pkg.activate(; temp=true); Pkg.add([\"JSON\", \"JSONSchema\"])
+end
 include(joinpath(\"$SCRIPT_DIR\", \"schema\", \"ValidateConfig.jl\"))
 using .ValidateConfig
 result = validate_config_file(;


### PR DESCRIPTION
Fix a bug related to `examples/cavity/convergence_study.jl` where the coarsest hexahedral mesh had no non-boundary dofs for the `order=1` case. Also better Julia package dependency management utilities in `scripts/`.

Resolves #27