### PR TITLE
Improve enum parsing from JSON

### DIFF
--- a/palace/drivers/transientsolver.cpp
+++ b/palace/drivers/transientsolver.cpp
@@ -217,8 +217,6 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
         return F{[=](double t) { return pulse_smootherstep(t, data.pulse_tau, delay); }};
       }
       break;
-    case config::TransientSolverData::ExcitationType::INVALID:
-      MFEM_ABORT("Unsupported source excitation type!");
   }
   return F{};
 }

--- a/palace/fem/multigrid.hpp
+++ b/palace/fem/multigrid.hpp
@@ -115,9 +115,6 @@ std::vector<std::unique_ptr<FECollection>> inline ConstructFECollections(
       case config::LinearSolverData::MultigridCoarsenType::LOGARITHMIC:
         p = (p + pmin) / 2;
         break;
-      case config::LinearSolverData::MultigridCoarsenType::INVALID:
-        MFEM_ABORT("Invalid coarsening type for p-multigrid levels!");
-        break;
     }
   }
   std::reverse(fecs.begin(), fecs.end());

--- a/palace/linalg/strumpack.cpp
+++ b/palace/linalg/strumpack.cpp
@@ -33,7 +33,6 @@ GetCompressionType(config::LinearSolverData::CompressionType type)
       return strumpack::CompressionType::ZFP_BLR_HODLR;
       break;
     case config::LinearSolverData::CompressionType::NONE:
-    case config::LinearSolverData::CompressionType::INVALID:
       return strumpack::CompressionType::NONE;
   }
   return strumpack::CompressionType::NONE;  // For compiler warning
@@ -100,7 +99,6 @@ StrumpackSolverBase<StrumpackSolverType>::StrumpackSolverBase(
       this->SetCompressionRelTol(lr_tol);
       break;
     case config::LinearSolverData::CompressionType::NONE:
-    case config::LinearSolverData::CompressionType::INVALID:
       break;
   }
 }

--- a/palace/main.cpp
+++ b/palace/main.cpp
@@ -176,9 +176,6 @@ int main(int argc, char *argv[])
       solver = std::make_unique<TransientSolver>(iodata, world_root, world_size, num_thread,
                                                  git_tag);
       break;
-    case config::ProblemData::Type::INVALID:
-      Mpi::Print(world_comm, "Error: Unsupported problem type!\n\n");
-      return 1;
   }
 
   // Read the mesh from file, refine, partition, and distribute it. Then nondimensionalize

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -63,9 +63,6 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
         elems.push_back(
             std::make_unique<UniformElementData>(elem.direction, attr_marker, h1_fespace));
         break;
-      case config::internal::ElementData::CoordinateSystem::INVALID:
-        MFEM_ABORT("Unexpected coordinate system for lumped port direction!");
-        break;
     }
   }
 

--- a/palace/models/surfacecurrentoperator.cpp
+++ b/palace/models/surfacecurrentoperator.cpp
@@ -32,9 +32,6 @@ SurfaceCurrentData::SurfaceCurrentData(const config::SurfaceCurrentData &data,
         elems.push_back(
             std::make_unique<UniformElementData>(elem.direction, attr_marker, h1_fespace));
         break;
-      case config::internal::ElementData::CoordinateSystem::INVALID:
-        MFEM_ABORT("Unexpected coordinate system for surface current source direction!");
-        break;
     }
   }
 }

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -177,9 +177,6 @@ TimeOperator::TimeOperator(const IoData &iodata, SpaceOperator &spaceop,
         type = mfem::TimeDependentOperator::EXPLICIT;
       }
       break;
-    case config::TransientSolverData::Type::INVALID:
-      MFEM_ABORT("Invalid transient solver type!");
-      break;
   }
 
   // Set up time-dependent operator for 2nd-order curl-curl equation for E.

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -74,8 +74,7 @@ struct ElementData
   enum class CoordinateSystem
   {
     CARTESIAN,
-    CYLINDRICAL,
-    INVALID = -1
+    CYLINDRICAL
   };
   CoordinateSystem coordinate_system = CoordinateSystem::CARTESIAN;
 
@@ -95,10 +94,9 @@ public:
     EIGENMODE,
     ELECTROSTATIC,
     MAGNETOSTATIC,
-    TRANSIENT,
-    INVALID = -1
+    TRANSIENT
   };
-  Type type = Type::INVALID;
+  Type type = Type::DRIVEN;
 
   // Level of printing.
   int verbose = 1;
@@ -592,11 +590,10 @@ public:
   // Eigenvalue solver type.
   enum class Type
   {
-    ARPACK,
-    SLEPC,
-    FEAST,
     DEFAULT,
-    INVALID = -1
+    SLEPC,
+    ARPACK,
+    FEAST
   };
   Type type = Type::DEFAULT;
 
@@ -641,11 +638,10 @@ public:
   // Time integration scheme type.
   enum class Type
   {
+    DEFAULT,
     GEN_ALPHA,
     NEWMARK,
-    CENTRAL_DIFF,
-    DEFAULT,
-    INVALID = -1
+    CENTRAL_DIFF
   };
   Type type = Type::DEFAULT;
 
@@ -657,10 +653,9 @@ public:
     DIFF_GAUSSIAN,
     MOD_GAUSSIAN,
     RAMP_STEP,
-    SMOOTH_STEP,
-    INVALID = -1
+    SMOOTH_STEP
   };
-  ExcitationType excitation = ExcitationType::INVALID;
+  ExcitationType excitation = ExcitationType::SINUSOIDAL;
 
   // Excitation parameters: frequency [GHz] and pulse width [ns].
   double pulse_f = 0.0;
@@ -687,27 +682,25 @@ public:
   // Solver type.
   enum class Type
   {
+    DEFAULT,
     AMS,
     BOOMER_AMG,
     MUMPS,
     SUPERLU,
     STRUMPACK,
-    STRUMPACK_MP,
-    DEFAULT,
-    INVALID = -1
+    STRUMPACK_MP
   };
   Type type = Type::DEFAULT;
 
   // Krylov solver type.
   enum class KspType
   {
+    DEFAULT,
     CG,
     MINRES,
     GMRES,
     FGMRES,
-    BICGSTAB,
-    DEFAULT,
-    INVALID = -1
+    BICGSTAB
   };
   KspType ksp_type = KspType::DEFAULT;
 
@@ -730,8 +723,7 @@ public:
   enum class MultigridCoarsenType
   {
     LINEAR,
-    LOGARITHMIC,
-    INVALID = -1
+    LOGARITHMIC
   };
   MultigridCoarsenType mg_coarsen_type = MultigridCoarsenType::LOGARITHMIC;
 
@@ -764,10 +756,9 @@ public:
   // Choose left or right preconditioning.
   enum class SideType
   {
-    RIGHT,
-    LEFT,
     DEFAULT,
-    INVALID = -1
+    RIGHT,
+    LEFT
   };
   SideType pc_side_type = SideType::DEFAULT;
 
@@ -775,12 +766,11 @@ public:
   // direct solvers.
   enum class SymFactType
   {
+    DEFAULT,
     METIS,
     PARMETIS,
     SCOTCH,
-    PTSCOTCH,
-    DEFAULT,
-    INVALID = -1
+    PTSCOTCH
   };
   SymFactType sym_fact_type = SymFactType::DEFAULT;
 
@@ -794,8 +784,7 @@ public:
     HODLR,
     ZFP,
     BLR_HODLR,
-    ZFP_BLR_HODLR,
-    INVALID = -1
+    ZFP_BLR_HODLR
   };
   CompressionType strumpack_compression_type = CompressionType::NONE;
   double strumpack_lr_tol = 1.0e-3;
@@ -820,8 +809,7 @@ public:
   {
     MGS,
     CGS,
-    CGS2,
-    INVALID = -1
+    CGS2
   };
   OrthogType gs_orthog_type = OrthogType::MGS;
 


### PR DESCRIPTION
Previously every enum defined in `configfile.hpp` had a `*_INVALID` option because the behavior of the `NLOHMANN_JSON_SERIALIZE_ENUM` macro's `from_json` was to assign to the first enum in the list if no matching value was found in the provided map. This PR writes adds a custom `from_json` function which throws an error in this case, since this was always what we wanted to do, and allows us to remove these extraneous `*_INVALID` enum options from the code.