### PR TITLE
Return exit code from Palace in wrapper script

### DIFF
--- a/scripts/palace
+++ b/scripts/palace
@@ -127,11 +127,12 @@ if $SERIAL; then
     # Run sequential simulation
     if [[ -n "$WORK_DIR" ]]; then
         echo ">> cd $WORK_DIR && $PALACE $CONFIG"
-        cd $WORK_DIR && $PALACE $CONFIG
+        cd $WORK_DIR
     else
         echo ">> $PALACE $CONFIG"
-        $PALACE $CONFIG
     fi
+    $PALACE $CONFIG
+    EXIT_CODE=$?
 else
     # Configure parallel MPI execution
     LAUNCHER=${LAUNCHER:-mpirun}
@@ -161,6 +162,7 @@ else
         # Local execution
         echo ">> $MPIRUN $PALACE $CONFIG"
         $MPIRUN $PALACE $CONFIG
+        EXIT_CODE=$?
     else
         NODE_FILE=mpi_nodes
         cat $NODE_LIST | sort | uniq > $NODE_FILE
@@ -172,9 +174,14 @@ else
         # Distributed execution
         echo ">> $MPIRUN $PALACE $CONFIG"
         $MPIRUN $PALACE $CONFIG
+        EXIT_CODE=$?
+
         rm $NODE_FILE
     fi
 fi
 
 # Reset user environment
 OMP_NUM_THREADS=$NUM_THREADS_BACKUP
+
+# Return the exit code from Palace
+exit $EXIT_CODE


### PR DESCRIPTION
Previously, even if the binary exited with non-zero exit code the wrapper script would still return 0.