### PR TITLE
Fix json schema int bug

### DIFF
--- a/scripts/schema/config/solver.json
+++ b/scripts/schema/config/solver.json
@@ -104,7 +104,7 @@
         "MaxIts": { "type": "integer", "exclusiveMinimum": 0 },
         "MaxSize": { "type": "integer", "exclusiveMinimum": 0 },
         "InitialGuess": { "type": "boolean" },
-        "MGMaxLevels": { "type": "int", "minimum": 1 },
+        "MGMaxLevels": { "type": "integer", "minimum": 1 },
         "MGCoarsenType": { "type": "string" },
         "MGAuxiliarySmoother": { "type": "boolean" },
         "MGCycleIts": { "type": "integer", "exclusiveMinimum": 0 },


### PR DESCRIPTION
If using `MGMaxLevels` the json validator would fail because `int` isn't the same as `integer`. Tested fix using a config with `"MGMaxLevels": 1`.