### PR TITLE
Change postprocessing AMR subdirectory and update docs

### DIFF
--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -111,8 +111,8 @@ conditions as well as any material interfaces in the computational domain.
 ## Adaptive Mesh Refinement
 
 At the start of an adaptive mesh refinement iteration, if
-[`config["Model"]["Refinement]["SaveAdaptIterations"]`]
+[`config["Model"]["Refinement"]["SaveAdaptIterations"]`]
 (../config/model.md#model%5B%22Refinement%22%5D) is enabled, the postprocessing results from
-the previous solve will be saved off within a subdirectory denoted `iterationX` where `X` is
-the iteration number. The results in the top level directory will always be those from the
-most recent successful solve.
+the solve on the previous mesh will be saved off within a subdirectory denoted `iterationX`,
+where `X` is the (1-based) iteration number. The results in the top level directory will
+always be those from the most recent successful solve.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -107,3 +107,12 @@ the output directory specified under [`config["Problem"]["Output"]`]
 In addition to the full 3D fields, a ParaView data collection for the boundary mesh is also
 written to disk. The boundary mesh includes all surfaces with prescribed boundary
 conditions as well as any material interfaces in the computational domain.
+
+## Adaptive Mesh Refinement
+
+At the start of an adaptive mesh refinement iteration, if
+[`config["Model"]["Refinement]["SaveAdaptIterations"]`]
+(../config/model.md#model%5B%22Refinement%22%5D) is enabled, the postprocessing results from
+the previous solve will be saved off within a subdirectory denoted `iterationX` where `X` is
+the iteration number. The results in the top level directory will always be those from the
+most recent successful solve.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -108,9 +108,9 @@ In addition to the full 3D fields, a ParaView data collection for the boundary m
 written to disk. The boundary mesh includes all surfaces with prescribed boundary
 conditions as well as any material interfaces in the computational domain.
 
-## Adaptive Mesh Refinement
+## Adaptive mesh refinement
 
-At the start of an adaptive mesh refinement iteration, if
+At the start of an adaptive mesh refinement (AMR) iteration, if
 [`config["Model"]["Refinement"]["SaveAdaptIterations"]`]
 (../config/model.md#model%5B%22Refinement%22%5D) is enabled, the postprocessing results from
 the solve on the previous mesh will be saved off within a subdirectory denoted `iterationX`,

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -37,7 +37,7 @@ std::string GetPostDir(const std::string &output)
 
 std::string GetIterationPostDir(const std::string &output, int step, int width)
 {
-  return fmt::format("{}adapt{:0{}d}/", output, step, width);
+  return fmt::format("{}iteration{:0{}d}/", output, step, width);
 }
 
 void SaveIteration(MPI_Comm comm, const std::string &output, int step, int width)
@@ -57,7 +57,7 @@ void SaveIteration(MPI_Comm comm, const std::string &output, int step, int width
         fs::copy_options::recursive | fs::copy_options::overwrite_existing;
     for (const auto &f : fs::directory_iterator(output))
     {
-      if (f.path().filename().string().rfind("adapt") == 0)
+      if (f.path().filename().string().rfind("iteration") == 0)
       {
         continue;
       }


### PR DESCRIPTION
Change the AMR generated postprocessing subdirectory from `adaptX` to `iterationX` where `X` denotes the iteration number starting from 1 on the initial mesh. Additionally update the postprocessing section of the documentation to mention this directory.