### PR TITLE
Use libCEED for element-wise error estimate integrals

### DIFF
--- a/palace/fem/integ/curlcurl.cpp
+++ b/palace/fem/integ/curlcurl.cpp
@@ -26,7 +26,7 @@ void CurlCurlIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                                   CeedElemRestriction geom_data_restr,
                                   CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/curlcurlmass.cpp
+++ b/palace/fem/integ/curlcurlmass.cpp
@@ -19,7 +19,7 @@ void CurlCurlMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr
                                       CeedElemRestriction geom_data_restr,
                                       CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.
@@ -59,8 +59,8 @@ void CurlCurlMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr
     info.trial_ops |= EvalMode::Weight;
   }
 
-  // Set up the coefficient and assemble.
-  auto ctx = PopulateCoefficientContext((dim < 3) ? 1 : dim, space_dim, Q, Q_mass);
+  // Set up the coefficient and assemble. Mass goes first.
+  auto ctx = PopulateCoefficientContext(space_dim, Q_mass, (dim < 3) ? 1 : dim, Q);
   AssembleCeedOperator(info, (void *)ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed,
                        trial_restr, test_restr, trial_basis, test_basis, geom_data,
                        geom_data_restr, op);

--- a/palace/fem/integ/diffusion.cpp
+++ b/palace/fem/integ/diffusion.cpp
@@ -19,7 +19,7 @@ void DiffusionIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                                    CeedElemRestriction geom_data_restr,
                                    CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/diffusionmass.cpp
+++ b/palace/fem/integ/diffusionmass.cpp
@@ -20,7 +20,7 @@ void DiffusionMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_rest
                                        CeedElemRestriction geom_data_restr,
                                        CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.
@@ -61,8 +61,8 @@ void DiffusionMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_rest
   info.trial_ops = EvalMode::Grad | EvalMode::Interp;
   info.test_ops = EvalMode::Grad | EvalMode::Interp;
 
-  // Set up the coefficient and assemble.
-  auto ctx = PopulateCoefficientContext(space_dim, 1, Q, Q_mass);
+  // Set up the coefficient and assemble. Mass goes first.
+  auto ctx = PopulateCoefficientContext(1, Q_mass, space_dim, Q);
   AssembleCeedOperator(info, (void *)ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed,
                        trial_restr, test_restr, trial_basis, test_basis, geom_data,
                        geom_data_restr, op);

--- a/palace/fem/integ/divdiv.cpp
+++ b/palace/fem/integ/divdiv.cpp
@@ -18,7 +18,7 @@ void DivDivIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                                 CeedBasis test_basis, CeedVector geom_data,
                                 CeedElemRestriction geom_data_restr, CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/divdivmass.cpp
+++ b/palace/fem/integ/divdivmass.cpp
@@ -19,7 +19,7 @@ void DivDivMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                                     CeedElemRestriction geom_data_restr,
                                     CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.
@@ -60,8 +60,8 @@ void DivDivMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
   info.trial_ops = EvalMode::Div | EvalMode::Interp | EvalMode::Weight;
   info.test_ops = EvalMode::Div | EvalMode::Interp;
 
-  // Set up the coefficient and assemble.
-  auto ctx = PopulateCoefficientContext(1, space_dim, Q, Q_mass);
+  // Set up the coefficient and assemble. Mass goes first.
+  auto ctx = PopulateCoefficientContext(space_dim, Q_mass, 1, Q);
   AssembleCeedOperator(info, (void *)ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed,
                        trial_restr, test_restr, trial_basis, test_basis, geom_data,
                        geom_data_restr, op);

--- a/palace/fem/integ/grad.cpp
+++ b/palace/fem/integ/grad.cpp
@@ -19,7 +19,7 @@ void GradientIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                                   CeedElemRestriction geom_data_restr,
                                   CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/mass.cpp
+++ b/palace/fem/integ/mass.cpp
@@ -18,7 +18,7 @@ void MassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr,
                               CeedBasis test_basis, CeedVector geom_data,
                               CeedElemRestriction geom_data_restr, CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/mixedveccurl.cpp
+++ b/palace/fem/integ/mixedveccurl.cpp
@@ -27,7 +27,7 @@ void MixedVectorCurlIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_re
                                          CeedElemRestriction geom_data_restr,
                                          CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.
@@ -74,7 +74,7 @@ void MixedVectorWeakCurlIntegrator::Assemble(Ceed ceed, CeedElemRestriction tria
                                              CeedElemRestriction geom_data_restr,
                                              CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/mixedvecgrad.cpp
+++ b/palace/fem/integ/mixedvecgrad.cpp
@@ -27,7 +27,7 @@ void MixedVectorGradientIntegrator::Assemble(Ceed ceed, CeedElemRestriction tria
                                              CeedElemRestriction geom_data_restr,
                                              CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.
@@ -132,7 +132,7 @@ void MixedVectorWeakDivergenceIntegrator::Assemble(
     CeedBasis trial_basis, CeedBasis test_basis, CeedVector geom_data,
     CeedElemRestriction geom_data_restr, CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/integ/vecfemass.cpp
+++ b/palace/fem/integ/vecfemass.cpp
@@ -21,7 +21,7 @@ void VectorFEMassIntegrator::Assemble(Ceed ceed, CeedElemRestriction trial_restr
                                       CeedElemRestriction geom_data_restr,
                                       CeedOperator *op) const
 {
-  IntegratorInfo info;
+  CeedQFunctionInfo info;
   info.assemble_q_data = assemble_q_data;
 
   // Set up QFunctions.

--- a/palace/fem/libceed/basis.cpp
+++ b/palace/fem/libceed/basis.cpp
@@ -120,11 +120,10 @@ void InitMfemInterpolatorBasis(const mfem::FiniteElement &trial_fe,
   MFEM_VERIFY(trial_num_comp == test_num_comp && trial_num_comp == 1,
               "libCEED discrete linear operator requires same vdim = 1 for trial and test "
               "FE spaces!");
-  const int dim = trial_fe.GetDim();
   const int trial_P = trial_fe.GetDof();
   const int test_P = test_fe.GetDof();
-  mfem::DenseMatrix qX(dim, test_P), Gt(trial_P, test_P * dim), Bt;
-  mfem::Vector qW(test_P);
+  mfem::DenseMatrix Bt, Gt(trial_P, test_P);
+  mfem::Vector qX(test_P), qW(test_P);
   mfem::IsoparametricTransformation dummy;
   dummy.SetIdentityTransformation(trial_fe.GetGeomType());
   if (trial_fe.GetMapType() == test_fe.GetMapType())
@@ -159,9 +158,10 @@ void InitMfemInterpolatorBasis(const mfem::FiniteElement &trial_fe,
   qX = 0.0;
   qW = 0.0;
 
-  PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, GetCeedTopology(trial_fe.GetGeomType()),
-                                         trial_num_comp, trial_P, test_P, Bt.GetData(),
-                                         Gt.GetData(), qX.GetData(), qW.GetData(), basis));
+  // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
+  PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, trial_num_comp, trial_P,
+                                         test_P, Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                         qW.GetData(), basis));
 }
 
 }  // namespace

--- a/palace/fem/libceed/ceed.cpp
+++ b/palace/fem/libceed/ceed.cpp
@@ -79,18 +79,13 @@ std::string Print()
 void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv)
 {
   CeedMemType mem;
-  const CeedScalar *data;
   PalaceCeedCall(ceed, CeedVectorCreate(ceed, v.Size(), cv));
   PalaceCeedCall(ceed, CeedGetPreferredMemType(ceed, &mem));
-  if (mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
+  if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
   {
-    data = v.Read();
-  }
-  else
-  {
-    data = v.HostRead();
     mem = CEED_MEM_HOST;
   }
+  const auto *data = v.Read(mem == CEED_MEM_DEVICE);
   PalaceCeedCall(
       ceed, CeedVectorSetArray(*cv, mem, CEED_USE_POINTER, const_cast<CeedScalar *>(data)));
 }

--- a/palace/fem/libceed/ceed.cpp
+++ b/palace/fem/libceed/ceed.cpp
@@ -76,16 +76,23 @@ std::string Print()
   return std::string(ceed_resource);
 }
 
-void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv)
+void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init)
 {
   CeedMemType mem;
-  PalaceCeedCall(ceed, CeedVectorCreate(ceed, v.Size(), cv));
   PalaceCeedCall(ceed, CeedGetPreferredMemType(ceed, &mem));
   if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
   {
     mem = CEED_MEM_HOST;
   }
   const auto *data = v.Read(mem == CEED_MEM_DEVICE);
+  if (init)
+  {
+    PalaceCeedCall(ceed, CeedVectorCreate(ceed, v.Size(), cv));
+  }
+  else
+  {
+    PalaceCeedCall(ceed, CeedVectorTakeArray(*cv, mem, nullptr));
+  }
   PalaceCeedCall(
       ceed, CeedVectorSetArray(*cv, mem, CEED_USE_POINTER, const_cast<CeedScalar *>(data)));
 }

--- a/palace/fem/libceed/ceed.hpp
+++ b/palace/fem/libceed/ceed.hpp
@@ -54,8 +54,9 @@ void Finalize();
 // Get the configured libCEED backend.
 std::string Print();
 
-// Initialize a CeedVector from an mfem::Vector.
-void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv);
+// Initialize a CeedVector from an mfem::Vector. When init is false, expects the CeedVector
+// has already been initialized and just sets the data pointer.
+void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init = true);
 
 // Convert an MFEM geometry type to a libCEED one.
 CeedElemTopology GetCeedTopology(mfem::Geometry::Type geom);

--- a/palace/fem/libceed/coefficient.cpp
+++ b/palace/fem/libceed/coefficient.cpp
@@ -118,13 +118,12 @@ PopulateCoefficientContext(int dim, const MaterialPropertyCoefficient *Q, double
 }
 
 std::vector<CeedIntScalar>
-PopulateCoefficientContext(int dim, int dim_mass, const MaterialPropertyCoefficient *Q,
-                           const MaterialPropertyCoefficient *Q_mass, double a,
-                           double a_mass)
+PopulateCoefficientContext(int dim_mass, const MaterialPropertyCoefficient *Q_mass, int dim,
+                           const MaterialPropertyCoefficient *Q, double a_mass, double a)
 {
   // Mass coefficient comes first, then the other one for the QFunction.
-  auto ctx = PopulateCoefficientContext(dim, Q, a);
   auto ctx_mass = PopulateCoefficientContext(dim_mass, Q_mass, a_mass);
+  auto ctx = PopulateCoefficientContext(dim, Q, a);
   ctx_mass.insert(ctx_mass.end(), ctx.begin(), ctx.end());
   return ctx_mass;
 }

--- a/palace/fem/libceed/coefficient.hpp
+++ b/palace/fem/libceed/coefficient.hpp
@@ -20,9 +20,9 @@ std::vector<CeedIntScalar>
 PopulateCoefficientContext(int dim, const MaterialPropertyCoefficient *Q, double a = 1.0);
 
 std::vector<CeedIntScalar>
-PopulateCoefficientContext(int dim, int dim_mass, const MaterialPropertyCoefficient *Q,
-                           const MaterialPropertyCoefficient *Q_mass, double a = 1.0,
-                           double a_mass = 1.0);
+PopulateCoefficientContext(int dim_mass, const MaterialPropertyCoefficient *Q_mass, int dim,
+                           const MaterialPropertyCoefficient *Q, double a_mass = 1.0,
+                           double a = 1.0);
 
 }  // namespace ceed
 

--- a/palace/fem/libceed/integrator.cpp
+++ b/palace/fem/libceed/integrator.cpp
@@ -21,6 +21,7 @@ namespace palace::ceed
 
 namespace
 {
+
 void AddQFunctionActiveInputs(unsigned int ops, Ceed ceed, CeedBasis basis,
                               CeedQFunction qf, std::string name = "u")
 {
@@ -146,6 +147,7 @@ void AddOperatorActiveInputFields(unsigned int ops, Ceed ceed, CeedElemRestricti
 {
   AddOperatorActiveFields(ops, ceed, restr, basis, op, name, v);
 }
+
 void AddOperatorActiveOutputFields(unsigned int ops, Ceed ceed, CeedElemRestriction restr,
                                    CeedBasis basis, CeedOperator op, std::string name = "v",
                                    CeedVector v = CEED_VECTOR_ACTIVE)
@@ -457,8 +459,8 @@ void AssembleCeedOperator(const CeedQFunctionInfo &info, void *ctx, std::size_t 
               "CeedOperator should not have quadrature weight output!");
   if (!info.assemble_q_data)
   {
-    AddQFunctionActiveInputsOutputs(info.trial_ops, true, ceed, trial_basis, apply_qf);
-    AddQFunctionActiveInputsOutputs(info.test_ops, false, ceed, test_basis, apply_qf);
+    AddQFunctionActiveInputs(info.trial_ops, ceed, trial_basis, apply_qf);
+    AddQFunctionActiveOutputs(info.test_ops, ceed, test_basis, apply_qf);
   }
   else
   {
@@ -591,9 +593,8 @@ void AssembleCeedElementErrorIntegrator(
   {
     PalaceCeedCall(ceed, CeedQFunctionAddInput(apply_qf, "q_w", 1, CEED_EVAL_WEIGHT));
   }
-  AddQFunctionActiveInputsOutputs(info.trial_ops, true, ceed, input1_basis, apply_qf,
-                                  "u_1");
-  AddQFunctionActiveInputsOutputs(info.test_ops, true, ceed, input2_basis, apply_qf, "u_2");
+  AddQFunctionActiveInputs(info.trial_ops, ceed, input1_basis, apply_qf, "u_1");
+  AddQFunctionActiveInputs(info.test_ops, ceed, input2_basis, apply_qf, "u_2");
   PalaceCeedCall(ceed,
                  CeedQFunctionAddOutput(apply_qf, "v", elem_num_comp, CEED_EVAL_INTERP));
 

--- a/palace/fem/libceed/integrator.cpp
+++ b/palace/fem/libceed/integrator.cpp
@@ -589,6 +589,7 @@ void AssembleCeedElementErrorIntegrator(
   PalaceCeedCall(ceed, CeedBasisGetNumQuadraturePoints(input1_basis, &num_qpts));
   CeedBasis mesh_elem_basis;
   {
+    // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
     mfem::Vector Bt(num_qpts), Gt(num_qpts), qX(num_qpts), qW(num_qpts);
     Bt = 1.0;
     Gt = 0.0;

--- a/palace/fem/libceed/integrator.hpp
+++ b/palace/fem/libceed/integrator.hpp
@@ -23,7 +23,7 @@ enum EvalMode : unsigned int
 };
 
 // Data structure for CeedOperator construction for various integrators.
-struct IntegratorInfo
+struct CeedQFunctionInfo
 {
   // QFunctions for operator construction and application.
   CeedQFunctionUser apply_qf;
@@ -38,7 +38,7 @@ struct IntegratorInfo
   // operator application in true matrix-free fashion.
   bool assemble_q_data;
 
-  IntegratorInfo()
+  CeedQFunctionInfo()
     : apply_qf(nullptr), apply_qf_path(""), trial_ops(0), test_ops(0),
       assemble_q_data(false)
   {
@@ -59,7 +59,7 @@ void AssembleCeedGeometryData(Ceed ceed, CeedElemRestriction mesh_restr,
 
 // Construct libCEED operator using the given quadrature data, element restriction, and
 // basis objects.
-void AssembleCeedOperator(const IntegratorInfo &info, void *ctx, std::size_t ctx_size,
+void AssembleCeedOperator(const CeedQFunctionInfo &info, void *ctx, std::size_t ctx_size,
                           Ceed ceed, CeedElemRestriction trial_restr,
                           CeedElemRestriction test_restr, CeedBasis trial_basis,
                           CeedBasis test_basis, CeedVector geom_data,
@@ -71,6 +71,15 @@ void AssembleCeedOperator(const IntegratorInfo &info, void *ctx, std::size_t ctx
 void AssembleCeedInterpolator(Ceed ceed, CeedElemRestriction trial_restr,
                               CeedElemRestriction test_restr, CeedBasis interp_basis,
                               CeedOperator *op, CeedOperator *op_t);
+
+// Construct a libCEED operator which integrates the squared difference between two
+// functions over every element.
+void AssembleCeedElementErrorIntegrator(
+    const CeedQFunctionInfo &info, void *ctx, std::size_t ctx_size, Ceed ceed,
+    CeedVector input1, CeedVector input2, CeedElemRestriction input1_restr,
+    CeedElemRestriction input2_restr, CeedBasis input1_basis, CeedBasis input2_basis,
+    CeedElemRestriction mesh_elem_restr, CeedVector geom_data,
+    CeedElemRestriction geom_data_restr, CeedOperator *op);
 
 }  // namespace palace::ceed
 

--- a/palace/fem/libceed/operator.cpp
+++ b/palace/fem/libceed/operator.cpp
@@ -67,8 +67,8 @@ void Operator::AddOper(CeedOperator sub_op, CeedOperator sub_op_t)
   PalaceCeedCallBackend(CeedOperatorGetCeed(sub_op, &ceed));
   CeedSize l_in, l_out;
   PalaceCeedCall(ceed, CeedOperatorGetActiveVectorLengths(sub_op, &l_in, &l_out));
-  MFEM_VERIFY(mfem::internal::to_int(l_in) == width &&
-                  mfem::internal::to_int(l_out) == height,
+  MFEM_VERIFY((l_in < 0 || mfem::internal::to_int(l_in) == width) &&
+                  (l_out < 0 || mfem::internal::to_int(l_out) == height),
               "Dimensions mismatch for CeedOperator!");
   PalaceCeedCall(ceed, CeedCompositeOperatorAddSub(op[id], sub_op));
   PalaceCeedCall(ceed, CeedOperatorDestroy(&sub_op));

--- a/palace/fem/qfunctions/21/hcurlhdiv_21_qf.h
+++ b/palace/fem/qfunctions/21/hcurlhdiv_21_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hcurlhdiv_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], v_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBCx21(J_loc, coeff, adjJt_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];
@@ -39,7 +39,7 @@ CEED_QFUNCTION(f_apply_hdivhcurl_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], v_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBCx21(adjJt_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/21/hcurlhdiv_build_21_qf.h
+++ b/palace/fem/qfunctions/21/hcurlhdiv_build_21_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hcurlhdiv_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], qd_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBC21(J_loc, coeff, adjJt_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];
@@ -37,7 +37,7 @@ CEED_QFUNCTION(f_build_hdivhcurl_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], qd_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBC21(adjJt_loc, coeff, J_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/21/hdiv_21_qf.h
+++ b/palace/fem/qfunctions/21/hdiv_21_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hdiv_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], v_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBCx21(J_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/21/hdiv_build_21_qf.h
+++ b/palace/fem/qfunctions/21/hdiv_build_21_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hdiv_21)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[2], J_loc[2], qd_loc[1];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack21(adjJt + i, Q, adjJt_loc);
-    AdjJt21<false>(adjJt_loc, J_loc);
+    AdjJt21(adjJt_loc, J_loc);
     MultAtBA21(J_loc, coeff, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/21/l2mass_21_qf.h
+++ b/palace/fem/qfunctions/21/l2mass_21_qf.h
@@ -22,7 +22,7 @@ CEED_QFUNCTION(f_apply_l2mass_21)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[3], adjJt_loc[2], J_loc[2], v_loc[1];
       CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack21(adjJt + i, Q, adjJt_loc);
-      AdjJt21<false>(adjJt_loc, J_loc);
+      AdjJt21(adjJt_loc, J_loc);
       MultAtBCx21(J_loc, coeff, J_loc, u_loc, v_loc);
 
       v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/21/l2mass_build_21_qf.h
+++ b/palace/fem/qfunctions/21/l2mass_build_21_qf.h
@@ -20,7 +20,7 @@ CEED_QFUNCTION(f_build_l2mass_21)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[3], adjJt_loc[2], J_loc[2], qd_loc[1];
       CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack21(adjJt + i, Q, adjJt_loc);
-      AdjJt21<false>(adjJt_loc, J_loc);
+      AdjJt21(adjJt_loc, J_loc);
       MultAtBA21(J_loc, coeff, qd_loc);
 
       qd1[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/21/utils_21_qf.h
+++ b/palace/fem/qfunctions/21/utils_21_qf.h
@@ -13,7 +13,7 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ21(const CeedScalar J[2])
   return sqrt(J[0] * J[0] + J[1] * J[1]);
 }
 
-template <bool ComputeDet>
+template <bool ComputeDet = false>
 CEED_QFUNCTION_HELPER CeedScalar AdjJt21(const CeedScalar J[2], CeedScalar adjJt[2])
 {
   // Compute adj(J)^T / det(J) and store the result.

--- a/palace/fem/qfunctions/22/hcurlhdiv_22_qf.h
+++ b/palace/fem/qfunctions/22/hcurlhdiv_22_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hcurlhdiv_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], v_loc[2];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBCx22(J_loc, coeff, adjJt_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_apply_hdivhcurl_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], v_loc[2];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBCx22(adjJt_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/22/hcurlhdiv_build_22_qf.h
+++ b/palace/fem/qfunctions/22/hcurlhdiv_build_22_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hcurlhdiv_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], qd_loc[4];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBC22(J_loc, coeff, adjJt_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_hdivhcurl_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], qd_loc[4];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBC22(adjJt_loc, coeff, J_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/22/hcurlhdiv_error_22_qf.h
+++ b/palace/fem/qfunctions/22/hcurlhdiv_error_22_qf.h
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURLHDIV_ERROR_22_QF_H
+#define PALACE_LIBCEED_HCURLHDIV_ERROR_22_QF_H
+
+#include "../coeff/coeff_2_qf.h"
+#include "utils_22_qf.h"
+
+CEED_QFUNCTION(f_apply_hcurlhdiv_error_22)(void *__restrict__ ctx, CeedInt Q,
+                                           const CeedScalar *const *in,
+                                           CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar adjJt_loc[4], v1_loc[2], v2_loc[2];
+    MatUnpack22(adjJt + i, Q, adjJt_loc);
+    {
+      const CeedScalar u1_loc[2] = {u1[i + Q * 0], u1[i + Q * 1]};
+      CeedScalar coeff[3];
+      CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MultBAx22(adjJt_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[2] = {u2[i + Q * 0], u2[i + Q * 1]};
+      CeedScalar coeff[3], J_loc[4];
+      CoeffUnpack2(CoeffPairSecond<2>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      AdjJt22(adjJt_loc, J_loc);
+      MultBAx22(J_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v[i + Q * 0] = wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1]);
+    v[i + Q * 1] = wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_apply_hdivhcurl_error_22)(void *__restrict__ ctx, CeedInt Q,
+                                           const CeedScalar *const *in,
+                                           CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar adjJt_loc[4], v1_loc[2], v2_loc[2];
+    MatUnpack22(adjJt + i, Q, adjJt_loc);
+    {
+      const CeedScalar u1_loc[2] = {u1[i + Q * 0], u1[i + Q * 1]};
+      CeedScalar coeff[3], J_loc[4];
+      CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      AdjJt22(adjJt_loc, J_loc);
+      MultBAx22(J_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[2] = {u2[i + Q * 0], u2[i + Q * 1]};
+      CeedScalar coeff[3];
+      CoeffUnpack2(CoeffPairSecond<2>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MultBAx22(adjJt_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v[i + Q * 0] = wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1]);
+    v[i + Q * 1] = wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1]);
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_HCURLHDIV_ERROR_22_QF_H

--- a/palace/fem/qfunctions/22/hdiv_22_qf.h
+++ b/palace/fem/qfunctions/22/hdiv_22_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hdiv_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], v_loc[2];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBCx22(J_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/22/hdiv_build_22_qf.h
+++ b/palace/fem/qfunctions/22/hdiv_build_22_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hdiv_22)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[3], adjJt_loc[4], J_loc[4], qd_loc[3];
     CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack22(adjJt + i, Q, adjJt_loc);
-    AdjJt22<false>(adjJt_loc, J_loc);
+    AdjJt22(adjJt_loc, J_loc);
     MultAtBA22(J_loc, coeff, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/22/l2mass_22_qf.h
+++ b/palace/fem/qfunctions/22/l2mass_22_qf.h
@@ -22,7 +22,7 @@ CEED_QFUNCTION(f_apply_l2mass_22)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[3], adjJt_loc[4], J_loc[4], v_loc[2];
       CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack22(adjJt + i, Q, adjJt_loc);
-      AdjJt22<false>(adjJt_loc, J_loc);
+      AdjJt22(adjJt_loc, J_loc);
       MultAtBCx22(J_loc, coeff, J_loc, u_loc, v_loc);
 
       v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/22/l2mass_build_22_qf.h
+++ b/palace/fem/qfunctions/22/l2mass_build_22_qf.h
@@ -20,7 +20,7 @@ CEED_QFUNCTION(f_build_l2mass_22)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[3], adjJt_loc[4], J_loc[4], qd_loc[3];
       CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack22(adjJt + i, Q, adjJt_loc);
-      AdjJt22<false>(adjJt_loc, J_loc);
+      AdjJt22(adjJt_loc, J_loc);
       MultAtBA22(J_loc, coeff, qd_loc);
 
       qd1[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/22/utils_22_qf.h
+++ b/palace/fem/qfunctions/22/utils_22_qf.h
@@ -13,7 +13,7 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ22(const CeedScalar J[4])
   return J[0] * J[3] - J[1] * J[2];
 }
 
-template <bool ComputeDet>
+template <bool ComputeDet = false>
 CEED_QFUNCTION_HELPER CeedScalar AdjJt22(const CeedScalar J[4], CeedScalar adjJt[4])
 {
   // Compute adj(J)^T / det(J) and store the result.
@@ -33,6 +33,15 @@ CEED_QFUNCTION_HELPER void MatUnpack22(const CeedScalar *A, const CeedInt A_stri
   A_loc[1] = A[A_stride * 1];
   A_loc[2] = A[A_stride * 2];
   A_loc[3] = A[A_stride * 3];
+}
+
+CEED_QFUNCTION_HELPER void MultBx22(const CeedScalar B[3], const CeedScalar x[2],
+                                    CeedScalar y[2])
+{
+  // B: 0 1
+  //    1 2
+  y[0] = B[0] * x[0] + B[1] * x[1];
+  y[1] = B[1] * x[0] + B[2] * x[1];
 }
 
 CEED_QFUNCTION_HELPER void MultAtBCx22(const CeedScalar A[4], const CeedScalar B[3],

--- a/palace/fem/qfunctions/32/hcurlhdiv_32_qf.h
+++ b/palace/fem/qfunctions/32/hcurlhdiv_32_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hcurlhdiv_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], v_loc[2];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBCx32(J_loc, coeff, adjJt_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_apply_hdivhcurl_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], v_loc[2];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBCx32(adjJt_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/32/hcurlhdiv_build_32_qf.h
+++ b/palace/fem/qfunctions/32/hcurlhdiv_build_32_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hcurlhdiv_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], qd_loc[4];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBC32(J_loc, coeff, adjJt_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_hdivhcurl_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], qd_loc[4];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBC32(adjJt_loc, coeff, J_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/32/hdiv_32_qf.h
+++ b/palace/fem/qfunctions/32/hdiv_32_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hdiv_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], v_loc[2];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBCx32(J_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/32/hdiv_build_32_qf.h
+++ b/palace/fem/qfunctions/32/hdiv_build_32_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hdiv_32)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[6], J_loc[6], qd_loc[3];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack32(adjJt + i, Q, adjJt_loc);
-    AdjJt32<false>(adjJt_loc, J_loc);
+    AdjJt32(adjJt_loc, J_loc);
     MultAtBA32(J_loc, coeff, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/32/l2mass_32_qf.h
+++ b/palace/fem/qfunctions/32/l2mass_32_qf.h
@@ -22,7 +22,7 @@ CEED_QFUNCTION(f_apply_l2mass_32)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[6], adjJt_loc[6], J_loc[6], v_loc[2];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack32(adjJt + i, Q, adjJt_loc);
-      AdjJt32<false>(adjJt_loc, J_loc);
+      AdjJt32(adjJt_loc, J_loc);
       MultAtBCx32(J_loc, coeff, J_loc, u_loc, v_loc);
 
       v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/32/l2mass_build_32_qf.h
+++ b/palace/fem/qfunctions/32/l2mass_build_32_qf.h
@@ -20,7 +20,7 @@ CEED_QFUNCTION(f_build_l2mass_32)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[6], adjJt_loc[6], J_loc[6], qd_loc[3];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack32(adjJt + i, Q, adjJt_loc);
-      AdjJt32<false>(adjJt_loc, J_loc);
+      AdjJt32(adjJt_loc, J_loc);
       MultAtBA32(J_loc, coeff, qd_loc);
 
       qd1[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/32/utils_32_qf.h
+++ b/palace/fem/qfunctions/32/utils_32_qf.h
@@ -17,7 +17,7 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ32(const CeedScalar J[6])
   return sqrt(E * G - F * F);
 }
 
-template <bool ComputeDet>
+template <bool ComputeDet = false>
 CEED_QFUNCTION_HELPER CeedScalar AdjJt32(const CeedScalar J[6], CeedScalar adjJt[6])
 {
   // Compute adj(J)^T / det(J) and store the result.

--- a/palace/fem/qfunctions/33/hcurlh1d_error_22_qf.h
+++ b/palace/fem/qfunctions/33/hcurlh1d_error_22_qf.h
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURLH1D_ERROR_22_QF_H
+#define PALACE_LIBCEED_HCURLH1D_ERROR_22_QF_H
+
+#include "../coeff/coeff_2_qf.h"
+#include "utils_22_qf.h"
+
+CEED_QFUNCTION(f_apply_hcurlh1d_error_22)(void *__restrict__ ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar v1_loc[2], v2_loc[2];
+    {
+      const CeedScalar u1_loc[2] = {u1[i + Q * 0], u1[i + Q * 1]};
+      CeedScalar coeff[3], adjJt_loc[4];
+      CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MatUnpack22(adjJt + i, Q, adjJt_loc);
+      MultBAx22(adjJt_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[2] = {u2[i + Q * 0], u2[i + Q * 1]};
+      CeedScalar coeff[3];
+      CoeffUnpack2(CoeffPairSecond<2>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MultBx22(coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v[i + Q * 0] = wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1]);
+    v[i + Q * 1] = wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_apply_h1dhcurl_error_22)(void *__restrict__ ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar v1_loc[2], v2_loc[2];
+    {
+      const CeedScalar u1_loc[2] = {u1[i + Q * 0], u1[i + Q * 1]};
+      CeedScalar coeff[3];
+      CoeffUnpack2((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MultBx22(coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[2] = {u2[i + Q * 0], u2[i + Q * 1]};
+      CeedScalar coeff[3], adjJt_loc[4];
+      CoeffUnpack2(CoeffPairSecond<2>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MatUnpack22(adjJt + i, Q, adjJt_loc);
+      MultBAx22(adjJt_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v[i + Q * 0] = wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1]);
+    v[i + Q * 1] = wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1]);
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_HCURLH1D_ERROR_22_QF_H

--- a/palace/fem/qfunctions/33/hcurlh1d_error_33_qf.h
+++ b/palace/fem/qfunctions/33/hcurlh1d_error_33_qf.h
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURLH1D_ERROR_33_QF_H
+#define PALACE_LIBCEED_HCURLH1D_ERROR_33_QF_H
+
+#include "../coeff/coeff_3_qf.h"
+#include "utils_33_qf.h"
+
+CEED_QFUNCTION(f_apply_hcurlh1d_error_33)(void *__restrict__ ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar v1_loc[3], v2_loc[3];
+    {
+      const CeedScalar u1_loc[3] = {u1[i + Q * 0], u1[i + Q * 1], u1[i + Q * 2]};
+      CeedScalar coeff[6], adjJt_loc[9];
+      CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MatUnpack33(adjJt + i, Q, adjJt_loc);
+      MultBAx33(adjJt_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[3] = {u2[i + Q * 0], u2[i + Q * 1], u2[i + Q * 2]};
+      CeedScalar coeff[6];
+      CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MultBx33(coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v2_loc[2] -= v1_loc[2];
+    v[i + Q * 0] =
+        wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1] + v2_loc[2] * v2_loc[2]);
+    v[i + Q * 1] =
+        wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1] + v1_loc[2] * v1_loc[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_apply_h1dhcurl_error_33)(void *__restrict__ ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar v1_loc[3], v2_loc[3];
+    {
+      const CeedScalar u1_loc[3] = {u1[i + Q * 0], u1[i + Q * 1], u1[i + Q * 2]};
+      CeedScalar coeff[6];
+      CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MultBx33(coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[3] = {u2[i + Q * 0], u2[i + Q * 1], u2[i + Q * 2]};
+      CeedScalar coeff[6], adjJt_loc[9];
+      CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MatUnpack33(adjJt + i, Q, adjJt_loc);
+      MultBAx33(adjJt_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v2_loc[2] -= v1_loc[2];
+    v[i + Q * 0] =
+        wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1] + v2_loc[2] * v2_loc[2]);
+    v[i + Q * 1] =
+        wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1] + v1_loc[2] * v1_loc[2]);
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_HCURLH1D_ERROR_33_QF_H

--- a/palace/fem/qfunctions/33/hcurlhdiv_33_qf.h
+++ b/palace/fem/qfunctions/33/hcurlhdiv_33_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hcurlhdiv_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], v_loc[3];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBCx33(J_loc, coeff, adjJt_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];
@@ -41,7 +41,7 @@ CEED_QFUNCTION(f_apply_hdivhcurl_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], v_loc[3];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBCx33(adjJt_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/33/hcurlhdiv_build_33_qf.h
+++ b/palace/fem/qfunctions/33/hcurlhdiv_build_33_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hcurlhdiv_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], qd_loc[9];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBC33(J_loc, coeff, adjJt_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];
@@ -45,7 +45,7 @@ CEED_QFUNCTION(f_build_hdivhcurl_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], qd_loc[9];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBC33(adjJt_loc, coeff, J_loc, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/33/hcurlhdiv_error_33_qf.h
+++ b/palace/fem/qfunctions/33/hcurlhdiv_error_33_qf.h
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURLHDIV_ERROR_33_QF_H
+#define PALACE_LIBCEED_HCURLHDIV_ERROR_33_QF_H
+
+#include "../coeff/coeff_3_qf.h"
+#include "utils_33_qf.h"
+
+CEED_QFUNCTION(f_apply_hcurlhdiv_error_33)(void *__restrict__ ctx, CeedInt Q,
+                                           const CeedScalar *const *in,
+                                           CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar adjJt_loc[9], v1_loc[3], v2_loc[3];
+    MatUnpack33(adjJt + i, Q, adjJt_loc);
+    {
+      const CeedScalar u1_loc[3] = {u1[i + Q * 0], u1[i + Q * 1], u1[i + Q * 2]};
+      CeedScalar coeff[6];
+      CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      MultBAx33(adjJt_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[3] = {u2[i + Q * 0], u2[i + Q * 1], u2[i + Q * 2]};
+      CeedScalar coeff[6], J_loc[9];
+      CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      AdjJt33(adjJt_loc, J_loc);
+      MultBAx33(J_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v2_loc[2] -= v1_loc[2];
+    v[i + Q * 0] =
+        wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1] + v2_loc[2] * v2_loc[2]);
+    v[i + Q * 1] =
+        wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1] + v1_loc[2] * v1_loc[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_apply_hdivhcurl_error_33)(void *__restrict__ ctx, CeedInt Q,
+                                           const CeedScalar *const *in,
+                                           CeedScalar *const *out)
+{
+  const CeedScalar *attr = in[0], *wdetJ = in[0] + Q, *adjJt = in[0] + 2 * Q, *u1 = in[1],
+                   *u2 = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar adjJt_loc[9], v1_loc[3], v2_loc[3];
+    MatUnpack33(adjJt + i, Q, adjJt_loc);
+    {
+      const CeedScalar u1_loc[3] = {u1[i + Q * 0], u1[i + Q * 1], u1[i + Q * 2]};
+      CeedScalar coeff[6], J_loc[9];
+      CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
+      AdjJt33(adjJt_loc, J_loc);
+      MultBAx33(J_loc, coeff, u1_loc, v1_loc);
+    }
+    {
+      const CeedScalar u2_loc[3] = {u2[i + Q * 0], u2[i + Q * 1], u2[i + Q * 2]};
+      CeedScalar coeff[6];
+      CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
+      MultBAx33(adjJt_loc, coeff, u2_loc, v2_loc);
+    }
+    v2_loc[0] -= v1_loc[0];
+    v2_loc[1] -= v1_loc[1];
+    v2_loc[2] -= v1_loc[2];
+    v[i + Q * 0] =
+        wdetJ[i] * (v2_loc[0] * v2_loc[0] + v2_loc[1] * v2_loc[1] + v2_loc[2] * v2_loc[2]);
+    v[i + Q * 1] =
+        wdetJ[i] * (v1_loc[0] * v1_loc[0] + v1_loc[1] * v1_loc[1] + v1_loc[2] * v1_loc[2]);
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_HCURLHDIV_ERROR_33_QF_H

--- a/palace/fem/qfunctions/33/hdiv_33_qf.h
+++ b/palace/fem/qfunctions/33/hdiv_33_qf.h
@@ -19,7 +19,7 @@ CEED_QFUNCTION(f_apply_hdiv_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], v_loc[3];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBCx33(J_loc, coeff, J_loc, u_loc, v_loc);
 
     v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/33/hdiv_build_33_qf.h
+++ b/palace/fem/qfunctions/33/hdiv_build_33_qf.h
@@ -18,7 +18,7 @@ CEED_QFUNCTION(f_build_hdiv_33)(void *__restrict__ ctx, CeedInt Q,
     CeedScalar coeff[6], adjJt_loc[9], J_loc[9], qd_loc[6];
     CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
     MatUnpack33(adjJt + i, Q, adjJt_loc);
-    AdjJt33<false>(adjJt_loc, J_loc);
+    AdjJt33(adjJt_loc, J_loc);
     MultAtBA33(J_loc, coeff, qd_loc);
 
     qd[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/33/hdivmass_33_qf.h
+++ b/palace/fem/qfunctions/33/hdivmass_33_qf.h
@@ -16,11 +16,12 @@ CEED_QFUNCTION(f_apply_hdivmass_33)(void *__restrict__ ctx, CeedInt Q,
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
+    CeedScalar adjJt_loc[9];
+    MatUnpack33(adjJt + i, Q, adjJt_loc);
     {
       const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
-      CeedScalar coeff[6], adjJt_loc[9], v_loc[3];
+      CeedScalar coeff[6], v_loc[3];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
-      MatUnpack33(adjJt + i, Q, adjJt_loc);
       MultAtBCx33(adjJt_loc, coeff, adjJt_loc, u_loc, v_loc);
 
       v[i + Q * 0] = wdetJ[i] * v_loc[0];
@@ -29,10 +30,9 @@ CEED_QFUNCTION(f_apply_hdivmass_33)(void *__restrict__ ctx, CeedInt Q,
     }
     {
       const CeedScalar u_loc[3] = {curlu[i + Q * 0], curlu[i + Q * 1], curlu[i + Q * 2]};
-      CeedScalar coeff[6], adjJt_loc[9], J_loc[9], v_loc[3];
+      CeedScalar coeff[6], J_loc[9], v_loc[3];
       CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
-      MatUnpack33(adjJt + i, Q, adjJt_loc);
-      AdjJt33<false>(adjJt_loc, J_loc);
+      AdjJt33(adjJt_loc, J_loc);
       MultAtBCx33(J_loc, coeff, J_loc, u_loc, v_loc);
 
       curlv[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/33/hdivmass_build_33_qf.h
+++ b/palace/fem/qfunctions/33/hdivmass_build_33_qf.h
@@ -15,10 +15,11 @@ CEED_QFUNCTION(f_build_hdivmass_33)(void *__restrict__ ctx, CeedInt Q,
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
   {
+    CeedScalar adjJt_loc[9];
+    MatUnpack33(adjJt + i, Q, adjJt_loc);
     {
-      CeedScalar coeff[6], adjJt_loc[9], qd_loc[6];
+      CeedScalar coeff[6], qd_loc[6];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
-      MatUnpack33(adjJt + i, Q, adjJt_loc);
       MultAtBA33(adjJt_loc, coeff, qd_loc);
 
       qd1[i + Q * 0] = wdetJ[i] * qd_loc[0];
@@ -29,10 +30,9 @@ CEED_QFUNCTION(f_build_hdivmass_33)(void *__restrict__ ctx, CeedInt Q,
       qd1[i + Q * 5] = wdetJ[i] * qd_loc[5];
     }
     {
-      CeedScalar coeff[6], adjJt_loc[9], J_loc[9], qd_loc[6];
+      CeedScalar coeff[6], J_loc[9], qd_loc[6];
       CoeffUnpack3(CoeffPairSecond<3>((const CeedIntScalar *)ctx), (CeedInt)attr[i], coeff);
-      MatUnpack33(adjJt + i, Q, adjJt_loc);
-      AdjJt33<false>(adjJt_loc, J_loc);
+      AdjJt33(adjJt_loc, J_loc);
       MultAtBA33(J_loc, coeff, qd_loc);
 
       qd2[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/33/l2mass_33_qf.h
+++ b/palace/fem/qfunctions/33/l2mass_33_qf.h
@@ -22,7 +22,7 @@ CEED_QFUNCTION(f_apply_l2mass_33)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[6], adjJt_loc[9], J_loc[9], v_loc[3];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack33(adjJt + i, Q, adjJt_loc);
-      AdjJt33<false>(adjJt_loc, J_loc);
+      AdjJt33(adjJt_loc, J_loc);
       MultAtBCx33(J_loc, coeff, J_loc, u_loc, v_loc);
 
       v[i + Q * 0] = wdetJ[i] * v_loc[0];

--- a/palace/fem/qfunctions/33/l2mass_build_33_qf.h
+++ b/palace/fem/qfunctions/33/l2mass_build_33_qf.h
@@ -20,7 +20,7 @@ CEED_QFUNCTION(f_build_l2mass_33)(void *__restrict__ ctx, CeedInt Q,
       CeedScalar coeff[6], adjJt_loc[9], J_loc[9], qd_loc[6];
       CoeffUnpack3((const CeedIntScalar *)ctx, (CeedInt)attr[i], coeff);
       MatUnpack33(adjJt + i, Q, adjJt_loc);
-      AdjJt33<false>(adjJt_loc, J_loc);
+      AdjJt33(adjJt_loc, J_loc);
       MultAtBA33(J_loc, coeff, qd_loc);
 
       qd1[i + Q * 0] = wdetJ[i] * qd_loc[0];

--- a/palace/fem/qfunctions/33/utils_33_qf.h
+++ b/palace/fem/qfunctions/33/utils_33_qf.h
@@ -15,7 +15,7 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ33(const CeedScalar J[9])
          J[2] * (J[3] * J[7] - J[4] * J[6]);
 }
 
-template <bool ComputeDet>
+template <bool ComputeDet = false>
 CEED_QFUNCTION_HELPER CeedScalar AdjJt33(const CeedScalar J[9], CeedScalar adjJt[9])
 {
   // Compute adj(J)^T / det(J) and store the result.
@@ -46,6 +46,17 @@ CEED_QFUNCTION_HELPER void MatUnpack33(const CeedScalar *A, const CeedInt A_stri
   A_loc[6] = A[A_stride * 6];
   A_loc[7] = A[A_stride * 7];
   A_loc[8] = A[A_stride * 8];
+}
+
+CEED_QFUNCTION_HELPER void MultBx33(const CeedScalar B[6], const CeedScalar x[3],
+                                    CeedScalar y[3])
+{
+  // B: 0 1 2
+  //    1 3 4
+  //    2 4 5
+  y[0] = B[0] * x[0] + B[1] * x[1] + B[2] * x[2];
+  y[1] = B[1] * x[0] + B[3] * x[1] + B[4] * x[2];
+  y[2] = B[2] * x[0] + B[4] * x[1] + B[5] * x[2];
 }
 
 CEED_QFUNCTION_HELPER void MultAtBCx33(const CeedScalar A[9], const CeedScalar B[6],

--- a/palace/fem/qfunctions/hcurlh1d_error_qf.h
+++ b/palace/fem/qfunctions/hcurlh1d_error_qf.h
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURL_H1D_ERROR_QF_H
+#define PALACE_LIBCEED_HCURL_H1D_ERROR_QF_H
+
+// libCEED QFunctions for computing errors between two functions, one in H(curl) and one in
+// (H1)ᵈ (Piola transformations u = adj(J)^T / det(J) ̂u and u = ̂u).
+// in[0] is geometry quadrature data, shape [ncomp=2+space_dim*dim, Q]
+// in[1] is active vector 1, shape [qcomp=dim, ncomp=1, Q] or [ncomp=dim, Q]
+// in[2] is active vector 2, shape [ncomp=dim, Q] or [qcomp=dim, ncomp=1, Q]
+// out[0] is active vector, shape [ncomp=2, Q]
+
+// Only for the square Jacobian case where dim = space_dim.
+
+#include "22/hcurlh1d_error_22_qf.h"
+#include "33/hcurlh1d_error_33_qf.h"
+
+#endif  // PALACE_LIBCEED_HCURL_H1D_ERROR_QF_H

--- a/palace/fem/qfunctions/hcurlhdiv_error_qf.h
+++ b/palace/fem/qfunctions/hcurlhdiv_error_qf.h
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_HCURL_HDIV_ERROR_QF_H
+#define PALACE_LIBCEED_HCURL_HDIV_ERROR_QF_H
+
+// libCEED QFunctions for computing errors between two functions, one in H(curl) and one in
+// H(div) (Piola transformations u = adj(J)^T / det(J) ̂u and u = J / det(J) ̂u).
+// Note: J / det(J) = adj(adj(J)^T / det(J))^T
+// in[0] is geometry quadrature data, shape [ncomp=2+space_dim*dim, Q]
+// in[1] is active vector 1, shape [qcomp=dim, ncomp=1, Q]
+// in[2] is active vector 2, shape [qcomp=dim, ncomp=1, Q]
+// out[0] is active vector, shape [ncomp=2, Q]
+
+// Only for the square Jacobian case where dim = space_dim.
+
+#include "22/hcurlhdiv_error_22_qf.h"
+#include "33/hcurlhdiv_error_33_qf.h"
+
+#endif  // PALACE_LIBCEED_HCURL_HDIV_ERROR_QF_H

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -212,106 +212,118 @@ void CurlFluxErrorEstimator<VecType>::AddErrorIndicator(const VecType &U,
     nd_fespace.GetProlongationMatrix()->Mult(U.Imag(), U_gf.Imag());
     nd_fespace.GetProlongationMatrix()->Mult(F.Real(), F_gf.Real());
     nd_fespace.GetProlongationMatrix()->Mult(F.Imag(), F_gf.Imag());
-    U_gf.Real().HostRead();
-    U_gf.Imag().HostRead();
-    F_gf.Real().HostRead();
-    F_gf.Imag().HostRead();
   }
   else
   {
     nd_fespace.GetProlongationMatrix()->Mult(U, U_gf);
     nd_fespace.GetProlongationMatrix()->Mult(F, F_gf);
-    U_gf.HostRead();
-    F_gf.HostRead();
   }
 
-  // Loop over elements and accumulate the estimates from this component. The discontinuous
-  // flux is μ⁻¹ ∇ × U.
-  const auto &mesh = nd_fespace.GetParMesh();
-  Vector estimates(mesh.GetNE());
-  auto *h_estimates = estimates.HostWrite();
-  double norm2 = 0.0;
-  PalacePragmaOmp(parallel reduction(+ : norm2))
-  {
-    // Assuming dim == space_dim == curl_dim
-    mfem::IsoparametricTransformation T;
-    mfem::Array<int> dofs;
-    mfem::DofTransformation dof_trans;
-    mfem::Vector V_ip(mesh.SpaceDimension()), V_smooth(mesh.SpaceDimension()),
-        V_tmp(mesh.SpaceDimension()), loc_gf;
-    mfem::DenseMatrix Interp, Curl;
-
-    double loc_norm2 = 0.0;
-    PalacePragmaOmp(for schedule(static))
-    for (int e = 0; e < mesh.GetNE(); e++)
-    {
-      const mfem::FiniteElement &fe = *nd_fespace.Get().GetFE(e);
-      mesh.GetElementTransformation(e, &T);
-      nd_fespace.Get().GetElementDofs(e, dofs, dof_trans);
-      Interp.SetSize(fe.GetDof(), V_ip.Size());
-      Curl.SetSize(fe.GetDof(), V_ip.Size());
-      const int q_order = fem::DefaultIntegrationOrder::Get(T);
-      const mfem::IntegrationRule &ir =
-          mfem::IntRules.Get(mesh.GetElementGeometry(e), q_order);
-
-      double elem_err = 0.0;
-      for (int i = 0; i < ir.GetNPoints(); i++)
-      {
-        const mfem::IntegrationPoint &ip = ir.IntPoint(i);
-        T.SetIntPoint(&ip);
-        fe.CalcVShape(ip, Interp);
-        fe.CalcCurlShape(ip, Curl);
-        const double w = ip.weight * T.Weight();
-
-        auto AccumulateError = [&](const Vector &U_gf_, const Vector &F_gf_)
-        {
-          // μ⁻¹ ∇ × U -- μ⁻¹ |J|⁻¹ J ∇ × Uᵣ
-          U_gf_.GetSubVector(dofs, loc_gf);
-          if (dof_trans.GetDofTransformation())
-          {
-            dof_trans.InvTransformPrimal(loc_gf);
-          }
-          Curl.MultTranspose(loc_gf, V_ip);
-          T.Jacobian().Mult(V_ip, V_smooth);
-          mat_op.GetInvPermeability(T.Attribute).Mult(V_smooth, V_ip);
-          V_ip *= 1.0 / T.Weight();
-
-          // Smooth flux -- J⁻ᵀ Fᵣ
-          F_gf_.GetSubVector(dofs, loc_gf);
-          if (dof_trans.GetDofTransformation())
-          {
-            dof_trans.InvTransformPrimal(loc_gf);
-          }
-          Interp.MultTranspose(loc_gf, V_tmp);
-          T.InverseJacobian().MultTranspose(V_tmp, V_smooth);
-
-          V_smooth -= V_ip;
-          elem_err += w * (V_smooth * V_smooth);
-          return w * (V_ip * V_ip);
-        };
-        if constexpr (std::is_same<VecType, ComplexVector>::value)
-        {
-          loc_norm2 += AccumulateError(U_gf.Real(), F_gf.Real());
-          loc_norm2 += AccumulateError(U_gf.Imag(), F_gf.Imag());
-        }
-        else
-        {
-          loc_norm2 += AccumulateError(U_gf, F_gf);
-        }
-      }
-      h_estimates[e] = std::sqrt(elem_err);
-    }
-    norm2 += loc_norm2;
-  }
+  // Use libCEED operators to perform the error estimate integration over each element. The
+  // discontinuous flux is μ⁻¹ ∇ × U. Output is stored as error integral for all elements
+  // first, then scaling integral.
+  const auto &mesh = nd_fespace.GetMesh();
+  constexpr CeedInt elem_num_comp = 2;
+  Vector estimates(elem_num_comp * mesh.GetNE());
   estimates.UseDevice(true);
+  estimates = 0.0;
+  const std::size_t nt = ceed::internal::GetCeedObjects().size();
+  PalacePragmaOmp(parallel if (nt > 1))
+  {
+    Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
+    for (const auto &[geom, data] : mesh.GetCeedGeomFactorData(ceed))
+    {
+      // Only integrate over domain elements (not on the boundary).
+      if (mfem::Geometry::Dimension[geom] < mesh.Dimension())
+      {
+        continue;
+      }
+
+      // Create libCEED vector wrappers for use with libCEED operators. Each thread writes
+      // to non-overlapping entries of the estimates vector.
+      CeedVector estimates_vec, U_gf_vec, F_gf_vec;
+      ceed::InitCeedVector(estimates, ceed, &estimates_vec);
+      if constexpr (std::is_same<VecType, ComplexVector>::value)
+      {
+        ceed::InitCeedVector(U_gf.Real(), ceed, &U_gf_vec);
+        ceed::InitCeedVector(F_gf.Real(), ceed, &F_gf_vec);
+      }
+      else
+      {
+        ceed::InitCeedVector(U_gf, ceed, &U_gf_vec);
+        ceed::InitCeedVector(F_gf, ceed, &F_gf_vec);
+      }
+
+      // Construct mesh element restriction for elements of this element geometry type.
+      CeedElemRestriction mesh_elem_restr;
+      PalaceCeedCall(ceed,
+                     CeedElemRestrictionCreate(
+                         ceed, static_cast<CeedInt>(data.indices.size()), 1, elem_num_comp,
+                         mesh.GetNE(), elem_num_comp * mesh.GetNE(), CEED_MEM_HOST,
+                         CEED_COPY_VALUES, data.indices.data(), &mesh_elem_restr));
+
+      // Element restriction and basis objects for inputs.
+      CeedElemRestriction nd_restr =
+          nd_fespace.GetCeedElemRestriction(ceed, geom, data.indices);
+      CeedBasis nd_basis = nd_fespace.GetCeedBasis(ceed, geom);
+
+      // Construct coefficient for discontinuous flux.
+      MaterialPropertyCoefficient muinv_func(mat_op.GetAttributeToMaterial(),
+                                             mat_op.GetInvPermeability());
+      auto ctx = ceed::PopulateCoefficientContext(mesh.SpaceDimension(), &muinv_func,
+                                                  mesh.SpaceDimension(), nullptr);
+
+      // Assemble the libCEED operator. Inputs: Discontinuous flux, then smooth flux.
+      // Currently only supports 3D, since curl in 2D requires special treatment.
+      ceed::CeedQFunctionInfo info;
+      info.assemble_q_data = false;
+      switch (10 * mesh.SpaceDimension() + mesh.Dimension())
+      {
+        case 33:
+          info.apply_qf = f_apply_hdivhcurl_error_33;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_apply_hdivhcurl_error_33_loc);
+          break;
+        default:
+          MFEM_ABORT("Invalid value of (dim, space_dim) = ("
+                     << mesh.Dimension() << ", " << mesh.SpaceDimension()
+                     << ") for CurlFluxErrorEstimator!");
+      }
+      info.trial_ops = ceed::EvalMode::Curl;
+      info.test_ops = ceed::EvalMode::Interp;
+
+      CeedOperator op;
+      ceed::AssembleCeedElementErrorIntegrator(
+          info, (void *)ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, U_gf_vec,
+          F_gf_vec, nd_restr, nd_restr, nd_basis, nd_basis, mesh_elem_restr, data.geom_data,
+          data.geom_data_restr, &op);
+
+      // Do the integration (both input vectors are passive). For complex case, add sum of
+      // squares of real and imaginary parts to the estimates before square root.
+      PalaceCeedCall(ceed, CeedOperatorApplyAdd(op, CEED_VECTOR_NONE, estimates_vec,
+                                                CEED_REQUEST_IMMEDIATE));
+      if constexpr (std::is_same<VecType, ComplexVector>::value)
+      {
+        ceed::InitCeedVector(U_gf.Imag(), ceed, &U_gf_vec, false);
+        ceed::InitCeedVector(F_gf.Imag(), ceed, &F_gf_vec, false);
+        PalaceCeedCall(ceed, CeedOperatorApplyAdd(op, CEED_VECTOR_NONE, estimates_vec,
+                                                  CEED_REQUEST_IMMEDIATE));
+      }
+
+      // Cleanup.
+      PalaceCeedCall(ceed, CeedOperatorDestroy(&op));
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_elem_restr));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&estimates_vec));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&U_gf_vec));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&F_gf_vec));
+    }
+  }
 
   // Finalize the element-wise error estimates.
-  Mpi::GlobalSum(1, &norm2, mesh.GetComm());
-  if (norm2 > 0.0)
-  {
-    estimates *= 1.0 / std::sqrt(norm2);
-  }
-  indicator.AddIndicator(estimates);
+  Vector estimates0(estimates, 0, mesh.GetNE()),
+      estimates1(estimates, mesh.GetNE(), mesh.GetNE());
+  auto norm2 = linalg::Sum<Vector>(mesh.GetComm(), estimates1);
+  linalg::Sqrt(estimates0, (norm2 > 0.0) ? 1.0 / norm2 : 1.0);
+  indicator.AddIndicator(estimates0);
 }
 
 GradFluxErrorEstimator::GradFluxErrorEstimator(const MaterialOperator &mat_op,
@@ -349,13 +361,7 @@ void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
   const std::size_t nt = ceed::internal::GetCeedObjects().size();
   PalacePragmaOmp(parallel if (nt > 1))
   {
-    // Create libCEED vector wrappers for use with libCEED operators. Each thread writes to
-    // non-overlapping entries of the estimates vector.
     Ceed ceed = ceed::internal::GetCeedObjects()[utils::GetThreadNum()];
-    CeedVector estimates_vec, U_gf_vec, F_gf_vec;
-    ceed::InitCeedVector(estimates, ceed, &estimates_vec);
-    ceed::InitCeedVector(U_gf, ceed, &U_gf_vec);
-    ceed::InitCeedVector(F_gf, ceed, &F_gf_vec);
     for (const auto &[geom, data] : mesh.GetCeedGeomFactorData(ceed))
     {
       // Only integrate over domain elements (not on the boundary).
@@ -363,6 +369,13 @@ void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
       {
         continue;
       }
+
+      // Create libCEED vector wrappers for use with libCEED operators. Each thread writes
+      // to non-overlapping entries of the estimates vector.
+      CeedVector estimates_vec, U_gf_vec, F_gf_vec;
+      ceed::InitCeedVector(estimates, ceed, &estimates_vec);
+      ceed::InitCeedVector(U_gf, ceed, &U_gf_vec);
+      ceed::InitCeedVector(F_gf, ceed, &F_gf_vec);
 
       // Construct mesh element restriction for elements of this element geometry type.
       CeedElemRestriction mesh_elem_restr;
@@ -420,12 +433,10 @@ void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
       // Cleanup.
       PalaceCeedCall(ceed, CeedOperatorDestroy(&op));
       PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_elem_restr));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&estimates_vec));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&U_gf_vec));
+      PalaceCeedCall(ceed, CeedVectorDestroy(&F_gf_vec));
     }
-
-    // Cleanup.
-    PalaceCeedCall(ceed, CeedVectorDestroy(&estimates_vec));
-    PalaceCeedCall(ceed, CeedVectorDestroy(&U_gf_vec));
-    PalaceCeedCall(ceed, CeedVectorDestroy(&F_gf_vec));
   }
 
   // Finalize the element-wise error estimates.

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -8,6 +8,7 @@
 #include <mfem.hpp>
 #include "fem/errorindicator.hpp"
 #include "fem/fespace.hpp"
+#include "fem/libceed/operator.hpp"
 #include "linalg/ksp.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
@@ -57,14 +58,14 @@ public:
 template <typename VecType>
 class CurlFluxErrorEstimator
 {
-  // Reference to material property data (not owned).
-  const MaterialOperator &mat_op;
-
   // Finite element space used to represent U and F.
-  FiniteElementSpace &nd_fespace;
+  const FiniteElementSpace &nd_fespace;
 
   // Global L2 projection solver.
   FluxProjector<VecType> projector;
+
+  // Operator which performs the integration of the flux error on each element.
+  ceed::Operator integ_op;
 
   // Temporary vectors for error estimation.
   mutable VecType U_gf, F, F_gf;
@@ -83,14 +84,14 @@ public:
 // denotes a smooth reconstruction of ε ∇Uₕ with continuous normal component.
 class GradFluxErrorEstimator
 {
-  // Reference to material property data (not owned).
-  const MaterialOperator &mat_op;
-
   // Finite element spaces used to represent U and F.
-  FiniteElementSpace &h1_fespace, &rt_fespace;
+  const FiniteElementSpace &h1_fespace, &rt_fespace;
 
   // Global L2 projection solver.
   FluxProjector<Vector> projector;
+
+  // Operator which performs the integration of the flux error on each element.
+  ceed::Operator integ_op;
 
   // Temporary vectors for error estimation.
   mutable Vector U_gf, F, F_gf;

--- a/palace/linalg/vector.cpp
+++ b/palace/linalg/vector.cpp
@@ -735,6 +735,15 @@ void AXPBYPCZ(double alpha, const ComplexVector &x, double beta, const ComplexVe
   z.AXPBYPCZ(alpha, x, beta, y, gamma);
 }
 
+void Sqrt(Vector &x, double s)
+{
+  const bool use_dev = x.UseDevice();
+  const int N = x.Size();
+  auto *X = x.ReadWrite(use_dev);
+  mfem::forall_switch(use_dev, N,
+                      [=] MFEM_HOST_DEVICE(int i) { X[i] = std::sqrt(X[i] * s); });
+}
+
 }  // namespace linalg
 
 }  // namespace palace

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -246,6 +246,10 @@ template <typename VecType, typename ScalarType>
 void AXPBYPCZ(ScalarType alpha, const VecType &x, ScalarType beta, const VecType &y,
               ScalarType gamma, VecType &z);
 
+// Compute element-wise square root, optionally with scaling (multiplied before the square
+// root).
+void Sqrt(Vector &x, double s = 1.0);
+
 }  // namespace linalg
 
 }  // namespace palace


### PR DESCRIPTION
Resolves #213. Full error estimate calculation now takes place on GPU without host-device transfer.

Performance comparison for estimation time (the loop over mesh elements) on a particularly large example problem (on CPU):
- `main`: 1209.6 s
- This PR: 6.8 s