### PR TITLE
Fix for non-planar lumped ports

### DIFF
--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -69,7 +69,16 @@ public:
       bounding_box(mesh::GetBoundingBox(*fespace.GetParMesh(), marker, true)), direction(3)
   {
     MFEM_VERIFY(bounding_box.planar,
-                "Boundary elements must be coplanar to define a lumped element!");
+                [this]()
+                {
+                  std::stringstream ss;
+                  ss << "Boundary elements must be coplanar to define a lumped element:\n";
+                  auto l = bounding_box.Lengths();
+                  ss << "Dimensions (" << l[0] << " x " << l[1] << " x " << l[2] << ")\n";
+                  ss << "Area " << bounding_box.Area() << "\n";
+                  ss << "Volume " << bounding_box.Volume() << "\n";
+                  return ss.str();
+                }());
 
     // Check that the bounding box discovered matches the area. This validates that the
     // boundary elements form a right angled quadrilateral port.

--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -70,7 +70,7 @@ public:
   {
     // Check that the bounding box discovered matches the area. This validates that the
     // boundary elements form a right angled quadrilateral port.
-    constexpr double rel_tol = 1.0e-3;
+    constexpr double rel_tol = 1.0e-6;
     double A = GetArea(fespace);
     MFEM_VERIFY((!bounding_box.planar || (std::abs(A - bounding_box.Area()) / A < rel_tol)),
                 "Discovered bounding box area "
@@ -102,7 +102,7 @@ public:
       }
       Mpi::Warning(
           "User specified direction {:.3e} does not align with either bounding box "
-          "axis up to {:.3e} degrees.\n"
+          "axis up to {:.3e} degrees!\n"
           "Axis 1: {:.3e} ({:.3e} degrees)\nAxis 2: {:.3e} ({:.3e} degrees)\nAxis 3: "
           "{:.3e} ({:.3e} degrees)!\n",
           input_dir, angle_warning_deg, normal_0, deviation_deg[0], normal_1,
@@ -124,7 +124,7 @@ public:
     MFEM_ASSERT(
         (l - mesh::GetProjectedLength(*fespace.GetParMesh(), marker, true, input_dir)) / l <
             rel_tol,
-        "Bounding box discovered length should match projected length");
+        "Bounding box discovered length should match projected length!");
     w = A / l;
   }
 

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -113,10 +113,10 @@ BoundingBox GetBoundingBox(mfem::ParMesh &mesh, const mfem::Array<int> &marker, 
 BoundingBox GetBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr);
 
 // Helper function for computing the direction aligned length of a marked group.
-double GetDirectionalExtent(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr,
-                            const std::array<double, 3> &dir);
-double GetDirectionalExtent(mfem::ParMesh &mesh, int attr, bool bdr,
-                            const std::array<double, 3> &dir);
+double GetProjectedLength(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr,
+                          const std::array<double, 3> &dir);
+double GetProjectedLength(mfem::ParMesh &mesh, int attr, bool bdr,
+                          const std::array<double, 3> &dir);
 
 // Given a mesh and a marker, compute the diameter of a bounding circle/sphere, assuming
 // that the extrema points are in the marked group.

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -112,6 +112,12 @@ struct BoundingBall
 BoundingBox GetBoundingBox(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr);
 BoundingBox GetBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr);
 
+// Helper function for computing the direction aligned length of a marked group.
+double GetDirectionalExtent(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr,
+                            const std::array<double, 3> &dir);
+double GetDirectionalExtent(mfem::ParMesh &mesh, int attr, bool bdr,
+                            const std::array<double, 3> &dir);
+
 // Given a mesh and a marker, compute the diameter of a bounding circle/sphere, assuming
 // that the extrema points are in the marked group.
 BoundingBall GetBoundingBall(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr);


### PR DESCRIPTION
This PR fixes an issue where non-planar lumped ports were being errored out incorrectly. The fix involves fixing the bounding box calculation to better handle non-planar two dimensional objects embedded in three dimensional space, and only performing the quadrilateral area check against the integrated area if a planar port is discovered. An extra "GetProjectedLength" helper function is also included, at present it is only used in a debug assertion.

*Issue #, if available:*
https://github.com/awslabs/palace/issues/89
