### PR TITLE
Increase fp precision of first column of postpro files

### DIFF
--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -56,7 +56,7 @@ void WriteMetadata(const std::string &post_dir, const json &meta)
 
 BaseSolver::BaseSolver(const IoData &iodata, bool root, int size, int num_thread,
                        const char *git_tag)
-  : iodata(iodata), post_dir(GetPostDir(iodata.problem.output)), root(root), table(8, 9, 6)
+  : iodata(iodata), post_dir(GetPostDir(iodata.problem.output)), root(root), table(8, 9, 9)
 {
   // Create directory for output.
   if (root && !std::filesystem::exists(post_dir))

--- a/test/examples/runtests.jl
+++ b/test/examples/runtests.jl
@@ -1,10 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-using Test
 using Hwloc
-using CSV
-using DataFrames
 
 include("testcase.jl")
 


### PR DESCRIPTION
*Description of changes:*

Previously the floating point precision of the first column of all postprocessed data outputs was set to 6. I'm increasing it to 9 to match that of all other columns and to prevent unnecessary rounding (e.g. of frequency vectors for driven solves).

*Issue #, if available:* https://github.com/awslabs/palace/issues/112

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
