### PR TITLE
Make use of HYPRE for more linear algebra on GPU

### DIFF
--- a/palace/fem/bilinearform.cpp
+++ b/palace/fem/bilinearform.cpp
@@ -49,10 +49,9 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
   // This should work fine if some threads create an empty operator (no elements or boundary
   // elements).
   const std::size_t nt = ceed::internal::GetCeedObjects().size();
-  PalacePragmaOmp(parallel for schedule(static) if(nt > 1))
-  for (std::size_t i = 0; i < nt; i++)
+  PalacePragmaOmp(parallel if (nt > 1))
   {
-    Ceed ceed = ceed::internal::GetCeedObjects()[i];
+    Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
 
     // Initialize the composite operator on each thread.
     CeedOperator loc_op;
@@ -108,7 +107,7 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
       }
     }
     PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op));
-    op->AddOper(loc_op);  // Thread-safe
+    op->AddOper(loc_op);
   }
 
   return op;
@@ -222,10 +221,9 @@ std::unique_ptr<ceed::Operator> DiscreteLinearOperator::PartialAssemble() const
   // This should work fine if some threads create an empty operator (no elements or bounday
   // elements).
   const std::size_t nt = ceed::internal::GetCeedObjects().size();
-  PalacePragmaOmp(parallel for schedule(static) if(nt > 1))
-  for (std::size_t i = 0; i < nt; i++)
+  PalacePragmaOmp(parallel if (nt > 1))
   {
-    Ceed ceed = ceed::internal::GetCeedObjects()[i];
+    Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
 
     // Initialize the composite operators for each thread.
     CeedOperator loc_op, loc_op_t;
@@ -269,7 +267,7 @@ std::unique_ptr<ceed::Operator> DiscreteLinearOperator::PartialAssemble() const
     }
     PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op));
     PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op_t));
-    op->AddOper(loc_op, loc_op_t);  // Thread-safe
+    op->AddOper(loc_op, loc_op_t);
   }
 
   // Construct dof multiplicity vector for scaling to account for dofs shared between

--- a/palace/fem/bilinearform.cpp
+++ b/palace/fem/bilinearform.cpp
@@ -49,7 +49,7 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
   // This should work fine if some threads create an empty operator (no elements or boundary
   // elements).
   const std::size_t nt = ceed::internal::GetCeedObjects().size();
-  PalacePragmaOmp(parallel for schedule(static))
+  PalacePragmaOmp(parallel for schedule(static) if(nt > 1))
   for (std::size_t i = 0; i < nt; i++)
   {
     Ceed ceed = ceed::internal::GetCeedObjects()[i];
@@ -222,7 +222,7 @@ std::unique_ptr<ceed::Operator> DiscreteLinearOperator::PartialAssemble() const
   // This should work fine if some threads create an empty operator (no elements or bounday
   // elements).
   const std::size_t nt = ceed::internal::GetCeedObjects().size();
-  PalacePragmaOmp(parallel for schedule(static))
+  PalacePragmaOmp(parallel for schedule(static) if(nt > 1))
   for (std::size_t i = 0; i < nt; i++)
   {
     Ceed ceed = ceed::internal::GetCeedObjects()[i];

--- a/palace/fem/bilinearform.cpp
+++ b/palace/fem/bilinearform.cpp
@@ -113,8 +113,8 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
   return op;
 }
 
-std::unique_ptr<mfem::SparseMatrix> BilinearForm::FullAssemble(const ceed::Operator &op,
-                                                               bool skip_zeros, bool set)
+std::unique_ptr<hypre::HypreCSRMatrix> BilinearForm::FullAssemble(const ceed::Operator &op,
+                                                                  bool skip_zeros, bool set)
 {
   return ceed::CeedOperatorFullAssemble(op, skip_zeros, set);
 }

--- a/palace/fem/bilinearform.cpp
+++ b/palace/fem/bilinearform.cpp
@@ -52,11 +52,6 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
   PalacePragmaOmp(parallel if (nt > 1))
   {
     Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
-
-    // Initialize the composite operator on each thread.
-    CeedOperator loc_op;
-    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op));
-
     for (const auto &[geom, data] : mesh.GetCeedGeomFactorData(ceed))
     {
       const auto trial_map_type =
@@ -80,8 +75,7 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
           integ->SetMapTypes(trial_map_type, test_map_type);
           integ->Assemble(ceed, trial_restr, test_restr, trial_basis, test_basis,
                           data.geom_data, data.geom_data_restr, &sub_op);
-          PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op, sub_op));
-          PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
+          op->AddOper(sub_op);  // Sub-operator owned by ceed::Operator
         }
       }
       else if (mfem::Geometry::Dimension[geom] == mesh.Dimension() - 1 &&
@@ -101,14 +95,14 @@ BilinearForm::PartialAssemble(const FiniteElementSpace &trial_fespace,
           integ->SetMapTypes(trial_map_type, test_map_type);
           integ->Assemble(ceed, trial_restr, test_restr, trial_basis, test_basis,
                           data.geom_data, data.geom_data_restr, &sub_op);
-          PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op, sub_op));
-          PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
+          op->AddOper(sub_op);  // Sub-operator owned by ceed::Operator
         }
       }
     }
-    PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op));
-    op->AddOper(loc_op);
   }
+
+  // Finalize the operator (call CeedOperatorCheckReady).
+  op->Finalize();
 
   return op;
 }
@@ -224,12 +218,6 @@ std::unique_ptr<ceed::Operator> DiscreteLinearOperator::PartialAssemble() const
   PalacePragmaOmp(parallel if (nt > 1))
   {
     Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
-
-    // Initialize the composite operators for each thread.
-    CeedOperator loc_op, loc_op_t;
-    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op));
-    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op_t));
-
     for (const auto &[geom, data] : mesh.GetCeedGeomFactorData(ceed))
     {
       if (mfem::Geometry::Dimension[geom] == mesh.Dimension() && !domain_interps.empty())
@@ -255,20 +243,17 @@ std::unique_ptr<ceed::Operator> DiscreteLinearOperator::PartialAssemble() const
         {
           CeedOperator sub_op, sub_op_t;
           interp->Assemble(ceed, trial_restr, test_restr, interp_basis, &sub_op, &sub_op_t);
-          PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op, sub_op));
-          PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op_t, sub_op_t));
-          PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
-          PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op_t));
+          op->AddOper(sub_op, sub_op_t);  // Sub-operator owned by ceed::Operator
         }
 
         // Basis is owned by the operator.
         PalaceCeedCall(ceed, CeedBasisDestroy(&interp_basis));
       }
     }
-    PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op));
-    PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op_t));
-    op->AddOper(loc_op, loc_op_t);
   }
+
+  // Finalize the operator (call CeedOperatorCheckReady).
+  op->Finalize();
 
   // Construct dof multiplicity vector for scaling to account for dofs shared between
   // elements (on host, then copy to device).

--- a/palace/fem/bilinearform.hpp
+++ b/palace/fem/bilinearform.hpp
@@ -9,6 +9,7 @@
 #include <mfem.hpp>
 #include "fem/integrator.hpp"
 #include "fem/libceed/operator.hpp"
+#include "linalg/hypre.hpp"
 
 namespace palace
 {
@@ -69,19 +70,19 @@ public:
     return PartialAssemble(GetTrialSpace(), GetTestSpace());
   }
 
-  std::unique_ptr<mfem::SparseMatrix> FullAssemble(bool skip_zeros) const
+  std::unique_ptr<hypre::HypreCSRMatrix> FullAssemble(bool skip_zeros) const
   {
     return FullAssemble(*PartialAssemble(), skip_zeros, false);
   }
 
-  static std::unique_ptr<mfem::SparseMatrix> FullAssemble(const ceed::Operator &op,
-                                                          bool skip_zeros)
+  static std::unique_ptr<hypre::HypreCSRMatrix> FullAssemble(const ceed::Operator &op,
+                                                             bool skip_zeros)
   {
     return FullAssemble(op, skip_zeros, false);
   }
 
-  static std::unique_ptr<mfem::SparseMatrix> FullAssemble(const ceed::Operator &op,
-                                                          bool skip_zeros, bool set);
+  static std::unique_ptr<hypre::HypreCSRMatrix> FullAssemble(const ceed::Operator &op,
+                                                             bool skip_zeros, bool set);
 
   std::unique_ptr<Operator> Assemble(bool skip_zeros) const;
 
@@ -120,13 +121,13 @@ public:
 
   std::unique_ptr<ceed::Operator> PartialAssemble() const;
 
-  std::unique_ptr<mfem::SparseMatrix> FullAssemble(bool skip_zeros) const
+  std::unique_ptr<hypre::HypreCSRMatrix> FullAssemble(bool skip_zeros) const
   {
     return BilinearForm::FullAssemble(*PartialAssemble(), skip_zeros, true);
   }
 
-  static std::unique_ptr<mfem::SparseMatrix> FullAssemble(const ceed::Operator &op,
-                                                          bool skip_zeros)
+  static std::unique_ptr<hypre::HypreCSRMatrix> FullAssemble(const ceed::Operator &op,
+                                                             bool skip_zeros)
   {
     return BilinearForm::FullAssemble(op, skip_zeros, true);
   }

--- a/palace/fem/errorindicator.hpp
+++ b/palace/fem/errorindicator.hpp
@@ -59,12 +59,7 @@ public:
   }
 
   // Return the mean local error indicator.
-  auto Mean(MPI_Comm comm) const
-  {
-    auto sum = local.Sum();
-    Mpi::GlobalSum(1, &sum, comm);
-    return sum / linalg::GlobalSize(comm, local);
-  }
+  auto Mean(MPI_Comm comm) const { return linalg::Mean(comm, local); }
 };
 
 }  // namespace palace

--- a/palace/fem/fespace.hpp
+++ b/palace/fem/fespace.hpp
@@ -48,6 +48,10 @@ private:
   {
     // The range restriction for interpolation operators needs to use a special
     // DofTransformation (not equal to the transpose of the domain restriction).
+    if (mesh.Dimension() < 3)
+    {
+      return false;
+    }
     const auto geom = fe.GetGeomType();
     const auto *dof_trans = fespace.FEColl()->DofTransformationForGeometry(geom);
     return (dof_trans && !dof_trans->IsIdentity());

--- a/palace/fem/libceed/ceed.cpp
+++ b/palace/fem/libceed/ceed.cpp
@@ -6,10 +6,6 @@
 #include <string_view>
 #include "utils/omp.hpp"
 
-#if defined(MFEM_USE_OPENMP)
-#include <omp.h>
-#endif
-
 namespace palace::ceed
 {
 
@@ -31,13 +27,10 @@ void Initialize(const char *resource, const char *jit_source_dir)
   {
     PalacePragmaOmp(master)
     {
-#if defined(MFEM_USE_OPENMP)
       // Only parallelize libCEED operators over threads when not using the GPU.
-      const int nt =
-          !std::string_view(resource).compare(0, 4, "/cpu") ? omp_get_num_threads() : 1;
-#else
-      const int nt = 1;
-#endif
+      const int nt = !std::string_view(resource).compare(0, 4, "/cpu")
+                         ? utils::GetNumActiveThreads()
+                         : 1;
       internal::ceeds.resize(nt, nullptr);
     }
   }

--- a/palace/fem/libceed/operator.cpp
+++ b/palace/fem/libceed/operator.cpp
@@ -21,6 +21,22 @@ Operator::Operator(int h, int w) : palace::Operator(h, w)
   op_t.resize(nt, nullptr);
   u.resize(nt, nullptr);
   v.resize(nt, nullptr);
+  PalacePragmaOmp(parallel if (op.size() > 1))
+  {
+    const int id = utils::GetThreadNum();
+    MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
+    CeedOperator loc_op, loc_op_t;
+    CeedVector loc_u, loc_v;
+    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op));
+    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op_t));
+    PalaceCeedCall(ceed, CeedVectorCreate(ceed, width, &loc_u));
+    PalaceCeedCall(ceed, CeedVectorCreate(ceed, height, &loc_v));
+    op[id] = loc_op;
+    op_t[id] = loc_op_t;
+    u[id] = loc_u;
+    v[id] = loc_v;
+  }
   temp.UseDevice(true);
 }
 
@@ -28,10 +44,9 @@ Operator::~Operator()
 {
   PalacePragmaOmp(parallel if (op.size() > 1))
   {
-    Ceed ceed;
     const int id = utils::GetThreadNum();
-    MFEM_ASSERT(id < op.size() && op[id],
-                "Out of bounds access for thread number " << id << "!");
+    MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
     PalaceCeedCallBackend(CeedOperatorGetCeed(op[id], &ceed));
     PalaceCeedCall(ceed, CeedOperatorDestroy(&op[id]));
     PalaceCeedCall(ceed, CeedOperatorDestroy(&op_t[id]));
@@ -40,32 +55,45 @@ Operator::~Operator()
   }
 }
 
-void Operator::AddOper(CeedOperator op_, CeedOperator op_t_)
+void Operator::AddOper(CeedOperator sub_op, CeedOperator sub_op_t)
 {
-  Ceed ceed;
-  CeedSize l_in, l_out;
-  CeedVector loc_u, loc_v;
-  PalaceCeedCallBackend(CeedOperatorGetCeed(op_, &ceed));
-  PalaceCeedCall(ceed, CeedOperatorGetActiveVectorLengths(op_, &l_in, &l_out));
-  MFEM_VERIFY((l_in == 0 && l_out == 0) || (mfem::internal::to_int(l_in) == width &&
-                                            mfem::internal::to_int(l_out) == height),
-              "Dimensions mismatch for CeedOperator!");
-  if (op_t_)
-  {
-    CeedSize l_in_t, l_out_t;
-    PalaceCeedCall(ceed, CeedOperatorGetActiveVectorLengths(op_t_, &l_in_t, &l_out_t));
-    MFEM_VERIFY((l_in_t == 0 && l_out_t == 0) || (l_in_t == l_out && l_out_t == l_in),
-                "Dimensions mismatch for transpose CeedOperator!");
-  }
-  PalaceCeedCall(ceed, CeedVectorCreate(ceed, l_in, &loc_u));
-  PalaceCeedCall(ceed, CeedVectorCreate(ceed, l_out, &loc_v));
-
+  // This should be called from within a OpenMP parallel region.
   const int id = utils::GetThreadNum();
   MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
-  op[id] = op_;
-  op_t[id] = op_t_;
-  u[id] = loc_u;
-  v[id] = loc_v;
+  Ceed ceed;
+  PalaceCeedCallBackend(CeedOperatorGetCeed(sub_op, &ceed));
+  CeedSize l_in, l_out;
+  PalaceCeedCall(ceed, CeedOperatorGetActiveVectorLengths(sub_op, &l_in, &l_out));
+  MFEM_VERIFY(mfem::internal::to_int(l_in) == width &&
+                  mfem::internal::to_int(l_out) == height,
+              "Dimensions mismatch for CeedOperator!");
+  PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(op[id], sub_op));
+  PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
+  if (sub_op_t)
+  {
+    Ceed ceed_t;
+    PalaceCeedCallBackend(CeedOperatorGetCeed(sub_op_t, &ceed_t));
+    MFEM_VERIFY(ceed_t == ceed, "Ceed context mismatch for transpose CeedOperator!");
+    CeedSize l_in_t, l_out_t;
+    PalaceCeedCall(ceed, CeedOperatorGetActiveVectorLengths(sub_op_t, &l_in_t, &l_out_t));
+    MFEM_VERIFY(l_in_t == l_out && l_out_t == l_in,
+                "Dimensions mismatch for transpose CeedOperator!");
+    PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(op_t[id], sub_op_t));
+    PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op_t));
+  }
+}
+
+void Operator::Finalize()
+{
+  PalacePragmaOmp(parallel if (op.size() > 1))
+  {
+    const int id = utils::GetThreadNum();
+    MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
+    PalaceCeedCallBackend(CeedOperatorGetCeed(op[id], &ceed));
+    PalaceCeedCall(ceed, CeedOperatorCheckReady(op[id]));
+    PalaceCeedCall(ceed, CeedOperatorCheckReady(op_t[id]));
+  }
 }
 
 void Operator::AssembleDiagonal(Vector &diag) const
@@ -84,10 +112,9 @@ void Operator::AssembleDiagonal(Vector &diag) const
 
   PalacePragmaOmp(parallel if (op.size() > 1))
   {
-    Ceed ceed;
     const int id = utils::GetThreadNum();
-    MFEM_ASSERT(id < op.size() && op[id],
-                "Out of bounds access for thread number " << id << "!");
+    MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
     PalaceCeedCallBackend(CeedOperatorGetCeed(op[id], &ceed));
     PalaceCeedCall(ceed, CeedVectorSetArray(v[id], mem, CEED_USE_POINTER, diag_data));
     PalaceCeedCall(
@@ -116,10 +143,9 @@ inline void CeedAddMult(const std::vector<CeedOperator> &op,
 
   PalacePragmaOmp(parallel if (op.size() > 1))
   {
-    Ceed ceed;
     const int id = utils::GetThreadNum();
-    MFEM_ASSERT(id < op.size() && op[id],
-                "Out of bounds access for thread number " << id << "!");
+    MFEM_ASSERT(id < op.size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
     PalaceCeedCallBackend(CeedOperatorGetCeed(op[id], &ceed));
     PalaceCeedCall(ceed, CeedVectorSetArray(u[id], mem, CEED_USE_POINTER,
                                             const_cast<CeedScalar *>(x_data)));
@@ -407,32 +433,36 @@ std::unique_ptr<hypre::HypreCSRMatrix> OperatorCOOtoCSR(Ceed ceed, CeedInt m, Ce
 std::unique_ptr<hypre::HypreCSRMatrix> CeedOperatorFullAssemble(const Operator &op,
                                                                 bool skip_zeros, bool set)
 {
-  if (op.Size() == 0)
-  {
-    return std::make_unique<hypre::HypreCSRMatrix>(op.Height(), op.Width(), 0);
-  }
-
   // Assemble operators on each thread.
   std::vector<std::unique_ptr<hypre::HypreCSRMatrix>> loc_mat(op.Size());
   PalacePragmaOmp(parallel if (op.Size() > 1))
   {
-    Ceed ceed;
     const int id = utils::GetThreadNum();
-    MFEM_ASSERT(id < op.Size() && op[id],
-                "Out of bounds access for thread number " << id << "!");
+    MFEM_ASSERT(id < op.Size(), "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
     PalaceCeedCallBackend(CeedOperatorGetCeed(op[id], &ceed));
 
-    // First, get matrix on master thread in COO format, withs rows/cols always on host and
-    // vals potentially on the device. Process skipping zeros if desired.
-    CeedSize nnz;
-    CeedInt *rows, *cols;
-    CeedVector vals;
-    CeedMemType mem;
-    CeedOperatorAssembleCOO(ceed, op[id], skip_zeros, &nnz, &rows, &cols, &vals, &mem);
+    // Check if the operator is empty, otherwise assemble.
+    CeedInt nsub_ops;
+    PalaceCeedCall(ceed, CeedCompositeOperatorGetNumSub(op[id], &nsub_ops));
+    if (nsub_ops == 0)
+    {
+      loc_mat[id] = std::make_unique<hypre::HypreCSRMatrix>(op.Height(), op.Width(), 0);
+    }
+    else
+    {
+      // First, get matrix on master thread in COO format, withs rows/cols always on host
+      // and vals potentially on the device. Process skipping zeros if desired.
+      CeedSize nnz;
+      CeedInt *rows, *cols;
+      CeedVector vals;
+      CeedMemType mem;
+      CeedOperatorAssembleCOO(ceed, op[id], skip_zeros, &nnz, &rows, &cols, &vals, &mem);
 
-    // Convert COO to CSR (on each thread). The COO memory is free'd internally.
-    loc_mat[id] =
-        OperatorCOOtoCSR(ceed, op.Height(), op.Width(), nnz, rows, cols, vals, mem, set);
+      // Convert COO to CSR (on each thread). The COO memory is free'd internally.
+      loc_mat[id] =
+          OperatorCOOtoCSR(ceed, op.Height(), op.Width(), nnz, rows, cols, vals, mem, set);
+    }
   }
 
   // Add CSR matrix objects from each thread (HYPRE's hypre_CSRMatrixAdd uses threads
@@ -443,19 +473,19 @@ std::unique_ptr<hypre::HypreCSRMatrix> CeedOperatorFullAssemble(const Operator &
   {
     b_mat = std::make_unique<hypre::HypreCSRMatrix>(hypre_CSRMatrixClone(*mat, 0));
     hypre_CSRMatrixSetConstantValues(*b_mat, 1.0);
-    for (std::size_t i = 1; i < op.Size(); i++)
+    for (std::size_t id = 1; id < op.Size(); id++)
     {
-      hypre_CSRMatrix *b_loc_mat = hypre_CSRMatrixClone(*loc_mat[i], 0);
+      hypre_CSRMatrix *b_loc_mat = hypre_CSRMatrixClone(*loc_mat[id], 0);
       hypre_CSRMatrixSetConstantValues(b_loc_mat, 1.0);
       b_mat = std::make_unique<hypre::HypreCSRMatrix>(
           hypre_CSRMatrixAdd(1.0, *b_mat, 1.0, b_loc_mat));
       hypre_CSRMatrixDestroy(b_loc_mat);
     }
   }
-  for (std::size_t i = 1; i < op.Size(); i++)
+  for (std::size_t id = 1; id < op.Size(); id++)
   {
     mat = std::make_unique<hypre::HypreCSRMatrix>(
-        hypre_CSRMatrixAdd(1.0, *mat, 1.0, *loc_mat[i]));
+        hypre_CSRMatrixAdd(1.0, *mat, 1.0, *loc_mat[id]));
   }
   if (set && op.Size() > 1)
   {
@@ -498,10 +528,10 @@ std::unique_ptr<Operator> CeedOperatorCoarsen(const Operator &op_fine,
   // types, integrators) of the original fine operator.
   PalacePragmaOmp(parallel if (op_fine.Size() > 1))
   {
-    Ceed ceed;
     const int id = utils::GetThreadNum();
-    MFEM_ASSERT(id < op_fine.Size() && op_fine[id],
+    MFEM_ASSERT(id < op_fine.Size(),
                 "Out of bounds access for thread number " << id << "!");
+    Ceed ceed;
     PalaceCeedCallBackend(CeedOperatorGetCeed(op_fine[id], &ceed));
     {
       Ceed ceed_parent;
@@ -511,37 +541,20 @@ std::unique_ptr<Operator> CeedOperatorCoarsen(const Operator &op_fine,
         ceed = ceed_parent;
       }
     }
-
-    // Initialize the composite operator on each thread.
-    CeedOperator loc_op;
-    PalaceCeedCall(ceed, CeedCompositeOperatorCreate(ceed, &loc_op));
-
-    bool composite;
-    PalaceCeedCall(ceed, CeedOperatorIsComposite(op_fine[id], &composite));
-    if (composite)
+    CeedInt nsub_ops_fine;
+    CeedOperator *sub_ops_fine;
+    PalaceCeedCall(ceed, CeedCompositeOperatorGetNumSub(op_fine[id], &nsub_ops_fine));
+    PalaceCeedCall(ceed, CeedCompositeOperatorGetSubList(op_fine[id], &sub_ops_fine));
+    for (CeedInt k = 0; k < nsub_ops_fine; k++)
     {
-      CeedInt nloc_ops_fine;
-      CeedOperator *loc_ops_fine;
-      PalaceCeedCall(ceed, CeedCompositeOperatorGetNumSub(op_fine[id], &nloc_ops_fine));
-      PalaceCeedCall(ceed, CeedCompositeOperatorGetSubList(op_fine[id], &loc_ops_fine));
-      for (CeedInt k = 0; k < nloc_ops_fine; k++)
-      {
-        CeedOperator sub_op;
-        SingleOperatorCoarsen(ceed, loc_ops_fine[k], &sub_op);
-        PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op, sub_op));
-        PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
-      }
+      CeedOperator sub_op_coarse;
+      SingleOperatorCoarsen(ceed, sub_ops_fine[k], &sub_op_coarse);
+      op_coarse->AddOper(sub_op_coarse);  // Sub-operator owned by ceed::Operator
     }
-    else
-    {
-      CeedOperator sub_op;
-      SingleOperatorCoarsen(ceed, op_fine[id], &sub_op);
-      PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(loc_op, sub_op));
-      PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));
-    }
-    PalaceCeedCall(ceed, CeedOperatorCheckReady(loc_op));
-    op_coarse->AddOper(loc_op);  // Thread-safe
   }
+
+  // Finalize the operator (call CeedOperatorCheckReady).
+  op_coarse->Finalize();
 
   return op_coarse;
 }

--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -44,7 +44,9 @@ public:
   CeedOperator operator[](std::size_t i) const { return op[i]; }
   auto Size() const { return op.size(); }
 
-  void AddOper(CeedOperator op_, CeedOperator op_t_ = nullptr);
+  void AddOper(CeedOperator sub_op, CeedOperator sub_op_t = nullptr);
+
+  void Finalize();
 
   void SetDofMultiplicity(Vector &&mult) { dof_multiplicity = std::move(mult); }
 

--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <vector>
-#include <mfem.hpp>
 #include "fem/libceed/ceed.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
@@ -15,6 +14,13 @@ namespace palace
 {
 
 class FiniteElementSpace;
+
+namespace hypre
+{
+
+class HypreCSRMatrix;
+
+}  // namespace hypre
 
 namespace ceed
 {
@@ -67,9 +73,9 @@ public:
   }
 };
 
-// Assemble a ceed::Operator as an mfem::SparseMatrix.
-std::unique_ptr<mfem::SparseMatrix> CeedOperatorFullAssemble(const Operator &op,
-                                                             bool skip_zeros, bool set);
+// Assemble a ceed::Operator as a CSR matrix.
+std::unique_ptr<hypre::HypreCSRMatrix> CeedOperatorFullAssemble(const Operator &op,
+                                                                bool skip_zeros, bool set);
 
 // Construct a coarse-level ceed::Operator, reusing the quadrature data and quadrature
 // function from the fine-level operator. Only available for square, symmetric operators

--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -19,23 +19,26 @@ class FiniteElementSpace;
 namespace ceed
 {
 
-// Wrapper class for libCEED's CeedOperator.
+//
+// Wrapper class for libCEED's CeedOperator, supporting composite operator construction and
+// application with multiple threads.
+//
 class Operator : public palace::Operator
 {
 protected:
-  std::vector<CeedOperator> ops, ops_t;
+  std::vector<CeedOperator> op, op_t;
   std::vector<CeedVector> u, v;
   Vector dof_multiplicity;
   mutable Vector temp;
 
 public:
-  Operator(int h, int w) : palace::Operator(h, w) { temp.UseDevice(true); }
+  Operator(int h, int w);
   ~Operator() override;
 
-  CeedOperator operator[](std::size_t i) const { return ops[i]; }
-  auto Size() const { return ops.size(); }
+  CeedOperator operator[](std::size_t i) const { return op[i]; }
+  auto Size() const { return op.size(); }
 
-  void AddOper(CeedOperator op, CeedOperator op_t = nullptr);
+  void AddOper(CeedOperator op_, CeedOperator op_t_ = nullptr);
 
   void SetDofMultiplicity(Vector &&mult) { dof_multiplicity = std::move(mult); }
 

--- a/palace/fem/libceed/restriction.cpp
+++ b/palace/fem/libceed/restriction.cpp
@@ -6,10 +6,6 @@
 #include <mfem.hpp>
 #include "utils/omp.hpp"
 
-#if defined(MFEM_USE_OPENMP)
-#include <omp.h>
-#endif
-
 namespace palace::ceed
 {
 
@@ -36,12 +32,7 @@ void InitLexicoRestr(const mfem::FiniteElementSpace &fespace,
   mfem::Array<bool> tp_el_orients(num_elem * P);
   int use_el_orients = 0;
 
-#if defined(MFEM_USE_OPENMP)
-  const int in_parallel = omp_in_parallel();
-#else
-  const int in_parallel = 0;
-#endif
-  PalacePragmaOmp(parallel reduction(+ : use_el_orients) if (in_parallel == 0))
+  PalacePragmaOmp(parallel reduction(+ : use_el_orients))
   {
     mfem::Array<int> dofs;
     mfem::DofTransformation dof_trans;
@@ -131,12 +122,7 @@ void InitNativeRestr(const mfem::FiniteElementSpace &fespace,
   }
   int use_el_orients = 0;
 
-#if defined(MFEM_USE_OPENMP)
-  const int in_parallel = omp_in_parallel();
-#else
-  const int in_parallel = 0;
-#endif
-  PalacePragmaOmp(parallel reduction(+ : use_el_orients) if (in_parallel == 0))
+  PalacePragmaOmp(parallel reduction(+ : use_el_orients))
   {
     mfem::Array<int> dofs;
     mfem::DofTransformation dof_trans;

--- a/palace/fem/libceed/restriction.cpp
+++ b/palace/fem/libceed/restriction.cpp
@@ -194,7 +194,7 @@ void InitNativeRestr(const mfem::FiniteElementSpace &fespace,
           int nnz = 0;
           for (int k = 0; k < P; k++)
           {
-            if (k < j - 1 && k > j + 1 && el_trans_j(k) != 0.0)
+            if ((k < j - 1 || k > j + 1) && el_trans_j(k) != 0.0)
             {
               nnz++;
             }

--- a/palace/fem/lumpedelement.cpp
+++ b/palace/fem/lumpedelement.cpp
@@ -5,6 +5,7 @@
 
 #include "fem/coefficient.hpp"
 #include "fem/integrator.hpp"
+#include "linalg/vector.hpp"
 #include "utils/communication.hpp"
 
 namespace palace
@@ -19,13 +20,13 @@ double GetArea(mfem::ParFiniteElementSpace &fespace, mfem::Array<int> &attr_mark
   mfem::LinearForm s(&fespace);
   s.AddBoundaryIntegrator(new BoundaryLFIntegrator(one_func), attr_marker);
   s.UseFastAssembly(false);
+  s.UseDevice(false);
   s.Assemble();
+  s.UseDevice(true);
 
   mfem::GridFunction ones(&fespace);
   ones = 1.0;
-  double dot = s * ones;
-  Mpi::GlobalSum(1, &dot, fespace.GetComm());
-  return dot;
+  return linalg::Dot<Vector>(fespace.GetComm(), s, ones);
 }
 
 }  // namespace

--- a/palace/fem/lumpedelement.cpp
+++ b/palace/fem/lumpedelement.cpp
@@ -23,10 +23,7 @@ double GetArea(mfem::ParFiniteElementSpace &fespace, mfem::Array<int> &attr_mark
   s.UseDevice(false);
   s.Assemble();
   s.UseDevice(true);
-
-  mfem::GridFunction ones(&fespace);
-  ones = 1.0;
-  return linalg::Dot<Vector>(fespace.GetComm(), s, ones);
+  return linalg::Sum<Vector>(fespace.GetComm(), s);
 }
 
 }  // namespace

--- a/palace/linalg/CMakeLists.txt
+++ b/palace/linalg/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/errorestimator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gmg.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hcurl.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hypre.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/jacobi.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ksp.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/iterative.cpp

--- a/palace/linalg/amg.cpp
+++ b/palace/linalg/amg.cpp
@@ -16,13 +16,10 @@ BoomerAmgSolver::BoomerAmgSolver(int cycle_it, int smooth_it, int print)
   // Set additional BoomerAMG options.
   int agg_levels = 1;  // Number of aggressive coarsening levels
   double theta = 0.5;  // AMG strength parameter = 0.25 is 2D optimal (0.5-0.8 for 3D)
+  if (mfem::Device::Allows(mfem::Backend::DEVICE_MASK))
   {
-    HYPRE_MemoryLocation loc;
-    HYPRE_GetMemoryLocation(&loc);
-    if (loc == HYPRE_MEMORY_DEVICE)  // Modify options for GPU-supported features
-    {
-      agg_levels = 0;
-    }
+    // Modify options for GPU-supported features.
+    agg_levels = 0;
   }
 
   SetAggressiveCoarsening(agg_levels);

--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -161,16 +161,13 @@ void HypreAmsSolver::InitializeSolver()
   int relax_type = 2;      // 2 = l1-SSOR, 4 = trunc. l1-SSOR, 1 = l1-Jacobi, 16 = Chebyshev
   double weight = 1.0;
   double omega = 1.0;
+  if (mfem::Device::Allows(mfem::Backend::DEVICE_MASK))
   {
-    HYPRE_MemoryLocation loc;
-    HYPRE_GetMemoryLocation(&loc);
-    if (loc == HYPRE_MEMORY_DEVICE)  // Modify options for GPU-supported features
-    {
-      coarsen_type = 8;
-      amg_agg_levels = 0;
-      amg_relax_type = 18;
-      relax_type = 1;
-    }
+    // Modify options for GPU-supported features.
+    coarsen_type = 8;
+    amg_agg_levels = 0;
+    amg_relax_type = 18;
+    relax_type = 1;
   }
 
   HYPRE_AMSSetSmoothingOptions(ams, relax_type, ams_smooth_it, weight, omega);

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -64,6 +64,10 @@ DivFreeSolver<VecType>::DivFreeSolver(
       const auto &h1_fespace_l = h1_fespaces.GetFESpaceAtLevel(l);
       auto M_l = BuildLevelParOperator<OperType>(std::move(m_vec[l]), h1_fespace_l);
       M_l->SetEssentialTrueDofs(h1_bdr_tdof_lists[l], Operator::DiagonalPolicy::DIAG_ONE);
+      if (l == h1_fespaces.GetNumLevels() - 1)
+      {
+        bdr_tdof_list_M = M_l->GetEssentialTrueDofs();
+      }
       M_mg->AddOperator(std::move(M_l));
     }
     M = std::move(M_mg);
@@ -76,7 +80,6 @@ DivFreeSolver<VecType>::DivFreeSolver(
                                             h1_fespaces.GetFinestFESpace(), false);
   }
   Grad = &h1_fespaces.GetFinestFESpace().GetDiscreteInterpolator();
-  bdr_tdof_list_M = &h1_bdr_tdof_lists.back();
 
   // The system matrix for the projection is real and SPD.
   auto amg = std::make_unique<MfemWrapperSolver<OperType>>(

--- a/palace/linalg/hypre.cpp
+++ b/palace/linalg/hypre.cpp
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hypre.hpp"
+
+namespace palace::hypre
+{
+
+HypreVector::HypreVector(hypre_Vector *vec) : vec(vec) {}
+
+HypreVector::HypreVector(const Vector &x) : vec(nullptr)
+{
+  Update(x);
+}
+
+HypreVector::~HypreVector()
+{
+  hypre_SeqVectorDestroy(vec);
+}
+
+void HypreVector::Update(const Vector &x)
+{
+  const HYPRE_Int N = x.Size();
+  if (!vec)
+  {
+    vec = hypre_SeqVectorCreate(N);
+    hypre_SeqVectorSetDataOwner(vec, 0);
+    hypre_VectorData(vec) = const_cast<double *>(x.Read());
+    hypre_SeqVectorInitialize(vec);
+  }
+  else
+  {
+    hypre_SeqVectorSetSize(vec, N);
+    hypre_VectorData(vec) = const_cast<double *>(x.Read());
+  }
+}
+
+HypreCSRMatrix::HypreCSRMatrix(int h, int w, int nnz) : palace::Operator(h, w)
+{
+  mat = hypre_CSRMatrixCreate(h, w, nnz);
+  hypre_CSRMatrixInitialize(mat);
+}
+
+HypreCSRMatrix::HypreCSRMatrix(hypre_CSRMatrix *mat) : mat(mat)
+{
+  height = hypre_CSRMatrixNumRows(mat);
+  width = hypre_CSRMatrixNumCols(mat);
+}
+
+HypreCSRMatrix::~HypreCSRMatrix()
+{
+  hypre_CSRMatrixDestroy(mat);
+}
+
+void HypreCSRMatrix::AssembleDiagonal(Vector &diag) const
+{
+  diag.SetSize(height);
+  hypre_CSRMatrixExtractDiagonal(mat, diag.Write(), 0);
+}
+
+namespace
+{
+
+static HypreVector X, Y;
+
+}  // namespace
+
+void HypreCSRMatrix::Mult(const Vector &x, Vector &y) const
+{
+  X.Update(x);
+  Y.Update(y);
+  hypre_CSRMatrixMatvec(1.0, mat, X, 0.0, Y);
+}
+
+void HypreCSRMatrix::AddMult(const Vector &x, Vector &y, const double a) const
+{
+  X.Update(x);
+  Y.Update(y);
+  hypre_CSRMatrixMatvec(a, mat, X, 1.0, Y);
+}
+
+void HypreCSRMatrix::MultTranspose(const Vector &x, Vector &y) const
+{
+  X.Update(x);
+  Y.Update(y);
+  hypre_CSRMatrixMatvecT(1.0, mat, X, 0.0, Y);
+}
+
+void HypreCSRMatrix::AddMultTranspose(const Vector &x, Vector &y, const double a) const
+{
+  X.Update(x);
+  Y.Update(y);
+  hypre_CSRMatrixMatvecT(a, mat, X, 1.0, Y);
+}
+
+}  // namespace palace::hypre

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LINALG_HYPRE_HPP
+#define PALACE_LINALG_HYPRE_HPP
+
+#include <mfem.hpp>
+#include "linalg/operator.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace::hypre
+{
+
+// Helper function to initialize HYPRE and control use of GPU at runtime. This will call
+// HYPRE_SetMemoryLocation and HYPRE_SetExecutionPolicy to match the mfem::Device
+// configuration.
+inline void Initialize()
+{
+  mfem::Hypre::Init();
+  // HYPRE_SetSpGemmUseCusparse(1);  // MFEM sets to zero, so leave as is for now
+}
+
+//
+// Wrapper class for HYPRE's hypre_Vector, which can alias an mfem::Vector object for use
+// with HYPRE.
+//
+class HypreVector
+{
+private:
+  hypre_Vector *vec;
+
+public:
+  HypreVector(hypre_Vector *vec = nullptr);
+  HypreVector(const Vector &x);
+  ~HypreVector();
+
+  auto Size() const { return hypre_VectorSize(vec); }
+
+  void Update(const Vector &x);
+
+  operator hypre_Vector *() const { return vec; }
+};
+
+//
+// Wrapper class for HYPRE's hypre_CSRMatrix, an alternative to mfem::SparseMatrix with
+// increased functionality from HYPRE.
+//
+class HypreCSRMatrix : public palace::Operator
+{
+private:
+  hypre_CSRMatrix *mat;
+
+public:
+  HypreCSRMatrix(int h, int w, int nnz);
+  HypreCSRMatrix(hypre_CSRMatrix *mat);
+  ~HypreCSRMatrix();
+
+  auto NNZ() const { return hypre_CSRMatrixNumNonzeros(mat); }
+
+  const auto *GetI() const { return hypre_CSRMatrixI(mat); }
+  auto *GetI() { return hypre_CSRMatrixI(mat); }
+  const auto *GetJ() const { return hypre_CSRMatrixJ(mat); }
+  auto *GetJ() { return hypre_CSRMatrixJ(mat); }
+  const auto *GetData() const { return hypre_CSRMatrixData(mat); }
+  auto *GetData() { return hypre_CSRMatrixData(mat); }
+
+  void AssembleDiagonal(Vector &diag) const override;
+
+  void Mult(const Vector &x, Vector &y) const override;
+
+  void AddMult(const Vector &x, Vector &y, const double a = 1.0) const override;
+
+  void MultTranspose(const Vector &x, Vector &y) const override;
+
+  void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const override;
+
+  operator hypre_CSRMatrix *() const { return mat; }
+};
+
+}  // namespace palace::hypre
+
+#endif  // PALACE_LINALG_HYPRE_HPP

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -32,7 +32,7 @@ private:
   const bool use_R;
 
   // Lists of constrained essential boundary true dofs for elimination.
-  const mfem::Array<int> *dbc_tdof_list;
+  mfem::Array<int> dbc_tdof_list;
 
   // Diagonal policy for constrained true dofs.
   DiagonalPolicy diag_policy;
@@ -78,7 +78,10 @@ public:
 
   // Get the essential boundary condition true dofs associated with the operator. May be
   // nullptr.
-  const mfem::Array<int> *GetEssentialTrueDofs() const { return dbc_tdof_list; }
+  const mfem::Array<int> *GetEssentialTrueDofs() const
+  {
+    return dbc_tdof_list.Size() ? &dbc_tdof_list : nullptr;
+  }
 
   // Eliminate essential true dofs from the RHS vector b, using the essential boundary
   // condition values in x.
@@ -119,7 +122,7 @@ private:
   const bool use_R;
 
   // Lists of constrained essential boundary true dofs for elimination.
-  const mfem::Array<int> *dbc_tdof_list;
+  mfem::Array<int> dbc_tdof_list;
 
   // Diagonal policy for constrained true dofs.
   Operator::DiagonalPolicy diag_policy;
@@ -174,7 +177,10 @@ public:
 
   // Get the essential boundary condition true dofs associated with the operator. May be
   // nullptr.
-  const mfem::Array<int> *GetEssentialTrueDofs() const { return dbc_tdof_list; }
+  const mfem::Array<int> *GetEssentialTrueDofs() const
+  {
+    return dbc_tdof_list.Size() ? &dbc_tdof_list : nullptr;
+  }
 
   void AssembleDiagonal(ComplexVector &diag) const override;
 

--- a/palace/linalg/strumpack.cpp
+++ b/palace/linalg/strumpack.cpp
@@ -127,12 +127,7 @@ void StrumpackSolverBase<StrumpackSolverType>::SetOperator(const Operator &op)
               "StrumpackSolver requires a square HypreParMatrix operator!");
   auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hA);
   hypre_CSRMatrix *csr = hypre_MergeDiagAndOffd(parcsr);
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
-  if (hypre_GetActualMemLocation(hypre_CSRMatrixMemoryLocation(csr)) != hypre_MEMORY_HOST)
-  {
-    hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
-  }
-#endif
+  hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
 
   // Create the STRUMPACKRowLocMatrix by taking the internal data from a hypre_CSRMatrix.
   HYPRE_BigInt glob_n = hypre_ParCSRMatrixGlobalNumRows(parcsr);

--- a/palace/linalg/superlu.cpp
+++ b/palace/linalg/superlu.cpp
@@ -95,12 +95,7 @@ void SuperLUSolver::SetOperator(const Operator &op)
               "SuperLUSolver requires a square HypreParMatrix operator!");
   auto *parcsr = (hypre_ParCSRMatrix *)const_cast<mfem::HypreParMatrix &>(*hA);
   hypre_CSRMatrix *csr = hypre_MergeDiagAndOffd(parcsr);
-#if defined(HYPRE_USING_CUDA) || defined(HYPRE_USING_HIP) || defined(HYPRE_USING_SYCL)
-  if (hypre_GetActualMemLocation(hypre_CSRMatrixMemoryLocation(csr)) != hypre_MEMORY_HOST)
-  {
-    hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
-  }
-#endif
+  hypre_CSRMatrixMigrate(csr, HYPRE_MEMORY_HOST);
 
   // Create the SuperLURowLocMatrix by taking the internal data from a hypre_CSRMatrix.
   HYPRE_BigInt glob_n = hypre_ParCSRMatrixGlobalNumRows(parcsr);

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -76,7 +76,7 @@ void ComplexVector::Set(const std::complex<double> *py, int n, bool on_dev)
     y.UseDevice(true);
     {
       auto *Y = y.HostWrite();
-      PalacePragmaOmp(parallel for)
+      PalacePragmaOmp(parallel for schedule(static))
       for (int i = 0; i < n; i++)
       {
         Y[2 * i] = py[i].real();
@@ -119,7 +119,7 @@ void ComplexVector::Get(std::complex<double> *py, int n, bool on_dev) const
     // Need copy from device to host (host pointer but using device).
     const auto *XR = Real().HostRead();
     const auto *XI = Imag().HostRead();
-    PalacePragmaOmp(parallel for)
+    PalacePragmaOmp(parallel for schedule(static))
     for (int i = 0; i < n; i++)
     {
       py[i].real(XR[i]);

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -12,10 +12,7 @@
 namespace palace
 {
 
-ComplexVector::ComplexVector(int size)
-  : data(2 * size), xr(data, 0, size), xi(data, size, size)
-{
-}
+ComplexVector::ComplexVector(int size) : xr(size), xi(size) {}
 
 ComplexVector::ComplexVector(const ComplexVector &y) : ComplexVector(y.Size())
 {
@@ -44,25 +41,23 @@ ComplexVector::ComplexVector(Vector &y, int offset, int size)
 
 void ComplexVector::UseDevice(bool use_dev)
 {
-  data.UseDevice(use_dev);
   xr.UseDevice(use_dev);
   xi.UseDevice(use_dev);
 }
 
 void ComplexVector::SetSize(int size)
 {
-  data.SetSize(2 * size);
-  xr.MakeRef(data, 0, size);
-  xi.MakeRef(data, size, size);
+  xr.SetSize(size);
+  xi.SetSize(size);
 }
 
 void ComplexVector::MakeRef(Vector &y, int offset, int size)
 {
-  MFEM_ASSERT(y.Size() <= 2 * size,
+  MFEM_ASSERT(y.Size() >= offset + 2 * size,
               "Insufficient storage for ComplexVector alias reference of the given size!");
-  data.MakeRef(y, offset, 2 * size);
-  xr.MakeRef(data, offset, size);
-  xi.MakeRef(data, offset + size, size);
+  y.ReadWrite();  // Ensure memory is allocated on device before aliasing
+  xr.MakeRef(y, offset, size);
+  xi.MakeRef(y, offset + size, size);
 }
 
 void ComplexVector::Set(const ComplexVector &y)

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -609,6 +609,18 @@ std::complex<double> LocalDot(const ComplexVector &x, const ComplexVector &y)
           (&x == &y) ? 0.0 : (LocalDot(x.Imag(), y.Real()) - LocalDot(x.Real(), y.Imag()))};
 }
 
+double LocalSum(const Vector &x)
+{
+  static HypreVectorWrapper X;
+  X.Update(x);
+  return hypre_SeqVectorSumElts(X);
+}
+
+std::complex<double> LocalSum(const ComplexVector &x)
+{
+  return {LocalSum(x.Real()), LocalSum(x.Imag())};
+}
+
 template <>
 void AXPY(double alpha, const Vector &x, Vector &y)
 {

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -170,27 +170,31 @@ void SetRandomReal(MPI_Comm comm, VecType &x, int seed = 0);
 template <typename VecType>
 void SetRandomSign(MPI_Comm comm, VecType &x, int seed = 0);
 
-// Calculate the inner product yᴴ x or yᵀ x.
+// Calculate the local inner product yᴴ x or yᵀ x.
+double LocalDot(const Vector &x, const Vector &y);
+std::complex<double> LocalDot(const ComplexVector &x, const ComplexVector &y);
+
+// Calculate the parallel inner product yᴴ x or yᵀ x.
 template <typename VecType>
 inline auto Dot(MPI_Comm comm, const VecType &x, const VecType &y)
 {
-  auto dot = x * y;
+  auto dot = LocalDot(x, y);
   Mpi::GlobalSum(1, &dot, comm);
   return dot;
 }
 
 // Calculate the vector 2-norm.
 template <typename VecType>
-inline double Norml2(MPI_Comm comm, const VecType &x)
+inline auto Norml2(MPI_Comm comm, const VecType &x)
 {
   return std::sqrt(std::abs(Dot(comm, x, x)));
 }
 
 // Normalize the vector, possibly with respect to an SPD matrix B.
 template <typename VecType>
-inline double Normalize(MPI_Comm comm, VecType &x)
+inline auto Normalize(MPI_Comm comm, VecType &x)
 {
-  double norm = Norml2(comm, x);
+  auto norm = Norml2(comm, x);
   MFEM_ASSERT(norm > 0.0, "Zero vector norm in normalization!");
   x *= 1.0 / norm;
   return norm;

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -22,7 +22,7 @@ using Vector = mfem::Vector;
 class ComplexVector
 {
 private:
-  Vector data, xr, xi;
+  Vector xr, xi;
 
 public:
   // Create a vector with the given size.
@@ -43,10 +43,10 @@ public:
 
   // Flag for runtime execution on the mfem::Device. See the documentation for mfem::Vector.
   void UseDevice(bool use_dev);
-  bool UseDevice() const { return data.UseDevice(); }
+  bool UseDevice() const { return xr.UseDevice(); }
 
   // Return the size of the vector.
-  int Size() const { return data.Size() / 2; }
+  int Size() const { return xr.Size(); }
 
   // Set the size of the vector. See the notes for Vector::SetSize for behavior in the cases
   // where the new size is less than or greater than Size() or Capacity().

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -22,11 +22,11 @@ using Vector = mfem::Vector;
 class ComplexVector
 {
 private:
-  Vector xr_, xi_;
+  Vector data, xr, xi;
 
 public:
   // Create a vector with the given size.
-  ComplexVector(int n = 0);
+  ComplexVector(int size = 0);
 
   // Copy constructor.
   ComplexVector(const ComplexVector &y);
@@ -35,34 +35,38 @@ public:
   ComplexVector(const Vector &yr, const Vector &yi);
 
   // Copy constructor from an array of complex values.
-  ComplexVector(const std::complex<double> *py, int n, bool on_dev);
+  ComplexVector(const std::complex<double> *py, int size, bool on_dev);
+
+  // Create a vector referencing the memory of another vector, at the given base offset and
+  // size.
+  ComplexVector(Vector &y, int offset, int size);
 
   // Flag for runtime execution on the mfem::Device. See the documentation for mfem::Vector.
-  void UseDevice(bool use_dev)
-  {
-    xr_.UseDevice(use_dev);
-    xi_.UseDevice(use_dev);
-  }
-  bool UseDevice() const { return xr_.UseDevice(); }
+  void UseDevice(bool use_dev);
+  bool UseDevice() const { return data.UseDevice(); }
 
   // Return the size of the vector.
-  int Size() const { return xr_.Size(); }
+  int Size() const { return data.Size() / 2; }
 
   // Set the size of the vector. See the notes for Vector::SetSize for behavior in the cases
-  // where n is less than or greater than Size() or Capacity().
-  void SetSize(int n);
+  // where the new size is less than or greater than Size() or Capacity().
+  void SetSize(int size);
+
+  // Set this vector to reference the memory of another vector, at the given base offset and
+  // size.
+  void MakeRef(Vector &y, int offset, int size);
 
   // Get access to the real and imaginary vector parts.
-  const Vector &Real() const { return xr_; }
-  Vector &Real() { return xr_; }
-  const Vector &Imag() const { return xi_; }
-  Vector &Imag() { return xi_; }
+  const Vector &Real() const { return xr; }
+  Vector &Real() { return xr; }
+  const Vector &Imag() const { return xi; }
+  Vector &Imag() { return xi; }
 
   // Set from a ComplexVector, without resizing.
-  ComplexVector &operator=(const ComplexVector &y) { return Set(y); }
-  ComplexVector &Set(const ComplexVector &y)
+  void Set(const ComplexVector &y);
+  ComplexVector &operator=(const ComplexVector &y)
   {
-    Set(y.Real(), y.Imag());
+    Set(y);
     return *this;
   }
 
@@ -70,10 +74,10 @@ public:
   void Set(const Vector &yr, const Vector &yi);
 
   // Set from an array of complex values, without resizing.
-  void Set(const std::complex<double> *py, int n, bool on_dev);
+  void Set(const std::complex<double> *py, int size, bool on_dev);
 
   // Copy the vector into an array of complex values.
-  void Get(std::complex<double> *py, int n, bool on_dev) const;
+  void Get(std::complex<double> *py, int size, bool on_dev) const;
 
   // Set all entries equal to s.
   ComplexVector &operator=(std::complex<double> s);

--- a/palace/main.cpp
+++ b/palace/main.cpp
@@ -15,15 +15,14 @@
 #include "fem/errorindicator.hpp"
 #include "fem/libceed/ceed.hpp"
 #include "fem/mesh.hpp"
+#include "linalg/hypre.hpp"
 #include "linalg/slepc.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
 #include "utils/iodata.hpp"
+#include "utils/omp.hpp"
 #include "utils/timer.hpp"
 
-#if defined(MFEM_USE_OPENMP)
-#include <omp.h>
-#endif
 #if defined(MFEM_USE_STRUMPACK)
 #include <StrumpackConfig.hpp>
 #endif
@@ -62,9 +61,8 @@ static int ConfigureOmp()
   else
   {
     nt = 1;
-    omp_set_num_threads(nt);
   }
-  omp_set_dynamic(0);
+  utils::SetNumThreads(nt);
   return nt;
 #else
   return 0;
@@ -270,7 +268,7 @@ int main(int argc, char *argv[])
 #endif
 
   // Initialize Hypre and, optionally, SLEPc/PETSc.
-  mfem::Hypre::Init();
+  hypre::Initialize();
 #if defined(PALACE_WITH_SLEPC)
   slepc::Initialize(argc, argv, nullptr, nullptr);
   if (PETSC_COMM_WORLD != world_comm)

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -207,8 +207,10 @@ void CurlCurlOperator::GetExcitationVector(int idx, Vector &RHS)
   mfem::LinearForm rhs(&GetNDSpace().Get());
   rhs.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fb));
   rhs.UseFastAssembly(false);
+  rhs.UseDevice(false);
   rhs.Assemble();
-  GetNDSpace().Get().GetProlongationMatrix()->AddMultTranspose(rhs, RHS, -1.0);
+  rhs.UseDevice(true);
+  GetNDSpace().GetProlongationMatrix()->AddMultTranspose(rhs, RHS, -1.0);
   linalg::SetSubVector(RHS, dbc_tdof_lists.back(), 0.0);
 }
 

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -8,6 +8,7 @@
 #include "fem/integrator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/multigrid.hpp"
+#include "linalg/hypre.hpp"
 #include "linalg/rap.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
@@ -168,9 +169,9 @@ std::unique_ptr<Operator> CurlCurlOperator::GetStiffnessMatrix()
     {
       Mpi::Print(" Level {:d} (p = {:d}): {:d} unknowns", l,
                  nd_fespace_l.GetMaxElementOrder(), nd_fespace_l.GlobalTrueVSize());
-      if (const auto *k_spm = dynamic_cast<const mfem::SparseMatrix *>(k_vec[l].get()))
+      if (const auto *k_spm = dynamic_cast<const hypre::HypreCSRMatrix *>(k_vec[l].get()))
       {
-        HYPRE_BigInt nnz = k_spm->NumNonZeroElems();
+        HYPRE_BigInt nnz = k_spm->NNZ();
         Mpi::GlobalSum(1, &nnz, nd_fespace_l.GetComm());
         Mpi::Print(", {:d} NNZ\n", nnz);
       }

--- a/palace/models/domainpostoperator.cpp
+++ b/palace/models/domainpostoperator.cpp
@@ -80,9 +80,9 @@ DomainPostOperator::GetElectricFieldEnergy(const mfem::ParComplexGridFunction &E
   if (M_ND)
   {
     M_ND->Mult(E.real(), D);
-    double res = mfem::InnerProduct(E.real(), D);
+    double res = linalg::LocalDot(E.real(), D);
     M_ND->Mult(E.imag(), D);
-    res += mfem::InnerProduct(E.imag(), D);
+    res += linalg::LocalDot(E.imag(), D);
     Mpi::GlobalSum(1, &res, E.ParFESpace()->GetComm());
     return 0.5 * res;
   }
@@ -96,7 +96,7 @@ double DomainPostOperator::GetElectricFieldEnergy(const mfem::ParGridFunction &E
   if (M_ND)
   {
     M_ND->Mult(E, D);
-    double res = mfem::InnerProduct(E, D);
+    double res = linalg::LocalDot(E, D);
     Mpi::GlobalSum(1, &res, E.ParFESpace()->GetComm());
     return 0.5 * res;
   }
@@ -111,9 +111,9 @@ DomainPostOperator::GetMagneticFieldEnergy(const mfem::ParComplexGridFunction &B
   if (M_RT)
   {
     M_RT->Mult(B.real(), H);
-    double res = mfem::InnerProduct(B.real(), H);
+    double res = linalg::LocalDot(B.real(), H);
     M_RT->Mult(B.imag(), H);
-    res += mfem::InnerProduct(B.imag(), H);
+    res += linalg::LocalDot(B.imag(), H);
     Mpi::GlobalSum(1, &res, B.ParFESpace()->GetComm());
     return 0.5 * res;
   }
@@ -127,7 +127,7 @@ double DomainPostOperator::GetMagneticFieldEnergy(const mfem::ParGridFunction &B
   if (M_RT)
   {
     M_RT->Mult(B, H);
-    double res = mfem::InnerProduct(B, H);
+    double res = linalg::LocalDot(B, H);
     Mpi::GlobalSum(1, &res, B.ParFESpace()->GetComm());
     return 0.5 * res;
   }
@@ -148,9 +148,9 @@ double DomainPostOperator::GetDomainElectricFieldEnergy(
     return 0.0;
   }
   it->second.first->Mult(E.real(), D);
-  double res = mfem::InnerProduct(E.real(), D);
+  double res = linalg::LocalDot(E.real(), D);
   it->second.first->Mult(E.imag(), D);
-  res += mfem::InnerProduct(E.imag(), D);
+  res += linalg::LocalDot(E.imag(), D);
   Mpi::GlobalSum(1, &res, E.ParFESpace()->GetComm());
   return 0.5 * res;
 }
@@ -167,7 +167,7 @@ DomainPostOperator::GetDomainElectricFieldEnergy(int idx,
     return 0.0;
   }
   it->second.first->Mult(E, D);
-  double res = mfem::InnerProduct(E, D);
+  double res = linalg::LocalDot(E, D);
   Mpi::GlobalSum(1, &res, E.ParFESpace()->GetComm());
   return 0.5 * res;
 }
@@ -184,9 +184,9 @@ double DomainPostOperator::GetDomainMagneticFieldEnergy(
     return 0.0;
   }
   it->second.second->Mult(B.real(), H);
-  double res = mfem::InnerProduct(B.real(), H);
+  double res = linalg::LocalDot(B.real(), H);
   it->second.second->Mult(B.imag(), H);
-  res += mfem::InnerProduct(B.imag(), H);
+  res += linalg::LocalDot(B.imag(), H);
   Mpi::GlobalSum(1, &res, B.ParFESpace()->GetComm());
   return 0.5 * res;
 }
@@ -203,7 +203,7 @@ DomainPostOperator::GetDomainMagneticFieldEnergy(int idx,
     return 0.0;
   }
   it->second.second->Mult(B, H);
-  double res = mfem::InnerProduct(B, H);
+  double res = linalg::LocalDot(B, H);
   Mpi::GlobalSum(1, &res, B.ParFESpace()->GetComm());
   return 0.5 * res;
 }

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -7,6 +7,7 @@
 #include "fem/integrator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/multigrid.hpp"
+#include "linalg/hypre.hpp"
 #include "linalg/rap.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
@@ -187,9 +188,9 @@ std::unique_ptr<Operator> LaplaceOperator::GetStiffnessMatrix()
     {
       Mpi::Print(" Level {:d} (p = {:d}): {:d} unknowns", l,
                  h1_fespace_l.GetMaxElementOrder(), h1_fespace_l.GlobalTrueVSize());
-      if (const auto *k_spm = dynamic_cast<const mfem::SparseMatrix *>(k_vec[l].get()))
+      if (const auto *k_spm = dynamic_cast<const hypre::HypreCSRMatrix *>(k_vec[l].get()))
       {
-        HYPRE_BigInt nnz = k_spm->NumNonZeroElems();
+        HYPRE_BigInt nnz = k_spm->NNZ();
         Mpi::GlobalSum(1, &nnz, h1_fespace_l.GetComm());
         Mpi::Print(", {:d} NNZ\n", nnz);
       }

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -186,7 +186,9 @@ void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespa
     s = std::make_unique<mfem::LinearForm>(&nd_fespace);
     s->AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fb), attr_marker);
     s->UseFastAssembly(false);
+    s->UseDevice(false);
     s->Assemble();
+    s->UseDevice(true);
   }
 
   // The voltage across a port is computed using the electric field solution.
@@ -207,7 +209,9 @@ void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespa
     v = std::make_unique<mfem::LinearForm>(&nd_fespace);
     v->AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fb), attr_marker);
     v->UseFastAssembly(false);
+    v->UseDevice(false);
     v->Assemble();
+    v->UseDevice(true);
   }
 }
 
@@ -242,7 +246,9 @@ double LumpedPortData::GetPower(mfem::ParGridFunction &E, mfem::ParGridFunction 
   mfem::LinearForm p(&nd_fespace);
   p.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fb), attr_marker);
   p.UseFastAssembly(false);
+  p.UseDevice(false);
   p.Assemble();
+  p.UseDevice(true);
   double dot = p * E;
   Mpi::GlobalSum(1, &dot, E.ParFESpace()->GetComm());
   return dot;
@@ -277,8 +283,12 @@ std::complex<double> LumpedPortData::GetPower(mfem::ParComplexGridFunction &E,
   pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbi), attr_marker);
   pr.UseFastAssembly(false);
   pi.UseFastAssembly(false);
+  pr.UseDevice(false);
+  pi.UseDevice(false);
   pr.Assemble();
   pi.Assemble();
+  pr.UseDevice(true);
+  pi.UseDevice(true);
   std::complex<double> dot((pr * E.real()) + (pi * E.imag()),
                            (pr * E.imag()) - (pi * E.real()));
   Mpi::GlobalSum(1, &dot, E.ParFESpace()->GetComm());

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -9,6 +9,7 @@
 #include "fem/integrator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/multigrid.hpp"
+#include "linalg/hypre.hpp"
 #include "linalg/rap.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
@@ -769,14 +770,14 @@ std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(double a0, doub
       {
         Mpi::Print(" Level {:d}{} (p = {:d}): {:d} unknowns", l, aux ? " (auxiliary)" : "",
                    fespace_l.GetMaxElementOrder(), fespace_l.GlobalTrueVSize());
-        const auto *b_spm = dynamic_cast<const mfem::SparseMatrix *>(br_l.get());
+        const auto *b_spm = dynamic_cast<const hypre::HypreCSRMatrix *>(br_l.get());
         if (!b_spm)
         {
-          b_spm = dynamic_cast<const mfem::SparseMatrix *>(bi_l.get());
+          b_spm = dynamic_cast<const hypre::HypreCSRMatrix *>(bi_l.get());
         }
         if (b_spm)
         {
-          HYPRE_BigInt nnz = b_spm->NumNonZeroElems();
+          HYPRE_BigInt nnz = b_spm->NNZ();
           Mpi::GlobalSum(1, &nnz, fespace_l.GetComm());
           Mpi::Print(", {:d} NNZ\n", nnz);
         }

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -947,8 +947,10 @@ bool SpaceOperator::AddExcitationVector1Internal(Vector &RHS1)
   mfem::LinearForm rhs1(&GetNDSpace().Get());
   rhs1.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fb));
   rhs1.UseFastAssembly(false);
+  rhs1.UseDevice(false);
   rhs1.Assemble();
-  GetNDSpace().Get().GetProlongationMatrix()->AddMultTranspose(rhs1, RHS1);
+  rhs1.UseDevice(true);
+  GetNDSpace().GetProlongationMatrix()->AddMultTranspose(rhs1, RHS1);
   return true;
 }
 
@@ -966,15 +968,24 @@ bool SpaceOperator::AddExcitationVector2Internal(double omega, ComplexVector &RH
   {
     return false;
   }
-  mfem::LinearForm rhs2r(&GetNDSpace().Get()), rhs2i(&GetNDSpace().Get());
-  rhs2r.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbr));
-  rhs2i.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbi));
-  rhs2r.UseFastAssembly(false);
-  rhs2i.UseFastAssembly(false);
-  rhs2r.Assemble();
-  rhs2i.Assemble();
-  GetNDSpace().Get().GetProlongationMatrix()->AddMultTranspose(rhs2r, RHS2.Real());
-  GetNDSpace().Get().GetProlongationMatrix()->AddMultTranspose(rhs2i, RHS2.Imag());
+  {
+    mfem::LinearForm rhs2(&GetNDSpace().Get());
+    rhs2.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbr));
+    rhs2.UseFastAssembly(false);
+    rhs2.UseDevice(false);
+    rhs2.Assemble();
+    rhs2.UseDevice(true);
+    GetNDSpace().GetProlongationMatrix()->AddMultTranspose(rhs2, RHS2.Real());
+  }
+  {
+    mfem::LinearForm rhs2(&GetNDSpace().Get());
+    rhs2.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbi));
+    rhs2.UseFastAssembly(false);
+    rhs2.UseDevice(false);
+    rhs2.Assemble();
+    rhs2.UseDevice(true);
+    GetNDSpace().GetProlongationMatrix()->AddMultTranspose(rhs2, RHS2.Imag());
+  }
   return true;
 }
 

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -5,6 +5,7 @@
 
 #include <complex>
 #include "fem/integrator.hpp"
+#include "linalg/vector.hpp"
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
@@ -263,8 +264,10 @@ double SurfacePostOperator::GetLocalSurfaceIntegral(const SurfaceData &data,
   mfem::LinearForm s(ones.FESpace());
   s.AddBoundaryIntegrator(new BoundaryLFIntegrator(fb), attr_marker);
   s.UseFastAssembly(false);
+  s.UseDevice(false);
   s.Assemble();
-  return s * ones;
+  s.UseDevice(true);
+  return linalg::LocalDot(s, ones);
 }
 
 }  // namespace palace

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -142,12 +142,8 @@ std::unique_ptr<mfem::Coefficient> SurfacePostOperator::SurfaceFluxData::GetCoef
 SurfacePostOperator::SurfacePostOperator(const IoData &iodata,
                                          const MaterialOperator &mat_op,
                                          mfem::ParFiniteElementSpace &h1_fespace)
-  : mat_op(mat_op), ones(&h1_fespace)
+  : mat_op(mat_op), h1_fespace(h1_fespace)
 {
-  // Define a constant 1 function on the scalar finite element space for computing surface
-  // integrals.
-  ones = 1.0;
-
   // Surface dielectric loss postprocessing.
   for (const auto &[idx, data] : iodata.boundaries.postpro.dielectric)
   {
@@ -261,13 +257,13 @@ double SurfacePostOperator::GetLocalSurfaceIntegral(const SurfaceData &data,
   }
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
-  mfem::LinearForm s(ones.FESpace());
+  mfem::LinearForm s(&h1_fespace);
   s.AddBoundaryIntegrator(new BoundaryLFIntegrator(fb), attr_marker);
   s.UseFastAssembly(false);
   s.UseDevice(false);
   s.Assemble();
   s.UseDevice(true);
-  return linalg::LocalDot(s, ones);
+  return linalg::LocalSum(s);
 }
 
 }  // namespace palace

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -81,8 +81,9 @@ private:
   // Reference to material property operator (not owned).
   const MaterialOperator &mat_op;
 
-  // Unit function used for computing surface integrals.
-  mutable mfem::GridFunction ones;
+  // Reference to scalar finite element space used for computing surface integrals (not
+  // owned).
+  mfem::ParFiniteElementSpace &h1_fespace;
 
   double GetLocalSurfaceIntegral(const SurfaceData &data,
                                  const mfem::ParGridFunction &U) const;

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -929,8 +929,12 @@ void WavePortData::Initialize(double omega)
     port_si->AddDomainIntegrator(new VectorFEDomainLFIntegrator(port_nxH0i_func));
     port_sr->UseFastAssembly(false);
     port_si->UseFastAssembly(false);
+    port_sr->UseDevice(false);
+    port_si->UseDevice(false);
     port_sr->Assemble();
     port_si->Assemble();
+    port_sr->UseDevice(true);
+    port_si->UseDevice(true);
     Normalize(*port_S0t, *port_E0t, *port_E0n, *port_sr, *port_si);
   }
 }
@@ -1009,8 +1013,12 @@ std::complex<double> WavePortData::GetPower(mfem::ParComplexGridFunction &E,
   pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(nxHi_func), attr_marker);
   pr.UseFastAssembly(false);
   pi.UseFastAssembly(false);
+  pr.UseDevice(false);
+  pi.UseDevice(false);
   pr.Assemble();
   pi.Assemble();
+  pr.UseDevice(true);
+  pi.UseDevice(true);
   std::complex<double> dot(-(pr * E.real()) - (pi * E.imag()),
                            -(pr * E.imag()) + (pi * E.real()));
   Mpi::GlobalSum(1, &dot, nd_fespace.GetComm());

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -64,7 +64,8 @@ private:
   double mu_eps_min;
 
   // Operator storage for repeated boundary mode eigenvalue problem solves.
-  std::unique_ptr<mfem::HypreParMatrix> Atnr, Atni, Antr, Anti, Annr, Anni, Br, Bi;
+  std::unique_ptr<mfem::HypreParMatrix> Atnr, Atni, Antr, Anti, Annr, Anni;
+  std::unique_ptr<ComplexOperator> B;
   ComplexVector v0, e0;
 
   // Eigenvalue solver for boundary modes.

--- a/palace/utils/CMakeLists.txt
+++ b/palace/utils/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/geodata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/iodata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/meshio.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/omp.cpp
 )

--- a/palace/utils/omp.cpp
+++ b/palace/utils/omp.cpp
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "omp.hpp"
+
+#if defined(MFEM_USE_OPENMP)
+#include <omp.h>
+#endif
+
+namespace palace::utils
+{
+
+void SetNumThreads(int nt)
+{
+#if defined(MFEM_USE_OPENMP)
+  omp_set_num_threads(nt);
+#endif
+}
+
+int GetMaxThreads()
+{
+#if defined(MFEM_USE_OPENMP)
+  return omp_get_max_threads();
+#else
+  return 1;
+#endif
+}
+
+int GetNumActiveThreads()
+{
+#if defined(MFEM_USE_OPENMP)
+  return omp_get_num_threads();
+#else
+  return 1;
+#endif
+}
+
+int GetThreadNum()
+{
+#if defined(MFEM_USE_OPENMP)
+  return omp_get_thread_num();
+#else
+  return 0;
+#endif
+}
+
+int InParallel()
+{
+#if defined(MFEM_USE_OPENMP)
+  return omp_in_parallel();
+#else
+  return 0;
+#endif
+}
+
+}  // namespace palace::utils

--- a/palace/utils/omp.hpp
+++ b/palace/utils/omp.hpp
@@ -13,4 +13,24 @@
 #define PalacePragmaOmp(x)
 #endif
 
+namespace palace::utils
+{
+
+// Set the number of OpenMP threads to be used for parallel regions.
+void SetNumThreads(int nt);
+
+// Return maximum number of OpenMP threads.
+int GetMaxThreads();
+
+// Return number of active OpenMP threads.
+int GetNumActiveThreads();
+
+// Return the current thread ID.
+int GetThreadNum();
+
+// Return whether or not the current scope is inside a parallel OpenMP region.
+int InParallel();
+
+}  // namespace palace::utils
+
 #endif  // PALACE_UTILS_OMP_HPP


### PR DESCRIPTION
NOTE: Builds on https://github.com/awslabs/palace/pull/184

- Use HYPRE's inner-product routine (wraps cuBLAS/equivalent) instead of MFEM's custom kernel
- Use HYPRE's sequential `hypre_CSRMatrix` data structure instead of `mfem::SparseMatrix` to speed up CPU-based CSR assembly with OpenMP