### PR TITLE
Add owning and non constructors from mfem::SparseMatrix

### DIFF
--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -111,8 +111,8 @@ void HypreAmsSolver::ConstructAuxiliaryMatrices(FiniteElementSpace &nd_fespace,
     pi.SetAssemblyLevel(mfem::AssemblyLevel::LEGACY);
     pi.Assemble(skip_zeros_interp);
     pi.Finalize(skip_zeros_interp);
-    ParOperator RAP_Pi(std::make_unique<hypre::HypreCSRMatrix>(*pi.LoseMat()), h1d_fespace,
-                       nd_fespace, true);
+    ParOperator RAP_Pi(std::make_unique<hypre::HypreCSRMatrix>(std::move(*pi.LoseMat())),
+                       h1d_fespace, nd_fespace, true);
     Pi = RAP_Pi.StealParallelAssemble();
     if (cycle_type >= 10)
     {

--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -111,8 +111,8 @@ void HypreAmsSolver::ConstructAuxiliaryMatrices(FiniteElementSpace &nd_fespace,
     pi.SetAssemblyLevel(mfem::AssemblyLevel::LEGACY);
     pi.Assemble(skip_zeros_interp);
     pi.Finalize(skip_zeros_interp);
-    ParOperator RAP_Pi(std::make_unique<hypre::HypreCSRMatrix>(std::move(*pi.LoseMat())),
-                       h1d_fespace, nd_fespace, true);
+    ParOperator RAP_Pi(std::make_unique<hypre::HypreCSRMatrix>(pi.SpMat()), h1d_fespace,
+                       nd_fespace, true);
     Pi = RAP_Pi.StealParallelAssemble();
     if (cycle_type >= 10)
     {

--- a/palace/linalg/ams.cpp
+++ b/palace/linalg/ams.cpp
@@ -6,6 +6,7 @@
 #include "fem/bilinearform.hpp"
 #include "fem/fespace.hpp"
 #include "fem/integrator.hpp"
+#include "linalg/hypre.hpp"
 #include "linalg/rap.hpp"
 #include "utils/omp.hpp"
 
@@ -110,7 +111,7 @@ void HypreAmsSolver::ConstructAuxiliaryMatrices(FiniteElementSpace &nd_fespace,
     pi.SetAssemblyLevel(mfem::AssemblyLevel::LEGACY);
     pi.Assemble(skip_zeros_interp);
     pi.Finalize(skip_zeros_interp);
-    ParOperator RAP_Pi(std::unique_ptr<mfem::SparseMatrix>(pi.LoseMat()), h1d_fespace,
+    ParOperator RAP_Pi(std::make_unique<hypre::HypreCSRMatrix>(*pi.LoseMat()), h1d_fespace,
                        nd_fespace, true);
     Pi = RAP_Pi.StealParallelAssemble();
     if (cycle_type >= 10)

--- a/palace/linalg/hypre.cpp
+++ b/palace/linalg/hypre.cpp
@@ -47,6 +47,31 @@ HypreCSRMatrix::HypreCSRMatrix(hypre_CSRMatrix *mat) : mat(mat)
   width = hypre_CSRMatrixNumCols(mat);
 }
 
+HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &m)
+  : palace::Operator(m.Height(), m.Width())
+{
+  // Initialize the internal hypre matrix.
+  mat = hypre_CSRMatrixCreate(height, width, m.NumNonZeroElems());
+
+  // Copy the I, J and Data vectors.
+  hypre_CSRMatrixI(mat) = m.GetI();
+  hypre_CSRMatrixJ(mat) = m.GetJ();
+  hypre_CSRMatrixData(mat) = m.GetData();
+
+  // Match the memory class of the sparse matrix.
+  hypre_CSRMatrixMemoryLocation(mat) = (m.GetMemoryClass() == mfem::MemoryClass::DEVICE)
+                                           ? HYPRE_MEMORY_DEVICE
+                                           : HYPRE_MEMORY_HOST;
+}
+
+HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &&m) : HypreCSRMatrix(m)
+{
+  // Given m is an rvalue, additionally take ownership of the pointers.
+  m.SetGraphOwner(false);
+  m.SetDataOwner(false);
+  hypre_CSRMatrixOwnsData(mat) = true;
+}
+
 HypreCSRMatrix::~HypreCSRMatrix()
 {
   hypre_CSRMatrixDestroy(mat);

--- a/palace/linalg/hypre.cpp
+++ b/palace/linalg/hypre.cpp
@@ -47,7 +47,7 @@ HypreCSRMatrix::HypreCSRMatrix(hypre_CSRMatrix *mat) : mat(mat)
   width = hypre_CSRMatrixNumCols(mat);
 }
 
-HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &&m)
+HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &m)
   : palace::Operator(m.Height(), m.Width())
 {
   mat = hypre_CSRMatrixCreate(height, width, m.NumNonZeroElems());
@@ -55,16 +55,16 @@ HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &&m)
   hypre_CSRMatrixJ(mat) = m.ReadWriteJ();
   hypre_CSRMatrixData(mat) = m.ReadWriteData();
 
-  // Given m is an rvalue, additionally take ownership of the pointers.
-  m.SetGraphOwner(false);
-  m.SetDataOwner(false);
-  hypre_CSRMatrixOwnsData(mat) = true;
-
   hypre_CSRMatrixInitialize(mat);
 }
 
 HypreCSRMatrix::~HypreCSRMatrix()
 {
+  if (hypre_CSRMatrixOwnsData(mat) == false)
+  {
+    hypre_CSRMatrixI(mat) = nullptr;
+    hypre_CSRMatrixRownnz(mat) = nullptr;
+  }
   hypre_CSRMatrixDestroy(mat);
 }
 

--- a/palace/linalg/hypre.cpp
+++ b/palace/linalg/hypre.cpp
@@ -35,32 +35,34 @@ void HypreVector::Update(const Vector &x)
   }
 }
 
-HypreCSRMatrix::HypreCSRMatrix(int h, int w, int nnz) : palace::Operator(h, w)
+HypreCSRMatrix::HypreCSRMatrix(int h, int w, int nnz)
+  : palace::Operator(h, w), hypre_managed_memory(true)
 {
   mat = hypre_CSRMatrixCreate(h, w, nnz);
   hypre_CSRMatrixInitialize(mat);
 }
 
-HypreCSRMatrix::HypreCSRMatrix(hypre_CSRMatrix *mat) : mat(mat)
+HypreCSRMatrix::HypreCSRMatrix(hypre_CSRMatrix *mat) : mat(mat), hypre_managed_memory(true)
 {
   height = hypre_CSRMatrixNumRows(mat);
   width = hypre_CSRMatrixNumCols(mat);
 }
 
 HypreCSRMatrix::HypreCSRMatrix(mfem::SparseMatrix &m)
-  : palace::Operator(m.Height(), m.Width())
+  : palace::Operator(m.Height(), m.Width()), hypre_managed_memory(false)
 {
   mat = hypre_CSRMatrixCreate(height, width, m.NumNonZeroElems());
   hypre_CSRMatrixI(mat) = m.ReadWriteI();
   hypre_CSRMatrixJ(mat) = m.ReadWriteJ();
   hypre_CSRMatrixData(mat) = m.ReadWriteData();
+  hypre_CSRMatrixOwnsData(mat) = 0;
 
   hypre_CSRMatrixInitialize(mat);
 }
 
 HypreCSRMatrix::~HypreCSRMatrix()
 {
-  if (hypre_CSRMatrixOwnsData(mat) == false)
+  if (!hypre_managed_memory)
   {
     hypre_CSRMatrixI(mat) = nullptr;
     hypre_CSRMatrixRownnz(mat) = nullptr;

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -49,13 +49,13 @@ class HypreCSRMatrix : public palace::Operator
 {
 private:
   hypre_CSRMatrix *mat;
-
-  bool hypre_managed_memory;
+  mfem::Array<HYPRE_Int> data_I, data_J;
+  bool hypre_own_I;
 
 public:
   HypreCSRMatrix(int h, int w, int nnz);
   HypreCSRMatrix(hypre_CSRMatrix *mat);
-  HypreCSRMatrix(mfem::SparseMatrix &m);
+  HypreCSRMatrix(const mfem::SparseMatrix &m);
   ~HypreCSRMatrix();
 
   auto NNZ() const { return hypre_CSRMatrixNumNonzeros(mat); }

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -53,6 +53,10 @@ private:
 public:
   HypreCSRMatrix(int h, int w, int nnz);
   HypreCSRMatrix(hypre_CSRMatrix *mat);
+  // Non-owning constructor - m retains control of I, J and Data pointers.
+  HypreCSRMatrix(mfem::SparseMatrix &m);
+  // Owning constructor - m gives up control of I, J and Data pointers.
+  HypreCSRMatrix(mfem::SparseMatrix &&m);
   ~HypreCSRMatrix();
 
   auto NNZ() const { return hypre_CSRMatrixNumNonzeros(mat); }

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -50,6 +50,8 @@ class HypreCSRMatrix : public palace::Operator
 private:
   hypre_CSRMatrix *mat;
 
+  bool hypre_managed_memory;
+
 public:
   HypreCSRMatrix(int h, int w, int nnz);
   HypreCSRMatrix(hypre_CSRMatrix *mat);

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -53,8 +53,7 @@ private:
 public:
   HypreCSRMatrix(int h, int w, int nnz);
   HypreCSRMatrix(hypre_CSRMatrix *mat);
-  // Owning constructor - m gives up control of I, J and Data pointers.
-  HypreCSRMatrix(mfem::SparseMatrix &&m);
+  HypreCSRMatrix(mfem::SparseMatrix &m);
   ~HypreCSRMatrix();
 
   auto NNZ() const { return hypre_CSRMatrixNumNonzeros(mat); }

--- a/palace/linalg/hypre.hpp
+++ b/palace/linalg/hypre.hpp
@@ -53,8 +53,6 @@ private:
 public:
   HypreCSRMatrix(int h, int w, int nnz);
   HypreCSRMatrix(hypre_CSRMatrix *mat);
-  // Non-owning constructor - m retains control of I, J and Data pointers.
-  HypreCSRMatrix(mfem::SparseMatrix &m);
   // Owning constructor - m gives up control of I, J and Data pointers.
   HypreCSRMatrix(mfem::SparseMatrix &&m);
   ~HypreCSRMatrix();


### PR DESCRIPTION
*Description of changes:*
Add owning and non owning constructors for `HypreCSRMatrix` from `mfem::SparseMatrix`.

*Issue #, if available:*
https://github.com/awslabs/palace/issues/216
