### PR TITLE
Fix GitHub Action for Intel 2023.1 compilers

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Configure Intel oneAPI compiler
         if: matrix.compiler == 'intel'
         run: |
+          sudo apt-get remove -y gcc-10 g++-10 && sudo apt-get autoremove -y
           sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
                                   intel-oneapi-compiler-fortran
 


### PR DESCRIPTION
A bug from GCC 10.4 shows up in `nlohmann/json` with the new 2023.1 `icx`/`icpx` compilers during CI builds.

https://github.com/gcc-mirror/gcc/commit/423cd47cfc9640ba3d6811b780e8a0b94b704dcb
https://bugs.mageia.org/show_bug.cgi?id=30658