### PR TITLE
Patch for ParNCMesh::Update bug

### DIFF
--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -363,6 +363,7 @@ set(MFEM_PATCH_FILES
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_par_tet_mesh_fix.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_ncmesh_interior_boundary_dev.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_mesh_const_fix.diff"
+  "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_pncmesh_update_fix.diff"
 )
 
 include(ExternalProject)

--- a/extern/patch/mfem/patch_pncmesh_update_fix.diff
+++ b/extern/patch/mfem/patch_pncmesh_update_fix.diff
@@ -1,0 +1,13 @@
+diff --git a/mesh/pncmesh.cpp b/mesh/pncmesh.cpp
+index cd6625e9c..a8a88081f 100644
+--- a/mesh/pncmesh.cpp
++++ b/mesh/pncmesh.cpp
+@@ -107,6 +107,8 @@ void ParNCMesh::Update()
+       entity_owner[i].DeleteAll();
+       entity_pmat_group[i].DeleteAll();
+       entity_index_rank[i].DeleteAll();
++      entity_conf_group[i].DeleteAll();
++      entity_elem_local[i].DeleteAll();
+    }
+ 
+    shared_vertices.Clear();


### PR DESCRIPTION
Proposed changes to `sjg/geodata-updates` to patch the issue with `"SaveAdaptMesh": true` causing segfaults. Tested on the cavity example with
```
    "Refinement":
    {
      "MaxIts": 2,
      "SaveAdaptMesh": true
    }
```
