### PR TITLE
Fix bug with mesh nondimensionalization for parallel meshes

### DIFF
--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -45,8 +45,8 @@ private:
 
   // Objects for grid function postprocessing from the FE solution.
   const bool has_imaginary;
-  std::optional<mfem::ParComplexGridFunction> E, B;
-  std::optional<mfem::ParGridFunction> V, A;
+  mutable std::optional<mfem::ParComplexGridFunction> E, B;
+  mutable std::optional<mfem::ParGridFunction> V, A;
   std::unique_ptr<mfem::VectorCoefficient> Esr, Esi, Bsr, Bsi, As, Jsr, Jsi;
   std::unique_ptr<mfem::Coefficient> Vs, Ue, Um, Qsr, Qsi;
 

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -404,9 +404,21 @@ void ScaleMesh(mfem::Mesh &mesh, double L)
     double *v = mesh.GetVertex(i);
     std::transform(v, v + mesh.SpaceDimension(), v, [L](double val) { return val * L; });
   }
+  if (auto *pmesh = dynamic_cast<mfem::ParMesh *>(&mesh))
+  {
+    for (int i = 0; i < pmesh->face_nbr_vertices.Size(); i++)
+    {
+      double *v = pmesh->face_nbr_vertices[i]();
+      std::transform(v, v + mesh.SpaceDimension(), v, [L](double val) { return val * L; });
+    }
+  }
   if (mesh.GetNodes())
   {
     *mesh.GetNodes() *= L;
+    if (auto *pnodes = dynamic_cast<mfem::ParGridFunction *>(mesh.GetNodes()))
+    {
+      pnodes->FaceNbrData() *= L;
+    }
   }
 }
 


### PR DESCRIPTION
This results from https://github.com/awslabs/palace/pull/128, where we are rescaling the mesh nodes before writing the VTU output for ParaView visualization. For parallel simulations, the neighbor mesh nodes also need to be scaled so that evaluation using the neighbor `ElementTransformation` objects works.

Also from that PR, this fixes the output of fields with non-identity Piola transformations from the reference to physical space evaluations. H(curl) fields transform with `J^{-T}` and thus need scaling with L when the mesh nodes are scaled by L. Likewise H(div) transform with `J / |J|` and thus need scaling with `L^{d-1}`.

Resolves https://github.com/awslabs/palace/issues/156
