### PR TITLE
Fix Documenter cleanup GitHub Action when preview docs are not built

### DIFF
--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -14,14 +14,13 @@ jobs:
 
       - name: Delete preview and history
         env:
-            PRNUM: ${{ github.event.number }}
+          PRNUM: ${{ github.event.number }}
         run: |
+          if [[ -d previews/PR$PRNUM ]]; then
             git config user.name "Documenter.jl"
             git config user.email "documenter@juliadocs.github.io"
-            git rm -rf "previews/PR$PRNUM"
+            git rm -rf previews/PR$PRNUM
             git commit -m "delete preview"
             git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
-
-      - name: Push changes
-        run: |
             git push --force origin gh-pages-new:gh-pages
+          fi


### PR DESCRIPTION
PRs from forks do not deploy preview docs, so we get CI workflow failures like https://github.com/awslabs/palace/actions/runs/5593909532. This should resolve the issue.