### PR TITLE
Fix configuration file parsing for obscure `std::regex` bug

### DIFF
--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -71,7 +71,10 @@ std::stringstream PreprocessFile(const char *filename)
     // Handle the given string which is only numeric with possible hyphens.
     int num;
     auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.length(), num);
-    MFEM_VERIFY(ptr != str.data(), "Invalid integer conversion in range expansion!");
+    MFEM_VERIFY(
+        ec == std::errc(),
+        "Invalid integer conversion in range expansion"
+            << (ec == std::errc::result_out_of_range ? " (integer out of range)!" : "!"));
     if (ptr == str.data() + str.length())
     {
       return std::string(str);
@@ -79,7 +82,10 @@ std::stringstream PreprocessFile(const char *filename)
     // Range specified, expand the bounds.
     int num2;
     auto [ptr2, ec2] = std::from_chars(ptr + 1, str.data() + str.length(), num2);
-    MFEM_VERIFY(ptr2 != ptr + 1, "Invalid integer conversion in range expansion!");
+    MFEM_VERIFY(
+        ec2 == std::errc(),
+        "Invalid integer conversion in range expansion"
+            << (ec2 == std::errc::result_out_of_range ? " (integer out of range)!" : "!"));
     std::string rng;
     while (num < num2)
     {

--- a/palace/utils/iodata.hpp
+++ b/palace/utils/iodata.hpp
@@ -4,7 +4,6 @@
 #ifndef PALACE_UTILS_IODATA_HPP
 #define PALACE_UTILS_IODATA_HPP
 
-#include <sstream>
 #include "utils/configfile.hpp"
 
 namespace mfem
@@ -34,9 +33,6 @@ private:
   // Characteristic reference length [m] and time [ns] for nondimensionalization.
   double Lc, tc;
   bool init;
-
-  // Preprocess the configuration file for parsing.
-  void PreprocessFile(const char *filename, std::stringstream &buffer);
 
   // Check configuration file options and compatibility with requested problem type.
   void CheckConfiguration();


### PR DESCRIPTION
For configuration files with large lists of boundary or domain attributes (for example, some 20k entries in one case), the range expansion step of configuration file parsing encounters a segmentation fault. This only shows up with GCC (not Clang) and appears to be a C++ STL bug. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66456 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61582 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164.

This PR rewrites this step of the parser to avoid use of `std::regex` instead.