### PR TITLE
Default order for Chebyshev polynomial smoothing

### DIFF
--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -413,8 +413,10 @@ multigrid preconditioners (when `"UseMultigrid"` is `true` or `"Type"` is `"AMS"
 `"MGSmoothIts" [1]` :  Number of pre- and post-smooth iterations used for multigrid
 preconditioners (when `"UseMultigrid"` is `true` or `"Type"` is `"AMS"` or `"BoomerAMG"`).
 
-`"MGSmoothOrder" [4]` :  Order of polynomial smoothing for geometric multigrid
-preconditioning (when `"UseMultigrid"` is `true`).
+`"MGSmoothOrder" [0]` :  Order of polynomial smoothing for geometric multigrid
+preconditioning (when `"UseMultigrid"` is `true`). A value less than 1 defaults to twice
+the solution order given in [`config["Solver"]["Order"]`]
+(problem.md#config%5B%22Solver%22%5D) or 4, whichever is larger.
 
 `"PCMatReal" [false]` :  When set to `true`, constructs the preconditioner for frequency
 domain problems using a real-valued approximation of the system matrix. This is always

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -65,9 +65,11 @@ DivFreeSolver::DivFreeSolver(const MaterialOperator &mat_op,
   std::unique_ptr<Solver<Operator>> pc;
   if (h1_fespaces.GetNumLevels() > 1)
   {
+    const int mg_smooth_order =
+        std::max(h1_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<Operator>>(
-        std::move(amg), h1_fespaces, nullptr, 1, 1, 2, 1.0, 0.0, true, pa_order_threshold,
-        pa_discrete_interp);
+        std::move(amg), h1_fespaces, nullptr, 1, 1, mg_smooth_order, 1.0, 0.0, true,
+        pa_order_threshold, pa_discrete_interp);
   }
   else
   {

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -63,12 +63,8 @@ ConfigureLinearSolver(const mfem::ParFiniteElementSpaceHierarchy &fespaces, doub
   std::unique_ptr<Solver<Operator>> pc;
   if (fespaces.GetNumLevels() > 1)
   {
-    const int dim = fespaces.GetFinestFESpace().GetParMesh()->Dimension();
-    const auto type = fespaces.GetFinestFESpace().FEColl()->GetRangeType(dim);
     const int mg_smooth_order =
-        (type == mfem::FiniteElement::SCALAR)
-            ? 2
-            : std::max(fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
+        std::max(fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<Operator>>(
         std::move(amg), fespaces, nullptr, 1, 1, mg_smooth_order, 1.0, 0.0, true,
         pa_order_threshold, pa_discrete_interp);

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -96,7 +96,7 @@ FluxProjector::FluxProjector(const MaterialOperator &mat_op,
                              bool pa_discrete_interp)
 {
   BlockTimer bt(Timer::CONSTRUCTESTIMATOR);
-  constexpr int skip_zeros = false;
+  constexpr bool skip_zeros = false;
   {
     constexpr auto MatType = MaterialPropertyType::INV_PERMEABILITY;
     MaterialPropertyCoefficient<MatType> muinv_func(mat_op);
@@ -120,7 +120,7 @@ FluxProjector::FluxProjector(const MaterialOperator &mat_op,
                              bool pa_discrete_interp)
 {
   BlockTimer bt(Timer::CONSTRUCTESTIMATOR);
-  constexpr int skip_zeros = false;
+  constexpr bool skip_zeros = false;
   {
     constexpr auto MatType = MaterialPropertyType::PERMITTIVITY_REAL;
     MaterialPropertyCoefficient<MatType> epsilon_func(mat_op);

--- a/palace/linalg/hcurl.cpp
+++ b/palace/linalg/hcurl.cpp
@@ -71,8 +71,10 @@ WeightedHCurlNormSolver::WeightedHCurlNormSolver(
   std::unique_ptr<Solver<Operator>> pc;
   if (nd_fespaces.GetNumLevels() > 1)
   {
+    const int mg_smooth_order =
+        std::max(nd_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<Operator>>(
-        std::move(ams), nd_fespaces, &h1_fespaces, 1, 1, 2, 1.0, 0.0, true,
+        std::move(ams), nd_fespaces, &h1_fespaces, 1, 1, mg_smooth_order, 1.0, 0.0, true,
         pa_order_threshold, pa_discrete_interp);
   }
   else

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -746,7 +746,7 @@ public:
   int mg_smooth_it = 1;
 
   // Order of polynomial smoothing for geometric multigrid.
-  int mg_smooth_order = 4;
+  int mg_smooth_order = -1;
 
   // Safety factors for eigenvalue estimates associated with Chebyshev smoothing for
   // geometric multigrid.

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -420,6 +420,10 @@ void IoData::CheckConfiguration()
       solver.linear.mg_smooth_aux = 1;
     }
   }
+  if (solver.linear.mg_smooth_order < 0)
+  {
+    solver.linear.mg_smooth_order = std::max(2 * solver.order, 4);
+  }
 }
 
 namespace


### PR DESCRIPTION
Set default smoother order for multigrid based on the solver order, and increase smooth order for mass-matrix solve in error estimation.