### PR TITLE
Fixing a range of compiler warnings for shadow/unused variables

### DIFF
--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -164,7 +164,7 @@ void EigenSolver::Solve(std::vector<std::unique_ptr<mfem::ParMesh>> &mesh,
   std::unique_ptr<KspSolver> ksp;
   std::unique_ptr<KspPreconditioner> pc;
 #if defined(PALACE_WITH_SLEPC)
-  auto *feast = dynamic_cast<feast::FeastEigenSolver *>(eigen.get());
+  auto * const feast = dynamic_cast<feast::FeastEigenSolver *>(eigen.get());
   if (feast)
   {
     // Configure the FEAST integration contour. The linear solvers are set up inside the
@@ -339,8 +339,7 @@ void EigenSolver::Solve(std::vector<std::unique_ptr<mfem::ParMesh>> &mesh,
 #if defined(PALACE_WITH_SLEPC)
   if (!ksp)
   {
-    const auto &feast = dynamic_cast<const feast::FeastEigenSolver &>(*eigen);
-    SaveMetadata(feast.GetTotalKspMult(), feast.GetTotalKspIter());
+    SaveMetadata(feast->GetTotalKspMult(), feast->GetTotalKspIter());
   }
   else
 #endif

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -164,7 +164,7 @@ void EigenSolver::Solve(std::vector<std::unique_ptr<mfem::ParMesh>> &mesh,
   std::unique_ptr<KspSolver> ksp;
   std::unique_ptr<KspPreconditioner> pc;
 #if defined(PALACE_WITH_SLEPC)
-  auto * const feast = dynamic_cast<feast::FeastEigenSolver *>(eigen.get());
+  auto *const feast = dynamic_cast<feast::FeastEigenSolver *>(eigen.get());
   if (feast)
   {
     // Configure the FEAST integration contour. The linear solvers are set up inside the

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -217,8 +217,7 @@ private:
   const mfem::Vector side;
   mutable mfem::Vector C1, V, nor;
 
-  int Initialize(mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip,
-                 mfem::Vector &V)
+  int Initialize(mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
   {
     // Get neighboring elements.
     mfem::ElementTransformation *T1, *T2;
@@ -277,7 +276,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::MA>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution and neighboring element attribute.
-  Initialize(T, ip, V);
+  Initialize(T, ip);
   GetNormal(T, ip, nor);
 
   // Metal-air interface: 0.5 * t / ϵ_MA * |E_n|² .
@@ -290,7 +289,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::MS>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution and neighboring element attribute.
-  int attr = Initialize(T, ip, V);
+  int attr = Initialize(T, ip);
   GetNormal(T, ip, nor);
 
   // Metal-substrate interface: 0.5 * t * (ϵ_S)² / ϵ_MS * |E_n|² .
@@ -304,7 +303,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::SA>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution and neighboring element attribute.
-  Initialize(T, ip, V);
+  Initialize(T, ip);
   GetNormal(T, ip, nor);
 
   // Substrate-air interface: 0.5 * t * (ϵ_SA * |E_t|² + 1 / ϵ_MS * |E_n|²) .
@@ -318,7 +317,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::DEFAULT>::
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution and neighboring element attribute.
-  Initialize(T, ip, V);
+  Initialize(T, ip);
 
   // No specific interface, use full field evaluation: 0.5 * t * ϵ * |E|² .
   return 0.5 * ts * epsilon * (V * V);

--- a/palace/linalg/feast.cpp
+++ b/palace/linalg/feast.cpp
@@ -1198,7 +1198,7 @@ void FeastPEPSolver::SolveProjectedProblem(const petsc::PetscDenseMatrix &Q_,
   for (PetscInt i = 0; i < m0; i++)
   {
     eig_[i] = alpha[sort[i]];
-    const PetscScalar* const local_pXQ = XQ->GetArrayRead();
+    const PetscScalar *const local_pXQ = XQ->GetArrayRead();
     PetscScalar *pXQ0 = XQ0->GetArray();
     PalacePetscCall(PetscArraycpy(pXQ0 + mQ * i, local_pXQ + 2 * mQ * sort[i], mQ));
     XQ->RestoreArrayRead(local_pXQ);

--- a/palace/linalg/feast.hpp
+++ b/palace/linalg/feast.hpp
@@ -55,7 +55,7 @@ protected:
   PetscInt nev, m0, mQ;
 
   // Number of moments to consider for subspace construction.
-  PetscInt M;
+  PetscInt N_moments;
 
   // Relative eigenvalue error convergence tolerance for the solver.
   PetscReal rtol;
@@ -192,7 +192,7 @@ public:
   {
     MFEM_ABORT("SetWhichEigenpairs not defined for FeastEigenSolver!");
   }
-  void SetShiftInvert(double tr, double ti, bool precond = false) override
+  void SetShiftInvert(double tr_in, double ti_in, bool precond = false) override
   {
     MFEM_ABORT("SetShiftInvert not defined for FeastEigenSolver!");
   }

--- a/palace/linalg/ksp.cpp
+++ b/palace/linalg/ksp.cpp
@@ -104,8 +104,10 @@ void KspSolver::Configure(const IoData &iodata)
   }
 }
 
-void KspSolver::ConfigureVerbose(int print, const std::string &prefix)
+void KspSolver::ConfigureVerbose(int print_input, const std::string &prefix)
 {
+  print = print_input;
+
   // Manage debugging output.
   if (print > 0)
   {

--- a/palace/linalg/superlu.cpp
+++ b/palace/linalg/superlu.cpp
@@ -37,7 +37,7 @@ int GetNpDep(int np, bool use_3d)
 
 SuperLUSolver::SuperLUSolver(MPI_Comm comm, config::LinearSolverData::SymFactType reorder,
                              bool use_3d, int print)
-  : mfem::Solver(), comm(comm), A(nullptr), solver(comm, GetNpDep(Mpi::Size(comm), use_3d))
+  : mfem::Solver(), A(nullptr), solver(comm, GetNpDep(Mpi::Size(comm), use_3d))
 {
   // Configure the solver.
   if (print > 1)

--- a/palace/linalg/superlu.hpp
+++ b/palace/linalg/superlu.hpp
@@ -20,7 +20,6 @@ namespace palace
 class SuperLUSolver : public mfem::Solver
 {
 private:
-  MPI_Comm comm;
   std::unique_ptr<mfem::SuperLURowLocMatrix> A;
   mfem::SuperLUSolver solver;
 

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -467,6 +467,7 @@ double RomOperator::ComputeError(double omega)
   return num / den;
 }
 
+// static
 void RomOperator::BVMatProjectInternal(petsc::PetscDenseMatrix &V, petsc::PetscParMatrix &A,
                                        petsc::PetscDenseMatrix &Ar,
                                        petsc::PetscParVector &r, int n0, int n)
@@ -515,6 +516,7 @@ void RomOperator::BVMatProjectInternal(petsc::PetscDenseMatrix &V, petsc::PetscP
   }
 }
 
+// static
 void RomOperator::BVDotVecInternal(petsc::PetscDenseMatrix &V, petsc::PetscParVector &b,
                                    petsc::PetscParVector &br, int n0, int n)
 {

--- a/palace/models/romoperator.hpp
+++ b/palace/models/romoperator.hpp
@@ -65,10 +65,10 @@ private:
   double ComputeError(double omega);
 
   // Helper functions for reduced-order matrix or vector construction/update.
-  void BVMatProjectInternal(petsc::PetscDenseMatrix &V, petsc::PetscParMatrix &A,
+  static void BVMatProjectInternal(petsc::PetscDenseMatrix &V, petsc::PetscParMatrix &A,
                             petsc::PetscDenseMatrix &Ar, petsc::PetscParVector &r, int n0,
                             int n);
-  void BVDotVecInternal(petsc::PetscDenseMatrix &V, petsc::PetscParVector &b,
+  static void BVDotVecInternal(petsc::PetscDenseMatrix &V, petsc::PetscParVector &b,
                         petsc::PetscParVector &br, int n0, int n);
 
 public:

--- a/palace/models/romoperator.hpp
+++ b/palace/models/romoperator.hpp
@@ -66,10 +66,10 @@ private:
 
   // Helper functions for reduced-order matrix or vector construction/update.
   static void BVMatProjectInternal(petsc::PetscDenseMatrix &V, petsc::PetscParMatrix &A,
-                            petsc::PetscDenseMatrix &Ar, petsc::PetscParVector &r, int n0,
-                            int n);
+                                   petsc::PetscDenseMatrix &Ar, petsc::PetscParVector &r,
+                                   int n0, int n);
   static void BVDotVecInternal(petsc::PetscDenseMatrix &V, petsc::PetscParVector &b,
-                        petsc::PetscParVector &br, int n0, int n);
+                               petsc::PetscParVector &br, int n0, int n);
 
 public:
   RomOperator(const IoData &iodata, SpaceOperator &sp, int nmax);

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -101,9 +101,9 @@ InterfaceDielectricData::InterfaceDielectricData(
 }
 
 std::unique_ptr<mfem::Coefficient>
-InterfaceDielectricData::GetCoefficient(
-    int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-    const std::map<int, int> &local_to_shared) const
+InterfaceDielectricData::GetCoefficient(int i, const mfem::ParGridFunction &U,
+                                        const MaterialOperator &mat_op,
+                                        const std::map<int, int> &local_to_shared) const
 {
   switch (type)
   {
@@ -124,22 +124,22 @@ InterfaceDielectricData::GetCoefficient(
   return {};  // For compiler warning
 }
 
-SurfaceChargeData::SurfaceChargeData(
-    const config::CapacitanceData &data, mfem::ParMesh &mesh)
+SurfaceChargeData::SurfaceChargeData(const config::CapacitanceData &data,
+                                     mfem::ParMesh &mesh)
 {
   attr_markers.emplace_back();
   mesh::AttrToMarker(mesh.bdr_attributes.Max(), data.attributes, attr_markers.back());
 }
 
-std::unique_ptr<mfem::Coefficient> SurfaceChargeData::GetCoefficient(
-    int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-    const std::map<int, int> &local_to_shared) const
+std::unique_ptr<mfem::Coefficient>
+SurfaceChargeData::GetCoefficient(int i, const mfem::ParGridFunction &U,
+                                  const MaterialOperator &mat_op,
+                                  const std::map<int, int> &local_to_shared) const
 {
   return std::make_unique<BdrChargeCoefficient>(U, mat_op, local_to_shared);
 }
 
-SurfaceFluxData::SurfaceFluxData(const config::InductanceData &data,
-                                                      mfem::ParMesh &mesh)
+SurfaceFluxData::SurfaceFluxData(const config::InductanceData &data, mfem::ParMesh &mesh)
 {
   // Check inputs.
   MFEM_VERIFY(data.direction.length() == 2 &&
@@ -177,19 +177,18 @@ SurfaceFluxData::SurfaceFluxData(const config::InductanceData &data,
   mesh::AttrToMarker(mesh.bdr_attributes.Max(), data.attributes, attr_markers.back());
 }
 
-std::unique_ptr<mfem::Coefficient> SurfaceFluxData::GetCoefficient(
-    int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-    const std::map<int, int> &local_to_shared) const
+std::unique_ptr<mfem::Coefficient>
+SurfaceFluxData::GetCoefficient(int i, const mfem::ParGridFunction &U,
+                                const MaterialOperator &mat_op,
+                                const std::map<int, int> &local_to_shared) const
 {
   return std::make_unique<BdrFluxCoefficient>(U, direction, local_to_shared);
 }
 
 namespace
 {
-double GetSurfaceIntegral(const SurfaceData &data,
-                          const mfem::ParGridFunction &U,
-                          const mfem::ParGridFunction &ones,
-                          const MaterialOperator &mat_op,
+double GetSurfaceIntegral(const SurfaceData &data, const mfem::ParGridFunction &U,
+                          const mfem::ParGridFunction &ones, const MaterialOperator &mat_op,
                           const std::map<int, int> &local_to_shared)
 {
   // Integrate the coefficient over the boundary attributes making up this surface index.
@@ -205,7 +204,7 @@ double GetSurfaceIntegral(const SurfaceData &data,
   return s(ones);
 }
 
-} // namespace
+}  // namespace
 
 SurfacePostOperator::SurfacePostOperator(const IoData &iodata, const MaterialOperator &mat,
                                          const std::map<int, int> &l2s,
@@ -270,6 +269,5 @@ double SurfacePostOperator::GetSurfaceMagneticFlux(int idx,
               "Unknown inductance postprocessing surface index requested!");
   return GetSurfaceIntegral(it->second, B, ones, mat_op, local_to_shared);
 }
-
 
 }  // namespace palace

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -25,7 +25,6 @@ struct InductanceData;
 
 }  // namespace config
 
-
 struct SurfaceData
 {
   mutable std::vector<mfem::Array<int>> attr_markers;
@@ -34,7 +33,7 @@ struct SurfaceData
 
   virtual std::unique_ptr<mfem::Coefficient>
   GetCoefficient(int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-                  const std::map<int, int> &local_to_shared) const = 0;
+                 const std::map<int, int> &local_to_shared) const = 0;
 };
 struct InterfaceDielectricData : public SurfaceData
 {
@@ -42,12 +41,11 @@ struct InterfaceDielectricData : public SurfaceData
   double epsilon, ts, tandelta;
   std::vector<mfem::Vector> sides;
 
-  InterfaceDielectricData(const config::InterfaceDielectricData &data,
-                          mfem::ParMesh &mesh);
+  InterfaceDielectricData(const config::InterfaceDielectricData &data, mfem::ParMesh &mesh);
 
   std::unique_ptr<mfem::Coefficient>
   GetCoefficient(int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-                  const std::map<int, int> &local_to_shared) const override;
+                 const std::map<int, int> &local_to_shared) const override;
 };
 struct SurfaceChargeData : public SurfaceData
 {
@@ -55,7 +53,7 @@ struct SurfaceChargeData : public SurfaceData
 
   std::unique_ptr<mfem::Coefficient>
   GetCoefficient(int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-                  const std::map<int, int> &local_to_shared) const override;
+                 const std::map<int, int> &local_to_shared) const override;
 };
 struct SurfaceFluxData : public SurfaceData
 {
@@ -65,9 +63,8 @@ struct SurfaceFluxData : public SurfaceData
 
   std::unique_ptr<mfem::Coefficient>
   GetCoefficient(int i, const mfem::ParGridFunction &U, const MaterialOperator &mat_op,
-                  const std::map<int, int> &local_to_shared) const override;
+                 const std::map<int, int> &local_to_shared) const override;
 };
-
 
 //
 // A class handling boundary surface postprocessing.
@@ -89,6 +86,7 @@ private:
 
   // Unit function used for computing surface integrals.
   mfem::ParGridFunction ones;
+
 public:
   SurfacePostOperator(const IoData &iodata, const MaterialOperator &mat,
                       const std::map<int, int> &l2s,

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -558,7 +558,6 @@ void WavePortData::GetInitialSpace(int nt, int nn, petsc::PetscParVector &y0)
   y0.RestoreArray(py0);
 }
 
-
 std::complex<double> WavePortData::Solve()
 {
   double eig[2];

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -72,9 +72,9 @@ private:
                    mfem::Array<int> &h1_tdof_list);
 
   // Configure and solve the linear eigenvalue problem for the boundary mode.
-  void GetInitialSpace(int nt, int nn, petsc::PetscParVector &y0);
-  std::complex<double> Solve(petsc::PetscParVector &y0, petsc::PetscParVector &e0,
-                             petsc::PetscParVector &e, petsc::PetscScatter &scatter);
+  static void GetInitialSpace(int nt, int nn, petsc::PetscParVector &y0);
+
+  std::complex<double> Solve();
 
 public:
   WavePortData(const config::WavePortData &data, const MaterialOperator &mat_op,
@@ -146,10 +146,9 @@ private:
   // Mapping from port index to data structure containing port information.
   std::map<int, WavePortData> ports;
   mfem::Array<int> port_marker;
-  void SetUpBoundaryProperties(const IoData &iodata, const MaterialOperator &mat_op,
-                               mfem::ParFiniteElementSpace &nd_fespace,
+  void SetUpBoundaryProperties(mfem::ParFiniteElementSpace &nd_fespace,
                                mfem::ParFiniteElementSpace &h1_fespace);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(mfem::ParMesh &mesh);
 
   // Compute boundary modes for all wave port boundaries at the specified frequency.
   void Initialize(double omega);


### PR DESCRIPTION
*Description of changes:*
- Turned on some extra warnings (Wshadow) whilst hunting a bug on another branch, there were a few extra errors here that produced some noise. This PR resolves them, I don't believe there were any correctness issues, due to type resolution picking the correct variable in many cases. 
- The change to SurfacePostOperator is the most significant. The substructs were in error marking the GetCoefficient arguments as shadowing `mat_op` and `local_to_shared`. Given these subtypes were already being leaked through the accessor methods for their containers, I just moved the types in to the palace namespace. 
- In a few other spots, the ambiguity was resolved by switching to no argument or static methods, and in others by changing a local variable name.
