### PR TITLE
Use `macos-latest-xl` runners for MacOS GitHub Actions jobs

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -43,7 +43,7 @@ jobs:
             with-solver: superlu
             with-eigensolver: slepc
 
-    runs-on: macos-latest
+    runs-on: macos-latest-xl
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/