### PR TITLE
Use `mfem::Workspace` for temporary `Vector` allocations

### DIFF
--- a/cmake/ExternalHYPRE.cmake
+++ b/cmake/ExternalHYPRE.cmake
@@ -141,7 +141,7 @@ if(PALACE_WITH_CUDA)
     "--with-cuda-home=${CUDA_DIR}"
     "--enable-curand"
     "--enable-cusparse"
-    "--enable-device-memory-pool"
+    # "--enable-device-memory-pool"
   )
   if(NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
     list(GET CMAKE_CUDA_ARCHITECTURES 0 HYPRE_CUDA_ARCH)

--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -364,6 +364,7 @@ set(MFEM_PATCH_FILES
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_par_tet_mesh_fix.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_mesh_prism_vtu_fix.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_workspace_vectors.diff"
+  "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_workspace_vectors_2.diff"
   "${CMAKE_SOURCE_DIR}/extern/patch/mfem/patch_hypre_runtime_compute_policy.diff"
 )
 

--- a/extern/patch/mfem/patch_workspace_vectors.diff
+++ b/extern/patch/mfem/patch_workspace_vectors.diff
@@ -1068,10 +1068,10 @@ index 000000000..b5c0ebae8
 +   WorkspaceVector(WorkspaceVector &&other);
 +
 +   /// No copy constructor.
-+   WorkspaceVector(WorkspaceVector &other) = delete;
++   WorkspaceVector(const WorkspaceVector &other) = delete;
 +
 +   /// Copy assignment: copy contents of vector, not metadata.
-+   WorkspaceVector& operator=(WorkspaceVector &other)
++   WorkspaceVector& operator=(const WorkspaceVector &other)
 +   {
 +      Vector::operator=(other);
 +      return *this;

--- a/extern/patch/mfem/patch_workspace_vectors_2.diff
+++ b/extern/patch/mfem/patch_workspace_vectors_2.diff
@@ -1,0 +1,74 @@
+diff --git a/general/workspace.cpp b/general/workspace.cpp
+index ad8210a61..3ec077dfa 100644
+--- a/general/workspace.cpp
++++ b/general/workspace.cpp
+@@ -15,11 +15,11 @@ namespace mfem
+ {
+ 
+ WorkspaceVector::WorkspaceVector(
+-   internal::WorkspaceChunk &chunk_, int offset_, int n)
++   internal::WorkspaceChunk &chunk_, int offset_, int n, int padding)
+    : Vector(chunk_.GetData(), chunk_.GetOffset(), n),
+      chunk(chunk_),
+      offset(offset_),
+-     original_size(n)
++     original_size(n + padding)
+ {
+    UseDevice(true);
+ }
+@@ -48,8 +48,11 @@ WorkspaceChunk::WorkspaceChunk(int capacity)
+ WorkspaceVector WorkspaceChunk::NewVector(int n)
+ {
+    MFEM_ASSERT(HasCapacityFor(n), "Requested vector is too large.");
+-   WorkspaceVector vector(*this, offset, n);
+-   offset += n;
++   constexpr int alignment = 16;
++   const int s = (n * sizeof(double)) % alignment;
++   const int padding = (s > 0) ? (alignment - s) / sizeof(double) : 0;
++   WorkspaceVector vector(*this, offset, n, padding);
++   offset += n + padding;
+    vector_count += 1;
+    return vector;
+ }
+diff --git a/general/workspace.hpp b/general/workspace.hpp
+index b5c0ebae8..e41e71b11 100644
+--- a/general/workspace.hpp
++++ b/general/workspace.hpp
+@@ -50,7 +50,8 @@ class WorkspaceVector : public Vector
+    bool moved_from = false;
+ 
+    /// Private constructor, create with Workspace::NewVector() instead.
+-   WorkspaceVector(internal::WorkspaceChunk &chunk_, int offset_, int n);
++   WorkspaceVector(internal::WorkspaceChunk &chunk_, int offset_, int n,
++                   int padding = 0);
+ 
+ public:
+    /// @brief Move constructor. The moved-from WorkspaceVector has @a
+@@ -104,6 +105,9 @@ public:
+    /// Create a WorkspaceChunk with the given @a capacity.
+    WorkspaceChunk(int capacity);
+ 
++   /// Return the data offset.
++   int GetOffset() const { return offset; }
++
+    /// @brief Return the available capacity (i.e. the largest vector that will
+    /// fit in this chunk).
+    int GetAvailableCapacity() const { return data.Size() - offset; }
+@@ -115,15 +119,12 @@ public:
+    /// "original capacity" remains unchained.
+    int GetOriginalCapacity() const { return original_capacity; }
+ 
+-   /// Return the data offset.
+-   int GetOffset() const { return offset; }
++   /// Returns true if this chunk can fit a new vector of size @a n.
++   bool HasCapacityFor(int n) const { return n <= GetAvailableCapacity(); }
+ 
+    /// Sets whether the chunk is in the front of the list
+    void SetFront(bool front_) { front = front_; }
+ 
+-   /// Returns true if this chunk can fit a new vector of size @a n.
+-   bool HasCapacityFor(int n) const { return n <= GetAvailableCapacity(); }
+-
+    /// Returns true if this chunk is empty.
+    bool IsEmpty() const { return vector_count == 0; }
+ 

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -19,6 +19,7 @@
 #include "utils/communication.hpp"
 #include "utils/iodata.hpp"
 #include "utils/timer.hpp"
+#include "utils/workspace.hpp"
 
 namespace palace
 {
@@ -177,7 +178,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // projected appropriately.
   if (iodata.solver.eigenmode.init_v0)
   {
-    ComplexVector v0;
+    auto v0 = workspace::NewVector<ComplexVector>(E.Size());
     if (iodata.solver.eigenmode.init_v0_const)
     {
       Mpi::Print(" Using constant starting vector\n");
@@ -196,8 +197,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
     // Debug
     // const auto &Grad = spaceop.GetGradMatrix();
-    // ComplexVector r0(Grad->Width());
-    // r0.UseDevice(true);
+    // auto r0 = workspace::NewVector<ComplexVector>(Grad.Width());
     // Grad.MultTranspose(v0.Real(), r0.Real());
     // Grad.MultTranspose(v0.Imag(), r0.Imag());
     // r0.Print();

--- a/palace/fem/fespace.hpp
+++ b/palace/fem/fespace.hpp
@@ -31,9 +31,6 @@ private:
   mutable ceed::CeedObjectMap<CeedBasis> basis;
   mutable ceed::CeedObjectMap<CeedElemRestriction> restr, interp_restr, interp_range_restr;
 
-  // Temporary storage for operator applications.
-  mutable ComplexVector tx, lx, ly;
-
   bool HasUniqueInterpRestriction(const mfem::FiniteElement &fe) const
   {
     // For interpolation operators and tensor-product elements, we need native (not
@@ -63,9 +60,6 @@ public:
     : fespace(&mesh.Get(), std::forward<T>(args)...), mesh(mesh)
   {
     ResetCeedObjects();
-    tx.UseDevice(true);
-    lx.UseDevice(true);
-    ly.UseDevice(true);
   }
   virtual ~FiniteElementSpace() { ResetCeedObjects(); }
 
@@ -128,48 +122,6 @@ public:
   BuildCeedElemRestriction(const mfem::FiniteElementSpace &fespace, Ceed ceed,
                            mfem::Geometry::Type geom, const std::vector<int> &indices,
                            bool is_interp = false, bool is_interp_range = false);
-
-  template <typename VecType>
-  auto &GetTVector() const
-  {
-    tx.SetSize(GetTrueVSize());
-    if constexpr (std::is_same<VecType, ComplexVector>::value)
-    {
-      return tx;
-    }
-    else
-    {
-      return tx.Real();
-    }
-  }
-
-  template <typename VecType>
-  auto &GetLVector() const
-  {
-    lx.SetSize(GetVSize());
-    if constexpr (std::is_same<VecType, ComplexVector>::value)
-    {
-      return lx;
-    }
-    else
-    {
-      return lx.Real();
-    }
-  }
-
-  template <typename VecType>
-  auto &GetLVector2() const
-  {
-    ly.SetSize(GetVSize());
-    if constexpr (std::is_same<VecType, ComplexVector>::value)
-    {
-      return ly;
-    }
-    else
-    {
-      return ly.Real();
-    }
-  }
 
   // Get the associated MPI communicator.
   MPI_Comm GetComm() const { return fespace.GetComm(); }

--- a/palace/fem/libceed/operator.hpp
+++ b/palace/fem/libceed/operator.hpp
@@ -35,7 +35,6 @@ protected:
   std::vector<CeedOperator> op, op_t;
   std::vector<CeedVector> u, v;
   Vector dof_multiplicity;
-  mutable Vector temp;
 
 public:
   Operator(int h, int w);

--- a/palace/linalg/arpack.cpp
+++ b/palace/linalg/arpack.cpp
@@ -675,7 +675,7 @@ void ArpackPEPSolver::SetOperators(const ComplexOperator &K, const ComplexOperat
 int ArpackPEPSolver::Solve()
 {
   // Set some defaults (from SLEPc ARPACK interface). The problem size is the size of the
-  // 2$ block linearized problem.
+  // 2x2 block linearized problem.
   CheckParameters();
   HYPRE_BigInt N = n;
   Mpi::GlobalSum(1, &N, comm);

--- a/palace/linalg/arpack.hpp
+++ b/palace/linalg/arpack.hpp
@@ -84,9 +84,6 @@ protected:
   // which case identity is used.
   const Operator *opB;
 
-  // Workspace vector for operator applications.
-  mutable ComplexVector x1, y1, z1;
-
   // Perform the ARPACK RCI loop.
   int SolveInternal(int n, std::complex<double> *r, std::complex<double> *V,
                     std::complex<double> *eig, int *perm);
@@ -217,9 +214,6 @@ private:
 
   // Operator norms for scaling.
   mutable double normK, normC, normM;
-
-  // Workspace vectors for operator applications.
-  mutable ComplexVector x2, y2;
 
 protected:
   void ApplyOp(const std::complex<double> *px, std::complex<double> *py) const override;

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -221,7 +221,7 @@ void ChebyshevSmoother<OperType>::Mult(const VecType &x, VecType &y) const
     }
     else
     {
-      r.VecType::operator=(x);
+      r = x;
       y = 0.0;
     }
 
@@ -289,7 +289,7 @@ void ChebyshevSmoother1stKind<OperType>::Mult(const VecType &x, VecType &y) cons
     }
     else
     {
-      r.VecType::operator=(x);
+      r = x;
       y = 0.0;
     }
 

--- a/palace/linalg/chebyshev.hpp
+++ b/palace/linalg/chebyshev.hpp
@@ -40,31 +40,16 @@ private:
   // Maximum operator eigenvalue for Chebyshev polynomial smoothing.
   double lambda_max, sf_max;
 
-  // Temporary vector for smoother application.
-  mutable VecType d;
-
 public:
   ChebyshevSmoother(MPI_Comm comm, int smooth_it, int poly_order, double sf_max);
 
   void SetOperator(const OperType &op) override;
 
-  void Mult(const VecType &x, VecType &y) const override
-  {
-    MFEM_ABORT("ChebyshevSmoother implements Mult2 using an additional preallocated "
-               "temporary vector!");
-  }
+  void Mult(const VecType &x, VecType &y) const override;
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
-  }
-
-  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
-
-  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override
-  {
-    Mult2(x, y, r);  // Assumes operator symmetry
+    Mult(x, y);  // Assumes operator symmetry
   }
 };
 
@@ -96,32 +81,17 @@ private:
   // polynomial smoothing.
   double theta, delta, sf_max, sf_min;
 
-  // Temporary vector for smoother application.
-  mutable VecType d;
-
 public:
   ChebyshevSmoother1stKind(MPI_Comm comm, int smooth_it, int poly_order, double sf_max,
                            double sf_min);
 
   void SetOperator(const OperType &op) override;
 
-  void Mult(const VecType &x, VecType &y) const override
-  {
-    MFEM_ABORT("ChebyshevSmoother1stKind implements Mult2 using an additional preallocated "
-               "temporary vector!");
-  }
+  void Mult(const VecType &x, VecType &y) const override;
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother1stKind implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
-  }
-
-  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
-
-  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override
-  {
-    Mult2(x, y, r);  // Assumes operator symmetry
+    Mult(x, y);  // Assumes operator symmetry
   }
 };
 

--- a/palace/linalg/distrelaxation.hpp
+++ b/palace/linalg/distrelaxation.hpp
@@ -46,9 +46,6 @@ private:
   mutable std::unique_ptr<Solver<OperType>> B;
   std::unique_ptr<Solver<OperType>> B_G;
 
-  // Temporary vectors for smoother application.
-  mutable VecType x_G, y_G, r_G;
-
 public:
   DistRelaxationSmoother(MPI_Comm comm, const Operator &G, int smooth_it,
                          int cheby_smooth_it, int cheby_order, double cheby_sf_max,
@@ -62,21 +59,9 @@ public:
 
   void SetOperators(const OperType &op, const OperType &op_G);
 
-  void Mult(const VecType &x, VecType &y) const override
-  {
-    MFEM_ABORT("DistRelaxationSmoother implements Mult2 using an additional preallocated "
-               "temporary vector!");
-  }
+  void Mult(const VecType &x, VecType &y) const override;
 
-  void MultTranspose(const VecType &x, VecType &y) const override
-  {
-    MFEM_ABORT("DistRelaxationSmoother implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
-  }
-
-  void Mult2(const VecType &x, VecType &y, VecType &r) const override;
-
-  void MultTranspose2(const VecType &x, VecType &y, VecType &r) const override;
+  void MultTranspose(const VecType &x, VecType &y) const override;
 };
 
 }  // namespace palace

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -91,10 +91,9 @@ DivFreeSolver<VecType>::DivFreeSolver(
     const int mg_smooth_order =
         std::max(h1_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<OperType>>(
-        h1_fespaces.GetFinestFESpace().GetComm(),
-
-        std::move(amg), h1_fespaces.GetProlongationOperators(), nullptr, 1, 1,
-        mg_smooth_order, 1.0, 0.0, true);
+        h1_fespaces.GetFinestFESpace().GetComm(), std::move(amg),
+        h1_fespaces.GetProlongationOperators(), nullptr, 1, 1, mg_smooth_order, 1.0, 0.0,
+        true);
   }
   else
   {

--- a/palace/linalg/divfree.hpp
+++ b/palace/linalg/divfree.hpp
@@ -46,9 +46,6 @@ private:
   // Linear solver for the projected linear system (Gᵀ M G) y = x.
   std::unique_ptr<BaseKspSolver<OperType>> ksp;
 
-  // Workspace objects for solver application.
-  mutable VecType psi, rhs;
-
 public:
   DivFreeSolver(const MaterialOperator &mat_op, FiniteElementSpace &nd_fespace,
                 AuxiliaryFiniteElementSpaceHierarchy &h1_fespaces,

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -38,9 +38,6 @@ private:
   // Linear solver and preconditioner for the projected linear system.
   std::unique_ptr<BaseKspSolver<OperType>> ksp;
 
-  // Workspace object for solver application.
-  mutable VecType rhs;
-
 public:
   FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &nd_fespace,
                 double tol, int max_it, int print);
@@ -63,9 +60,6 @@ class CurlFluxErrorEstimator
 
   // Global L2 projection solver.
   FluxProjector<VecType> projector;
-
-  // Temporary vectors for error estimation.
-  mutable VecType F, F_gf, U_gf;
 
 public:
   CurlFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &nd_fespace,
@@ -92,9 +86,6 @@ class GradFluxErrorEstimator
 
   // Global L2 projection solver.
   FluxProjector<Vector> projector;
-
-  // Temporary vectors for error estimation.
-  mutable Vector F, F_gf, U_gf;
 
 public:
   GradFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &rt_fespace,

--- a/palace/linalg/gmg.hpp
+++ b/palace/linalg/gmg.hpp
@@ -46,15 +46,11 @@ private:
   // Smoothers for each level. Coarse-level solver is B[0].
   mutable std::vector<std::unique_ptr<Solver<OperType>>> B;
 
-  // Temporary vectors for preconditioner application. The type of these is dictated by the
-  // MFEM Operator interface for multiple RHS.
-  mutable std::vector<VecType> X, Y, R;
-
   // Enable timer contribution for Timer::KSP_COARSE_SOLVE.
   bool use_timer;
 
   // Internal function to perform a single V-cycle iteration.
-  void VCycle(int l, bool initial_guess) const;
+  void VCycle(const VecType &x, VecType &y, int l, bool initial_guess) const;
 
 public:
   GeometricMultigridSolver(MPI_Comm comm, std::unique_ptr<Solver<OperType>> &&coarse_solver,

--- a/palace/linalg/iterative.cpp
+++ b/palace/linalg/iterative.cpp
@@ -380,7 +380,7 @@ void CgSolver<OperType>::Mult(const VecType &b, VecType &x) const
   }
   else
   {
-    r.VecType::operator=(b);
+    r = b;
     x = 0.0;
   }
   if (B)
@@ -389,7 +389,7 @@ void CgSolver<OperType>::Mult(const VecType &b, VecType &x) const
   }
   else
   {
-    z.VecType::operator=(r);
+    z = r;
   }
   beta = linalg::Dot(comm, z, r);
   CheckDot(beta, "PCG preconditioner is not positive definite: (Br, r) = ");
@@ -424,7 +424,7 @@ void CgSolver<OperType>::Mult(const VecType &b, VecType &x) const
     }
     if (!it)
     {
-      p.VecType::operator=(z);
+      p = z;
     }
     else
     {
@@ -446,7 +446,7 @@ void CgSolver<OperType>::Mult(const VecType &b, VecType &x) const
     }
     else
     {
-      z.VecType::operator=(r);
+      z = r;
     }
     beta = linalg::Dot(comm, z, r);
     CheckDot(beta, "PCG preconditioner is not positive definite: (Br, r) = ");
@@ -644,7 +644,7 @@ void GmresSolver<OperType>::Mult(const VecType &b, VecType &x) const
     }
     else  // B && pc_side == PrecSide::RIGHT
     {
-      r.VecType::operator=(0.0);
+      r = 0.0;
       for (int k = 0; k <= j; k++)
       {
         r.Add(s[k], V[k]);

--- a/palace/linalg/iterative.hpp
+++ b/palace/linalg/iterative.hpp
@@ -133,9 +133,6 @@ protected:
   using IterativeSolver<OperType>::final_res;
   using IterativeSolver<OperType>::final_it;
 
-  // Temporary workspace for solve.
-  mutable VecType r, z, p;
-
 public:
   CgSolver(MPI_Comm comm, int print) : IterativeSolver<OperType>(comm, print) {}
 
@@ -183,9 +180,6 @@ protected:
   using IterativeSolver<OperType>::final_res;
   using IterativeSolver<OperType>::final_it;
 
-  // Maximum subspace dimension for restarted GMRES.
-  mutable int max_dim;
-
   // Orthogonalization method for orthonormalizing a newly computed vector against a basis
   // at each iteration.
   OrthogType orthog_type;
@@ -193,12 +187,11 @@ protected:
   // Use left or right preconditioning.
   PrecSide pc_side;
 
+  // Maximum subspace dimension for restarted GMRES.
+  mutable int max_dim;
+
   // Temporary workspace for solve.
   mutable std::vector<VecType> V;
-  mutable VecType r;
-  mutable std::vector<ScalarType> H;
-  mutable std::vector<ScalarType> s, sn;
-  mutable std::vector<RealType> cs;
 
   // Allocate storage for solve.
   virtual void Initialize() const;
@@ -206,19 +199,19 @@ protected:
 
 public:
   GmresSolver(MPI_Comm comm, int print)
-    : IterativeSolver<OperType>(comm, print), max_dim(-1), orthog_type(OrthogType::MGS),
-      pc_side(PrecSide::LEFT)
+    : IterativeSolver<OperType>(comm, print), orthog_type(OrthogType::MGS),
+      pc_side(PrecSide::LEFT), max_dim(-1)
   {
   }
-
-  // Set the dimension for restart.
-  void SetRestartDim(int dim) { max_dim = dim; }
 
   // Set the orthogonalization method.
   void SetOrthogonalization(OrthogType type) { orthog_type = type; }
 
   // Set the side for preconditioning.
   virtual void SetPrecSide(PrecSide side) { pc_side = side; }
+
+  // Set the dimension for restart.
+  void SetRestartDim(int dim) { max_dim = dim; }
 
   void Mult(const VecType &b, VecType &x) const override;
 };
@@ -254,14 +247,10 @@ protected:
   using GmresSolver<OperType>::final_res;
   using GmresSolver<OperType>::final_it;
 
-  using GmresSolver<OperType>::max_dim;
   using GmresSolver<OperType>::orthog_type;
   using GmresSolver<OperType>::pc_side;
+  using GmresSolver<OperType>::max_dim;
   using GmresSolver<OperType>::V;
-  using GmresSolver<OperType>::H;
-  using GmresSolver<OperType>::s;
-  using GmresSolver<OperType>::sn;
-  using GmresSolver<OperType>::cs;
 
   // Temporary workspace for solve.
   mutable std::vector<VecType> Z;

--- a/palace/linalg/operator.cpp
+++ b/palace/linalg/operator.cpp
@@ -636,10 +636,9 @@ double SpectralNorm(MPI_Comm comm, const ComplexOperator &A, bool herm, double t
   int it = 0;
   double res = 0.0;
   double l = 0.0, l0 = 0.0;
-  ComplexVector u(A.Height()), v(A.Height());
-  u.UseDevice(true);
-  v.UseDevice(true);
-  SetRandom(comm, u);
+  auto u = workspace::NewVector<ComplexVector>(A.Height());
+  auto v = workspace::NewVector<ComplexVector>(A.Height());
+  SetRandom<ComplexVector>(comm, u);
   Normalize(comm, u);
   while (it < max_it)
   {

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -62,11 +62,9 @@ void ParOperator::EliminateRHS(const Vector &x, Vector &b) const
   auto ly = workspace::NewVector<Vector>(test_fespace.GetVSize());
   A->Mult(lx, ly);
 
-  {
-    auto ty = workspace::NewVector<Vector>(test_fespace.GetTrueVSize());
-    RestrictionMatrixMult(ly, ty);
-    b.Add(-1.0, ty);
-  }
+  auto ty = workspace::NewVector<Vector>(test_fespace.GetTrueVSize());
+  RestrictionMatrixMult(ly, ty);
+  b.Add(-1.0, ty);
   if (diag_policy == DiagonalPolicy::DIAG_ONE)
   {
     linalg::SetSubVector(b, dbc_tdof_list, x);

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -44,7 +44,6 @@ private:
   // Helper methods for operator application.
   void RestrictionMatrixMult(const Vector &ly, Vector &ty) const;
   void RestrictionMatrixMultTranspose(const Vector &ty, Vector &ly) const;
-  Vector &GetTestLVector() const;
 
   ParOperator(std::unique_ptr<Operator> &&dA, const Operator *pA,
               const FiniteElementSpace &trial_fespace,
@@ -133,7 +132,6 @@ private:
   // Helper methods for operator application.
   void RestrictionMatrixMult(const ComplexVector &ly, ComplexVector &ty) const;
   void RestrictionMatrixMultTranspose(const ComplexVector &ty, ComplexVector &ly) const;
-  ComplexVector &GetTestLVector() const;
 
   ComplexParOperator(std::unique_ptr<Operator> &&dAr, std::unique_ptr<Operator> &&dAi,
                      const Operator *pAr, const Operator *pAi,

--- a/palace/linalg/slepc.hpp
+++ b/palace/linalg/slepc.hpp
@@ -74,9 +74,6 @@ public:
     JD
   };
 
-  // Workspace vector for operator applications.
-  mutable ComplexVector x1, y1;
-
 protected:
   // Control print level for debugging.
   int print;
@@ -172,6 +169,9 @@ public:
   // the new matrix, only normalization.
   void RescaleEigenvectors(int num_eig) override;
 
+  // Get the (local) size of the eigenvalue problem.
+  virtual PetscInt Size() const = 0;
+
   // Get the basis vectors object.
   virtual BV GetBV() const = 0;
 
@@ -229,6 +229,8 @@ public:
   std::complex<double> GetEigenvalue(int i) const override;
 
   void GetEigenvector(int i, ComplexVector &x) const override;
+
+  PetscInt Size() const override;
 
   BV GetBV() const override;
 
@@ -296,9 +298,6 @@ public:
   // (not owned).
   const ComplexOperator *opK, *opC, *opM;
 
-  // Workspace vectors for operator applications.
-  mutable ComplexVector x2, y2;
-
 private:
   // Operator norms for scaling.
   mutable PetscReal normK, normC, normM;
@@ -321,6 +320,8 @@ public:
   void SetInitialSpace(const ComplexVector &v) override;
 
   void GetEigenvector(int i, ComplexVector &x) const override;
+
+  PetscInt Size() const override;
 };
 
 // Base class for SLEPc's PEP problem type.
@@ -364,6 +365,8 @@ public:
   std::complex<double> GetEigenvalue(int i) const override;
 
   void GetEigenvector(int i, ComplexVector &x) const override;
+
+  PetscInt Size() const override;
 
   BV GetBV() const override;
 

--- a/palace/linalg/solver.hpp
+++ b/palace/linalg/solver.hpp
@@ -47,21 +47,6 @@ public:
   {
     MFEM_ABORT("MultTranspose() is not implemented for base class Solver<OperType>!");
   }
-
-  // Apply the solver with a preallocated temporary storage vector.
-  virtual void Mult2(const VecType &x, VecType &y, VecType &r) const
-  {
-    MFEM_ABORT("Mult2() with temporary storage vector is not implemented for base class "
-               "Solver<OperType>!");
-  }
-
-  // Apply the solver for the transpose problem with a preallocated temporary storage
-  //  vector.
-  virtual void MultTranspose2(const VecType &x, VecType &y, VecType &r) const
-  {
-    MFEM_ABORT("MultTranspose2() with temporary storage vector is not implemented for base "
-               "class Solver<OperType>!");
-  }
 };
 
 // This solver wraps a real-valued mfem::Solver for application to complex-valued problems

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -8,6 +8,7 @@
 #include <mfem/general/forall.hpp>
 #include "linalg/hypre.hpp"
 #include "utils/omp.hpp"
+#include "utils/workspace.hpp"
 
 namespace palace
 {
@@ -101,8 +102,7 @@ void ComplexVector::Set(const std::complex<double> *py, int size, bool on_dev)
   else if (!on_dev)
   {
     // Need copy from host to device (host pointer but using device).
-    Vector y(2 * size);
-    y.UseDevice(true);
+    auto y = workspace::NewVector<Vector>(2 * size);
     {
       auto *Y = y.HostWrite();
       PalacePragmaOmp(parallel for schedule(static))

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -35,11 +35,6 @@ ComplexVector::ComplexVector(const std::complex<double> *py, int size, bool on_d
   Set(py, size, on_dev);
 }
 
-ComplexVector::ComplexVector(Vector &y, int offset, int size)
-{
-  MakeRef(y, offset, size);
-}
-
 void ComplexVector::UseDevice(bool use_dev)
 {
   xr.UseDevice(use_dev);
@@ -48,17 +43,13 @@ void ComplexVector::UseDevice(bool use_dev)
 
 void ComplexVector::SetSize(int size)
 {
-  xr.SetSize(size);
-  xi.SetSize(size);
-}
-
-void ComplexVector::MakeRef(Vector &y, int offset, int size)
-{
-  MFEM_ASSERT(y.Size() >= offset + 2 * size,
-              "Insufficient storage for ComplexVector alias reference of the given size!");
-  y.ReadWrite();  // Ensure memory is allocated on device before aliasing
-  xr.MakeRef(y, offset, size);
-  xi.MakeRef(y, offset + size, size);
+  if (size != Size())
+  {
+    MFEM_VERIFY(Size() == 0 || (xr.OwnsData() && xi.OwnsData()),
+                "Alias vectors should not be resized!");
+    xr.SetSize(size);
+    xi.SetSize(size);
+  }
 }
 
 void ComplexVector::Set(const ComplexVector &y)

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -21,7 +21,7 @@ using Vector = mfem::Vector;
 // A complex-valued vector represented as two real vectors, one for each component.
 class ComplexVector
 {
-private:
+protected:
   Vector xr, xi;
 
 public:
@@ -37,10 +37,6 @@ public:
   // Copy constructor from an array of complex values.
   ComplexVector(const std::complex<double> *py, int size, bool on_dev);
 
-  // Create a vector referencing the memory of another vector, at the given base offset and
-  // size.
-  ComplexVector(Vector &y, int offset, int size);
-
   // Flag for runtime execution on the mfem::Device. See the documentation for mfem::Vector.
   void UseDevice(bool use_dev);
   bool UseDevice() const { return xr.UseDevice(); }
@@ -51,10 +47,6 @@ public:
   // Set the size of the vector. See the notes for Vector::SetSize for behavior in the cases
   // where the new size is less than or greater than Size() or Capacity().
   void SetSize(int size);
-
-  // Set this vector to reference the memory of another vector, at the given base offset and
-  // size.
-  void MakeRef(Vector &y, int offset, int size);
 
   // Get access to the real and imaginary vector parts.
   const Vector &Real() const { return xr; }

--- a/palace/models/domainpostoperator.hpp
+++ b/palace/models/domainpostoperator.hpp
@@ -31,9 +31,6 @@ private:
   std::unique_ptr<Operator> M_elec, M_mag;
   std::map<int, std::pair<std::unique_ptr<Operator>, std::unique_ptr<Operator>>> M_i;
 
-  // Temporary vectors for inner product calculations.
-  mutable Vector D, H;
-
 public:
   DomainPostOperator(const IoData &iodata, const MaterialOperator &mat_op,
                      const FiniteElementSpace &nd_fespace,

--- a/palace/utils/workspace.hpp
+++ b/palace/utils/workspace.hpp
@@ -18,12 +18,14 @@ namespace palace::workspace
 class ComplexWorkspaceVector : public ComplexVector
 {
 private:
-  mfem::WorkspaceVector data;
+  mfem::WorkspaceVector data_xr, data_xi;
 
 public:
-  ComplexWorkspaceVector(int size) : data(mfem::Workspace::NewVector(2 * size))
+  ComplexWorkspaceVector(int size)
+    : data_xr(mfem::Workspace::NewVector(size)), data_xi(mfem::Workspace::NewVector(size))
   {
-    MakeRef(data, 0, size);
+    xr.MakeRef(data_xr, 0, size);
+    xi.MakeRef(data_xi, 0, size);
   }
 
   // No copy constructor.

--- a/palace/utils/workspace.hpp
+++ b/palace/utils/workspace.hpp
@@ -27,10 +27,10 @@ public:
   }
 
   // No copy constructor.
-  ComplexWorkspaceVector(ComplexWorkspaceVector &other) = delete;
+  ComplexWorkspaceVector(const ComplexWorkspaceVector &other) = delete;
 
   // Copy assignment: copy contents of vector, not metadata.
-  ComplexWorkspaceVector &operator=(ComplexWorkspaceVector &other)
+  ComplexWorkspaceVector &operator=(const ComplexWorkspaceVector &other)
   {
     ComplexVector::operator=(other);
     return *this;

--- a/palace/utils/workspace.hpp
+++ b/palace/utils/workspace.hpp
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_UTILS_WORKSPACE_HPP
+#define PALACE_UTILS_WORKSPACE_HPP
+
+#include <mfem/general/workspace.hpp>
+#include "linalg/vector.hpp"
+
+namespace palace::workspace
+{
+
+//
+// Utility class and functions for complex-valued temporary workspace vectors. See
+// mfem::Workspace and mfem::WorkspaceVector.
+//
+
+class ComplexWorkspaceVector : public ComplexVector
+{
+private:
+  mfem::WorkspaceVector data;
+
+public:
+  ComplexWorkspaceVector(int size) : data(mfem::Workspace::NewVector(2 * size))
+  {
+    MakeRef(data, 0, size);
+  }
+
+  // No copy constructor.
+  ComplexWorkspaceVector(ComplexWorkspaceVector &other) = delete;
+
+  // Copy assignment: copy contents of vector, not metadata.
+  ComplexWorkspaceVector &operator=(ComplexWorkspaceVector &other)
+  {
+    ComplexVector::operator=(other);
+    return *this;
+  }
+
+  // Cannot move to an existing ComplexWorkspaceVector.
+  ComplexWorkspaceVector &operator=(ComplexWorkspaceVector &&other) = delete;
+
+  // All other operator=, inherit from ComplexVector.
+  using ComplexVector::operator=;
+};
+
+template <typename T>
+auto NewVector(int size);
+
+template <>
+inline auto NewVector<Vector>(int size)
+{
+  return mfem::Workspace::NewVector(size);
+}
+
+template <>
+inline auto NewVector<ComplexVector>(int size)
+{
+  return ComplexWorkspaceVector(size);
+}
+
+}  // namespace palace::workspace
+
+#endif  // PALACE_UTILS_WORKSPACE_HPP


### PR DESCRIPTION
NOTE: Builds on https://github.com/awslabs/palace/pull/184 (and https://github.com/awslabs/palace/pull/194, and now https://github.com/awslabs/palace/pull/204)

See https://github.com/mfem/mfem/pull/4065

~~TODO: Add patch on MFEM for https://github.com/mfem/mfem/pull/4065 to enable this functionality~~ -> Done as part of https://github.com/awslabs/palace/pull/184