### PR TITLE
Add `Manifest.toml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ examples/**/postpro*/
 examples/**/log*/
 spack/local/packages/palace/__pycache__/
 test/ref/**/*.json
+.*.swp
+.DS_Store
 .gitlab-ci-local
-**/.DS_Store
-**/.*.swp
 Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/ref/**/*.json
 .gitlab-ci-local
 **/.DS_Store
 **/.*.swp
+Manifest.toml


### PR DESCRIPTION
*Description of changes:*
This PR adds the documentation-generated `Manifest.toml` to the gitignore.

Closes #73

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
