### PR TITLE
Fix cryptic error for empty arrays in JSON config file

### DIFF
--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -72,6 +72,10 @@ std::stringstream PreprocessFile(const char *filename)
   auto RangeExpand = [](std::string_view str) -> std::string
   {
     // Handle the given string which is only numeric with possible hyphens.
+    if (str.empty())
+    {
+      return "";
+    }
     int num;
     auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.length(), num);
     MFEM_VERIFY(

--- a/palace/utils/prettyprint.hpp
+++ b/palace/utils/prettyprint.hpp
@@ -72,7 +72,7 @@ inline void PrettyPrint(const Container<T, U...> &data, T scale,
       auto j = i;
       if (scale == 1)
       {
-        while ((j + 1 != data.end()) && *(j + 1) == (*j) + 1)
+        while ((std::next(j) != data.end()) && *std::next(j) == (*j) + 1)
         {
           j++;
         }
@@ -90,7 +90,7 @@ inline void PrettyPrint(const Container<T, U...> &data, T scale,
         w = internal::PrePrint(comm, w, wi, lead) + wi;
         Mpi::Print(comm, "{:d}-{:d}", (*i) * scale, (*j) * scale);
       }
-      i = j + 1;
+      i = std::next(j);
     }
     else
     {

--- a/scripts/schema/config/boundaries.json
+++ b/scripts/schema/config/boundaries.json
@@ -13,12 +13,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        }
+        "Attributes": { "$ref": "#/$defs/Attributes" }
       }
     },
     "PMC":
@@ -28,12 +23,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        }
+        "Attributes": { "$ref": "#/$defs/Attributes" }
       }
     },
     "Impedance":
@@ -47,12 +37,7 @@
         "required": ["Attributes"],
         "properties":
         {
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Rs": { "type": "number" },
           "Ls": { "type": "number" },
           "Cs": { "type": "number" }
@@ -66,12 +51,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        },
+        "Attributes": { "$ref": "#/$defs/Attributes" },
         "Order": { "type": "integer" }
       }
     },
@@ -86,12 +66,7 @@
         "required": ["Attributes", "Conductivity"],
         "properties":
         {
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Conductivity": { "type": "number" },
           "Permeability": { "type": "number" },
           "Thickness": { "type": "number" },
@@ -111,12 +86,7 @@
         "properties":
         {
           "Index": { "type": "integer" },
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Direction": { "$ref": "#/$defs/Direction" },
           "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] },
           "R": { "type": "number" },
@@ -138,12 +108,7 @@
               "required": ["Attributes", "Direction"],
               "properties":
               {
-                "Attributes":
-                {
-                  "type": "array",
-                  "additionalItems": false,
-                  "items": { "type": "integer"}
-                },
+                "Attributes": { "$ref": "#/$defs/Attributes" },
                 "Direction": { "$ref": "#/$defs/Direction" },
                 "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] }
               }
@@ -164,12 +129,7 @@
         "properties":
         {
           "Index": { "type": "integer" },
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Mode": { "type": "integer", "exclusiveMinimum": 0 },
           "Offset": { "type": "number", "minimum": 0.0 },
           "Excitation": { "type": "boolean" },
@@ -184,12 +144,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        }
+        "Attributes": { "$ref": "#/$defs/Attributes" }
       }
     },
     "SurfaceCurrent":
@@ -204,12 +159,7 @@
         "properties":
         {
           "Index": { "type": "integer" },
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Direction": { "$ref": "#/$defs/Direction" },
           "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] },
           "Elements":
@@ -223,12 +173,7 @@
               "required": ["Attributes", "Direction"],
               "properties":
               {
-                "Attributes":
-                {
-                  "type": "array",
-                  "additionalItems": false,
-                  "items": { "type": "integer"}
-                },
+                "Attributes": { "$ref": "#/$defs/Attributes" },
                 "Direction": { "$ref": "#/$defs/Direction" },
                 "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] }
               }
@@ -244,12 +189,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        }
+        "Attributes": { "$ref": "#/$defs/Attributes" }
       }
     },
     "ZeroCharge":
@@ -259,12 +199,7 @@
       "required": ["Attributes"],
       "properties":
       {
-        "Attributes":
-        {
-          "type": "array",
-          "additionalItems": false,
-          "items": { "type": "integer"}
-        }
+        "Attributes": { "$ref": "#/$defs/Attributes" }
       }
     },
     "Terminal":
@@ -279,12 +214,7 @@
         "properties":
         {
           "Index": { "type": "integer" },
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"}
-          }
+          "Attributes": { "$ref": "#/$defs/Attributes" }
         }
       }
     },
@@ -307,12 +237,7 @@
             "properties":
             {
               "Index": { "type": "integer" },
-              "Attributes":
-              {
-                "type": "array",
-                "additionalItems": false,
-                "items": { "type": "integer"}
-              }
+              "Attributes": { "$ref": "#/$defs/Attributes" }
             }
           }
         },
@@ -328,12 +253,7 @@
             "properties":
             {
               "Index": { "type": "integer" },
-              "Attributes":
-              {
-                "type": "array",
-                "additionalItems": false,
-                "items": { "type": "integer"}
-              },
+              "Attributes": { "$ref": "#/$defs/Attributes" },
               "Direction": { "$ref": "#/$defs/Direction" },
               "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] }
             }
@@ -351,12 +271,7 @@
             "properties":
             {
               "Index": { "type": "integer" },
-              "Attributes":
-              {
-                "type": "array",
-                "additionalItems": false,
-                "items": { "type": "integer"}
-              },
+              "Attributes": { "$ref": "#/$defs/Attributes" },
               "Side": { "$ref": "#/$defs/Direction" },
               "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] },
               "Permittivity": { "type": "number" },
@@ -376,12 +291,7 @@
                   "required": ["Attributes"],
                   "properties":
                   {
-                    "Attributes":
-                    {
-                      "type": "array",
-                      "additionalItems": false,
-                      "items": { "type": "integer"}
-                    },
+                    "Attributes": { "$ref": "#/$defs/Attributes" },
                     "Side": { "$ref": "#/$defs/Direction" },
                     "CoordinateSystem": { "type": "string", "enum": ["Cartesian", "Cylindrical"] }
                   }
@@ -395,6 +305,13 @@
   },
   "$defs":
   {
+    "Attributes":
+    {
+      "type": "array",
+      "additionalItems": false,
+      "items": { "type": "integer"},
+      "minItems": 1
+    },
     "Direction":
     {
       "anyOf":

--- a/scripts/schema/config/domains.json
+++ b/scripts/schema/config/domains.json
@@ -17,13 +17,7 @@
         "required": ["Attributes"],
         "properties":
         {
-          "Attributes":
-          {
-            "type": "array",
-            "additionalItems": false,
-            "items": { "type": "integer"},
-            "minItems": 1
-          },
+          "Attributes": { "$ref": "#/$defs/Attributes" },
           "Permeability":
           {
             "oneOf" :
@@ -112,12 +106,7 @@
             "properties":
             {
               "Index": { "type": "integer" },
-              "Attributes":
-              {
-                "type": "array",
-                "additionalItems": false,
-                "items": { "type": "integer"}
-              }
+              "Attributes": { "$ref": "#/$defs/Attributes" }
             }
           }
         },
@@ -140,6 +129,16 @@
           }
         }
       }
+    }
+  },
+  "$defs":
+  {
+    "Attributes":
+    {
+      "type": "array",
+      "additionalItems": false,
+      "items": { "type": "integer"},
+      "minItems": 1
     }
   }
 }


### PR DESCRIPTION
Previously, an (incorrect) configuration file array specified as `"Attributes": []` would lead to an error like:

```
Verification failed: (ec == std::errc()) is false:
 --> Invalid integer conversion in range expansion!
 ... in function: palace::{anonymous}::PreprocessFile(const char*)::<lambda(std::string_view)>
 ... in file: /apps/palace/palace/palace/utils/iodata.cpp:77
```

This case is now handled and checked for in the JSON Schema during `--dry-run`.