### PR TITLE
Make built docs downloadable from CI in PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,7 @@ jobs:
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
           julia --project=docs --color=yes docs/make.jl
 
-      - name: Docs as artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'pull_request' }}
+      - uses: actions/upload-artifact@v3
         with:
           name: docs
           path: docs/build/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,11 @@ jobs:
         run: |
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
           julia --project=docs --color=yes docs/make.jl
+
+      - name: Docs as artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          name: docs
+          path: docs/build/
+          retention-days: 7


### PR DESCRIPTION
*Description of changes:*

Make built docs downloadable from GitHub Actions CI in PRs for 7 days.

Closes #66 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
