### PR TITLE
Minor warning fixes

### DIFF
--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -142,7 +142,7 @@ void BaseSolver::SolveEstimateMarkRefine(
   const auto &refinement = iodata.model.refinement;
   const bool use_amr = [&]()
   {
-    if (dynamic_cast<const TransientSolver *>(this) != nullptr)
+    if (refinement.max_it > 0 && dynamic_cast<const TransientSolver *>(this) != nullptr)
     {
       Mpi::Warning("AMR is not currently supported for transient simulations!\n");
       return false;

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -3,6 +3,7 @@
 
 #include "timeoperator.hpp"
 
+#include <limits>
 #include <vector>
 #include "linalg/iterative.hpp"
 #include "linalg/jacobi.hpp"
@@ -66,6 +67,7 @@ public:
       auto pcg = std::make_unique<CgSolver<Operator>>(comm, 0);
       pcg->SetInitialGuess(iodata.solver.linear.initial_guess);
       pcg->SetRelTol(iodata.solver.linear.tol);
+      pcg->SetAbsTol(std::numeric_limits<double>::epsilon());
       pcg->SetMaxIter(iodata.solver.linear.max_it);
       auto jac = std::make_unique<JacobiSmoother<Operator>>();
       kspM = std::make_unique<KspSolver>(std::move(pcg), std::move(jac));

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -381,7 +381,7 @@ void IoData::CheckConfiguration()
         problem.type == config::ProblemData::Type::MAGNETOSTATIC)
     {
       // Default true only driven simulations without adaptive frequency sweep, transient
-      // simulations, or electrostatic or magnetostatics.
+      // simulations, electrostatics, or magnetostatics.
       solver.linear.initial_guess = 1;
     }
     else


### PR DESCRIPTION
- Do not print AMR warning for transient simulations without AMR enabled
- Add absolute tolerance for transient linear solve to silence warnings when RHS vector is zero
- Fix a comment