### PR TITLE
Cleanup in `geodata.hpp/cpp`

### DIFF
--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -363,6 +363,7 @@ set(MFEM_PATCH_FILES
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_par_tet_mesh_fix.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_ncmesh_interior_boundary_dev.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_mesh_const_fix.diff"
+  "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_pncmesh_update_fix.diff"
 )
 
 include(ExternalProject)

--- a/extern/patch/mfem/patch_pncmesh_update_fix.diff
+++ b/extern/patch/mfem/patch_pncmesh_update_fix.diff
@@ -1,0 +1,13 @@
+diff --git a/mesh/pncmesh.cpp b/mesh/pncmesh.cpp
+index cd6625e9c..a8a88081f 100644
+--- a/mesh/pncmesh.cpp
++++ b/mesh/pncmesh.cpp
+@@ -107,6 +107,8 @@ void ParNCMesh::Update()
+       entity_owner[i].DeleteAll();
+       entity_pmat_group[i].DeleteAll();
+       entity_index_rank[i].DeleteAll();
++      entity_conf_group[i].DeleteAll();
++      entity_elem_local[i].DeleteAll();
+    }
+ 
+    shared_vertices.Clear();

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -360,7 +360,7 @@ void LumpedPortOperator::SetUpBoundaryProperties(const IoData &iodata,
   }
 }
 
-void LumpedPortOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh)
+void LumpedPortOperator::PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh)
 {
   // Print out BC info for all port attributes.
   if (ports.empty())

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -379,8 +379,7 @@ void LumpedPortOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &
           continue;
         }
         const int attr = i + 1;
-        mfem::Vector nor;
-        mesh::GetSurfaceNormal(mesh, attr, nor);
+        mfem::Vector normal = mesh::GetSurfaceNormal(mesh, attr);
         const double Rs = data.GetR() * data.GetToSquare(*elem);
         const double Ls = data.GetL() * data.GetToSquare(*elem);
         const double Cs = data.GetC() / data.GetToSquare(*elem);
@@ -418,11 +417,11 @@ void LumpedPortOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &
         }
         if (mesh.SpaceDimension() == 3)
         {
-          Mpi::Print(" n = ({:+.1f}, {:+.1f}, {:+.1f})", nor(0), nor(1), nor(2));
+          Mpi::Print(" n = ({:+.1f}, {:+.1f}, {:+.1f})", normal(0), normal(1), normal(2));
         }
         else
         {
-          Mpi::Print(" n = ({:+.1f}, {:+.1f})", nor(0), nor(1));
+          Mpi::Print(" n = ({:+.1f}, {:+.1f})", normal(0), normal(1));
         }
         Mpi::Print("\n");
       }

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -90,7 +90,7 @@ private:
   mfem::Array<int> port_marker, port_Rs_marker, port_Ls_marker, port_Cs_marker;
   void SetUpBoundaryProperties(const IoData &iodata,
                                mfem::ParFiniteElementSpace &h1_fespace);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh);
 
 public:
   LumpedPortOperator(const IoData &iodata, mfem::ParFiniteElementSpace &h1_fespace);

--- a/palace/models/surfaceconductivityoperator.cpp
+++ b/palace/models/surfaceconductivityoperator.cpp
@@ -108,8 +108,7 @@ void SurfaceConductivityOperator::PrintBoundaryInfo(const IoData &iodata,
     if (conductivity_marker[i])
     {
       const int attr = i + 1;
-      mfem::Vector nor;
-      mesh::GetSurfaceNormal(mesh, attr, nor);
+      mfem::Vector normal = mesh::GetSurfaceNormal(mesh, attr);
       Mpi::Print(" {:d}: σ = {:.3e} S/m", attr,
                  iodata.DimensionalizeValue(IoData::ValueType::CONDUCTIVITY, bdr_sigma(i)));
       if (bdr_h(i) > 0.0)
@@ -119,11 +118,11 @@ void SurfaceConductivityOperator::PrintBoundaryInfo(const IoData &iodata,
       }
       if (mesh.SpaceDimension() == 3)
       {
-        Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", nor(0), nor(1), nor(2));
+        Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", normal(0), normal(1), normal(2));
       }
       else
       {
-        Mpi::Print(", n = ({:+.1f}, {:+.1f})", nor(0), nor(1));
+        Mpi::Print(", n = ({:+.1f}, {:+.1f})", normal(0), normal(1));
       }
       Mpi::Print("\n");
     }

--- a/palace/models/surfaceconductivityoperator.cpp
+++ b/palace/models/surfaceconductivityoperator.cpp
@@ -14,7 +14,7 @@ namespace palace
 using namespace std::complex_literals;
 
 SurfaceConductivityOperator::SurfaceConductivityOperator(const IoData &iodata,
-                                                         mfem::ParMesh &mesh)
+                                                         const mfem::ParMesh &mesh)
 {
   // Set up finite conductivity boundary conditions.
   SetUpBoundaryProperties(iodata, mesh);
@@ -96,7 +96,7 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
 }
 
 void SurfaceConductivityOperator::PrintBoundaryInfo(const IoData &iodata,
-                                                    mfem::ParMesh &mesh)
+                                                    const mfem::ParMesh &mesh)
 {
   if (conductivity_marker.Size() && conductivity_marker.Max() == 0)
   {

--- a/palace/models/surfaceconductivityoperator.hpp
+++ b/palace/models/surfaceconductivityoperator.hpp
@@ -23,10 +23,10 @@ private:
   mfem::Vector bdr_sigma, bdr_mu, bdr_h;
   mfem::Array<int> conductivity_marker;
   void SetUpBoundaryProperties(const IoData &iodata, const mfem::ParMesh &mesh);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh);
 
 public:
-  SurfaceConductivityOperator(const IoData &iodata, mfem::ParMesh &mesh);
+  SurfaceConductivityOperator(const IoData &iodata, const mfem::ParMesh &mesh);
 
   // Returns array marking finite conductivity boundary attributes.
   const mfem::Array<int> &GetMarker() const { return conductivity_marker; }

--- a/palace/models/surfacecurrentoperator.cpp
+++ b/palace/models/surfacecurrentoperator.cpp
@@ -125,16 +125,15 @@ void SurfaceCurrentOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMe
           continue;
         }
         const int attr = i + 1;
-        mfem::Vector nor;
-        mesh::GetSurfaceNormal(mesh, attr, nor);
+        mfem::Vector normal = mesh::GetSurfaceNormal(mesh, attr);
         Mpi::Print(" {:d}: Index = {:d}", attr, idx);
         if (mesh.SpaceDimension() == 3)
         {
-          Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", nor(0), nor(1), nor(2));
+          Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", normal(0), normal(1), normal(2));
         }
         else
         {
-          Mpi::Print(", n = ({:+.1f}, {:+.1f})", nor(0), nor(1));
+          Mpi::Print(", n = ({:+.1f}, {:+.1f})", normal(0), normal(1));
         }
         Mpi::Print("\n");
       }

--- a/palace/models/surfacecurrentoperator.cpp
+++ b/palace/models/surfacecurrentoperator.cpp
@@ -107,7 +107,8 @@ void SurfaceCurrentOperator::SetUpBoundaryProperties(
   }
 }
 
-void SurfaceCurrentOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh)
+void SurfaceCurrentOperator::PrintBoundaryInfo(const IoData &iodata,
+                                               const mfem::ParMesh &mesh)
 {
   if (sources.empty())
   {

--- a/palace/models/surfacecurrentoperator.hpp
+++ b/palace/models/surfacecurrentoperator.hpp
@@ -58,7 +58,7 @@ private:
   mfem::Array<int> source_marker;
   void SetUpBoundaryProperties(const IoData &iodata,
                                mfem::ParFiniteElementSpace &h1_fespace);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh);
 
 public:
   SurfaceCurrentOperator(const IoData &iodata, mfem::ParFiniteElementSpace &h1_fespace);

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -109,8 +109,7 @@ void SurfaceImpedanceOperator::PrintBoundaryInfo(const IoData &iodata, mfem::Par
     if (impedance_marker[i])
     {
       const int attr = i + 1;
-      mfem::Vector nor;
-      mesh::GetSurfaceNormal(mesh, attr, nor);
+      mfem::Vector normal = mesh::GetSurfaceNormal(mesh, attr);
       bool comma = false;
       Mpi::Print(" {:d}:", attr);
       if (std::abs(Z_Rsinv(i)) > 0.0)
@@ -147,11 +146,11 @@ void SurfaceImpedanceOperator::PrintBoundaryInfo(const IoData &iodata, mfem::Par
       }
       if (mesh.SpaceDimension() == 3)
       {
-        Mpi::Print(" n = ({:+.1f}, {:+.1f}, {:+.1f})", nor(0), nor(1), nor(2));
+        Mpi::Print(" n = ({:+.1f}, {:+.1f}, {:+.1f})", normal(0), normal(1), normal(2));
       }
       else
       {
-        Mpi::Print(" n = ({:+.1f}, {:+.1f})", nor(0), nor(1));
+        Mpi::Print(" n = ({:+.1f}, {:+.1f})", normal(0), normal(1));
       }
       Mpi::Print("\n");
     }

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -12,7 +12,7 @@ namespace palace
 {
 
 SurfaceImpedanceOperator::SurfaceImpedanceOperator(const IoData &iodata,
-                                                   mfem::ParMesh &mesh)
+                                                   const mfem::ParMesh &mesh)
 {
   // Set up impedance boundary conditions.
   SetUpBoundaryProperties(iodata, mesh);
@@ -97,7 +97,8 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
   mesh::AttrToMarker(bdr_attr_max, impedance_Cs_bcs, impedance_Cs_marker);
 }
 
-void SurfaceImpedanceOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh)
+void SurfaceImpedanceOperator::PrintBoundaryInfo(const IoData &iodata,
+                                                 const mfem::ParMesh &mesh)
 {
   if (impedance_marker.Size() && impedance_marker.Max() == 0)
   {

--- a/palace/models/surfaceimpedanceoperator.hpp
+++ b/palace/models/surfaceimpedanceoperator.hpp
@@ -24,10 +24,10 @@ private:
   mfem::Array<int> impedance_marker, impedance_Rs_marker, impedance_Ls_marker,
       impedance_Cs_marker;
   void SetUpBoundaryProperties(const IoData &iodata, const mfem::ParMesh &mesh);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh);
 
 public:
-  SurfaceImpedanceOperator(const IoData &iodata, mfem::ParMesh &mesh);
+  SurfaceImpedanceOperator(const IoData &iodata, const mfem::ParMesh &mesh);
 
   // Returns array marking surface impedance attributes.
   const mfem::Array<int> &GetMarker() const { return impedance_marker; }

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -1003,7 +1003,7 @@ void WavePortOperator::SetUpBoundaryProperties(
   }
 }
 
-void WavePortOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh)
+void WavePortOperator::PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh)
 {
   // Print out BC info for all port attributes.
   if (ports.empty())

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -1020,18 +1020,17 @@ void WavePortOperator::PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &me
         continue;
       }
       const int attr = i + 1;
-      mfem::Vector nor;
-      mesh::GetSurfaceNormal(mesh, attr, nor);
+      mfem::Vector normal = mesh::GetSurfaceNormal(mesh, attr);
       Mpi::Print(
           " {:d}: Index = {:d}, mode = {:d}, d = {:.3e} m", attr, idx, data.GetModeIndex(),
           iodata.DimensionalizeValue(IoData::ValueType::LENGTH, data.GetOffsetDistance()));
       if (mesh.SpaceDimension() == 3)
       {
-        Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", nor(0), nor(1), nor(2));
+        Mpi::Print(", n = ({:+.1f}, {:+.1f}, {:+.1f})", normal(0), normal(1), normal(2));
       }
       else
       {
-        Mpi::Print(", n = ({:+.1f}, {:+.1f})", nor(0), nor(1));
+        Mpi::Print(", n = ({:+.1f}, {:+.1f})", normal(0), normal(1));
       }
       Mpi::Print("\n");
     }

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -142,7 +142,7 @@ private:
   void SetUpBoundaryProperties(const IoData &iodata, const MaterialOperator &mat_op,
                                const mfem::ParFiniteElementSpace &nd_fespace,
                                const mfem::ParFiniteElementSpace &h1_fespace);
-  void PrintBoundaryInfo(const IoData &iodata, mfem::ParMesh &mesh);
+  void PrintBoundaryInfo(const IoData &iodata, const mfem::ParMesh &mesh);
 
   // Compute boundary modes for all wave port boundaries at the specified frequency.
   void Initialize(double omega);

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -618,6 +618,7 @@ void DomainPostData::SetUp(json &domains)
   }
   std::sort(attributes.begin(), attributes.end());
   attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
+  attributes.shrink_to_fit();
 
   // Cleanup
   postpro->erase("Energy");
@@ -642,6 +643,7 @@ void DomainData::SetUp(json &config)
   }
   std::sort(attributes.begin(), attributes.end());
   attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
+  attributes.shrink_to_fit();
   for (const auto &attr : postpro.attributes)
   {
     MFEM_VERIFY(std::lower_bound(attributes.begin(), attributes.end(), attr) !=
@@ -1315,6 +1317,7 @@ void BoundaryPostData::SetUp(json &boundaries)
   }
   std::sort(attributes.begin(), attributes.end());
   attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
+  attributes.shrink_to_fit();
 
   // Cleanup
   postpro->erase("Capacitance");
@@ -1376,6 +1379,7 @@ void BoundaryData::SetUp(json &config)
   attributes.insert(attributes.end(), postpro.attributes.begin(), postpro.attributes.end());
   std::sort(attributes.begin(), attributes.end());
   attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
+  attributes.shrink_to_fit();
 
   // Cleanup
   boundaries->erase("PEC");

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -614,8 +614,10 @@ void DomainPostData::SetUp(json &domains)
   // Store all unique postprocessing domain attributes.
   for (const auto &[idx, data] : energy)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
+  std::sort(attributes.begin(), attributes.end());
+  attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
 
   // Cleanup
   postpro->erase("Energy");
@@ -636,11 +638,14 @@ void DomainData::SetUp(json &config)
   // Store all unique domain attributes.
   for (const auto &data : materials)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
+  std::sort(attributes.begin(), attributes.end());
+  attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
   for (const auto &attr : postpro.attributes)
   {
-    MFEM_VERIFY(attributes.find(attr) != attributes.end(),
+    MFEM_VERIFY(std::lower_bound(attributes.begin(), attributes.end(), attr) !=
+                    attributes.end(),
                 "Domain postprocessing can only be enabled on domains which have a "
                 "corresponding \"Materials\" entry!");
   }
@@ -1295,19 +1300,21 @@ void BoundaryPostData::SetUp(json &boundaries)
   // Store all unique postprocessing boundary attributes.
   for (const auto &[idx, data] : capacitance)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
   for (const auto &[idx, data] : inductance)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
   for (const auto &[idx, data] : dielectric)
   {
     for (const auto &elem : data.elements)
     {
-      attributes.insert(elem.attributes.begin(), elem.attributes.end());
+      attributes.insert(attributes.end(), elem.attributes.begin(), elem.attributes.end());
     }
   }
+  std::sort(attributes.begin(), attributes.end());
+  attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
 
   // Cleanup
   postpro->erase("Capacitance");
@@ -1335,37 +1342,40 @@ void BoundaryData::SetUp(json &config)
   postpro.SetUp(*boundaries);
 
   // Store all unique boundary attributes.
-  attributes.insert(pec.attributes.begin(), pec.attributes.end());
-  attributes.insert(pmc.attributes.begin(), pmc.attributes.end());
-  attributes.insert(auxpec.attributes.begin(), auxpec.attributes.end());
-  attributes.insert(farfield.attributes.begin(), farfield.attributes.end());
+  attributes.insert(attributes.end(), pec.attributes.begin(), pec.attributes.end());
+  attributes.insert(attributes.end(), pmc.attributes.begin(), pmc.attributes.end());
+  attributes.insert(attributes.end(), auxpec.attributes.begin(), auxpec.attributes.end());
+  attributes.insert(attributes.end(), farfield.attributes.begin(),
+                    farfield.attributes.end());
   for (const auto &data : conductivity)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
   for (const auto &data : impedance)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
   for (const auto &[idx, data] : lumpedport)
   {
     for (const auto &elem : data.elements)
     {
-      attributes.insert(elem.attributes.begin(), elem.attributes.end());
+      attributes.insert(attributes.end(), elem.attributes.begin(), elem.attributes.end());
     }
   }
   for (const auto &[idx, data] : waveport)
   {
-    attributes.insert(data.attributes.begin(), data.attributes.end());
+    attributes.insert(attributes.end(), data.attributes.begin(), data.attributes.end());
   }
   for (const auto &[idx, data] : current)
   {
     for (const auto &elem : data.elements)
     {
-      attributes.insert(elem.attributes.begin(), elem.attributes.end());
+      attributes.insert(attributes.end(), elem.attributes.begin(), elem.attributes.end());
     }
   }
-  attributes.insert(postpro.attributes.begin(), postpro.attributes.end());
+  attributes.insert(attributes.end(), postpro.attributes.begin(), postpro.attributes.end());
+  std::sort(attributes.begin(), attributes.end());
+  attributes.erase(unique(attributes.begin(), attributes.end()), attributes.end());
 
   // Cleanup
   boundaries->erase("PEC");

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 #include <nlohmann/json_fwd.hpp>
@@ -289,7 +288,7 @@ struct DomainPostData
 {
 public:
   // Set of all postprocessing domain attributes.
-  std::set<int> attributes = {};
+  std::vector<int> attributes = {};
 
   // Domain postprocessing objects.
   DomainEnergyPostData energy;
@@ -302,7 +301,7 @@ struct DomainData
 {
 public:
   // Set of all domain attributes.
-  std::set<int> attributes = {};
+  std::vector<int> attributes = {};
 
   // Domain objects.
   DomainMaterialData materials = {};
@@ -521,7 +520,7 @@ struct BoundaryPostData
 {
 public:
   // Set of all postprocessing boundary attributes.
-  std::set<int> attributes = {};
+  std::vector<int> attributes = {};
 
   // Boundary postprocessing objects.
   CapacitancePostData capacitance = {};
@@ -535,7 +534,7 @@ struct BoundaryData
 {
 public:
   // Set of all boundary attributes.
-  std::set<int> attributes = {};
+  std::vector<int> attributes = {};
 
   // Boundary objects.
   PecBoundaryData pec = {};

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -455,7 +455,7 @@ ElementTypeInfo CheckElements(const mfem::Mesh &mesh)
 {
   // MeshGenerator is reduced over the communicator. This checks for geometries on any
   // processor.
-  auto meshgen = const_cast<mfem::Mesh &>(mesh).MeshGenerator();
+  auto meshgen = mesh.MeshGenerator();
   return {bool(meshgen & 1), bool(meshgen & 2), bool(meshgen & 4), bool(meshgen & 8)};
 }
 

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -50,20 +50,27 @@ struct ElementTypeInfo
 };
 
 // Simplified helper for describing the element types in a (Par)Mesh.
-ElementTypeInfo CheckElements(mfem::Mesh &mesh);
+ElementTypeInfo CheckElements(const mfem::Mesh &mesh);
 
 // Helper function to convert a set of attribute numbers to a marker array. The marker array
 // will be of size max_attr and it will contain only zeroes and ones. Ones indicate which
-// attribute numbers are present in the attrs array. In the special case when attrs has a
+// attribute numbers are present in the list array. In the special case when list has a
 // single entry equal to -1 the marker array will contain all ones.
-void AttrToMarker(int max_attr, const mfem::Array<int> &attrs, mfem::Array<int> &marker);
-void AttrToMarker(int max_attr, const std::vector<int> &attrs, mfem::Array<int> &marker);
+template <typename T>
+void AttrToMarker(int max_attr, const T &attr_list, mfem::Array<int> &marker);
+template <typename T>
+mfem::Array<int> AttrToMarker(int max_attr, const T &attr_list)
+{
+  mfem::Array<int> marker;
+  AttrToMarker(max_attr, attr_list, marker);
+  return marker;
+}
 
 // Helper function to construct the bounding box for all elements with the given attribute.
-void GetAxisAlignedBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr, mfem::Vector &min,
-                               mfem::Vector &max);
 void GetAxisAlignedBoundingBox(mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                                bool bdr, mfem::Vector &min, mfem::Vector &max);
+void GetAxisAlignedBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr, mfem::Vector &min,
+                               mfem::Vector &max);
 
 // Struct describing a bounding box in terms of the center and face normals. The normals
 // specify the direction from the center of the box.
@@ -132,14 +139,14 @@ BoundingBall GetBoundingBall(mfem::ParMesh &mesh, int attr, bool bdr);
 
 // Helper function to compute the average surface normal for all elements with the given
 // attribute.
-void GetSurfaceNormal(mfem::ParMesh &mesh, int attr, mfem::Vector &normal);
-void GetSurfaceNormal(mfem::ParMesh &mesh, const mfem::Array<int> &marker,
-                      mfem::Vector &normal);
+mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+                              bool average = true);
+mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, int attr, bool average = true);
+mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, bool average = true);
 
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from
 // the intermediate stages to disk. Returns the imbalance ratio before rebalancing.
-double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
-                     double tol);
+double RebalanceMesh(mfem::ParMesh &mesh, const IoData &iodata, double tol);
 
 }  // namespace mesh
 

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -67,10 +67,10 @@ mfem::Array<int> AttrToMarker(int max_attr, const T &attr_list)
 }
 
 // Helper function to construct the bounding box for all elements with the given attribute.
-void GetAxisAlignedBoundingBox(mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                                bool bdr, mfem::Vector &min, mfem::Vector &max);
-void GetAxisAlignedBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr, mfem::Vector &min,
-                               mfem::Vector &max);
+void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr,
+                               mfem::Vector &min, mfem::Vector &max);
 
 // Struct describing a bounding box in terms of the center and face normals. The normals
 // specify the direction from the center of the box.
@@ -123,26 +123,28 @@ struct BoundingBall
 };
 
 // Helper functions for computing bounding boxes from a mesh and markers.
-BoundingBox GetBoundingBox(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr);
-BoundingBox GetBoundingBox(mfem::ParMesh &mesh, int attr, bool bdr);
+BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+                           bool bdr);
+BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr);
 
 // Helper function for computing the direction aligned length of a marked group.
-double GetProjectedLength(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr,
-                          const std::array<double, 3> &dir);
-double GetProjectedLength(mfem::ParMesh &mesh, int attr, bool bdr,
+double GetProjectedLength(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+                          bool bdr, const std::array<double, 3> &dir);
+double GetProjectedLength(const mfem::ParMesh &mesh, int attr, bool bdr,
                           const std::array<double, 3> &dir);
 
 // Given a mesh and a marker, compute the diameter of a bounding circle/sphere, assuming
 // that the extrema points are in the marked group.
-BoundingBall GetBoundingBall(mfem::ParMesh &mesh, const mfem::Array<int> &marker, bool bdr);
-BoundingBall GetBoundingBall(mfem::ParMesh &mesh, int attr, bool bdr);
+BoundingBall GetBoundingBall(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+                             bool bdr);
+BoundingBall GetBoundingBall(const mfem::ParMesh &mesh, int attr, bool bdr);
 
 // Helper function to compute the average surface normal for all elements with the given
 // attribute.
-mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, const mfem::Array<int> &marker,
+mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                               bool average = true);
-mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, int attr, bool average = true);
-mfem::Vector GetSurfaceNormal(mfem::ParMesh &mesh, bool average = true);
+mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, int attr, bool average = true);
+mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, bool average = true);
 
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from
 // the intermediate stages to disk. Returns the imbalance ratio before rebalancing.


### PR DESCRIPTION
Minor cleanup of geodata helper functions and declarations, in preparation for `palace::Mesh` class. Includes some `const` correctness fixes for `mfem::Mesh` enabled by https://github.com/awslabs/palace/pull/151.
