### PR TITLE
Remove some unneeded `SetIntPoint` calls for `Coefficient` evaluation

### DIFF
--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -196,8 +196,15 @@ public:
   {
   }
 
-  static void GetNormal(mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip,
-                        mfem::Vector &normal);
+  static void GetNormal(mfem::ElementTransformation &T, mfem::Vector &normal)
+  {
+    // Return normal vector to the boundary element at an integration point (it is assumed
+    // that the element transformation has already been configured at the integration point
+    // of interest).
+    normal.SetSize(T.GetSpaceDim());
+    mfem::CalcOrtho(T.Jacobian(), normal);
+    normal /= normal.Norml2();
+  }
 };
 
 // Computes surface current J_s = n x H on boundaries from B as a vector grid function
@@ -242,7 +249,7 @@ public:
     }
 
     // Orient with normal pointing into el1.
-    GetNormal(T, ip, nor);
+    GetNormal(T, nor);
     V.SetSize(vdim);
     if (C1 * nor < 0.0)
     {
@@ -296,7 +303,7 @@ public:
     }
 
     // Orient with normal pointing into el1.
-    GetNormal(T, ip, nor);
+    GetNormal(T, nor);
     return (C1 * nor < 0.0) ? -(VU * nor) : VU * nor;
   }
 };
@@ -338,7 +345,7 @@ public:
     }
 
     // Orient sign with the global direction.
-    GetNormal(T, ip, nor);
+    GetNormal(T, nor);
     return (dir * nor < 0.0) ? -(V * nor) : V * nor;
   }
 };
@@ -431,7 +438,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::MA>::Eval(
 {
   // Get single-sided solution and neighboring element attribute.
   Initialize(T, ip, V);
-  GetNormal(T, ip, nor);
+  GetNormal(T, nor);
 
   // Metal-air interface: 0.5 * t / ε_MA * |E_n|² .
   double Vn = V * nor;
@@ -444,7 +451,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::MS>::Eval(
 {
   // Get single-sided solution and neighboring element attribute.
   int attr = Initialize(T, ip, V);
-  GetNormal(T, ip, nor);
+  GetNormal(T, nor);
 
   // Metal-substrate interface: 0.5 * t * (ε_S)² / ε_MS * |E_n|² .
   const double Vn = V * nor;
@@ -458,7 +465,7 @@ inline double DielectricInterfaceCoefficient<DielectricInterfaceType::SA>::Eval(
 {
   // Get single-sided solution and neighboring element attribute.
   Initialize(T, ip, V);
-  GetNormal(T, ip, nor);
+  GetNormal(T, nor);
 
   // Substrate-air interface: 0.5 * t * (ε_SA * |E_t|² + 1 / ε_MS * |E_n|²) .
   double Vn = V * nor;
@@ -509,7 +516,6 @@ public:
   {
     if (T.ElementType == mfem::ElementTransformation::ELEMENT)
     {
-      T.SetIntPoint(&ip);
       return GetLocalEnergyDensity(T, ip, T.Attribute);
     }
     if (T.ElementType == mfem::ElementTransformation::BDR_ELEMENT)
@@ -673,7 +679,7 @@ public:
   double Eval(mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip) override
   {
     c->Eval(K, T, ip);
-    BdrGridFunctionCoefficient::GetNormal(T, ip, nor);
+    BdrGridFunctionCoefficient::GetNormal(T, nor);
     return K.InnerProduct(nor, nor);
   }
 };
@@ -1028,17 +1034,6 @@ inline void BdrGridFunctionCoefficient::GetElementTransformations(
     T1->Transform(mfem::Geometries.GetCenter(T1->GetGeometryType()), *C1);
     *C1 -= CF;  // Points into element 1 from the face
   }
-}
-
-inline void BdrGridFunctionCoefficient::GetNormal(mfem::ElementTransformation &T,
-                                                  const mfem::IntegrationPoint &ip,
-                                                  mfem::Vector &normal)
-{
-  // Return normal vector to the boundary element at the provided integration point.
-  normal.SetSize(T.GetSpaceDim());
-  T.SetIntPoint(&ip);
-  mfem::CalcOrtho(T.Jacobian(), normal);
-  normal /= normal.Norml2();
 }
 
 }  // namespace palace

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -196,11 +196,11 @@ public:
   {
   }
 
+  // Return normal vector to the boundary element at an integration point (it is assumed
+  // that the element transformation has already been configured at the integration point of
+  // interest).
   static void GetNormal(mfem::ElementTransformation &T, mfem::Vector &normal)
   {
-    // Return normal vector to the boundary element at an integration point (it is assumed
-    // that the element transformation has already been configured at the integration point
-    // of interest).
     normal.SetSize(T.GetSpaceDim());
     mfem::CalcOrtho(T.Jacobian(), normal);
     normal /= normal.Norml2();

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -430,6 +430,7 @@ public:
       else
       {
         submesh_T = submesh.GetElementTransformation(it->second);
+        submesh_T->SetIntPoint(&ip);
       }
 
       int i, o, iel1, iel2;
@@ -456,7 +457,6 @@ public:
 
     // Compute Re/Im{-1/i (ikₙ Eₜ + ∇ₜ Eₙ)}.
     mfem::Vector U;
-    submesh_T->SetIntPoint(&ip);
     if constexpr (RealPart)
     {
       Et.real().GetVectorValue(*submesh_T, ip, U);


### PR DESCRIPTION
An `mfem::ElementTransformation` is configured at the given integration point in the loop over quadrature points inside of the element, at the level of a `Linear/BilinearForm` assembly or `GridFunction` evaluation. Calling `SetIntPoint` again will reset the transformation and require redundant computation of the element Jacobian in cases where it could have been reused.