### PR TITLE
Updates for clang-format v16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,9 @@ AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignEscapedNewlines: Left
-AlignTrailingComments: true
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
 AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Configure Intel oneAPI compiler
         if: matrix.compiler == 'intel'
         run: |
-          sudo apt-get remove -y gcc-10 g++-10 && sudo apt-get autoremove -y
+          sudo apt-get remove -y gcc-9 g++-9 gcc-10 g++-10 && sudo apt-get autoremove -y
           sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
                                   intel-oneapi-compiler-fortran
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -20,13 +20,17 @@ jobs:
         with:
           version: '1'
 
+      # Install more recent clang-format from LLVM (match Homebrew v16)
       - name: Install clang-format
         run: |
-          sudo apt-get install -y clang-format-15
+          wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-16 main'
+          sudo apt-get update -q
+          sudo apt-get install -y clang-format-16
 
       - name: Check style
         run: |
-          ./scripts/format-source --clang-format clang-format-15
+          ./scripts/format-source --clang-format clang-format-16
           if [[ `git status -s | wc -l` -ne 0 ]]; then
             echo 'Error: Commit is not formatted!'
             echo 'Run '\`'./scripts/format-source'\`' in the source root directory'


### PR DESCRIPTION
Homebrew default clang is now v16.