### PR TITLE
Fix parsing of 2D COMSOL meshes

### DIFF
--- a/palace/utils/meshio.cpp
+++ b/palace/utils/meshio.cpp
@@ -624,7 +624,8 @@ void ConvertMeshComsol(const std::string &filename, std::ostream &buffer)
       input.read(reinterpret_cast<char *>(&nodes_start), sizeof(int));
     }
     MFEM_VERIFY(version == 4, "Only COMSOL files with Mesh version 4 are supported!");
-    MFEM_VERIFY(sdim == 3, "COMSOL mesh nodes are required to be in 2D or 3D space!");
+    MFEM_VERIFY(sdim == 2 || sdim == 3,
+                "COMSOL mesh nodes are required to be in 2D or 3D space!");
     MFEM_VERIFY(num_nodes > 0, "COMSOL mesh file contains no nodes!");
     MFEM_VERIFY(nodes_start >= 0, "COMSOL mesh nodes have a negative starting tag!");
   }


### PR DESCRIPTION
Fix check for vertex coordinate dimension when using COMSOL mesh formats. Resolves https://github.com/awslabs/palace/issues/102.