### PR TITLE
Correct log printing when Palace is built without OpenMP

### DIFF
--- a/palace/main.cpp
+++ b/palace/main.cpp
@@ -64,7 +64,7 @@ static int ConfigureOmp()
   omp_set_dynamic(0);
   return nt;
 #else
-  return 1;
+  return 0;
 #endif
 }
 


### PR DESCRIPTION
Minor fix to distinguish from an OpenMP build running with 1 thread.