### PR TITLE
Add option to remove high-order mesh curvature information

### DIFF
--- a/docs/src/config/model.md
+++ b/docs/src/config/model.md
@@ -89,3 +89,9 @@ Specified in mesh length units.
 
 `"Radius" [None]` : The radius of the sphere for this sphere refinement region, specified in
 mesh length units.
+
+### Advanced model options
+
+  - `"Partition" [""]`
+  - `"ReorientTetMesh" [false]`
+  - `"RemoveCurvature" [false]`

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -420,6 +420,7 @@ void ModelData::SetUp(json &config)
   Lc = model->value("Lc", Lc);
   partition = model->value("Partition", partition);
   reorient_tet = model->value("ReorientTetMesh", reorient_tet);
+  remove_curvature = model->value("RemoveCurvature", remove_curvature);
   refinement.SetUp(*model);
 
   // Cleanup
@@ -428,6 +429,7 @@ void ModelData::SetUp(json &config)
   model->erase("Lc");
   model->erase("Partition");
   model->erase("ReorientTetMesh");
+  model->erase("RemoveCurvature");
   model->erase("Refinement");
   MFEM_VERIFY(model->empty(),
               "Found an unsupported configuration file keyword under \"Model\"!\n"
@@ -439,6 +441,7 @@ void ModelData::SetUp(json &config)
   // std::cout << "Lc: " << Lc << '\n';
   // std::cout << "Partition: " << partition << '\n';
   // std::cout << "ReorientTetMesh: " << reorient_tet << '\n';
+  // std::cout << "RemoveCurvature: " << remove_curvature << '\n';
 }
 
 void MaterialDomainData::SetUp(json &domains)

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -168,6 +168,9 @@ public:
   // Call MFEM's ReorientTetMesh as a check of mesh orientation after partitioning.
   bool reorient_tet = false;
 
+  // Remove high-order curvature information from the mesh.
+  bool remove_curvature = false;
+
   // Object controlling mesh refinement.
   RefinementData refinement = {};
 

--- a/scripts/schema/config/model.json
+++ b/scripts/schema/config/model.json
@@ -11,6 +11,7 @@
     "Lc": { "type": "number", "exclusiveMinimum": 0.0 },
     "Partition": { "type": "string" },
     "ReorientTetMesh": { "type": "boolean" },
+    "RemoveCurvature": { "type": "boolean" },
     "Refinement":
     {
       "type": "object",


### PR DESCRIPTION
For debugging purposes, it can be useful to strip the nodes associated high-order curved meshes and deal with only the underlying straight-sided mesh defined by the element vertices. This PR adds a `RemoveCurvature` option to the configuration file which performs this operation after loading the mesh from disk.