### PR TITLE
Add <numeric> header for std::inclusive_scan

### DIFF
--- a/palace/fem/libceed/operator.cpp
+++ b/palace/fem/libceed/operator.cpp
@@ -3,6 +3,7 @@
 
 #include "operator.hpp"
 
+#include <numeric>
 #include <ceed.h>
 #include <mfem/general/forall.hpp>
 #include "fem/libceed/utils.hpp"


### PR DESCRIPTION
*Description of changes:* 
Add <numeric> header for std::inclusive_scan

*Issue #, if available:*
MSVS 2022 complains about this missing header. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
