### PR TITLE
Rebalance mesh after region-based refinement

### DIFF
--- a/examples/cpw/mesh/mesh.jl
+++ b/examples/cpw/mesh/mesh.jl
@@ -75,8 +75,8 @@ function generate_cpw_wave_mesh(;
     sep_dy = 0.5 * sep_dz
 
     # Mesh parameters
-    l_trace = 1.5 * trace_width_μm * 2^-refinement
-    l_farfield = 1.0 * substrate_height_μm * 2^-refinement
+    l_trace = 1.5 * trace_width_μm * (2.0^-refinement)
+    l_farfield = 1.0 * substrate_height_μm * (2.0^-refinement)
 
     # Chip pattern
     dy = 0.0
@@ -477,8 +477,8 @@ function generate_cpw_lumped_mesh(;
     sep_dy = 0.5 * sep_dz
 
     # Mesh parameters
-    l_trace = 1.5 * trace_width_μm * 2^-refinement
-    l_farfield = 1.0 * substrate_height_μm * 2^-refinement
+    l_trace = 1.5 * trace_width_μm * (2.0^-refinement)
+    l_farfield = 1.0 * substrate_height_μm * (2.0^-refinement)
 
     # Chip pattern
     dy = 0.0

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -215,8 +215,7 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
                final_elem_count - initial_elem_count, initial_elem_count, final_elem_count);
 
     // Optionally rebalance and write the adapted mesh to file.
-    const auto ratio_pre =
-        mesh::RebalanceMesh(fine_mesh, iodata, refinement.maximum_imbalance);
+    const auto ratio_pre = mesh::RebalanceMesh(fine_mesh, iodata);
     if (ratio_pre > refinement.maximum_imbalance)
     {
       int min_elem, max_elem;

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -150,7 +150,7 @@ mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, bool average = true);
 
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from
 // the intermediate stages to disk. Returns the imbalance ratio before rebalancing.
-double RebalanceMesh(mfem::ParMesh &mesh, const IoData &iodata, double tol);
+double RebalanceMesh(mfem::ParMesh &mesh, const IoData &iodata);
 
 }  // namespace mesh
 


### PR DESCRIPTION
This is enabled by the addition of conformal rebalancing for AMR. The mesh can get quite imbalanced following a few levels of local refinement and rebalancing speeds up the following simulations significantly.