### PR TITLE
Add OpenMP parallelism where possible

### DIFF
--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -588,6 +588,7 @@ void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int>
   }
   else
   {
+    mesh.GetNodes()->HostRead();
     const int ref = mesh.GetNodes()->FESpace()->GetMaxElementOrder();
     auto BBUpdate = [&ref](mfem::GeometryRefiner refiner, mfem::Geometry::Type &geom,
                            mfem::ElementTransformation &T, mfem::DenseMatrix &pointmat,

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -71,6 +71,8 @@ void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int>
                                bool bdr, mfem::Vector &min, mfem::Vector &max);
 void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr,
                                mfem::Vector &min, mfem::Vector &max);
+void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, mfem::Vector &min,
+                               mfem::Vector &max);
 
 // Struct describing a bounding box in terms of the center and face normals. The normals
 // specify the direction from the center of the box.

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -452,7 +452,7 @@ void IoData::NondimensionalizeInputs(mfem::ParMesh &mesh)
   else
   {
     mfem::Vector bbmin, bbmax;
-    mesh.GetBoundingBox(bbmin, bbmax);
+    mesh::GetAxisAlignedBoundingBox(mesh, bbmin, bbmax);
     bbmax -= bbmin;
     bbmax *= model.L0;  // [m]
     Lc = *std::max_element(bbmax.begin(), bbmax.end());


### PR DESCRIPTION
Expands use of OpenMP to a few detected hot-spots:
- AMS nodal coordinates construction
- Mesh bounding boxes and other loops in `geodata.cpp`