### PR TITLE
Timer fixes for linear solves

### DIFF
--- a/palace/linalg/divfree.hpp
+++ b/palace/linalg/divfree.hpp
@@ -9,6 +9,7 @@
 #include "linalg/ksp.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
+#include "utils/timer.hpp"
 
 namespace mfem
 {
@@ -55,6 +56,8 @@ public:
   // ∇ x y = 0.
   void Mult(Vector &y) const
   {
+    BlockTimer bt(Timer::DIVFREE);
+
     // Compute the divergence of y.
     WeakDiv->Mult(y, rhs);
 

--- a/palace/linalg/gmg.cpp
+++ b/palace/linalg/gmg.cpp
@@ -20,7 +20,7 @@ GeometricMultigridSolver<OperType>::GeometricMultigridSolver(
     bool cheby_4th_kind)
   : Solver<OperType>(), pc_it(cycle_it), P(P.begin(), P.end()), A(P.size() + 1),
     dbc_tdof_lists(P.size()), B(P.size() + 1), X(P.size() + 1), Y(P.size() + 1),
-    R(P.size() + 1)
+    R(P.size() + 1), use_timer(false)
 {
   // Configure levels of geometric coarsening. Multigrid vectors will be configured at first
   // call to Mult. The multigrid operator size is set based on the finest space dimension.
@@ -173,7 +173,7 @@ void GeometricMultigridSolver<OperType>::VCycle(int l, bool initial_guess) const
   B[l]->SetInitialGuess(initial_guess);
   if (l == 0)
   {
-    BlockTimer bt(Timer::COARSESOLVE);
+    BlockTimer bt(Timer::COARSESOLVE, use_timer);
     B[l]->Mult(X[l], Y[l]);
     return;
   }

--- a/palace/linalg/gmg.hpp
+++ b/palace/linalg/gmg.hpp
@@ -50,6 +50,9 @@ private:
   // MFEM Operator interface for multiple RHS.
   mutable std::vector<VecType> X, Y, R;
 
+  // Enable timer contribution for Timer::COARSESOLVE.
+  bool use_timer;
+
   // Internal function to perform a single V-cycle iteration.
   void VCycle(int l, bool initial_guess) const;
 
@@ -74,6 +77,8 @@ public:
   void SetOperator(const OperType &op) override;
 
   void Mult(const VecType &x, VecType &y) const override;
+
+  void EnableTimer() { use_timer = true; }
 };
 
 }  // namespace palace

--- a/palace/linalg/iterative.hpp
+++ b/palace/linalg/iterative.hpp
@@ -53,6 +53,9 @@ protected:
   mutable double initial_res, final_res;
   mutable int final_it;
 
+  // Enable timer contribution for Timer::PRECONDITIONER.
+  bool use_timer;
+
 public:
   IterativeSolver(MPI_Comm comm, int print);
 
@@ -99,6 +102,9 @@ public:
 
   // Get the associated MPI communicator.
   MPI_Comm GetComm() const { return comm; }
+
+  // Activate preconditioner timing during solves.
+  void EnableTimer() { use_timer = true; }
 };
 
 // Preconditioned Conjugate Gradient (CG) method for SPD linear systems.


### PR DESCRIPTION
Configure linear solver timing to only count preconditioning and coarse solve time for primary solvers (not error estimation, divergence-free projection, etc.). Also add timing category for divergence-free projection for eigenvalue solves.