### PR TITLE
Bugfix: Coefficient for empty `attr_list`

### DIFF
--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -661,6 +661,12 @@ void MaterialPropertyCoefficient::AddMaterialProperty(const mfem::Array<int> &at
   // Preprocess the attribute list. If any of the given attributes already have material
   // properties assigned, then they all need to point to the same material and it is
   // updated in place. Otherwise a new material is added for these attributes.
+  if (attr_list.Size() == 0)
+  {
+    // No attributes, nothing to add.
+    return;
+  }
+
   int mat_idx = -1;
   for (auto attr : attr_list)
   {


### PR DESCRIPTION
*Description of changes:*
https://github.com/awslabs/palace/pull/166 introduced an issue where coefficients with matching attribute lists, might have different size K, if all the attributes are `-1`. This is a consequence of [these lines](https://github.com/awslabs/palace/blob/main/palace/models/materialoperator.cpp#L696-L706) where a coefficient goes from size zero to size 1, even if there were no local attributes associated. This triggers [these lines](https://github.com/awslabs/palace/blob/main/palace/models/materialoperator.cpp#L627-L635) if `attr_mat` is all -1, but the incoming coefficient is of size zero. This can occur if one rank does not have any piece of the relevant geometry. The fix is if `attr_list` is entry in adding a coefficient, to do nothing.
