### PR TITLE
Config file option for disabling h-multigrid

### DIFF
--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -459,6 +459,7 @@ vectors in Krylov subspace methods or other parts of the code.
 ### Advanced linear solver options
 
   - `"InitialGuess" [true]`
+  - `"MGUseMesh" [true]`
   - `"MGAuxiliarySmoother" [true]`
   - `"MGSmoothEigScaleMax" [1.0]`
   - `"MGSmoothEigScaleMin" [0.0]`

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -1683,6 +1683,7 @@ void LinearSolverData::SetUp(json &solver)
   // Options related to multigrid.
   mg_max_levels = linear->value("MGMaxLevels", mg_max_levels);
   mg_coarsen_type = linear->value("MGCoarsenType", mg_coarsen_type);
+  mg_use_mesh = linear->value("MGUseMesh", mg_use_mesh);
   mg_cycle_it = linear->value("MGCycleIts", mg_cycle_it);
   mg_smooth_aux = linear->value("MGAuxiliarySmoother", mg_smooth_aux);
   mg_smooth_it = linear->value("MGSmoothIts", mg_smooth_it);
@@ -1722,6 +1723,7 @@ void LinearSolverData::SetUp(json &solver)
 
   linear->erase("MGMaxLevels");
   linear->erase("MGCoarsenType");
+  linear->erase("MGUseMesh");
   linear->erase("MGCycleIts");
   linear->erase("MGAuxiliarySmoother");
   linear->erase("MGSmoothIts");
@@ -1760,6 +1762,7 @@ void LinearSolverData::SetUp(json &solver)
 
   // std::cout << "MGMaxLevels: " << mg_max_levels << '\n';
   // std::cout << "MGCoarsenType: " << mg_coarsen_type << '\n';
+  // std::cout << "MGUseMesh: " << mg_use_mesh << '\n';
   // std::cout << "MGCycleIts: " << mg_cycle_it << '\n';
   // std::cout << "MGAuxiliarySmoother: " << mg_smooth_aux << '\n';
   // std::cout << "MGSmoothIts: " << mg_smooth_it << '\n';

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -763,6 +763,10 @@ public:
   };
   MultigridCoarsenType mg_coarsen_type = MultigridCoarsenType::LOGARITHMIC;
 
+  // Controls whether or not to include in the geometric multigrid hierarchy the mesh levels
+  // from uniform refinement.
+  bool mg_use_mesh = true;
+
   // Number of iterations for preconditioners which support it. For multigrid, this is the
   // number of V-cycles per Krylov solver iteration.
   int mg_cycle_it = 1;

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -199,7 +199,7 @@ void RefineMesh(const IoData &iodata, std::vector<std::unique_ptr<mfem::ParMesh>
       max_region_ref_levels = sphere.ref_levels;
     }
   }
-  if (iodata.solver.linear.mg_max_levels > 1)
+  if (iodata.solver.linear.mg_use_mesh && iodata.solver.linear.mg_max_levels > 1)
   {
     mesh.reserve(1 + uniform_ref_levels + max_region_ref_levels);
   }

--- a/scripts/schema/config/solver.json
+++ b/scripts/schema/config/solver.json
@@ -108,6 +108,7 @@
         "InitialGuess": { "type": "boolean" },
         "MGMaxLevels": { "type": "integer", "minimum": 1 },
         "MGCoarsenType": { "type": "string" },
+        "MGUseMesh": { "type": "boolean" },
         "MGAuxiliarySmoother": { "type": "boolean" },
         "MGCycleIts": { "type": "integer", "exclusiveMinimum": 0 },
         "MGSmoothIts": { "type": "integer", "exclusiveMinimum": 0 },


### PR DESCRIPTION
Add option to disable mesh refinement levels from MG hierarchy: `"MGUseMesh"` (default is true).