### PR TITLE
Fix ParaView output on boundary mesh for shared faces

### DIFF
--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -646,24 +646,30 @@ void PostOperator::WriteFields(int step, double time, const ErrorIndicator *indi
     {
       // Piola transform: J^-T
       E->real() *= L;
+      E->real().FaceNbrData() *= L;
       if (has_imaginary)
       {
         E->imag() *= L;
+        E->imag().FaceNbrData() *= L;
       }
     }
     if (B)
     {
       // Piola transform: J / |J|
-      B->real() *= std::pow(L, mesh.Dimension() - 1);
+      const auto Ld = std::pow(L, mesh.Dimension() - 1);
+      B->real() *= Ld;
+      B->real().FaceNbrData() *= Ld;
       if (has_imaginary)
       {
-        B->imag() *= std::pow(L, mesh.Dimension() - 1);
+        B->imag() *= Ld;
+        B->imag().FaceNbrData() *= Ld;
       }
     }
     if (A)
     {
       // Piola transform: J^-T
       *A *= L;
+      A->FaceNbrData() *= L;
     }
   };
   mesh::DimensionalizeMesh(mesh, mesh_Lc0);


### PR DESCRIPTION
We redimensionalize the mesh coordinates and the local parts of the fields, but also need to redimensionalize the face neighbor data vectors (which have already been exchanged, based on the nondimensional dof data). This resolves issues where the fields for shared faces appear to be very small or very large relative to the rest of the boundary visualization.

Note: This should not have an effect on surface integrals based on boundary coefficients for problems with internal boundaries (like integrated charge, or surface participation). These integrals are computed outside of the field nondimensionalization/redimensionalization, so this bug only affects visualization and also only for parallel simulations which boundary elements coinciding with shared faces.