### PR TITLE
Support MSVS in the deprecated ignore

### DIFF
--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -227,10 +227,17 @@ void RefineMesh(const IoData &iodata, std::vector<std::unique_ptr<mfem::ParMesh>
   // refinement.
   if (iodata.model.reorient_tet && mesh.capacity() > 1)
   {
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+    mesh[0]->ReorientTetMesh();
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     mesh[0]->ReorientTetMesh();
 #pragma GCC diagnostic pop
+#endif
   }
 
   // Uniformly refine the mesh further in parallel, saving the level meshes for geometric
@@ -371,10 +378,17 @@ void RefineMesh(const IoData &iodata, std::vector<std::unique_ptr<mfem::ParMesh>
   // h-refinement geometric multigrid).
   if (iodata.model.reorient_tet && mesh.size() == 1)
   {
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+    mesh[0]->ReorientTetMesh();
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     mesh[0]->ReorientTetMesh();
 #pragma GCC diagnostic pop
+#endif
   }
 
   // Print some mesh information.


### PR DESCRIPTION
*Description of changes:*
Support MSVS in the deprecated ignore, using #ifdef _WIN32 statement.

*Issue #, if available:*
MSVS compiler cannot recognize the GCC ignore syntax. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
