### PR TITLE
Collection of minor performance fixes during profiling and GPU testing

### DIFF
--- a/palace/fem/fespace.hpp
+++ b/palace/fem/fespace.hpp
@@ -300,7 +300,8 @@ public:
   std::vector<const Operator *> GetDiscreteInterpolators() const
   {
     std::vector<const Operator *> G_(GetNumLevels());
-    for (std::size_t l = 0; l < G_.size(); l++)
+    G_[0] = nullptr;  // No discrete interpolator for coarsest level
+    for (std::size_t l = 1; l < G_.size(); l++)
     {
       G_[l] = &GetDiscreteInterpolatorAtLevel(l);
     }

--- a/palace/fem/libceed/basis.cpp
+++ b/palace/fem/libceed/basis.cpp
@@ -192,7 +192,7 @@ void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,
   if constexpr (false)
   {
     std::cout << "New interpolator basis (" << ceed << ", " << &trial_fe << ", " << &test_fe
-              << ")\n";
+              << ", " << (trial_fe.GetMapType() == test_fe.GetMapType()) << ")\n";
   }
   if constexpr (false)
   {

--- a/palace/fem/libceed/ceed.cpp
+++ b/palace/fem/libceed/ceed.cpp
@@ -3,6 +3,7 @@
 
 #include "ceed.hpp"
 
+#include <string_view>
 #include "utils/omp.hpp"
 
 #if defined(MFEM_USE_OPENMP)
@@ -31,7 +32,9 @@ void Initialize(const char *resource, const char *jit_source_dir)
     PalacePragmaOmp(master)
     {
 #if defined(MFEM_USE_OPENMP)
-      const int nt = omp_get_num_threads();
+      // Only parallelize libCEED operators over threads when not using the GPU.
+      const int nt =
+          !std::string_view(resource).compare(0, 4, "/cpu") ? omp_get_num_threads() : 1;
 #else
       const int nt = 1;
 #endif

--- a/palace/fem/libceed/integrator.cpp
+++ b/palace/fem/libceed/integrator.cpp
@@ -346,7 +346,9 @@ int CeedGeometryDataGetSpaceDimension(CeedElemRestriction geom_data_restr, CeedI
 
 void AssembleCeedGeometryData(Ceed ceed, CeedElemRestriction mesh_restr,
                               CeedBasis mesh_basis, CeedVector mesh_nodes,
-                              CeedVector geom_data, CeedElemRestriction geom_data_restr)
+                              CeedElemRestriction attr_restr, CeedBasis attr_basis,
+                              CeedVector elem_attr, CeedVector geom_data,
+                              CeedElemRestriction geom_data_restr)
 {
   CeedInt dim, space_dim, num_elem, num_qpts;
   PalaceCeedCall(ceed, CeedBasisGetDimension(mesh_basis, &dim));
@@ -389,6 +391,7 @@ void AssembleCeedGeometryData(Ceed ceed, CeedElemRestriction mesh_restr,
   }
 
   // Inputs
+  PalaceCeedCall(ceed, CeedQFunctionAddInput(build_qf, "attr", 1, CEED_EVAL_INTERP));
   PalaceCeedCall(ceed, CeedQFunctionAddInput(build_qf, "q_w", 1, CEED_EVAL_WEIGHT));
   PalaceCeedCall(
       ceed, CeedQFunctionAddInput(build_qf, "grad_x", space_dim * dim, CEED_EVAL_GRAD));
@@ -409,6 +412,8 @@ void AssembleCeedGeometryData(Ceed ceed, CeedElemRestriction mesh_restr,
   PalaceCeedCall(ceed, CeedOperatorCreate(ceed, build_qf, nullptr, nullptr, &build_op));
   PalaceCeedCall(ceed, CeedQFunctionDestroy(&build_qf));
 
+  PalaceCeedCall(ceed,
+                 CeedOperatorSetField(build_op, "attr", attr_restr, attr_basis, elem_attr));
   PalaceCeedCall(ceed, CeedOperatorSetField(build_op, "q_w", CEED_ELEMRESTRICTION_NONE,
                                             mesh_basis, CEED_VECTOR_NONE));
   PalaceCeedCall(ceed, CeedOperatorSetField(build_op, "grad_x", mesh_restr, mesh_basis,

--- a/palace/fem/libceed/integrator.hpp
+++ b/palace/fem/libceed/integrator.hpp
@@ -53,7 +53,9 @@ int CeedGeometryDataGetSpaceDimension(CeedElemRestriction geom_data_restr, CeedI
 // libCEED operator.
 void AssembleCeedGeometryData(Ceed ceed, CeedElemRestriction mesh_restr,
                               CeedBasis mesh_basis, CeedVector mesh_nodes,
-                              CeedVector geom_data, CeedElemRestriction geom_data_restr);
+                              CeedElemRestriction attr_restr, CeedBasis attr_basis,
+                              CeedVector elem_attr, CeedVector geom_data,
+                              CeedElemRestriction geom_data_restr);
 
 // Construct libCEED operator using the given quadrature data, element restriction, and
 // basis objects.

--- a/palace/fem/qfunctions/21/geom_21_qf.h
+++ b/palace/fem/qfunctions/21/geom_21_qf.h
@@ -9,8 +9,8 @@
 CEED_QFUNCTION(f_build_geom_factor_21)(void *, CeedInt Q, const CeedScalar *const *in,
                                        CeedScalar *const *out)
 {
-  const CeedScalar *qw = in[0], *J = in[1];
-  CeedScalar *attr = out[0], *wdetJ = out[0] + Q, *adjJt = out[0] + 2 * Q;
+  const CeedScalar *attr = in[0], *qw = in[1], *J = in[2];
+  CeedScalar *qd_attr = out[0], *qd_wdetJ = out[0] + Q, *qd_adjJt = out[0] + 2 * Q;
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
@@ -18,10 +18,10 @@ CEED_QFUNCTION(f_build_geom_factor_21)(void *, CeedInt Q, const CeedScalar *cons
     MatUnpack21(J + i, Q, J_loc);
     const CeedScalar detJ = AdjJt21<true>(J_loc, adjJt_loc);
 
-    attr[i] = 0;
-    wdetJ[i] = qw[i] * detJ;
-    adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
-    adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
+    qd_attr[i] = attr[i];
+    qd_wdetJ[i] = qw[i] * detJ;
+    qd_adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
+    qd_adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
   }
   return 0;
 }

--- a/palace/fem/qfunctions/22/geom_22_qf.h
+++ b/palace/fem/qfunctions/22/geom_22_qf.h
@@ -9,8 +9,8 @@
 CEED_QFUNCTION(f_build_geom_factor_22)(void *, CeedInt Q, const CeedScalar *const *in,
                                        CeedScalar *const *out)
 {
-  const CeedScalar *qw = in[0], *J = in[1];
-  CeedScalar *attr = out[0], *wdetJ = out[0] + Q, *adjJt = out[0] + 2 * Q;
+  const CeedScalar *attr = in[0], *qw = in[1], *J = in[2];
+  CeedScalar *qd_attr = out[0], *qd_wdetJ = out[0] + Q, *qd_adjJt = out[0] + 2 * Q;
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
@@ -18,12 +18,12 @@ CEED_QFUNCTION(f_build_geom_factor_22)(void *, CeedInt Q, const CeedScalar *cons
     MatUnpack22(J + i, Q, J_loc);
     const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
 
-    attr[i] = 0;
-    wdetJ[i] = qw[i] * detJ;
-    adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
-    adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
-    adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
-    adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
+    qd_attr[i] = attr[i];
+    qd_wdetJ[i] = qw[i] * detJ;
+    qd_adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
+    qd_adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
+    qd_adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
+    qd_adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
   }
   return 0;
 }

--- a/palace/fem/qfunctions/32/geom_32_qf.h
+++ b/palace/fem/qfunctions/32/geom_32_qf.h
@@ -9,8 +9,8 @@
 CEED_QFUNCTION(f_build_geom_factor_32)(void *, CeedInt Q, const CeedScalar *const *in,
                                        CeedScalar *const *out)
 {
-  const CeedScalar *qw = in[0], *J = in[1];
-  CeedScalar *attr = out[0], *wdetJ = out[0] + Q, *adjJt = out[0] + 2 * Q;
+  const CeedScalar *attr = in[0], *qw = in[1], *J = in[2];
+  CeedScalar *qd_attr = out[0], *qd_wdetJ = out[0] + Q, *qd_adjJt = out[0] + 2 * Q;
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
@@ -18,14 +18,14 @@ CEED_QFUNCTION(f_build_geom_factor_32)(void *, CeedInt Q, const CeedScalar *cons
     MatUnpack32(J + i, Q, J_loc);
     const CeedScalar detJ = AdjJt32<true>(J_loc, adjJt_loc);
 
-    attr[i] = 0;
-    wdetJ[i] = qw[i] * detJ;
-    adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
-    adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
-    adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
-    adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
-    adjJt[i + Q * 4] = adjJt_loc[4] / detJ;
-    adjJt[i + Q * 5] = adjJt_loc[5] / detJ;
+    qd_attr[i] = attr[i];
+    qd_wdetJ[i] = qw[i] * detJ;
+    qd_adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
+    qd_adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
+    qd_adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
+    qd_adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
+    qd_adjJt[i + Q * 4] = adjJt_loc[4] / detJ;
+    qd_adjJt[i + Q * 5] = adjJt_loc[5] / detJ;
   }
   return 0;
 }

--- a/palace/fem/qfunctions/33/geom_33_qf.h
+++ b/palace/fem/qfunctions/33/geom_33_qf.h
@@ -9,8 +9,8 @@
 CEED_QFUNCTION(f_build_geom_factor_33)(void *, CeedInt Q, const CeedScalar *const *in,
                                        CeedScalar *const *out)
 {
-  const CeedScalar *qw = in[0], *J = in[1];
-  CeedScalar *attr = out[0], *wdetJ = out[0] + Q, *adjJt = out[0] + 2 * Q;
+  const CeedScalar *attr = in[0], *qw = in[1], *J = in[2];
+  CeedScalar *qd_attr = out[0], *qd_wdetJ = out[0] + Q, *qd_adjJt = out[0] + 2 * Q;
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
@@ -18,17 +18,17 @@ CEED_QFUNCTION(f_build_geom_factor_33)(void *, CeedInt Q, const CeedScalar *cons
     MatUnpack33(J + i, Q, J_loc);
     const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
 
-    attr[i] = 0;
-    wdetJ[i] = qw[i] * detJ;
-    adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
-    adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
-    adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
-    adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
-    adjJt[i + Q * 4] = adjJt_loc[4] / detJ;
-    adjJt[i + Q * 5] = adjJt_loc[5] / detJ;
-    adjJt[i + Q * 6] = adjJt_loc[6] / detJ;
-    adjJt[i + Q * 7] = adjJt_loc[7] / detJ;
-    adjJt[i + Q * 8] = adjJt_loc[8] / detJ;
+    qd_attr[i] = attr[i];
+    qd_wdetJ[i] = qw[i] * detJ;
+    qd_adjJt[i + Q * 0] = adjJt_loc[0] / detJ;
+    qd_adjJt[i + Q * 1] = adjJt_loc[1] / detJ;
+    qd_adjJt[i + Q * 2] = adjJt_loc[2] / detJ;
+    qd_adjJt[i + Q * 3] = adjJt_loc[3] / detJ;
+    qd_adjJt[i + Q * 4] = adjJt_loc[4] / detJ;
+    qd_adjJt[i + Q * 5] = adjJt_loc[5] / detJ;
+    qd_adjJt[i + Q * 6] = adjJt_loc[6] / detJ;
+    qd_adjJt[i + Q * 7] = adjJt_loc[7] / detJ;
+    qd_adjJt[i + Q * 8] = adjJt_loc[8] / detJ;
   }
   return 0;
 }

--- a/palace/fem/qfunctions/geom_qf.h
+++ b/palace/fem/qfunctions/geom_qf.h
@@ -6,8 +6,9 @@
 
 // libCEED QFunction for building geometry factors for integration and transformations.
 // At every quadrature point, compute qw * det(J) and adj(J)^T / |J| and store the result.
-// in[0] is quadrature weights, shape [Q]
-// in[1] is Jacobians, shape [qcomp=dim, ncomp=space_dim, Q]
+// in[0] is element attributes, shape [Q]
+// in[1] is quadrature weights, shape [Q]
+// in[2] is Jacobians, shape [qcomp=dim, ncomp=space_dim, Q]
 // out[0] is quadrature data, stored as {attribute, Jacobian determinant, (transpose)
 //        adjugate Jacobian} quadrature data, shape [ncomp=2+space_dim*dim, Q]
 

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -43,7 +43,6 @@ private:
 
   // Helper methods for operator application.
   void RestrictionMatrixMult(const Vector &ly, Vector &ty) const;
-  void RestrictionMatrixAddMult(const Vector &ly, Vector &ty) const;
   void RestrictionMatrixMultTranspose(const Vector &ty, Vector &ly) const;
   Vector &GetTestLVector() const;
 
@@ -130,7 +129,6 @@ private:
 
   // Helper methods for operator application.
   void RestrictionMatrixMult(const ComplexVector &ly, ComplexVector &ty) const;
-  void RestrictionMatrixAddMult(const ComplexVector &ly, ComplexVector &ty) const;
   void RestrictionMatrixMultTranspose(const ComplexVector &ty, ComplexVector &ly) const;
   ComplexVector &GetTestLVector() const;
 

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -163,7 +163,7 @@ std::unique_ptr<Operator> CurlCurlOperator::GetStiffnessMatrix()
                                          mat_op.GetInvPermeability());
   BilinearForm k(GetNDSpace());
   k.AddDomainIntegrator<CurlCurlIntegrator>(muinv_func);
-  k.AssembleQuadratureData();
+  // k.AssembleQuadratureData();
   auto k_vec = k.Assemble(GetNDSpaces(), skip_zeros);
   auto K = std::make_unique<MultigridOperator>(GetNDSpaces().GetNumLevels());
   for (std::size_t l = 0; l < GetNDSpaces().GetNumLevels(); l++)

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -184,7 +184,7 @@ std::unique_ptr<Operator> LaplaceOperator::GetStiffnessMatrix()
                                            mat_op.GetPermittivityReal());
   BilinearForm k(GetH1Space());
   k.AddDomainIntegrator<DiffusionIntegrator>(epsilon_func);
-  k.AssembleQuadratureData();
+  // k.AssembleQuadratureData();
   auto k_vec = k.Assemble(GetH1Spaces(), skip_zeros);
   auto K = std::make_unique<MultigridOperator>(GetH1Spaces().GetNumLevels());
   for (std::size_t l = 0; l < GetH1Spaces().GetNumLevels(); l++)

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -694,7 +694,7 @@ std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(double a0, doub
   const auto n_levels = GetNDSpaces().GetNumLevels();
   std::vector<std::unique_ptr<Operator>> br_vec(n_levels), bi_vec(n_levels),
       br_aux_vec(n_levels), bi_aux_vec(n_levels);
-  constexpr bool skip_zeros = false, assemble_q_data = true;
+  constexpr bool skip_zeros = false, assemble_q_data = false;
   if (std::is_same<OperType, ComplexOperator>::value && !pc_mat_real)
   {
     MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()),


### PR DESCRIPTION
- Only parallelize libCEED across OpenMP threads when CPU backends are used
- Add some missing `AddMult`/`AddMultTranspose` overrides and avoid calling them when they don't exist to avoid temporary vectors
- Avoid constructing discrete gradient matrix on coarse mesh unless necessary for coarse solve (AMS)