### PR TITLE
Add `palace::GridFunction` to unify `mfem::ParGridFunction` and `mfem::ParComplexGridFunction`

### DIFF
--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -568,7 +568,7 @@ void BaseSolver::PostprocessProbes(const PostOperator &postop, const std::string
   {
     return;
   }
-  const bool has_imaginary = postop.HasImaginary();
+  const bool has_imaginary = postop.HasImag();
   for (int f = 0; f < 2; f++)
   {
     // Probe data is ordered as [Fx1, Fy1, Fz1, Fx2, Fy2, Fz2, ...].

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gridfunction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integrator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/interpolator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/lumpedelement.cpp

--- a/palace/fem/gridfunction.cpp
+++ b/palace/fem/gridfunction.cpp
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gridfunction.hpp"
+
+#include "fem/fespace.hpp"
+
+namespace palace
+{
+
+GridFunction::GridFunction(mfem::ParFiniteElementSpace &fespace, bool complex)
+  : gfr(&fespace)
+{
+  if (complex)
+  {
+    gfi.SetSpace(&fespace);
+  }
+}
+
+GridFunction::GridFunction(FiniteElementSpace &fespace, bool complex)
+  : GridFunction(fespace.Get(), complex)
+{
+}
+
+GridFunction &GridFunction::operator=(std::complex<double> s)
+{
+  Real() = s.real();
+  if (HasImag())
+  {
+    Imag() = s.imag();
+  }
+  return *this;
+}
+
+GridFunction &GridFunction::operator*=(double s)
+{
+  Real() *= s;
+  if (HasImag())
+  {
+    Imag() *= s;
+  }
+  return *this;
+}
+
+void GridFunction::Update()
+{
+  Real().Update();
+  if (HasImag())
+  {
+    Imag().Update();
+  }
+}
+
+}  // namespace palace

--- a/palace/fem/gridfunction.cpp
+++ b/palace/fem/gridfunction.cpp
@@ -29,6 +29,12 @@ GridFunction &GridFunction::operator=(std::complex<double> s)
   {
     Imag() = s.imag();
   }
+  else
+  {
+    MFEM_ASSERT(
+        s.imag() == 0.0,
+        "Cannot assign complex scalar to a non-complex-valued GridFunction object!");
+  }
   return *this;
 }
 

--- a/palace/fem/gridfunction.hpp
+++ b/palace/fem/gridfunction.hpp
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_GRIDFUNCTION_HPP
+#define PALACE_FEM_GRIDFUNCTION_HPP
+
+#include <mfem.hpp>
+
+namespace palace
+{
+
+class FiniteElementSpace;
+
+//
+// A real- or complex-valued grid function represented as two real grid functions, one for
+// each component. This unifies mfem::ParGridFunction and mfem::ParComplexGridFunction, and
+// replaces the latter due to some issues observed with memory aliasing on GPUs.
+//
+class GridFunction
+{
+private:
+  mfem::ParGridFunction gfr, gfi;
+
+public:
+  GridFunction(mfem::ParFiniteElementSpace &fespace, bool complex = false);
+  GridFunction(FiniteElementSpace &fespace, bool complex = false);
+
+  // Get access to the real and imaginary grid function parts.
+  const mfem::ParGridFunction &Real() const { return gfr; }
+  mfem::ParGridFunction &Real() { return gfr; }
+  const mfem::ParGridFunction &Imag() const
+  {
+    MFEM_ASSERT(HasImag(),
+                "Invalid access of imaginary part of a real-valued GridFunction object!");
+    return gfi;
+  }
+  mfem::ParGridFunction &Imag()
+  {
+    MFEM_ASSERT(HasImag(),
+                "Invalid access of imaginary part of a real-valued GridFunction object!");
+    return gfi;
+  }
+
+  // Check if the grid function is suited for storing complex-valued fields.
+  bool HasImag() const { return (gfi.ParFESpace() != nullptr); }
+
+  // Get access to the underlying finite element space (match MFEM interface).
+  mfem::FiniteElementSpace *FESpace() { return gfr.FESpace(); }
+  const mfem::FiniteElementSpace *FESpace() const { return gfr.FESpace(); }
+  mfem::ParFiniteElementSpace *ParFESpace() { return gfr.ParFESpace(); }
+  const mfem::ParFiniteElementSpace *ParFESpace() const { return gfr.ParFESpace(); }
+
+  // Set all entries equal to s.
+  GridFunction &operator=(std::complex<double> s);
+  GridFunction &operator=(double s)
+  {
+    *this = std::complex<double>(s, 0.0);
+    return *this;
+  }
+
+  // Scale all entries by s.
+  GridFunction &operator*=(double s);
+
+  // Transform for space update (for example on mesh change).
+  void Update();
+
+  // Get the associated MPI communicator.
+  MPI_Comm GetComm() const { return ParFESpace()->GetComm(); }
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_GRIDFUNCTION_HPP

--- a/palace/fem/interpolator.cpp
+++ b/palace/fem/interpolator.cpp
@@ -4,6 +4,7 @@
 #include "interpolator.hpp"
 
 #include <algorithm>
+#include "fem/gridfunction.hpp"
 #include "utils/communication.hpp"
 #include "utils/iodata.hpp"
 
@@ -88,13 +89,12 @@ std::vector<double> InterpolationOperator::ProbeField(const mfem::ParGridFunctio
 #endif
 }
 
-std::vector<std::complex<double>>
-InterpolationOperator::ProbeField(const mfem::ParComplexGridFunction &U, bool has_imaginary)
+std::vector<std::complex<double>> InterpolationOperator::ProbeField(const GridFunction &U)
 {
-  std::vector<double> vr = ProbeField(U.real());
-  if (has_imaginary)
+  std::vector<double> vr = ProbeField(U.Real());
+  if (U.HasImag())
   {
-    std::vector<double> vi = ProbeField(U.imag());
+    std::vector<double> vi = ProbeField(U.Imag());
     std::vector<std::complex<double>> vals(vr.size());
     std::transform(vr.begin(), vr.end(), vi.begin(), vals.begin(),
                    [](double xr, double xi) { return std::complex<double>(xr, xi); });

--- a/palace/fem/interpolator.hpp
+++ b/palace/fem/interpolator.hpp
@@ -11,6 +11,7 @@
 namespace palace
 {
 
+class GridFunction;
 class IoData;
 
 //
@@ -24,15 +25,14 @@ private:
 #endif
   std::vector<int> op_idx;
 
+  std::vector<double> ProbeField(const mfem::ParGridFunction &U);
+
 public:
   InterpolationOperator(const IoData &iodata, mfem::ParMesh &mesh);
 
   const auto &GetProbes() const { return op_idx; }
 
-  std::vector<double> ProbeField(const mfem::ParGridFunction &U);
-
-  std::vector<std::complex<double>> ProbeField(const mfem::ParComplexGridFunction &U,
-                                               bool has_imaginary);
+  std::vector<std::complex<double>> ProbeField(const GridFunction &U);
 };
 
 }  // namespace palace

--- a/palace/models/domainpostoperator.hpp
+++ b/palace/models/domainpostoperator.hpp
@@ -10,17 +10,10 @@
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
 
-namespace mfem
-{
-
-class ParComplexGridFunction;
-class ParGridFunction;
-
-}  // namespace mfem
-
 namespace palace
 {
 
+class GridFunction;
 class FiniteElementSpace;
 class IoData;
 class MaterialOperator;
@@ -48,17 +41,13 @@ public:
 
   // Get volume integrals computing the electric or magnetic field energy in the entire
   // domain.
-  double GetElectricFieldEnergy(const mfem::ParComplexGridFunction &E) const;
-  double GetElectricFieldEnergy(const mfem::ParGridFunction &E) const;
-  double GetMagneticFieldEnergy(const mfem::ParComplexGridFunction &B) const;
-  double GetMagneticFieldEnergy(const mfem::ParGridFunction &B) const;
+  double GetElectricFieldEnergy(const GridFunction &E) const;
+  double GetMagneticFieldEnergy(const GridFunction &B) const;
 
   // Get volume integrals for the electric or magnetic field energy in a portion of the
   // domain.
-  double GetDomainElectricFieldEnergy(int idx, const mfem::ParComplexGridFunction &E) const;
-  double GetDomainElectricFieldEnergy(int idx, const mfem::ParGridFunction &E) const;
-  double GetDomainMagneticFieldEnergy(int idx, const mfem::ParComplexGridFunction &E) const;
-  double GetDomainMagneticFieldEnergy(int idx, const mfem::ParGridFunction &E) const;
+  double GetDomainElectricFieldEnergy(int idx, const GridFunction &E) const;
+  double GetDomainMagneticFieldEnergy(int idx, const GridFunction &E) const;
 };
 
 }  // namespace palace

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -14,6 +14,7 @@
 namespace palace
 {
 
+class GridFunction;
 class IoData;
 class MaterialOperator;
 class MaterialPropertyCoefficient;
@@ -63,12 +64,9 @@ public:
   double GetExcitationPower() const;
   double GetExcitationVoltage() const;
 
-  std::complex<double> GetSParameter(mfem::ParComplexGridFunction &E) const;
-  std::complex<double> GetPower(mfem::ParComplexGridFunction &E,
-                                mfem::ParComplexGridFunction &B) const;
-  double GetPower(mfem::ParGridFunction &E, mfem::ParGridFunction &B) const;
-  std::complex<double> GetVoltage(mfem::ParComplexGridFunction &E) const;
-  double GetVoltage(mfem::ParGridFunction &E) const;
+  std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetSParameter(GridFunction &E) const;
+  std::complex<double> GetVoltage(GridFunction &E) const;
 };
 
 //

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -13,6 +13,7 @@
 namespace palace
 {
 
+class GridFunction;
 class IoData;
 class MaterialOperator;
 
@@ -100,13 +101,9 @@ public:
   // Get surface integrals computing dielectric interface energy, surface charge, or
   // surface magnetic flux.
   double GetInterfaceLossTangent(int idx) const;
-  double GetInterfaceElectricFieldEnergy(int idx,
-                                         const mfem::ParComplexGridFunction &E) const;
-  double GetInterfaceElectricFieldEnergy(int idx, const mfem::ParGridFunction &E) const;
-  double GetSurfaceElectricCharge(int idx, const mfem::ParComplexGridFunction &E) const;
-  double GetSurfaceElectricCharge(int idx, const mfem::ParGridFunction &E) const;
-  double GetSurfaceMagneticFlux(int idx, const mfem::ParComplexGridFunction &B) const;
-  double GetSurfaceMagneticFlux(int idx, const mfem::ParGridFunction &B) const;
+  double GetInterfaceElectricFieldEnergy(int idx, const GridFunction &E) const;
+  double GetSurfaceElectricCharge(int idx, const GridFunction &E) const;
+  double GetSurfaceMagneticFlux(int idx, const GridFunction &B) const;
 };
 
 }  // namespace palace

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <mfem.hpp>
 #include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
 #include "fem/mesh.hpp"
 #include "linalg/eps.hpp"
 #include "linalg/ksp.hpp"
@@ -65,7 +66,7 @@ private:
 
   // Operator storage for repeated boundary mode eigenvalue problem solves.
   std::unique_ptr<mfem::HypreParMatrix> Atnr, Atni, Antr, Anti, Annr, Anni;
-  std::unique_ptr<ComplexOperator> B;
+  std::unique_ptr<ComplexOperator> B0;
   ComplexVector v0, e0;
 
   // Eigenvalue solver for boundary modes.
@@ -74,12 +75,10 @@ private:
   std::unique_ptr<EigenvalueSolver> eigen;
   std::unique_ptr<ComplexKspSolver> ksp;
 
-  // Grid functions storing the last computed electric field mode on the port.
-  std::unique_ptr<mfem::ParComplexGridFunction> port_E0t, port_E0n;
-
-  // Stored objects for computing functions of the port modes for use as an excitation or
-  // in postprocessing.
-  std::unique_ptr<mfem::ParGridFunction> port_S0t;
+  // Grid functions storing the last computed electric field mode on the port, and stored
+  // objects for computing functions of the port modes for use as an excitation or in
+  // postprocessing.
+  std::unique_ptr<GridFunction> port_E0t, port_E0n, port_S0t, port_E;
   std::unique_ptr<mfem::LinearForm> port_sr, port_si;
 
 public:
@@ -114,10 +113,9 @@ public:
     return 0.0;
   }
 
-  std::complex<double> GetSParameter(mfem::ParComplexGridFunction &E) const;
-  std::complex<double> GetPower(mfem::ParComplexGridFunction &E,
-                                mfem::ParComplexGridFunction &B) const;
-  std::complex<double> GetVoltage(mfem::ParComplexGridFunction &E) const
+  std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetSParameter(GridFunction &E) const;
+  std::complex<double> GetVoltage(GridFunction &E) const
   {
     MFEM_ABORT("GetVoltage is not yet implemented for wave port boundaries!");
     return 0.0;


### PR DESCRIPTION
We have observed some issues with `mfem::Memory` aliasing when running on GPUs, which look like error messages of the form:

```
CUDA error: (cudaMemcpy(dst, src, bytes, cudaMemcpyHostToDevice)) failed with error:
 --> misaligned address
 ... in function: void* mfem::CuMemcpyHtoD(void*, const void*, size_t)
 ... in file: /data/home/hughcars/palace/build_g5_48xlarge/extern/mfem/general/cuda.cpp:116
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 1.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```

One place this aliasing is used is `mfem::ComplexGridFunction` and `mfem::ParComplexGridFunction`. This PR replaces the aliases with two separate `ParGridFunction` objects for the real and imaginary parts, and resolves the errors in our testing. I'm not certain this is an error with MFEM's `MemoryManager` or just our use of it without adequate synchronization. But for now, keeping this objects stored separately seems to resolve the problems.

NOTE: This is on top of https://github.com/awslabs/palace/pull/193 and resolves the observed instances in testing for GPU support. https://github.com/awslabs/palace/pull/194 to follow this PR.