### PR TITLE
Bump GitHub actions versions for Node.js deprecation warnings

### DIFF
--- a/.github/workflows/build-and-test-linux-aarch64.yml
+++ b/.github/workflows/build-and-test-linux-aarch64.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: palace_ubuntu-latest_16-core
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -45,7 +45,7 @@ jobs:
 
     runs-on: macos-latest-xl
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
   cleanup-preview-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: gh-pages
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
           julia --project=docs --color=yes docs/make.jl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/build/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build and deploy
         env:

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -18,7 +18,7 @@ jobs:
   build-and-test-singularity:
     runs-on: palace_ubuntu-latest_16-core
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: singularityhub/install-singularity@main
 
@@ -42,7 +42,7 @@ jobs:
           julia --project=test/examples -e 'using Pkg; Pkg.instantiate()'
           julia --project=test/examples --color=yes test/examples/runtests.jl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CONTAINER_NAME }}
           path: ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,7 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Install more recent clang-format from LLVM (match Homebrew v16)
       - name: Install clang-format
@@ -43,7 +43,7 @@ jobs:
   check-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check JSON Schema
         run: |


### PR DESCRIPTION
Fixes the following warnings:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```