### PR TITLE
Record timing for each stage of AMR

### DIFF
--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -179,6 +179,7 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
   while (!ExhaustedResources(it, ntdof) && err >= refinement.tol)
   {
     // Print timing summary.
+    Mpi::Print("\nCumulative timing statistics:\n");
     BlockTimer::Print(comm);
     SaveMetadata(BlockTimer::GlobalTimer());
 

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -178,6 +178,10 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
   int it = 0;
   while (!ExhaustedResources(it, ntdof) && err >= refinement.tol)
   {
+    // Print timing summary.
+    BlockTimer::Print(comm);
+    SaveMetadata(BlockTimer::GlobalTimer());
+
     BlockTimer bt(Timer::ADAPTATION);
     Mpi::Print("\nAdaptive mesh refinement (AMR) iteration {:d}:\n"
                " Indicator norm = {:.3e}, global unknowns = {:d}\n"


### PR DESCRIPTION
AMR users often want to know how long a simulation takes not only for the whole, but also for each iteration. This is particularly helpful when running AMR simulations that might terminate due to running out of memory etc. where the final timing data will not be reported. This PR adds timing printing to the log, and recording of the meta data file, to each AMR loop in addition to the final print. 