### PR TITLE
Add `"Active"` config file field for lumped and wave ports

### DIFF
--- a/docs/src/config/boundaries.md
+++ b/docs/src/config/boundaries.md
@@ -250,6 +250,7 @@ accounts for nonzero metal thickness.
         "Direction": <string> or [<float array>],
         "CoordinateSystem": <string>,
         "Excitation": <bool>,
+        "Active": <bool>,
         "R": <float>,
         "L": <float>,
         "C": <float>,
@@ -294,6 +295,9 @@ instead.
 
 `"Excitation" [false]` :  Turns on or off port excitation for this lumped port boundary for
 driven or transient simulation types.
+
+`"Active" [true]` :  Turns on or off damping boundary condition for this lumped port
+boundary for driven or transient simulation types.
 
 `"R" [0.0]` :  Circuit resistance used for computing this lumped port boundary's impedance,
 ``\Omega``. This option should only be used along with the corresponding `"L"` and `"C"`
@@ -343,6 +347,7 @@ corresponding coordinate system.
         "Index": <int>,
         "Attributes": [<int array>],
         "Excitation": <bool>,
+        "Active": <bool>,
         "Mode": <int>,
         "Offset": <float>
     },
@@ -359,6 +364,9 @@ boundary.
 
 `"Excitation" [false]` :  Turns on or off port excitation for this wave port boundary for
 driven simulation types.
+
+`"Active" [true]` :  Turns on or off damping boundary condition for this wave port boundary
+for driven simulation types.
 
 `"Mode" [1]` :  Mode index (1-based) for the characteristic port mode of this wave port
 boundary. Ranked in order of decreasing wave number.

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -249,8 +249,11 @@ private:
         E.GetVectorValue(*FET.Elem2, FET.Elem2->GetIntPoint(), V);
         return FET.Elem2->Attribute;
       }
-      E.GetVectorValue(*FET.Elem1, FET.Elem1->GetIntPoint(), V);
-      return FET.Elem1->Attribute;
+      else
+      {
+        E.GetVectorValue(*FET.Elem1, FET.Elem1->GetIntPoint(), V);
+        return FET.Elem1->Attribute;
+      }
     }
     if (C1 * side < 0.0)
     {
@@ -258,9 +261,12 @@ private:
       E.GetVectorValue(*FET.Elem2, FET.Elem2->GetIntPoint(), V);
       return FET.Elem2->Attribute;
     }
-    // Get solution in el1.
-    E.GetVectorValue(*FET.Elem1, FET.Elem1->GetIntPoint(), V);
-    return FET.Elem1->Attribute;
+    else
+    {
+      // Get solution in el1.
+      E.GetVectorValue(*FET.Elem1, FET.Elem1->GetIntPoint(), V);
+      return FET.Elem1->Attribute;
+    }
   }
 
 public:
@@ -373,9 +379,9 @@ public:
       GetBdrElementNeighborTransformations(T, ip);
 
       // For interior faces, compute the value on the side where the speed of light is
-      // smaller (typically should choose the non-vacuum side).
-      if (FET.Elem2 && mat_op.GetLightSpeedMax(FET.Elem2->Attribute) <
-                           mat_op.GetLightSpeedMin(FET.Elem1->Attribute))
+      // larger (typically should choose the non-vacuum side).
+      if (FET.Elem2 && mat_op.GetLightSpeedMin(FET.Elem2->Attribute) >
+                           mat_op.GetLightSpeedMax(FET.Elem1->Attribute))
       {
         return GetLocalEnergyDensity(*FET.Elem2, FET.Elem2->GetIntPoint(),
                                      FET.Elem2->Attribute);
@@ -461,9 +467,9 @@ public:
     GetBdrElementNeighborTransformations(T, ip);
 
     // For interior faces, compute the value on the side where the speed of light is
-    // smaller (typically should choose the non-vacuum side).
-    if (FET.Elem2 && mat_op.GetLightSpeedMax(FET.Elem2->Attribute) <
-                         mat_op.GetLightSpeedMin(FET.Elem1->Attribute))
+    // larger (typically should choose the non-vacuum side).
+    if (FET.Elem2 && mat_op.GetLightSpeedMin(FET.Elem2->Attribute) >
+                         mat_op.GetLightSpeedMax(FET.Elem1->Attribute))
     {
       U.GetVectorValue(*FET.Elem2, FET.Elem2->GetIntPoint(), V);
     }
@@ -493,9 +499,9 @@ public:
     GetBdrElementNeighborTransformations(T, ip);
 
     // For interior faces, compute the value on the side where the speed of light is
-    // smaller (typically should choose the non-vacuum side).
-    if (FET.Elem2 && mat_op.GetLightSpeedMax(FET.Elem2->Attribute) <
-                         mat_op.GetLightSpeedMin(FET.Elem1->Attribute))
+    // larger (typically should choose the non-vacuum side).
+    if (FET.Elem2 && mat_op.GetLightSpeedMin(FET.Elem2->Attribute) >
+                         mat_op.GetLightSpeedMax(FET.Elem1->Attribute))
     {
       return U.GetValue(*FET.Elem2, FET.Elem2->GetIntPoint());
     }

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -41,7 +41,7 @@ public:
 
   // Lumped port properties.
   double R, L, C;
-  bool excitation;
+  bool excitation, active;
 
 private:
   // Linear forms for postprocessing integrated quantities on the port.

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -44,7 +44,7 @@ public:
   // Wave port properties.
   int mode_idx;
   double d_offset;
-  bool excitation;
+  bool excitation, active;
   std::complex<double> kn0;
   double omega0;
   mfem::Vector port_normal;

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -77,6 +77,7 @@ void ParseElementData(json &elem, const std::string &name, bool required,
                       internal::ElementData &data)
 {
   data.attributes = elem.at("Attributes").get<std::vector<int>>();  // Required
+  std::sort(data.attributes.begin(), data.attributes.end());
   auto it = elem.find(name);
   if (it != elem.end() && it->is_array())
   {
@@ -497,6 +498,7 @@ void DomainMaterialData::SetUp(json &domains)
         "Missing \"Attributes\" list for \"Materials\" domain in configuration file!");
     MaterialData &data = vecdata.emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
     ParseSymmetricMatrixData(*it, "Permeability", data.mu_r);
     ParseSymmetricMatrixData(*it, "Permittivity", data.epsilon_r);
     ParseSymmetricMatrixData(*it, "LossTan", data.tandelta);
@@ -545,6 +547,7 @@ void DomainEnergyPostData::SetUp(json &postpro)
                             "in configuration file!");
     DomainEnergyData &data = ret.first->second;
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
 
     // Debug
     // std::cout << "Index: " << ret.first->first << '\n';
@@ -820,7 +823,8 @@ void ConductivityBoundaryData::SetUp(json &boundaries)
         "Missing \"Conductivity\" boundary \"Conductivity\" in configuration file!");
     ConductivityData &data = vecdata.emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
-    data.sigma = it->at("Conductivity");                             // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
+    data.sigma = it->at("Conductivity");  // Required
     data.mu_r = it->value("Permeability", data.mu_r);
     data.h = it->value("Thickness", data.h);
     data.external = it->value("External", data.external);
@@ -860,6 +864,7 @@ void ImpedanceBoundaryData::SetUp(json &boundaries)
         "Missing \"Attributes\" list for \"Impedance\" boundary in configuration file!");
     ImpedanceData &data = vecdata.emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
     data.Rs = it->value("Rs", data.Rs);
     data.Ls = it->value("Ls", data.Ls);
     data.Cs = it->value("Cs", data.Cs);
@@ -920,6 +925,7 @@ void LumpedPortBoundaryData::SetUp(json &boundaries)
     data.Ls = it->value("Ls", data.Ls);
     data.Cs = it->value("Cs", data.Cs);
     data.excitation = it->value("Excitation", data.excitation);
+    data.active = it->value("Active", data.active);
     if (it->find("Attributes") != it->end())
     {
       MFEM_VERIFY(it->find("Elements") == it->end(),
@@ -962,6 +968,7 @@ void LumpedPortBoundaryData::SetUp(json &boundaries)
     // std::cout << "Ls: " << data.Ls << '\n';
     // std::cout << "Cs: " << data.Cs << '\n';
     // std::cout << "Excitation: " << data.excitation << '\n';
+    // std::cout << "Active: " << data.active << '\n';
     // for (const auto &elem : data.elements)
     // {
     //   std::cout << "Attributes: " << elem.attributes << '\n';
@@ -977,6 +984,7 @@ void LumpedPortBoundaryData::SetUp(json &boundaries)
     it->erase("Ls");
     it->erase("Cs");
     it->erase("Excitation");
+    it->erase("Active");
     it->erase("Attributes");
     it->erase("Direction");
     it->erase("CoordinateSystem");
@@ -1008,11 +1016,13 @@ void WavePortBoundaryData::SetUp(json &boundaries)
                             "boundaries in configuration file!");
     WavePortData &data = ret.first->second;
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
     data.mode_idx = it->value("Mode", data.mode_idx);
     MFEM_VERIFY(data.mode_idx > 0,
                 "\"WavePort\" boundary \"Mode\" must be positive (1-based)!");
     data.d_offset = it->value("Offset", data.d_offset);
     data.excitation = it->value("Excitation", data.excitation);
+    data.active = it->value("Active", data.active);
 
     // Debug
     // std::cout << "Index: " << ret.first->first << '\n';
@@ -1020,6 +1030,7 @@ void WavePortBoundaryData::SetUp(json &boundaries)
     // std::cout << "Mode: " << data.mode_idx << '\n';
     // std::cout << "Offset: " << data.d_offset << '\n';
     // std::cout << "Excitation: " << data.excitation << '\n';
+    // std::cout << "Active: " << data.active << '\n';
 
     // Cleanup
     it->erase("Index");
@@ -1027,6 +1038,7 @@ void WavePortBoundaryData::SetUp(json &boundaries)
     it->erase("Mode");
     it->erase("Offset");
     it->erase("Excitation");
+    it->erase("Active");
     MFEM_VERIFY(it->empty(),
                 "Found an unsupported configuration file keyword under \"WavePort\"!\n"
                     << it->dump(2));
@@ -1126,6 +1138,7 @@ void CapacitancePostData::SetUp(json &postpro)
                             "boundaries in configuration file!");
     CapacitanceData &data = ret.first->second;
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
+    std::sort(data.attributes.begin(), data.attributes.end());
 
     // Debug
     // std::cout << "Index: " << ret.first->first << '\n';

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -422,6 +422,9 @@ public:
   // Flag for source term in driven and transient simulations.
   bool excitation = false;
 
+  // Flag for boundary damping term in driven and transient simulations.
+  bool active = true;
+
   // For each lumped port index, each element contains a list of attributes making up a
   // single element of a potentially multielement lumped port.
   std::vector<internal::ElementData> elements = {};
@@ -436,14 +439,17 @@ public:
 struct WavePortData
 {
 public:
-  // Flag for source term in driven and transient simulations.
-  bool excitation = false;
-
   // Mode index for the numeric wave port.
   int mode_idx = 1;
 
   // Port offset for de-embedding [m].
   double d_offset = 0.0;
+
+  // Flag for source term in driven and transient simulations.
+  bool excitation = false;
+
+  // Flag for boundary damping term in driven and transient simulations.
+  bool active = true;
 
   // List of boundary attributes for this wave port.
   std::vector<int> attributes = {};

--- a/scripts/schema/config/boundaries.json
+++ b/scripts/schema/config/boundaries.json
@@ -126,6 +126,7 @@
           "Ls": { "type": "number" },
           "Cs": { "type": "number" },
           "Excitation": { "type": "boolean" },
+          "Active": { "type": "boolean" },
           "Elements":
           {
             "type": "array",
@@ -171,7 +172,8 @@
           },
           "Mode": { "type": "integer", "exclusiveMinimum": 0 },
           "Offset": { "type": "number", "minimum": 0.0 },
-          "Excitation": { "type": "boolean" }
+          "Excitation": { "type": "boolean" },
+          "Active": { "type": "boolean" }
         }
       }
     },


### PR DESCRIPTION
Resolves #171.

In addition, this PR changes field visualization on internal boundaries to always chose the field on the vacuum side (previously, sometimes used vacuum and sometimes used side with lower speed of light).