### PR TITLE
Multigrid cleanup from error estimation

### DIFF
--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -139,7 +139,7 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &spaceop, PostOperator &
 
   // Initialize structures for storing and reducing the results of error estimation.
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
       iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;
 
@@ -254,7 +254,7 @@ ErrorIndicator DrivenSolver::SweepAdaptive(SpaceOperator &spaceop, PostOperator 
 
   // Initialize structures for storing and reducing the results of error estimation.
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
       iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;
 

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -268,7 +268,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<mfem::ParMesh>> &mesh) cons
   // Calculate and record the error indicators.
   Mpi::Print("Computing solution error estimates\n\n");
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
       iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;
   for (int i = 0; i < iodata.solver.eigenmode.n; i++)

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -98,7 +98,7 @@ ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
 
   // Calculate and record the error indicators.
   Mpi::Print("Computing solution error estimates\n\n");
-  GradFluxErrorEstimator estimator(laplaceop.GetMaterialOp(), laplaceop.GetH1Spaces(),
+  GradFluxErrorEstimator estimator(laplaceop.GetMaterialOp(), laplaceop.GetH1Space(),
                                    iodata.solver.linear.estimator_tol,
                                    iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -102,7 +102,7 @@ ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
   // Calculate and record the error indicators.
   Mpi::Print("Computing solution error estimates\n\n");
   CurlFluxErrorEstimator<Vector> estimator(
-      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpaces(),
+      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpace(),
       iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;
   for (int i = 0; i < nstep; i++)

--- a/palace/drivers/transientsolver.cpp
+++ b/palace/drivers/transientsolver.cpp
@@ -78,7 +78,7 @@ TransientSolver::Solve(const std::vector<std::unique_ptr<mfem::ParMesh>> &mesh) 
   Mpi::Print("\n");
 
   // Initialize structures for storing and reducing the results of error estimation.
-  CurlFluxErrorEstimator<Vector> estimator(spaceop.GetMaterialOp(), spaceop.GetNDSpaces(),
+  CurlFluxErrorEstimator<Vector> estimator(spaceop.GetMaterialOp(), spaceop.GetNDSpace(),
                                            iodata.solver.linear.estimator_tol,
                                            iodata.solver.linear.estimator_max_it, 0);
   ErrorIndicator indicator;

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -38,11 +38,9 @@ private:
   mutable Vector rhs;
 
 public:
-  FluxProjector(const MaterialOperator &mat_op,
-                const FiniteElementSpaceHierarchy &nd_fespaces, double tol, int max_it,
-                int print);
-  FluxProjector(const MaterialOperator &mat_op,
-                const FiniteElementSpaceHierarchy &h1_fespaces,
+  FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &nd_fespace,
+                double tol, int max_it, int print);
+  FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &h1_fespace,
                 const FiniteElementSpace &h1d_fespace, double tol, int max_it, int print);
 
   template <typename VecType>
@@ -73,8 +71,8 @@ class CurlFluxErrorEstimator
 
 public:
   CurlFluxErrorEstimator(const MaterialOperator &mat_op,
-                         const FiniteElementSpaceHierarchy &nd_fespaces, double tol,
-                         int max_it, int print);
+                         const FiniteElementSpace &nd_fespace, double tol, int max_it,
+                         int print);
 
   // Compute elemental error indicators given a vector of true DOF.
   ErrorIndicator ComputeIndicators(const VecType &U) const;
@@ -109,8 +107,8 @@ class GradFluxErrorEstimator
 
 public:
   GradFluxErrorEstimator(const MaterialOperator &mat_op,
-                         const FiniteElementSpaceHierarchy &h1_fespaces, double tol,
-                         int max_it, int print);
+                         const FiniteElementSpace &h1_fespace, double tol, int max_it,
+                         int print);
 
   // Compute elemental error indicators given a vector of true DOF.
   ErrorIndicator ComputeIndicators(const Vector &U) const;


### PR DESCRIPTION
Remove need to assemble multigrid hierarchy for error estimation solve.

Missed from #143.

