### PR TITLE
Fix global synchronization bug for optional material properties

### DIFF
--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -346,6 +346,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
   mat_invLondon.SetSize(sdim, sdim, nmats);
   mat_c0_min.SetSize(nmats);
   mat_c0_max.SetSize(nmats);
+  has_losstan_attr = has_conductivity_attr = has_london_attr = false;
 
   int count = 0;
   for (std::size_t i = 0; i < iodata.domains.materials.size(); i++)

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -461,8 +461,8 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
 
     count++;
   }
-  int has_attr[3] = {has_losstan_attr, has_conductivity_attr, has_london_attr};
-  Mpi::GlobalMax(3, has_attr, mesh.GetComm());
+  bool has_attr[3] = {has_losstan_attr, has_conductivity_attr, has_london_attr};
+  Mpi::GlobalOr(3, has_attr, mesh.GetComm());
   has_losstan_attr = has_attr[0];
   has_conductivity_attr = has_attr[1];
   has_london_attr = has_attr[2];

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -420,10 +420,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
     mat_epsilon_imag(count) = T;
     if (mat_epsilon_imag(count).MaxMaxNorm() > 0.0)
     {
-      for (auto attr : data.attributes)
-      {
-        losstan_attr.Append(attr);
-      }
+      has_losstan_attr = true;
     }
 
     // ε * √(I + tan(δ) * tan(δ)ᵀ)
@@ -449,10 +446,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
     mat_sigma(count) = ToDenseMatrix(data.sigma);
     if (mat_sigma(count).MaxMaxNorm() > 0.0)
     {
-      for (auto attr : data.attributes)
-      {
-        conductivity_attr.Append(attr);
-      }
+      has_conductivity_attr = true;
     }
 
     // λ⁻² * μ⁻¹
@@ -461,14 +455,16 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
         std::abs(data.lambda_L) > 0.0 ? std::pow(data.lambda_L, -2.0) : 0.0;
     if (mat_invLondon(count).MaxMaxNorm() > 0.0)
     {
-      for (auto attr : data.attributes)
-      {
-        london_attr.Append(attr);
-      }
+      has_london_attr = true;
     }
 
     count++;
   }
+  int has_attr[3] = {has_losstan_attr, has_conductivity_attr, has_london_attr};
+  Mpi::GlobalMax(3, has_attr, mesh.GetComm());
+  has_losstan_attr = has_attr[0];
+  has_conductivity_attr = has_attr[1];
+  has_london_attr = has_attr[2];
 }
 
 mfem::Array<int> MaterialOperator::GetBdrAttributeToMaterial() const

--- a/palace/models/materialoperator.hpp
+++ b/palace/models/materialoperator.hpp
@@ -30,9 +30,9 @@ private:
       mat_c0, mat_sigma, mat_invLondon;
   mfem::Array<double> mat_c0_min, mat_c0_max;
 
-  // Domain attributes with nonzero loss tangent, electrical conductivity, London
-  // penetration depth.
-  mfem::Array<int> losstan_attr, conductivity_attr, london_attr;
+  // Flag for global domain attributes with nonzero loss tangent, electrical conductivity,
+  // of London penetration depth.
+  bool has_losstan_attr, has_conductivity_attr, has_london_attr;
 
   void SetUpMaterialProperties(const IoData &iodata, const mfem::ParMesh &mesh);
 
@@ -80,9 +80,9 @@ public:
   const auto &GetLightSpeedMin() const { return mat_c0_min; }
   const auto &GetLightSpeedMax() const { return mat_c0_max; }
 
-  bool HasLossTangent() const { return (losstan_attr.Size() > 0); }
-  bool HasConductivity() const { return (conductivity_attr.Size() > 0); }
-  bool HasLondonDepth() const { return (london_attr.Size() > 0); }
+  bool HasLossTangent() const { return has_losstan_attr; }
+  bool HasConductivity() const { return has_conductivity_attr; }
+  bool HasLondonDepth() const { return has_london_attr; }
 
   const auto &GetAttributeToMaterial() const { return attr_mat; }
   mfem::Array<int> GetBdrAttributeToMaterial() const;

--- a/palace/utils/communication.hpp
+++ b/palace/utils/communication.hpp
@@ -298,6 +298,18 @@ public:
     }
   }
 
+  // Global logical or (in-place, result is broadcast to all processes).
+  static void GlobalOr(int len, bool *buff, MPI_Comm comm)
+  {
+    GlobalOp(len, buff, MPI_LOR, comm);
+  }
+
+  // Global logical and (in-place, result is broadcast to all processes).
+  static void GlobalAnd(int len, bool *buff, MPI_Comm comm)
+  {
+    GlobalOp(len, buff, MPI_LAND, comm);
+  }
+
   // Global broadcast from root.
   template <typename T>
   static void Broadcast(int len, T *buff, int root, MPI_Comm comm)


### PR DESCRIPTION
Methods like `MaterialOperator::HasLossTangent` are expected to return a value which is consistent globally. This is not the case currently, as material properties are parsed only with respect to local subdomains. This PR fixes this issue and potential hangs for large processor counts or small domains of nonzero loss tangent or conductivity.