### PR TITLE
Revisit multigrid operator construction and full-assembly

### DIFF
--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -26,10 +26,10 @@ protected:
   std::vector<CeedOperator> ops, ops_t;
   std::vector<CeedVector> u, v;
   Vector dof_multiplicity;
-  mutable Vector temp_u, temp_v;
+  mutable Vector temp;
 
 public:
-  Operator(int h, int w) : palace::Operator(h, w) {}
+  Operator(int h, int w) : palace::Operator(h, w) { temp.UseDevice(true); }
   ~Operator() override;
 
   CeedOperator operator[](std::size_t i) const { return ops[i]; }

--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -69,8 +69,8 @@ std::unique_ptr<mfem::SparseMatrix> CeedOperatorFullAssemble(const Operator &op,
                                                              bool skip_zeros, bool set);
 
 // Construct a coarse-level ceed::Operator, reusing the quadrature data and quadrature
-// function from the fine-level operator. Only available for square operators (same input
-// and output spaces).
+// function from the fine-level operator. Only available for square, symmetric operators
+// (same input and output spaces).
 std::unique_ptr<Operator> CeedOperatorCoarsen(const Operator &op_fine,
                                               const FiniteElementSpace &fespace_coarse);
 

--- a/palace/linalg/amg.cpp
+++ b/palace/linalg/amg.cpp
@@ -3,8 +3,6 @@
 
 #include "amg.hpp"
 
-#include "linalg/rap.hpp"
-
 namespace palace
 {
 
@@ -25,19 +23,6 @@ BoomerAmgSolver::BoomerAmgSolver(int cycle_it, int smooth_it, int print)
 
   // int coarse_relax_type = 8;  // l1-symm. GS (inexact coarse solve)
   // HYPRE_BoomerAMGSetCycleRelaxType(*this, coarse_relax_type, 3);
-}
-
-void BoomerAmgSolver::SetOperator(const Operator &op)
-{
-  const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
-  if (PtAP)
-  {
-    mfem::HypreBoomerAMG::SetOperator(PtAP->ParallelAssemble());
-  }
-  else
-  {
-    mfem::HypreBoomerAMG::SetOperator(op);
-  }
 }
 
 }  // namespace palace

--- a/palace/linalg/amg.hpp
+++ b/palace/linalg/amg.hpp
@@ -5,7 +5,6 @@
 #define PALACE_LINALG_AMG_HPP
 
 #include <mfem.hpp>
-#include "linalg/operator.hpp"
 #include "utils/iodata.hpp"
 
 namespace palace
@@ -23,8 +22,6 @@ public:
                       iodata.solver.linear.mg_smooth_it, print)
   {
   }
-
-  void SetOperator(const Operator &op) override;
 };
 
 }  // namespace palace

--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -115,9 +115,9 @@ void HypreAmsSolver::ConstructAuxiliaryMatrices(FiniteElementSpace &nd_fespace,
   else
   {
     // Fall back to MFEM legacy assembly for identity interpolator.
-    mfem::ParFiniteElementSpace h1d_fespace(&mesh, &h1_fespace.GetFEColl(), space_dim,
-                                            mfem::Ordering::byVDIM);
-    mfem::DiscreteLinearOperator pi(&h1d_fespace, &nd_fespace.Get());
+    FiniteElementSpace h1d_fespace(h1_fespace.GetMesh(), &h1_fespace.GetFEColl(), space_dim,
+                                   mfem::Ordering::byVDIM);
+    mfem::DiscreteLinearOperator pi(&h1d_fespace.Get(), &nd_fespace.Get());
     pi.AddDomainInterpolator(new mfem::IdentityInterpolator);
     pi.SetAssemblyLevel(mfem::AssemblyLevel::LEGACY);
     pi.Assemble();

--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -208,16 +208,7 @@ void HypreAmsSolver::SetOperator(const Operator &op)
     HYPRE_AMSDestroy(ams);
     InitializeSolver();
   }
-
-  const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
-  if (PtAP)
-  {
-    A = &PtAP->ParallelAssemble();
-  }
-  else
-  {
-    A = dynamic_cast<mfem::HypreParMatrix *>(const_cast<Operator *>(&op));
-  }
+  A = const_cast<mfem::HypreParMatrix *>(dynamic_cast<const mfem::HypreParMatrix *>(&op));
   MFEM_VERIFY(A, "HypreAmsSolver requires a HypreParMatrix operator!");
   height = A->Height();
   width = A->Width();

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -162,7 +162,6 @@ template <typename OperType>
 void ChebyshevSmoother<OperType>::SetOperator(const OperType &op)
 {
   A = &op;
-  r.SetSize(op.Height());
   d.SetSize(op.Height());
   dinv.SetSize(op.Height());
   op.AssembleDiagonal(dinv);
@@ -177,7 +176,7 @@ void ChebyshevSmoother<OperType>::SetOperator(const OperType &op)
 }
 
 template <typename OperType>
-void ChebyshevSmoother<OperType>::Mult(const VecType &x, VecType &y) const
+void ChebyshevSmoother<OperType>::Mult2(const VecType &x, VecType &y, VecType &r) const
 {
   // Apply smoother: y = y + p(A) (x - A y) .
   for (int it = 0; it < pc_it; it++)
@@ -222,7 +221,6 @@ template <typename OperType>
 void ChebyshevSmoother1stKind<OperType>::SetOperator(const OperType &op)
 {
   A = &op;
-  r.SetSize(op.Height());
   d.SetSize(op.Height());
   dinv.SetSize(op.Height());
   op.AssembleDiagonal(dinv);
@@ -244,7 +242,8 @@ void ChebyshevSmoother1stKind<OperType>::SetOperator(const OperType &op)
 }
 
 template <typename OperType>
-void ChebyshevSmoother1stKind<OperType>::Mult(const VecType &x, VecType &y) const
+void ChebyshevSmoother1stKind<OperType>::Mult2(const VecType &x, VecType &y,
+                                               VecType &r) const
 {
   // Apply smoother: y = y + p(A) (x - A y) .
   for (int it = 0; it < pc_it; it++)

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -4,7 +4,6 @@
 #include "chebyshev.hpp"
 
 #include <mfem/general/forall.hpp>
-#include "linalg/rap.hpp"
 
 namespace palace
 {
@@ -151,9 +150,10 @@ inline void ApplyOrderK(const double sd, const double sr, const ComplexVector &d
 }  // namespace
 
 template <typename OperType>
-ChebyshevSmoother<OperType>::ChebyshevSmoother(int smooth_it, int poly_order, double sf_max)
-  : Solver<OperType>(), pc_it(smooth_it), order(poly_order), A(nullptr), lambda_max(0.0),
-    sf_max(sf_max)
+ChebyshevSmoother<OperType>::ChebyshevSmoother(MPI_Comm comm, int smooth_it, int poly_order,
+                                               double sf_max)
+  : Solver<OperType>(), comm(comm), pc_it(smooth_it), order(poly_order), A(nullptr),
+    lambda_max(0.0), sf_max(sf_max)
 {
   MFEM_VERIFY(order > 0, "Polynomial order for Chebyshev smoothing must be positive!");
 }
@@ -161,24 +161,16 @@ ChebyshevSmoother<OperType>::ChebyshevSmoother(int smooth_it, int poly_order, do
 template <typename OperType>
 void ChebyshevSmoother<OperType>::SetOperator(const OperType &op)
 {
-  using ParOperType =
-      typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
-                                ComplexParOperator, ParOperator>::type;
-
   A = &op;
   r.SetSize(op.Height());
   d.SetSize(op.Height());
-
-  const auto *PtAP = dynamic_cast<const ParOperType *>(&op);
-  MFEM_VERIFY(PtAP,
-              "ChebyshevSmoother requires a ParOperator or ComplexParOperator operator!");
   dinv.SetSize(op.Height());
-  PtAP->AssembleDiagonal(dinv);
+  op.AssembleDiagonal(dinv);
   dinv.Reciprocal();
 
   // Set up Chebyshev coefficients using the computed maximum eigenvalue estimate. See
   // mfem::OperatorChebyshevSmoother or Adams et al. (2003).
-  lambda_max = sf_max * GetLambdaMax(PtAP->GetComm(), *A, dinv);
+  lambda_max = sf_max * GetLambdaMax(comm, *A, dinv);
 
   this->height = op.Height();
   this->width = op.Width();
@@ -217,10 +209,11 @@ void ChebyshevSmoother<OperType>::Mult(const VecType &x, VecType &y) const
 }
 
 template <typename OperType>
-ChebyshevSmoother1stKind<OperType>::ChebyshevSmoother1stKind(int smooth_it, int poly_order,
-                                                             double sf_max, double sf_min)
-  : Solver<OperType>(), pc_it(smooth_it), order(poly_order), A(nullptr), theta(0.0),
-    sf_max(sf_max), sf_min(sf_min)
+ChebyshevSmoother1stKind<OperType>::ChebyshevSmoother1stKind(MPI_Comm comm, int smooth_it,
+                                                             int poly_order, double sf_max,
+                                                             double sf_min)
+  : Solver<OperType>(), comm(comm), pc_it(smooth_it), order(poly_order), A(nullptr),
+    theta(0.0), sf_max(sf_max), sf_min(sf_min)
 {
   MFEM_VERIFY(order > 0, "Polynomial order for Chebyshev smoothing must be positive!");
 }
@@ -228,20 +221,11 @@ ChebyshevSmoother1stKind<OperType>::ChebyshevSmoother1stKind(int smooth_it, int 
 template <typename OperType>
 void ChebyshevSmoother1stKind<OperType>::SetOperator(const OperType &op)
 {
-  using ParOperType =
-      typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
-                                ComplexParOperator, ParOperator>::type;
-
   A = &op;
   r.SetSize(op.Height());
   d.SetSize(op.Height());
-
-  const auto *PtAP = dynamic_cast<const ParOperType *>(&op);
-  MFEM_VERIFY(
-      PtAP,
-      "ChebyshevSmoother1stKind requires a ParOperator or ComplexParOperator operator!");
   dinv.SetSize(op.Height());
-  PtAP->AssembleDiagonal(dinv);
+  op.AssembleDiagonal(dinv);
   dinv.Reciprocal();
 
   // Set up Chebyshev coefficients using the computed maximum eigenvalue estimate. The
@@ -250,7 +234,7 @@ void ChebyshevSmoother1stKind<OperType>::SetOperator(const OperType &op)
   {
     sf_min = 1.69 / (std::pow(order, 1.68) + 2.11 * order + 1.98);
   }
-  const double lambda_max = sf_max * GetLambdaMax(PtAP->GetComm(), *A, dinv);
+  const double lambda_max = sf_max * GetLambdaMax(comm, *A, dinv);
   const double lambda_min = sf_min * lambda_max;
   theta = 0.5 * (lambda_max + lambda_min);
   delta = 0.5 * (lambda_max - lambda_min);

--- a/palace/linalg/chebyshev.hpp
+++ b/palace/linalg/chebyshev.hpp
@@ -40,19 +40,31 @@ private:
   // Maximum operator eigenvalue for Chebyshev polynomial smoothing.
   double lambda_max, sf_max;
 
-  // Temporary vectors for smoother application.
-  mutable VecType r, d;
+  // Temporary vector for smoother application.
+  mutable VecType d;
 
 public:
   ChebyshevSmoother(MPI_Comm comm, int smooth_it, int poly_order, double sf_max);
 
   void SetOperator(const OperType &op) override;
 
-  void Mult(const VecType &x, VecType &y) const override;
+  void Mult(const VecType &x, VecType &y) const override
+  {
+    MFEM_ABORT("ChebyshevSmoother implements Mult2 using an additional preallocated "
+               "temporary vector!");
+  }
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    Mult(x, y);  // Assumes operator symmetry
+    MFEM_ABORT("ChebyshevSmoother implements MultTranspose2 using an additional "
+               "preallocated temporary vector!");
+  }
+
+  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
+
+  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override
+  {
+    Mult2(x, y, r);  // Assumes operator symmetry
   }
 };
 
@@ -84,8 +96,8 @@ private:
   // polynomial smoothing.
   double theta, delta, sf_max, sf_min;
 
-  // Temporary vectors for smoother application.
-  mutable VecType r, d;
+  // Temporary vector for smoother application.
+  mutable VecType d;
 
 public:
   ChebyshevSmoother1stKind(MPI_Comm comm, int smooth_it, int poly_order, double sf_max,
@@ -93,11 +105,23 @@ public:
 
   void SetOperator(const OperType &op) override;
 
-  void Mult(const VecType &x, VecType &y) const override;
+  void Mult(const VecType &x, VecType &y) const override
+  {
+    MFEM_ABORT("ChebyshevSmoother1stKind implements Mult2 using an additional preallocated "
+               "temporary vector!");
+  }
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    Mult(x, y);  // Assumes operator symmetry
+    MFEM_ABORT("ChebyshevSmoother1stKind implements MultTranspose2 using an additional "
+               "preallocated temporary vector!");
+  }
+
+  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
+
+  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override
+  {
+    Mult2(x, y, r);  // Assumes operator symmetry
   }
 };
 

--- a/palace/linalg/chebyshev.hpp
+++ b/palace/linalg/chebyshev.hpp
@@ -25,6 +25,9 @@ class ChebyshevSmoother : public Solver<OperType>
   using VecType = typename Solver<OperType>::VecType;
 
 private:
+  // MPI communicator associated with the solver operator and vectors.
+  MPI_Comm comm;
+
   // Number of smoother iterations and polynomial order.
   const int pc_it, order;
 
@@ -41,7 +44,7 @@ private:
   mutable VecType r, d;
 
 public:
-  ChebyshevSmoother(int smooth_it, int poly_order, double sf_max);
+  ChebyshevSmoother(MPI_Comm comm, int smooth_it, int poly_order, double sf_max);
 
   void SetOperator(const OperType &op) override;
 
@@ -65,6 +68,9 @@ class ChebyshevSmoother1stKind : public Solver<OperType>
   using VecType = typename Solver<OperType>::VecType;
 
 private:
+  // MPI communicator associated with the solver operator and vectors.
+  MPI_Comm comm;
+
   // Number of smoother iterations and polynomial order.
   const int pc_it, order;
 
@@ -82,7 +88,8 @@ private:
   mutable VecType r, d;
 
 public:
-  ChebyshevSmoother1stKind(int smooth_it, int poly_order, double sf_max, double sf_min);
+  ChebyshevSmoother1stKind(MPI_Comm comm, int smooth_it, int poly_order, double sf_max,
+                           double sf_min);
 
   void SetOperator(const OperType &op) override;
 

--- a/palace/linalg/distrelaxation.cpp
+++ b/palace/linalg/distrelaxation.cpp
@@ -12,7 +12,7 @@ namespace palace
 
 template <typename OperType>
 DistRelaxationSmoother<OperType>::DistRelaxationSmoother(
-    const Operator &G, int smooth_it, int cheby_smooth_it, int cheby_order,
+    MPI_Comm comm, const Operator &G, int smooth_it, int cheby_smooth_it, int cheby_order,
     double cheby_sf_max, double cheby_sf_min, bool cheby_4th_kind)
   : Solver<OperType>(), pc_it(smooth_it), G(&G), A(nullptr), A_G(nullptr),
     dbc_tdof_list_G(nullptr)
@@ -20,17 +20,17 @@ DistRelaxationSmoother<OperType>::DistRelaxationSmoother(
   // Initialize smoothers.
   if (cheby_4th_kind)
   {
-    B = std::make_unique<ChebyshevSmoother<OperType>>(cheby_smooth_it, cheby_order,
+    B = std::make_unique<ChebyshevSmoother<OperType>>(comm, cheby_smooth_it, cheby_order,
                                                       cheby_sf_max);
-    B_G = std::make_unique<ChebyshevSmoother<OperType>>(cheby_smooth_it, cheby_order,
+    B_G = std::make_unique<ChebyshevSmoother<OperType>>(comm, cheby_smooth_it, cheby_order,
                                                         cheby_sf_max);
   }
   else
   {
-    B = std::make_unique<ChebyshevSmoother1stKind<OperType>>(cheby_smooth_it, cheby_order,
-                                                             cheby_sf_max, cheby_sf_min);
-    B_G = std::make_unique<ChebyshevSmoother1stKind<OperType>>(cheby_smooth_it, cheby_order,
-                                                               cheby_sf_max, cheby_sf_min);
+    B = std::make_unique<ChebyshevSmoother1stKind<OperType>>(
+        comm, cheby_smooth_it, cheby_order, cheby_sf_max, cheby_sf_min);
+    B_G = std::make_unique<ChebyshevSmoother1stKind<OperType>>(
+        comm, cheby_smooth_it, cheby_order, cheby_sf_max, cheby_sf_min);
   }
   B_G->SetInitialGuess(false);
 }

--- a/palace/linalg/distrelaxation.hpp
+++ b/palace/linalg/distrelaxation.hpp
@@ -47,7 +47,7 @@ private:
   std::unique_ptr<Solver<OperType>> B_G;
 
   // Temporary vectors for smoother application.
-  mutable VecType r, x_G, y_G;
+  mutable VecType x_G, y_G, r_G;
 
 public:
   DistRelaxationSmoother(MPI_Comm comm, const Operator &G, int smooth_it,
@@ -59,11 +59,24 @@ public:
     MFEM_ABORT("SetOperator with a single operator is not implemented for "
                "DistRelaxationSmoother, use the two argument signature instead!");
   }
+
   void SetOperators(const OperType &op, const OperType &op_G);
 
-  void Mult(const VecType &x, VecType &y) const override;
+  void Mult(const VecType &x, VecType &y) const override
+  {
+    MFEM_ABORT("DistRelaxationSmoother implements Mult2 using an additional preallocated "
+               "temporary vector!");
+  }
 
-  void MultTranspose(const VecType &x, VecType &y) const override;
+  void MultTranspose(const VecType &x, VecType &y) const override
+  {
+    MFEM_ABORT("DistRelaxationSmoother implements MultTranspose2 using an additional "
+               "preallocated temporary vector!");
+  }
+
+  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
+
+  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override;
 };
 
 }  // namespace palace

--- a/palace/linalg/distrelaxation.hpp
+++ b/palace/linalg/distrelaxation.hpp
@@ -50,9 +50,9 @@ private:
   mutable VecType r, x_G, y_G;
 
 public:
-  DistRelaxationSmoother(const Operator &G, int smooth_it, int cheby_smooth_it,
-                         int cheby_order, double cheby_sf_max, double cheby_sf_min,
-                         bool cheby_4th_kind);
+  DistRelaxationSmoother(MPI_Comm comm, const Operator &G, int smooth_it,
+                         int cheby_smooth_it, int cheby_order, double cheby_sf_max,
+                         double cheby_sf_min, bool cheby_4th_kind);
 
   void SetOperator(const OperType &op) override
   {

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -49,14 +49,16 @@ DivFreeSolver::DivFreeSolver(const MaterialOperator &mat_op, FiniteElementSpace 
   bdr_tdof_list_M = &h1_bdr_tdof_lists.back();
 
   // The system matrix for the projection is real and SPD.
-  auto amg =
-      std::make_unique<WrapperSolver<Operator>>(std::make_unique<BoomerAmgSolver>(1, 1, 0));
+  auto amg = std::make_unique<MfemWrapperSolver<Operator>>(
+      std::make_unique<BoomerAmgSolver>(1, 1, 0));
   std::unique_ptr<Solver<Operator>> pc;
   if (h1_fespaces.GetNumLevels() > 1)
   {
     const int mg_smooth_order =
         std::max(h1_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<Operator>>(
+        h1_fespaces.GetFinestFESpace().GetComm(),
+
         std::move(amg), h1_fespaces.GetProlongationOperators(), nullptr, 1, 1,
         mg_smooth_order, 1.0, 0.0, true);
   }

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -43,8 +43,7 @@ public:
   FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &h1_fespace,
                 const FiniteElementSpace &h1d_fespace, double tol, int max_it, int print);
 
-  template <typename VecType>
-  void Mult(const VecType &x, VecType &y) const;
+  void Mult(const Vector &x, Vector &y) const;
 };
 
 // Class used for computing curl flux error estimate, i.e. || μ⁻¹ ∇ × Uₕ - F ||_K where F
@@ -66,7 +65,7 @@ class CurlFluxErrorEstimator
   FluxProjector projector;
 
   // Temporary vectors for error estimation.
-  mutable VecType F;
+  mutable Vector F;
   mutable GridFunctionType F_gf, U_gf;
 
 public:

--- a/palace/linalg/gmg.cpp
+++ b/palace/linalg/gmg.cpp
@@ -178,7 +178,7 @@ void GeometricMultigridSolver<OperType>::VCycle(int l, bool initial_guess) const
     B[l]->Mult(X[l], Y[l]);
     return;
   }
-  B[l]->Mult(X[l], Y[l]);
+  B[l]->Mult2(X[l], Y[l], R[l]);
 
   // Compute residual.
   A[l]->Mult(Y[l], R[l]);
@@ -198,7 +198,7 @@ void GeometricMultigridSolver<OperType>::VCycle(int l, bool initial_guess) const
 
   // Post-smooth, with nonzero initial guess.
   B[l]->SetInitialGuess(true);
-  B[l]->MultTranspose(X[l], Y[l]);
+  B[l]->MultTranspose2(X[l], Y[l], R[l]);
 }
 
 template class GeometricMultigridSolver<Operator>;

--- a/palace/linalg/gmg.hpp
+++ b/palace/linalg/gmg.hpp
@@ -57,17 +57,17 @@ private:
   void VCycle(int l, bool initial_guess) const;
 
 public:
-  GeometricMultigridSolver(std::unique_ptr<Solver<OperType>> &&coarse_solver,
+  GeometricMultigridSolver(MPI_Comm comm, std::unique_ptr<Solver<OperType>> &&coarse_solver,
                            const std::vector<const Operator *> &P,
                            const std::vector<const Operator *> *G, int cycle_it,
                            int smooth_it, int cheby_order, double cheby_sf_max,
                            double cheby_sf_min, bool cheby_4th_kind);
-  GeometricMultigridSolver(const IoData &iodata,
+  GeometricMultigridSolver(MPI_Comm comm, const IoData &iodata,
                            std::unique_ptr<Solver<OperType>> &&coarse_solver,
                            const std::vector<const Operator *> &P,
                            const std::vector<const Operator *> *G = nullptr)
     : GeometricMultigridSolver(
-          std::move(coarse_solver), P, G, iodata.solver.linear.mg_cycle_it,
+          comm, std::move(coarse_solver), P, G, iodata.solver.linear.mg_cycle_it,
           iodata.solver.linear.mg_smooth_it, iodata.solver.linear.mg_smooth_order,
           iodata.solver.linear.mg_smooth_sf_max, iodata.solver.linear.mg_smooth_sf_min,
           iodata.solver.linear.mg_smooth_cheby_4th)

--- a/palace/linalg/hcurl.cpp
+++ b/palace/linalg/hcurl.cpp
@@ -67,7 +67,7 @@ WeightedHCurlNormSolver::WeightedHCurlNormSolver(
 
   // The system matrix K + M is real and SPD. We use Hypre's AMS solver as the coarse-level
   // multigrid solve.
-  auto ams = std::make_unique<WrapperSolver<Operator>>(std::make_unique<HypreAmsSolver>(
+  auto ams = std::make_unique<MfemWrapperSolver<Operator>>(std::make_unique<HypreAmsSolver>(
       nd_fespaces.GetFESpaceAtLevel(0), h1_fespaces.GetFESpaceAtLevel(0), 1, 1, 1, false,
       false, 0));
   std::unique_ptr<Solver<Operator>> pc;
@@ -77,8 +77,8 @@ WeightedHCurlNormSolver::WeightedHCurlNormSolver(
     const int mg_smooth_order =
         std::max(nd_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<Operator>>(
-        std::move(ams), nd_fespaces.GetProlongationOperators(), &G, 1, 1, mg_smooth_order,
-        1.0, 0.0, true);
+        nd_fespaces.GetFinestFESpace().GetComm(), std::move(ams),
+        nd_fespaces.GetProlongationOperators(), &G, 1, 1, mg_smooth_order, 1.0, 0.0, true);
   }
   else
   {

--- a/palace/linalg/jacobi.cpp
+++ b/palace/linalg/jacobi.cpp
@@ -4,7 +4,6 @@
 #include "jacobi.hpp"
 
 #include <mfem/general/forall.hpp>
-#include "linalg/rap.hpp"
 
 namespace palace
 {
@@ -57,15 +56,8 @@ inline void Apply(const ComplexVector &dinv, const ComplexVector &x, ComplexVect
 template <typename OperType>
 void JacobiSmoother<OperType>::SetOperator(const OperType &op)
 {
-  using ParOperType =
-      typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
-                                ComplexParOperator, ParOperator>::type;
-
-  const auto *PtAP = dynamic_cast<const ParOperType *>(&op);
-  MFEM_VERIFY(PtAP,
-              "JacobiSmoother requires a ParOperator or ComplexParOperator operator!");
   dinv.SetSize(op.Height());
-  PtAP->AssembleDiagonal(dinv);
+  op.AssembleDiagonal(dinv);
   dinv.Reciprocal();
 
   this->height = op.Height();

--- a/palace/linalg/ksp.cpp
+++ b/palace/linalg/ksp.cpp
@@ -115,8 +115,22 @@ std::unique_ptr<IterativeSolver<OperType>> ConfigureKrylovSolver(MPI_Comm comm,
 template <typename OperType, typename T, typename... U>
 auto MakeWrapperSolver(U &&...args)
 {
-  return std::make_unique<WrapperSolver<OperType>>(
-      std::make_unique<T>(std::forward<U>(args)...));
+  // Sparse direct solver types copy the input matrix, so there is no need to save the
+  // parallel assembled operator.
+  constexpr bool save_assembled = !(false ||
+#if defined(MFEM_USE_SUPERLU)
+                                    std::is_same<T, SuperLUSolver>::value ||
+#endif
+#if defined(MFEM_USE_STRUMPACK)
+                                    std::is_same<T, StrumpackSolver>::value ||
+                                    std::is_same<T, StrumpackMixedPrecisionSolver>::value ||
+#endif
+#if defined(MFEM_USE_MUMPS)
+                                    std::is_same<T, MumpsSolver>::value ||
+#endif
+                                    false);
+  return std::make_unique<MfemWrapperSolver<OperType>>(
+      std::make_unique<T>(std::forward<U>(args)...), save_assembled);
 }
 
 template <typename OperType>
@@ -199,12 +213,12 @@ ConfigurePreconditionerSolver(MPI_Comm comm, const IoData &iodata,
                                   "primary space and auxiliary spaces for construction!");
         const auto G = aux_fespaces->GetDiscreteInterpolators();
         return std::make_unique<GeometricMultigridSolver<OperType>>(
-            iodata, std::move(pc), fespaces.GetProlongationOperators(), &G);
+            comm, iodata, std::move(pc), fespaces.GetProlongationOperators(), &G);
       }
       else
       {
         return std::make_unique<GeometricMultigridSolver<OperType>>(
-            iodata, std::move(pc), fespaces.GetProlongationOperators());
+            comm, iodata, std::move(pc), fespaces.GetProlongationOperators());
       }
     }();
     gmg->EnableTimer();  // Enable timing for primary geometric multigrid solver

--- a/palace/linalg/mumps.cpp
+++ b/palace/linalg/mumps.cpp
@@ -5,8 +5,6 @@
 
 #if defined(MFEM_USE_MUMPS)
 
-#include "linalg/rap.hpp"
-
 namespace palace
 {
 
@@ -47,19 +45,6 @@ MumpsSolver::MumpsSolver(MPI_Comm comm, mfem::MUMPSSolver::MatType sym,
   if (blr_tol > 0.0)
   {
     SetBLRTol(blr_tol);
-  }
-}
-
-void MumpsSolver::SetOperator(const Operator &op)
-{
-  const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
-  if (PtAP)
-  {
-    mfem::MUMPSSolver::SetOperator(PtAP->ParallelAssemble());
-  }
-  else
-  {
-    mfem::MUMPSSolver::SetOperator(op);
   }
 }
 

--- a/palace/linalg/mumps.hpp
+++ b/palace/linalg/mumps.hpp
@@ -8,7 +8,6 @@
 
 #if defined(MFEM_USE_MUMPS)
 
-#include "linalg/operator.hpp"
 #include "utils/iodata.hpp"
 
 namespace palace
@@ -38,8 +37,6 @@ public:
                   print)
   {
   }
-
-  void SetOperator(const Operator &op) override;
 };
 
 }  // namespace palace

--- a/palace/linalg/operator.cpp
+++ b/palace/linalg/operator.cpp
@@ -10,37 +10,7 @@
 namespace palace
 {
 
-bool ComplexOperator::IsReal() const
-{
-  MFEM_ABORT("IsReal() is not implemented for base class ComplexOperator!");
-  return false;
-}
-
-bool ComplexOperator::IsImag() const
-{
-  MFEM_ABORT("IsImag() is not implemented for base class ComplexOperator!");
-  return false;
-}
-
-bool ComplexOperator::HasReal() const
-{
-  MFEM_ABORT("HasReal() is not implemented for base class ComplexOperator!");
-  return false;
-}
-
-bool ComplexOperator::HasImag() const
-{
-  MFEM_ABORT("HasImag() is not implemented for base class ComplexOperator!");
-  return false;
-}
-
 const Operator *ComplexOperator::Real() const
-{
-  MFEM_ABORT("Real() is not implemented for base class ComplexOperator!");
-  return nullptr;
-}
-
-Operator *ComplexOperator::Real()
 {
   MFEM_ABORT("Real() is not implemented for base class ComplexOperator!");
   return nullptr;
@@ -52,10 +22,9 @@ const Operator *ComplexOperator::Imag() const
   return nullptr;
 }
 
-Operator *ComplexOperator::Imag()
+void ComplexOperator::AssembleDiagonal(ComplexVector &diag) const
 {
-  MFEM_ABORT("Imag() is not implemented for base class ComplexOperator!");
-  return nullptr;
+  MFEM_ABORT("Base class ComplexOperator does not implement AssembleDiagonal!");
 }
 
 void ComplexOperator::MultTranspose(const ComplexVector &x, ComplexVector &y) const
@@ -88,7 +57,7 @@ void ComplexOperator::AddMultHermitianTranspose(const ComplexVector &x, ComplexV
 
 ComplexWrapperOperator::ComplexWrapperOperator(std::unique_ptr<Operator> &&dAr,
                                                std::unique_ptr<Operator> &&dAi,
-                                               Operator *pAr, Operator *pAi)
+                                               const Operator *pAr, const Operator *pAi)
   : ComplexOperator(), data_Ar(std::move(dAr)), data_Ai(std::move(dAi)),
     Ar((data_Ar != nullptr) ? data_Ar.get() : pAr),
     Ai((data_Ai != nullptr) ? data_Ai.get() : pAi)
@@ -106,9 +75,22 @@ ComplexWrapperOperator::ComplexWrapperOperator(std::unique_ptr<Operator> &&Ar,
 {
 }
 
-ComplexWrapperOperator::ComplexWrapperOperator(Operator *Ar, Operator *Ai)
+ComplexWrapperOperator::ComplexWrapperOperator(const Operator *Ar, const Operator *Ai)
   : ComplexWrapperOperator(nullptr, nullptr, Ar, Ai)
 {
+}
+
+void ComplexWrapperOperator::AssembleDiagonal(ComplexVector &diag) const
+{
+  diag = 0.0;
+  if (Ar)
+  {
+    Ar->AssembleDiagonal(diag.Real());
+  }
+  if (Ai)
+  {
+    Ai->AssembleDiagonal(diag.Imag());
+  }
 }
 
 void ComplexWrapperOperator::Mult(const ComplexVector &x, ComplexVector &y) const

--- a/palace/linalg/operator.cpp
+++ b/palace/linalg/operator.cpp
@@ -217,9 +217,6 @@ void ComplexWrapperOperator::AddMult(const ComplexVector &x, ComplexVector &y,
   const Vector &xi = x.Imag();
   Vector &yr = y.Real();
   Vector &yi = y.Imag();
-  // MFEM_VERIFY(a.real() == 0.0 || a.imag() == 0.0,
-  //             "ComplexWrapperOperator::AddMult does not support a general complex-valued
-  //             " "coefficient!");
   if (a.real() != 0.0 && a.imag() != 0.0)
   {
     ty.SetSize(height);
@@ -287,9 +284,6 @@ void ComplexWrapperOperator::AddMultTranspose(const ComplexVector &x, ComplexVec
   const Vector &xi = x.Imag();
   Vector &yr = y.Real();
   Vector &yi = y.Imag();
-  // MFEM_VERIFY(a.real() == 0.0 || a.imag() == 0.0,
-  //             "ComplexWrapperOperator::AddMultTranspose does not support a general "
-  //             "complex-valued coefficient!");
   if (a.real() != 0.0 && a.imag() != 0.0)
   {
     tx.SetSize(width);
@@ -358,9 +352,6 @@ void ComplexWrapperOperator::AddMultHermitianTranspose(const ComplexVector &x,
   const Vector &xi = x.Imag();
   Vector &yr = y.Real();
   Vector &yi = y.Imag();
-  // MFEM_VERIFY(a.real() == 0.0 || a.imag() == 0.0,
-  //             "ComplexWrapperOperator::AddMultHermitianTranspose does not support a "
-  //             "general complex-valued coefficient!");
   if (a.real() != 0.0 && a.imag() != 0.0)
   {
     tx.SetSize(width);

--- a/palace/linalg/operator.hpp
+++ b/palace/linalg/operator.hpp
@@ -115,6 +115,7 @@ class SumOperator : public Operator
 {
 private:
   std::vector<std::pair<const Operator *, double>> ops;
+  mutable Vector z;
 
 public:
   SumOperator(int s) : Operator(s) {}

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -6,12 +6,9 @@
 
 #include <memory>
 #include <mfem.hpp>
+#include "fem/fespace.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
-
-// XX TODO: Many ParOperator and ComplexParOperator objects could share the same local
-//          temporary vectors used in parallel matrix-vector products (lx, ly, ty) for
-//          improved memory usage.
 
 namespace palace
 {
@@ -31,7 +28,7 @@ private:
   const Operator *A;
 
   // Finite element spaces for parallel prolongation and restriction.
-  const mfem::ParFiniteElementSpace &trial_fespace, &test_fespace;
+  const FiniteElementSpace &trial_fespace, &test_fespace;
   const bool use_R;
 
   // Lists of constrained essential boundary true dofs for elimination.
@@ -44,32 +41,29 @@ private:
   // deleted.
   mutable std::unique_ptr<mfem::HypreParMatrix> RAP;
 
-  // Temporary storage for operator application.
-  mutable Vector lx, ly, ty;
-
   // Helper methods for operator application.
   void RestrictionMatrixMult(const Vector &ly, Vector &ty) const;
-  void RestrictionMatrixAddMult(const Vector &ly, Vector &ty, const double a) const;
+  void RestrictionMatrixAddMult(const Vector &ly, Vector &ty) const;
   void RestrictionMatrixMultTranspose(const Vector &ty, Vector &ly) const;
+  Vector &GetTestLVector() const;
 
   ParOperator(std::unique_ptr<Operator> &&dA, const Operator *pA,
-              const mfem::ParFiniteElementSpace &trial_fespace,
-              const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
+              const FiniteElementSpace &trial_fespace,
+              const FiniteElementSpace &test_fespace, bool test_restrict);
 
 public:
   // Construct the parallel operator, inheriting ownership of the local operator.
-  ParOperator(std::unique_ptr<Operator> &&A,
-              const mfem::ParFiniteElementSpace &trial_fespace,
-              const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
-  ParOperator(std::unique_ptr<Operator> &&A, const mfem::ParFiniteElementSpace &fespace)
+  ParOperator(std::unique_ptr<Operator> &&A, const FiniteElementSpace &trial_fespace,
+              const FiniteElementSpace &test_fespace, bool test_restrict);
+  ParOperator(std::unique_ptr<Operator> &&A, const FiniteElementSpace &fespace)
     : ParOperator(std::move(A), fespace, fespace, false)
   {
   }
 
   // Non-owning constructors.
-  ParOperator(const Operator &A, const mfem::ParFiniteElementSpace &trial_fespace,
-              const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
-  ParOperator(const Operator &A, const mfem::ParFiniteElementSpace &fespace)
+  ParOperator(const Operator &A, const FiniteElementSpace &trial_fespace,
+              const FiniteElementSpace &test_fespace, bool test_restrict);
+  ParOperator(const Operator &A, const FiniteElementSpace &fespace)
     : ParOperator(A, fespace, fespace, false)
   {
   }
@@ -122,11 +116,11 @@ private:
   const ComplexWrapperOperator *A;
 
   // Finite element spaces for parallel prolongation and restriction.
-  const mfem::ParFiniteElementSpace &trial_fespace, &test_fespace;
+  const FiniteElementSpace &trial_fespace, &test_fespace;
   const bool use_R;
 
   // Lists of constrained essential boundary true dofs for elimination.
-  mutable const mfem::Array<int> *dbc_tdof_list;
+  const mfem::Array<int> *dbc_tdof_list;
 
   // Diagonal policy for constrained true dofs.
   Operator::DiagonalPolicy diag_policy;
@@ -134,38 +128,35 @@ private:
   // Real and imaginary parts of the operator as non-owning ParOperator objects.
   std::unique_ptr<ParOperator> RAPr, RAPi;
 
-  // Temporary storage for operator application.
-  mutable ComplexVector lx, ly, ty;
-
   // Helper methods for operator application.
   void RestrictionMatrixMult(const ComplexVector &ly, ComplexVector &ty) const;
-  void RestrictionMatrixAddMult(const ComplexVector &ly, ComplexVector &ty,
-                                const double a) const;
+  void RestrictionMatrixAddMult(const ComplexVector &ly, ComplexVector &ty) const;
   void RestrictionMatrixMultTranspose(const ComplexVector &ty, ComplexVector &ly) const;
+  ComplexVector &GetTestLVector() const;
 
   ComplexParOperator(std::unique_ptr<Operator> &&dAr, std::unique_ptr<Operator> &&dAi,
                      const Operator *pAr, const Operator *pAi,
-                     const mfem::ParFiniteElementSpace &trial_fespace,
-                     const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
+                     const FiniteElementSpace &trial_fespace,
+                     const FiniteElementSpace &test_fespace, bool test_restrict);
 
 public:
   // Construct the complex-valued parallel operator from the separate real and imaginary
   // parts, inheriting ownership of the local operator.
   ComplexParOperator(std::unique_ptr<Operator> &&Ar, std::unique_ptr<Operator> &&Ai,
-                     const mfem::ParFiniteElementSpace &trial_fespace,
-                     const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
+                     const FiniteElementSpace &trial_fespace,
+                     const FiniteElementSpace &test_fespace, bool test_restrict);
   ComplexParOperator(std::unique_ptr<Operator> &&Ar, std::unique_ptr<Operator> &&Ai,
-                     const mfem::ParFiniteElementSpace &fespace)
+                     const FiniteElementSpace &fespace)
     : ComplexParOperator(std::move(Ar), std::move(Ai), fespace, fespace, false)
   {
   }
 
   // Non-owning constructors.
   ComplexParOperator(const Operator *Ar, const Operator *Ai,
-                     const mfem::ParFiniteElementSpace &trial_fespace,
-                     const mfem::ParFiniteElementSpace &test_fespace, bool test_restrict);
+                     const FiniteElementSpace &trial_fespace,
+                     const FiniteElementSpace &test_fespace, bool test_restrict);
   ComplexParOperator(const Operator *Ar, const Operator *Ai,
-                     const mfem::ParFiniteElementSpace &fespace)
+                     const FiniteElementSpace &fespace)
     : ComplexParOperator(Ar, Ai, fespace, fespace, false)
   {
   }

--- a/palace/linalg/solver.cpp
+++ b/palace/linalg/solver.cpp
@@ -3,36 +3,113 @@
 
 #include "solver.hpp"
 
+#include "linalg/rap.hpp"
+
 namespace palace
 {
 
 template <>
-void WrapperSolver<Operator>::SetOperator(const Operator &op)
+void MfemWrapperSolver<Operator>::SetOperator(const Operator &op)
 {
-  pc->SetOperator(op);
+  // Operator is always assembled as a HypreParMatrix.
+  if (const auto *hA = dynamic_cast<const mfem::HypreParMatrix *>(&op))
+  {
+    pc->SetOperator(*hA);
+  }
+  else
+  {
+    const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
+    MFEM_VERIFY(PtAP,
+                "MfemWrapperSolver must be able to construct a HypreParMatrix operator!");
+    pc->SetOperator(PtAP->ParallelAssemble());
+    if (!save_assembled)
+    {
+      PtAP->StealParallelAssemble();
+    }
+  }
   this->height = op.Height();
   this->width = op.Width();
 }
 
 template <>
-void WrapperSolver<ComplexOperator>::SetOperator(const ComplexOperator &op)
+void MfemWrapperSolver<ComplexOperator>::SetOperator(const ComplexOperator &op)
 {
-  MFEM_VERIFY(op.IsReal() && op.HasReal(),
-              "WrapperSolver::SetOperator requires an operator which is purely real for "
-              "mfem::Solver!");
-  pc->SetOperator(*op.Real());
+  // XX TODO: Test complex matrix assembly if coarse solve supports it
+  // Assemble the real and imaginary parts, then add.
+  const mfem::HypreParMatrix *hAr = nullptr, *hAi = nullptr;
+  const ParOperator *PtAPr = nullptr, *PtAPi = nullptr;
+  if (op.Real())
+  {
+    hAr = dynamic_cast<const mfem::HypreParMatrix *>(op.Real());
+    if (!hAr)
+    {
+      PtAPr = dynamic_cast<const ParOperator *>(op.Real());
+      MFEM_VERIFY(PtAPr,
+                  "MfemWrapperSolver must be able to construct a HypreParMatrix operator!");
+      hAr = &PtAPr->ParallelAssemble();
+    }
+  }
+  if (op.Imag())
+  {
+    hAi = dynamic_cast<const mfem::HypreParMatrix *>(op.Imag());
+    if (!hAi)
+    {
+      PtAPi = dynamic_cast<const ParOperator *>(op.Imag());
+      MFEM_VERIFY(PtAPi,
+                  "MfemWrapperSolver must be able to construct a HypreParMatrix operator!");
+      hAi = &PtAPi->ParallelAssemble();
+    }
+  }
+  if (hAr && hAi)
+  {
+    A.reset(mfem::Add(1.0, *hAr, 1.0, *hAi));
+    if (PtAPr)
+    {
+      PtAPr->StealParallelAssemble();
+    }
+    if (PtAPi)
+    {
+      PtAPi->StealParallelAssemble();
+    }
+    pc->SetOperator(*A);
+    if (!save_assembled)
+    {
+      A.reset();
+    }
+  }
+  else if (hAr)
+  {
+    pc->SetOperator(*hAr);
+    if (PtAPr && !save_assembled)
+    {
+      PtAPr->StealParallelAssemble();
+    }
+  }
+  else if (hAi)
+  {
+    pc->SetOperator(*hAi);
+    if (PtAPi && !save_assembled)
+    {
+      PtAPi->StealParallelAssemble();
+    }
+  }
+  else
+  {
+    MFEM_ABORT("Empty ComplexOperator for MfemWrapperSolver!");
+  }
   this->height = op.Height();
   this->width = op.Width();
 }
 
 template <>
-void WrapperSolver<Operator>::Mult(const Vector &x, Vector &y) const
+void MfemWrapperSolver<Operator>::Mult(const Vector &x, Vector &y) const
 {
   pc->Mult(x, y);
 }
 
 template <>
-void WrapperSolver<ComplexOperator>::Mult(const ComplexVector &x, ComplexVector &y) const
+void MfemWrapperSolver<ComplexOperator>::Mult(const ComplexVector &x,
+                                              ComplexVector &y) const
 {
   mfem::Array<const Vector *> X(2);
   mfem::Array<Vector *> Y(2);

--- a/palace/linalg/solver.hpp
+++ b/palace/linalg/solver.hpp
@@ -47,6 +47,21 @@ public:
   {
     MFEM_ABORT("MultTranspose() is not implemented for base class Solver<OperType>!");
   }
+
+  // Apply the solver with a preallocated temporary storage vector.
+  virtual void Mult2(const VecType &x, VecType &y, VecType &r) const
+  {
+    MFEM_ABORT("Mult2() with temporary storage vector is not implemented for base class "
+               "Solver<OperType>!");
+  }
+
+  // Apply the solver for the transpose problem with a preallocated temporary storage
+  //  vector.
+  virtual void MultTranspose2(const VecType &x, VecType &y, VecType &r) const
+  {
+    MFEM_ABORT("MultTranspose2() with temporary storage vector is not implemented for base "
+               "class Solver<OperType>!");
+  }
 };
 
 // This solver wraps a real-valued mfem::Solver for application to complex-valued problems

--- a/palace/linalg/strumpack.cpp
+++ b/palace/linalg/strumpack.cpp
@@ -5,8 +5,6 @@
 
 #if defined(MFEM_USE_STRUMPACK)
 
-#include "linalg/rap.hpp"
-
 namespace palace
 {
 
@@ -113,37 +111,33 @@ template <typename StrumpackSolverType>
 void StrumpackSolverBase<StrumpackSolverType>::SetOperator(const Operator &op)
 {
   // Convert the input operator to a distributed STRUMPACK matrix (always assume a symmetric
-  // sparsity pattern). This is very similar to the MFEM STRUMPACKRowLocMatrix from a
+  // sparsity pattern). This is very similar to the MFEM's STRUMPACKRowLocMatrix from a
   // HypreParMatrix but avoids using the communicator from the Hypre matrix in the case that
   // the solver is constructed on a different communicator.
-  const mfem::HypreParMatrix *hypA;
-  const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
-  if (PtAP)
-  {
-    hypA = &PtAP->ParallelAssemble();
-  }
-  else
-  {
-    hypA = dynamic_cast<const mfem::HypreParMatrix *>(&op);
-    MFEM_VERIFY(hypA, "StrumpackSolver requires a HypreParMatrix operator!");
-  }
-  auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hypA);
-  hypA->HostRead();
+  const auto *hA = dynamic_cast<const mfem::HypreParMatrix *>(&op);
+  MFEM_VERIFY(hA && hA->GetGlobalNumRows() == hA->GetGlobalNumCols(),
+              "StrumpackSolver requires a square HypreParMatrix operator!");
+  auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hA);
   hypre_CSRMatrix *csr = hypre_MergeDiagAndOffd(parcsr);
-  hypA->HypreRead();
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
+  if (hypre_GetActualMemLocation(hypre_CSRMatrixMemoryLocation(csr)) != hypre_MEMORY_HOST)
+  {
+    hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
+  }
+#endif
 
   // Create the STRUMPACKRowLocMatrix by taking the internal data from a hypre_CSRMatrix.
-  HYPRE_Int n_loc = csr->num_rows;
-  HYPRE_BigInt first_row = parcsr->first_row_index;
-  HYPRE_Int *I = csr->i;
-  HYPRE_BigInt *J = csr->big_j;
-  double *data = csr->data;
+  HYPRE_BigInt glob_n = hypre_ParCSRMatrixGlobalNumRows(parcsr);
+  HYPRE_BigInt first_row = hypre_ParCSRMatrixFirstRowIndex(parcsr);
+  HYPRE_Int n_loc = hypre_CSRMatrixNumRows(csr);
+  HYPRE_Int *I = hypre_CSRMatrixI(csr);
+  HYPRE_BigInt *J = hypre_CSRMatrixBigJ(csr);
+  double *data = hypre_CSRMatrixData(csr);
 
   // Safe to delete the matrix since STRUMPACK copies it on input. Also clean up the Hypre
   // data structure once we are done with it.
 #if !defined(HYPRE_BIGINT)
-  mfem::STRUMPACKRowLocMatrix A(comm, n_loc, first_row, hypA->GetGlobalNumRows(),
-                                hypA->GetGlobalNumCols(), I, J, data, true);
+  mfem::STRUMPACKRowLocMatrix A(comm, n_loc, first_row, glob_n, glob_n, I, J, data, true);
 #else
   int n_loc_int = static_cast<int>(n_loc);
   MFEM_ASSERT(n_loc == (HYPRE_Int)n_loc_int,
@@ -154,8 +148,8 @@ void StrumpackSolverBase<StrumpackSolverType>::SetOperator(const Operator &op)
     II[i] = static_cast<int>(I[i]);
     MFEM_ASSERT(I[i] == (HYPRE_Int)II[i], "Overflow error for local sparse matrix index!");
   }
-  mfem::STRUMPACKRowLocMatrix A(comm, n_loc_int, first_row, hypA->GetGlobalNumRows(),
-                                hypA->GetGlobalNumCols(), II, J, data, true);
+  mfem::STRUMPACKRowLocMatrix A(comm, n_loc_int, first_row, glob_n, glob_n, II.HostRead(),
+                                J, data, true);
 #endif
   StrumpackSolverType::SetOperator(A);
   hypre_CSRMatrixDestroy(csr);

--- a/palace/linalg/superlu.cpp
+++ b/palace/linalg/superlu.cpp
@@ -5,7 +5,6 @@
 
 #if defined(MFEM_USE_SUPERLU)
 
-#include "linalg/rap.hpp"
 #include "utils/communication.hpp"
 
 namespace palace
@@ -82,43 +81,40 @@ SuperLUSolver::SuperLUSolver(MPI_Comm comm, config::LinearSolverData::SymFactTyp
 
 void SuperLUSolver::SetOperator(const Operator &op)
 {
-  // For repeated factorizations, always reuse the sparsity pattern. This is very similar to
-  // the MFEM SuperLURowLocMatrix from a HypreParMatrix but avoids using the communicator
-  // from the Hypre matrix in the case that the solver is constructed on a different
-  // communicator.
+  // For repeated factorizations, always reuse the sparsity pattern.
   if (A)
   {
     solver.SetFact(mfem::superlu::SamePattern_SameRowPerm);
   }
-  const mfem::HypreParMatrix *hypA;
-  const auto *PtAP = dynamic_cast<const ParOperator *>(&op);
-  if (PtAP)
-  {
-    hypA = &PtAP->ParallelAssemble();
-  }
-  else
-  {
-    hypA = dynamic_cast<const mfem::HypreParMatrix *>(&op);
-    MFEM_VERIFY(hypA, "SuperLUSolver requires a HypreParMatrix operator!");
-  }
-  auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hypA);
-  hypA->HostRead();
+
+  // This is very similar to the MFEM SuperLURowLocMatrix from a HypreParMatrix but avoids
+  // using the communicator from the Hypre matrix in the case that the solver is
+  // constructed on a different communicator.
+  const auto *hA = dynamic_cast<const mfem::HypreParMatrix *>(&op);
+  MFEM_VERIFY(hA && hA->GetGlobalNumRows() == hA->GetGlobalNumCols(),
+              "SuperLUSolver requires a square HypreParMatrix operator!");
+  auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hA);
   hypre_CSRMatrix *csr = hypre_MergeDiagAndOffd(parcsr);
-  hypA->HypreRead();
+#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
+  if (hypre_GetActualMemLocation(hypre_CSRMatrixMemoryLocation(csr)) != hypre_MEMORY_HOST)
+  {
+    hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
+  }
+#endif
 
   // Create the SuperLURowLocMatrix by taking the internal data from a hypre_CSRMatrix.
-  HYPRE_Int n_loc = csr->num_rows;
-  HYPRE_BigInt first_row = parcsr->first_row_index;
-  HYPRE_Int *I = csr->i;
-  HYPRE_BigInt *J = csr->big_j;
-  double *data = csr->data;
+  HYPRE_BigInt glob_n = hypre_ParCSRMatrixGlobalNumRows(parcsr);
+  HYPRE_BigInt first_row = hypre_ParCSRMatrixFirstRowIndex(parcsr);
+  HYPRE_Int n_loc = hypre_CSRMatrixNumRows(csr);
+  HYPRE_Int *I = hypre_CSRMatrixI(csr);
+  HYPRE_BigInt *J = hypre_CSRMatrixBigJ(csr);
+  double *data = hypre_CSRMatrixData(csr);
 
   // We need to save A because SuperLU does not copy the input matrix. Also clean up the
   // Hypre data structure once we are done with it.
 #if !defined(HYPRE_BIGINT)
-  A = std::make_unique<mfem::SuperLURowLocMatrix>(comm, n_loc, first_row,
-                                                  hypA->GetGlobalNumRows(),
-                                                  hypA->GetGlobalNumCols(), I, J, data);
+  A = std::make_unique<mfem::SuperLURowLocMatrix>(comm, n_loc, first_row, glob_n, glob_n, I,
+                                                  J, data);
 #else
   int n_loc_int = static_cast<int>(n_loc);
   MFEM_ASSERT(n_loc == (HYPRE_Int)n_loc_int,
@@ -129,9 +125,8 @@ void SuperLUSolver::SetOperator(const Operator &op)
     II[i] = static_cast<int>(I[i]);
     MFEM_ASSERT(I[i] == (HYPRE_Int)II[i], "Overflow error for local sparse matrix index!");
   }
-  A = std::make_unique<mfem::SuperLURowLocMatrix>(comm, n_loc_int, first_row,
-                                                  hypA->GetGlobalNumRows(),
-                                                  hypA->GetGlobalNumCols(), II, J, data);
+  A = std::make_unique<mfem::SuperLURowLocMatrix>(comm, n_loc_int, first_row, glob_n,
+                                                  glob_n, II.HostRead(), J, data);
 #endif
   solver.SetOperator(*A);
   height = solver.Height();

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -31,6 +31,10 @@ ComplexVector::ComplexVector(const std::complex<double> *py, int n) : ComplexVec
 
 void ComplexVector::SetSize(int n)
 {
+  if (x.Size() == 2 * n)
+  {
+    return;
+  }
   x.SetSize(2 * n);
   xr.MakeRef(x, 0, n);
   xi.MakeRef(x, n, n);

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -175,28 +175,26 @@ void PrintHeader(const mfem::ParFiniteElementSpace &h1_fespace,
 
 std::unique_ptr<Operator> LaplaceOperator::GetStiffnessMatrix()
 {
+  // When partially assembled, the coarse operators can reuse the fine operator quadrature
+  // data if the spaces correspond to the same mesh.
   PrintHeader(GetH1Space(), GetNDSpace(), print_hdr);
+
+  constexpr bool skip_zeros = false;
+  MaterialPropertyCoefficient epsilon_func(mat_op.GetAttributeToMaterial(),
+                                           mat_op.GetPermittivityReal());
+  BilinearForm k(GetH1Space());
+  k.AddDomainIntegrator<DiffusionIntegrator>(epsilon_func);
+  k.AssembleQuadratureData();
+  auto k_vec = k.Assemble(GetH1Spaces(), skip_zeros);
   auto K = std::make_unique<MultigridOperator>(GetH1Spaces().GetNumLevels());
   for (std::size_t l = 0; l < GetH1Spaces().GetNumLevels(); l++)
   {
-    // Force coarse level operator to be fully assembled always.
     const auto &h1_fespace_l = GetH1Spaces().GetFESpaceAtLevel(l);
     if (print_hdr)
     {
       Mpi::Print(" Level {:d} (p = {:d}): {:d} unknowns", l,
                  h1_fespace_l.GetMaxElementOrder(), h1_fespace_l.GlobalTrueVSize());
-    }
-    constexpr bool skip_zeros = false;
-    MaterialPropertyCoefficient epsilon_func(mat_op.GetAttributeToMaterial(),
-                                             mat_op.GetPermittivityReal());
-    BilinearForm k(h1_fespace_l);
-    k.AddDomainIntegrator<DiffusionIntegrator>(epsilon_func);
-    auto K_l = std::make_unique<ParOperator>(
-        (l > 0) ? k.Assemble(skip_zeros) : k.FullAssemble(skip_zeros), h1_fespace_l);
-    if (print_hdr)
-    {
-      if (const auto *k_spm =
-              dynamic_cast<const mfem::SparseMatrix *>(&K_l->LocalOperator()))
+      if (const auto *k_spm = dynamic_cast<const mfem::SparseMatrix *>(k_vec[l].get()))
       {
         HYPRE_BigInt nnz = k_spm->NumNonZeroElems();
         Mpi::GlobalSum(1, &nnz, h1_fespace_l.GetComm());
@@ -207,9 +205,11 @@ std::unique_ptr<Operator> LaplaceOperator::GetStiffnessMatrix()
         Mpi::Print("\n");
       }
     }
+    auto K_l = std::make_unique<ParOperator>(std::move(k_vec[l]), h1_fespace_l);
     K_l->SetEssentialTrueDofs(dbc_tdof_lists[l], Operator::DiagonalPolicy::DIAG_ONE);
     K->AddOperator(std::move(K_l));
   }
+
   print_hdr = false;
   return K;
 }

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -33,20 +33,20 @@ inline void ProjectMatInternal(MPI_Comm comm, const std::vector<Vector> &V,
   {
     // Fill block of Vᴴ A V = [  | Vᴴ A vj ] . We can optimize the matrix-vector product
     // since the columns of V are real.
-    MFEM_VERIFY(A.HasReal() || A.HasImag(),
+    MFEM_VERIFY(A.Real() || A.Imag(),
                 "Invalid zero ComplexOperator for PROM matrix projection!");
-    if (A.HasReal())
+    if (A.Real())
     {
       A.Real()->Mult(V[j], r.Real());
     }
-    if (A.HasImag())
+    if (A.Imag())
     {
       A.Imag()->Mult(V[j], r.Imag());
     }
     for (int i = 0; i < n; i++)
     {
-      Ar(i, j).real(A.HasReal() ? V[i] * r.Real() : 0.0);  // Local inner product
-      Ar(i, j).imag(A.HasImag() ? V[i] * r.Imag() : 0.0);
+      Ar(i, j).real(A.Real() ? V[i] * r.Real() : 0.0);  // Local inner product
+      Ar(i, j).imag(A.Imag() ? V[i] * r.Imag() : 0.0);
     }
   }
   Mpi::GlobalSum((n - n0) * n, Ar.data() + n0 * n, comm);

--- a/palace/models/spaceoperator.hpp
+++ b/palace/models/spaceoperator.hpp
@@ -169,10 +169,10 @@ public:
                                                   const ComplexOperator *K,
                                                   const ComplexOperator *M);
 
-  // Construct the real, optionally SPD matrix for frequency or time domain linear system
-  // preconditioning (Mr > 0, Mi < 0, |Mr + i Mi| is done on the material property
-  // coefficient, not the matrix entries themselves):
-  //             B = a0 K + a1 C -/+ a2 |Mr + i Mi| + A2r(a3) + A2i(a3) .
+  // Construct the matrix for frequency or time domain linear system preconditioning. If it
+  // is real-valued (Mr > 0, Mi < 0, |Mr + Mi| is done on the material property coefficient,
+  // not the matrix entries themselves):
+  //             B = a0 K + a1 C -/+ a2 |Mr + Mi| + A2r(a3) + A2i(a3) .
   template <typename OperType>
   std::unique_ptr<OperType> GetPreconditionerMatrix(double a0, double a1, double a2,
                                                     double a3);

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -653,7 +653,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
 #error "Wave port solver requires building with SuperLU_DIST, STRUMPACK, or MUMPS!"
 #endif
     }
-    auto pc = std::make_unique<WrapperSolver<ComplexOperator>>(
+    auto pc = std::make_unique<MfemWrapperSolver<ComplexOperator>>(
         [&]() -> std::unique_ptr<mfem::Solver>
         {
           if (pc_type == config::LinearSolverData::Type::SUPERLU)
@@ -688,6 +688,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
           }
           return {};
         }());
+    pc->SetSaveAssembled(false);
     ksp = std::make_unique<ComplexKspSolver>(std::move(gmres), std::move(pc));
 
     // Define the eigenvalue solver.


### PR DESCRIPTION
NOTE: Based on #166

Summary of changes:
- Coarse operators for p-multigrid reuse the quadrature data from the fine level to reduce the need for JIT compiling a new QFunction and assembling new quadrature data. This is the approach from https://arxiv.org/pdf/2204.01722.pdf.
- Refactor coarse operator parallel full assembly to be in one place. This should enable https://github.com/awslabs/palace/issues/142 by some relatively simple changes inside of `MfemWrapperSolver`.