### PR TITLE
Add `"EstimatorMG"` option for estimation mass matrix linear solve

### DIFF
--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -337,6 +337,9 @@ directory specified by [`config["Problem"]["Output"]`](problem.md#config%5B%22Pr
     "PCSide": <string>,
     "DivFreeTol": <float>,
     "DivFreeMaxIts": <float>,
+    "EstimatorTol": <float>,
+    "EstimatorMaxIts": <float>,
+    "EstimatorMG": <bool>,
     "GSOrthogonalization": <string>
 }
 ```
@@ -447,6 +450,9 @@ error estimate calculation.
 
 `"EstimatorMaxIts" [1000]` :  Maximum number of iterations for flux projection use in the
 error estimate calculation.
+
+`"EstimatorMG" [false]` :  Set to true in order to enable multigrid preconditioner with AMG
+coarse solve for the error estimate linear solver, instead of just Jacobi.
 
 `"GSOrthogonalization" ["MGS"]` :  Gram-Schmidt variant used to explicitly orthogonalize
 vectors in Krylov subspace methods or other parts of the code.

--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -448,7 +448,7 @@ the eigenmode simulation type.
 `"EstimatorTol" [1e-6]` :  Relative tolerance for flux projection used in the
 error estimate calculation.
 
-`"EstimatorMaxIts" [1000]` :  Maximum number of iterations for flux projection use in the
+`"EstimatorMaxIts" [10000]` :  Maximum number of iterations for flux projection use in the
 error estimate calculation.
 
 `"EstimatorMG" [false]` :  Set to true in order to enable multigrid preconditioner with AMG

--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -142,8 +142,8 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &spaceop, PostOperator &
 
   // Initialize structures for storing and reducing the results of error estimation.
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
-      iodata.solver.linear.estimator_max_it, 0);
+      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      iodata.solver.linear.estimator_max_it, 0, iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
 
   // Main frequency sweep loop.
@@ -242,8 +242,8 @@ ErrorIndicator DrivenSolver::SweepAdaptive(SpaceOperator &spaceop, PostOperator 
 
   // Initialize structures for storing and reducing the results of error estimation.
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
-      iodata.solver.linear.estimator_max_it, 0);
+      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      iodata.solver.linear.estimator_max_it, 0, iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
 
   // Configure the PROM operator which performs the parameter space sampling and basis

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -273,8 +273,8 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Calculate and record the error indicators.
   Mpi::Print("\nComputing solution error estimates\n");
   CurlFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpace(), iodata.solver.linear.estimator_tol,
-      iodata.solver.linear.estimator_max_it, 0);
+      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      iodata.solver.linear.estimator_max_it, 0, iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
   if (!KM)
   {

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -146,7 +146,7 @@ ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
       else if (j > i)
       {
         linalg::AXPBYPCZ(1.0, V[i], 1.0, V[j], 0.0, Vij);
-        postop.SetVGridFunction(Vij);
+        postop.SetVGridFunction(Vij, false);
         double Ue = postop.GetEFieldEnergy();
         C(i, j) = Ue - 0.5 * (C(i, i) + C(j, j));
         Cm(i, j) = -C(i, j);

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -93,9 +93,10 @@ ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
 
   // Calculate and record the error indicators.
   Mpi::Print("\nComputing solution error estimates\n");
-  GradFluxErrorEstimator estimator(laplaceop.GetMaterialOp(), laplaceop.GetH1Space(),
-                                   iodata.solver.linear.estimator_tol,
-                                   iodata.solver.linear.estimator_max_it, 0);
+  GradFluxErrorEstimator estimator(
+      laplaceop.GetMaterialOp(), laplaceop.GetH1Space(), laplaceop.GetRTSpaces(),
+      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
+      iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
   for (int i = 0; i < nstep; i++)
   {

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -44,6 +44,13 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   Vector RHS(K->Height());
   std::vector<Vector> V(nstep);
 
+  // Initialize structures for storing and reducing the results of error estimation.
+  GradFluxErrorEstimator estimator(
+      laplaceop.GetMaterialOp(), laplaceop.GetH1Space(), laplaceop.GetRTSpaces(),
+      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
+      iodata.solver.linear.estimator_mg);
+  ErrorIndicator indicator;
+
   // Main loop over terminal boundaries.
   Mpi::Print("\nComputing electrostatic fields for {:d} terminal boundar{}\n", nstep,
              (nstep > 1) ? "ies" : "y");
@@ -65,6 +72,10 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
                linalg::Norml2(laplaceop.GetComm(), V[step]),
                linalg::Norml2(laplaceop.GetComm(), RHS));
 
+    // Calculate and record the error indicators.
+    Mpi::Print(" Updating solution error estimates\n");
+    estimator.AddErrorIndicator(V[step], indicator);
+
     // Next terminal.
     step++;
   }
@@ -72,12 +83,13 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Postprocess the capacitance matrix from the computed field solutions.
   BlockTimer bt1(Timer::POSTPRO);
   SaveMetadata(ksp);
-  return {Postprocess(laplaceop, postop, V), laplaceop.GlobalTrueVSize()};
+  Postprocess(laplaceop, postop, V, indicator);
+  return {indicator, laplaceop.GlobalTrueVSize()};
 }
 
-ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
-                                                PostOperator &postop,
-                                                const std::vector<Vector> &V) const
+void ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop, PostOperator &postop,
+                                      const std::vector<Vector> &V,
+                                      const ErrorIndicator &indicator) const
 {
   // Postprocess the Maxwell capacitance matrix. See p. 97 of the COMSOL AC/DC Module manual
   // for the associated formulas based on the electric field energy based on a unit voltage
@@ -90,19 +102,6 @@ ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
   int nstep = static_cast<int>(terminal_sources.size());
   mfem::DenseMatrix C(nstep), Cm(nstep);
   Vector E(Grad.Height()), Vij(Grad.Width());
-
-  // Calculate and record the error indicators.
-  Mpi::Print("\nComputing solution error estimates\n");
-  GradFluxErrorEstimator estimator(
-      laplaceop.GetMaterialOp(), laplaceop.GetH1Space(), laplaceop.GetRTSpaces(),
-      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
-      iodata.solver.linear.estimator_mg);
-  ErrorIndicator indicator;
-  for (int i = 0; i < nstep; i++)
-  {
-    estimator.AddErrorIndicator(V[i], indicator);
-  }
-
   int i = 0;
   for (const auto &[idx, data] : terminal_sources)
   {
@@ -157,7 +156,6 @@ ErrorIndicator ElectrostaticSolver::Postprocess(LaplaceOperator &laplaceop,
   mfem::DenseMatrix Cinv(C);
   Cinv.Invert();  // In-place, uses LAPACK (when available) and should be cheap
   PostprocessTerminals(terminal_sources, C, Cinv, Cm);
-  return indicator;
 }
 
 void ElectrostaticSolver::PostprocessTerminals(

--- a/palace/drivers/electrostaticsolver.hpp
+++ b/palace/drivers/electrostaticsolver.hpp
@@ -35,8 +35,8 @@ class Timer;
 class ElectrostaticSolver : public BaseSolver
 {
 private:
-  ErrorIndicator Postprocess(LaplaceOperator &laplaceop, PostOperator &postop,
-                             const std::vector<Vector> &V) const;
+  void Postprocess(LaplaceOperator &laplaceop, PostOperator &postop,
+                   const std::vector<Vector> &V, const ErrorIndicator &indicator) const;
 
   void PostprocessTerminals(const std::map<int, mfem::Array<int>> &terminal_sources,
                             const mfem::DenseMatrix &C, const mfem::DenseMatrix &Cinv,

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -44,6 +44,13 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   Vector RHS(K->Height());
   std::vector<Vector> A(nstep);
 
+  // Initialize structures for storing and reducing the results of error estimation.
+  CurlFluxErrorEstimator<Vector> estimator(
+      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpaces(),
+      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
+      iodata.solver.linear.estimator_mg);
+  ErrorIndicator indicator;
+
   // Main loop over current source boundaries.
   Mpi::Print("\nComputing magnetostatic fields for {:d} source boundar{}\n", nstep,
              (nstep > 1) ? "ies" : "y");
@@ -67,6 +74,10 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
                linalg::Norml2(curlcurlop.GetComm(), A[step]),
                linalg::Norml2(curlcurlop.GetComm(), RHS));
 
+    // Calculate and record the error indicators.
+    Mpi::Print(" Updating solution error estimates\n");
+    estimator.AddErrorIndicator(A[step], indicator);
+
     // Next source.
     step++;
   }
@@ -74,12 +85,13 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Postprocess the capacitance matrix from the computed field solutions.
   BlockTimer bt1(Timer::POSTPRO);
   SaveMetadata(ksp);
-  return {Postprocess(curlcurlop, postop, A), curlcurlop.GlobalTrueVSize()};
+  Postprocess(curlcurlop, postop, A, indicator);
+  return {indicator, curlcurlop.GlobalTrueVSize()};
 }
 
-ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
-                                                PostOperator &postop,
-                                                const std::vector<Vector> &A) const
+void MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop, PostOperator &postop,
+                                      const std::vector<Vector> &A,
+                                      const ErrorIndicator &indicator) const
 {
   // Postprocess the Maxwell inductance matrix. See p. 97 of the COMSOL AC/DC Module manual
   // for the associated formulas based on the magnetic field energy based on a current
@@ -94,19 +106,6 @@ ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
   mfem::DenseMatrix M(nstep), Mm(nstep);
   Vector B(Curl.Height()), Aij(Curl.Width());
   Vector Iinc(nstep);
-
-  // Calculate and record the error indicators.
-  Mpi::Print("\nComputing solution error estimates\n");
-  CurlFluxErrorEstimator<Vector> estimator(
-      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpaces(),
-      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
-      iodata.solver.linear.estimator_mg);
-  ErrorIndicator indicator;
-  for (int i = 0; i < nstep; i++)
-  {
-    estimator.AddErrorIndicator(A[i], indicator);
-  }
-
   int i = 0;
   for (const auto &[idx, data] : surf_j_op)
   {
@@ -166,7 +165,6 @@ ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
   mfem::DenseMatrix Minv(M);
   Minv.Invert();  // In-place, uses LAPACK (when available) and should be cheap
   PostprocessTerminals(surf_j_op, M, Minv, Mm);
-  return indicator;
 }
 
 void MagnetostaticSolver::PostprocessTerminals(const SurfaceCurrentOperator &surf_j_op,

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -98,8 +98,9 @@ ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
   // Calculate and record the error indicators.
   Mpi::Print("\nComputing solution error estimates\n");
   CurlFluxErrorEstimator<Vector> estimator(
-      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpace(),
-      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0);
+      curlcurlop.GetMaterialOp(), curlcurlop.GetNDSpaces(),
+      iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
+      iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
   for (int i = 0; i < nstep; i++)
   {

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -154,7 +154,7 @@ ErrorIndicator MagnetostaticSolver::Postprocess(CurlCurlOperator &curlcurlop,
       else if (j > i)
       {
         linalg::AXPBYPCZ(1.0, A[i], 1.0, A[j], 0.0, Aij);
-        postop.SetAGridFunction(Aij);
+        postop.SetAGridFunction(Aij, false);
         double Um = postop.GetHFieldEnergy();
         M(i, j) = Um / (Iinc(i) * Iinc(j)) -
                   0.5 * (M(i, i) * Iinc(i) / Iinc(j) + M(j, j) * Iinc(j) / Iinc(i));

--- a/palace/drivers/magnetostaticsolver.hpp
+++ b/palace/drivers/magnetostaticsolver.hpp
@@ -33,8 +33,8 @@ class Timer;
 class MagnetostaticSolver : public BaseSolver
 {
 private:
-  ErrorIndicator Postprocess(CurlCurlOperator &curlcurlop, PostOperator &postop,
-                             const std::vector<Vector> &A) const;
+  void Postprocess(CurlCurlOperator &curlcurlop, PostOperator &postop,
+                   const std::vector<Vector> &A, const ErrorIndicator &indicator) const;
 
   void PostprocessTerminals(const SurfaceCurrentOperator &surf_j_op,
                             const mfem::DenseMatrix &M, const mfem::DenseMatrix &Minv,

--- a/palace/drivers/transientsolver.cpp
+++ b/palace/drivers/transientsolver.cpp
@@ -79,9 +79,9 @@ TransientSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   Mpi::Print("\n");
 
   // Initialize structures for storing and reducing the results of error estimation.
-  CurlFluxErrorEstimator<Vector> estimator(spaceop.GetMaterialOp(), spaceop.GetNDSpace(),
-                                           iodata.solver.linear.estimator_tol,
-                                           iodata.solver.linear.estimator_max_it, 0);
+  CurlFluxErrorEstimator<Vector> estimator(
+      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), iodata.solver.linear.estimator_tol,
+      iodata.solver.linear.estimator_max_it, 0, iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
 
   // Main time integration loop.

--- a/palace/linalg/amg.cpp
+++ b/palace/linalg/amg.cpp
@@ -9,21 +9,24 @@ namespace palace
 BoomerAmgSolver::BoomerAmgSolver(int cycle_it, int smooth_it, int print)
   : mfem::HypreBoomerAMG()
 {
-  SetPrintLevel((print > 1) ? print - 1 : 0);
-  SetMaxIter(cycle_it);
-  SetTol(0.0);
+  HYPRE_BoomerAMGSetPrintLevel(*this, (print > 1) ? print - 1 : 0);
+  HYPRE_BoomerAMGSetMaxIter(*this, cycle_it);
+  HYPRE_BoomerAMGSetTol(*this, 0.0);
 
   // Set additional BoomerAMG options.
   int agg_levels = 1;  // Number of aggressive coarsening levels
   double theta = 0.5;  // AMG strength parameter = 0.25 is 2D optimal (0.5-0.8 for 3D)
+  int relax_type = 8;  // 8 = l1-symm. GS, 13 = l1-GS, 18 = l1-Jacobi, 16 = Chebyshev
   if (mfem::Device::Allows(mfem::Backend::DEVICE_MASK))
   {
     // Modify options for GPU-supported features.
     agg_levels = 0;
+    relax_type = 18;
   }
 
-  SetAggressiveCoarsening(agg_levels);
-  SetStrengthThresh(theta);
+  HYPRE_BoomerAMGSetAggNumLevels(*this, agg_levels);
+  HYPRE_BoomerAMGSetStrongThreshold(*this, theta);
+  HYPRE_BoomerAMGSetRelaxType(*this, relax_type);
   HYPRE_BoomerAMGSetNumSweeps(*this, smooth_it);
 
   // int coarse_relax_type = 8;  // l1-symm. GS (inexact coarse solve)

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -13,16 +13,18 @@ namespace
 
 double GetLambdaMax(MPI_Comm comm, const Operator &A, const Vector &dinv)
 {
+  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
   DiagonalOperator Dinv(dinv);
   ProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, false);
+  return linalg::SpectralNorm(comm, DinvA, true);
 }
 
 double GetLambdaMax(MPI_Comm comm, const ComplexOperator &A, const ComplexVector &dinv)
 {
+  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
   ComplexDiagonalOperator Dinv(dinv);
   ComplexProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, false);
+  return linalg::SpectralNorm(comm, DinvA, A.IsReal());
 }
 
 template <bool Transpose = false>

--- a/palace/linalg/chebyshev.hpp
+++ b/palace/linalg/chebyshev.hpp
@@ -41,7 +41,7 @@ private:
   double lambda_max, sf_max;
 
   // Temporary vector for smoother application.
-  mutable VecType d;
+  mutable VecType d, r;
 
 public:
   ChebyshevSmoother(MPI_Comm comm, int smooth_it, int poly_order, double sf_max);
@@ -50,14 +50,22 @@ public:
 
   void Mult(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother implements Mult2 using an additional preallocated "
-               "temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    Mult2(x, y, r);
   }
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    MultTranspose2(x, y, r);
   }
 
   void Mult2(const VecType &x, VecType &y, VecType &r) const override;
@@ -97,7 +105,7 @@ private:
   double theta, delta, sf_max, sf_min;
 
   // Temporary vector for smoother application.
-  mutable VecType d;
+  mutable VecType d, r;
 
 public:
   ChebyshevSmoother1stKind(MPI_Comm comm, int smooth_it, int poly_order, double sf_max,
@@ -107,14 +115,22 @@ public:
 
   void Mult(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother1stKind implements Mult2 using an additional preallocated "
-               "temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    Mult2(x, y, r);
   }
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("ChebyshevSmoother1stKind implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    MultTranspose2(x, y, r);
   }
 
   void Mult2(const VecType &x, VecType &y, VecType &r) const override;

--- a/palace/linalg/distrelaxation.hpp
+++ b/palace/linalg/distrelaxation.hpp
@@ -47,7 +47,7 @@ private:
   std::unique_ptr<Solver<OperType>> B_G;
 
   // Temporary vectors for smoother application.
-  mutable VecType x_G, y_G, r_G;
+  mutable VecType x_G, y_G, r_G, r;
 
 public:
   DistRelaxationSmoother(MPI_Comm comm, const Operator &G, int smooth_it,
@@ -64,14 +64,22 @@ public:
 
   void Mult(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("DistRelaxationSmoother implements Mult2 using an additional preallocated "
-               "temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    Mult2(x, y, r);
   }
 
   void MultTranspose(const VecType &x, VecType &y) const override
   {
-    MFEM_ABORT("DistRelaxationSmoother implements MultTranspose2 using an additional "
-               "preallocated temporary vector!");
+    if (r.Size() != y.Size())
+    {
+      r.SetSize(y.Size());
+      r.UseDevice(true);
+    }
+    MultTranspose2(x, y, r);
   }
 
   void Mult2(const VecType &x, VecType &y, VecType &r) const override;

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -90,10 +90,9 @@ DivFreeSolver<VecType>::DivFreeSolver(
     const int mg_smooth_order =
         std::max(h1_fespaces.GetFinestFESpace().GetMaxElementOrder(), 2);
     pc = std::make_unique<GeometricMultigridSolver<OperType>>(
-        h1_fespaces.GetFinestFESpace().GetComm(),
-
-        std::move(amg), h1_fespaces.GetProlongationOperators(), nullptr, 1, 1,
-        mg_smooth_order, 1.0, 0.0, true);
+        h1_fespaces.GetFinestFESpace().GetComm(), std::move(amg),
+        h1_fespaces.GetProlongationOperators(), nullptr, 1, 1, mg_smooth_order, 1.0, 0.0,
+        true);
   }
   else
   {

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -88,13 +88,20 @@ auto ConfigureLinearSolver(const FiniteElementSpaceHierarchy &fespaces, double t
   else
   {
     auto amg = std::make_unique<BoomerAmgSolver>(1, 1, 0);
-    amg->SetStrengthThresh(0.8);    // More coarsening to save memory
-    const int mg_smooth_order = 1;  // Basically damped Jacobi smoother
-    pc = std::make_unique<GeometricMultigridSolver<OperType>>(
-        fespaces.GetFinestFESpace().GetComm(),
-        std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg)),
-        fespaces.GetProlongationOperators(), nullptr, 1, 1, mg_smooth_order, 1.0, 0.0,
-        true);
+    amg->SetStrengthThresh(0.8);  // More coarsening to save memory
+    if (fespaces.GetNumLevels() > 1)
+    {
+      const int mg_smooth_order = 1;  // Basically damped Jacobi smoother
+      pc = std::make_unique<GeometricMultigridSolver<OperType>>(
+          fespaces.GetFinestFESpace().GetComm(),
+          std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg)),
+          fespaces.GetProlongationOperators(), nullptr, 1, 1, mg_smooth_order, 1.0, 0.0,
+          true);
+    }
+    else
+    {
+      pc = std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg));
+    }
   }
 
   auto pcg =

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -6,8 +6,10 @@
 #include <limits>
 #include "fem/bilinearform.hpp"
 #include "fem/integrator.hpp"
-#include "linalg/chebyshev.hpp"
+#include "linalg/amg.hpp"
+#include "linalg/gmg.hpp"
 #include "linalg/iterative.hpp"
+#include "linalg/jacobi.hpp"
 #include "linalg/rap.hpp"
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
@@ -21,35 +23,85 @@ namespace
 {
 
 template <typename OperType>
-auto WrapOperator(std::unique_ptr<Operator> &&op);
+auto BuildLevelParOperator(std::unique_ptr<Operator> &&a,
+                           const FiniteElementSpace &trial_fespace,
+                           const FiniteElementSpace &test_fespace);
 
 template <>
-auto WrapOperator<Operator>(std::unique_ptr<Operator> &&op)
+auto BuildLevelParOperator<Operator>(std::unique_ptr<Operator> &&a,
+                                     const FiniteElementSpace &trial_fespace,
+                                     const FiniteElementSpace &test_fespace)
 {
-  return std::move(op);
+  return std::make_unique<ParOperator>(std::move(a), trial_fespace, test_fespace, false);
 }
 
 template <>
-auto WrapOperator<ComplexOperator>(std::unique_ptr<Operator> &&op)
+auto BuildLevelParOperator<ComplexOperator>(std::unique_ptr<Operator> &&a,
+                                            const FiniteElementSpace &trial_fespace,
+                                            const FiniteElementSpace &test_fespace)
 {
-  return std::make_unique<ComplexWrapperOperator>(std::move(op), nullptr);
-}
-
-auto GetMassMatrix(const FiniteElementSpace &fespace)
-{
-  constexpr bool skip_zeros = false;
-  BilinearForm m(fespace);
-  m.AddDomainIntegrator<VectorFEMassIntegrator>();
-  return std::make_unique<ParOperator>(m.Assemble(skip_zeros), fespace);
+  return std::make_unique<ComplexParOperator>(std::move(a), nullptr, trial_fespace,
+                                              test_fespace, false);
 }
 
 template <typename OperType>
-auto ConfigureLinearSolver(MPI_Comm comm, double tol, int max_it, int print,
-                           int mg_smooth_order)
+auto BuildLevelParOperator(std::unique_ptr<Operator> &&a, const FiniteElementSpace &fespace)
+{
+  return BuildLevelParOperator<OperType>(std::move(a), fespace, fespace);
+}
+
+template <typename OperType>
+std::unique_ptr<OperType> GetMassMatrix(const FiniteElementSpaceHierarchy &fespaces,
+                                        bool use_mg)
+{
+  constexpr bool skip_zeros = false;
+  BilinearForm m(fespaces.GetFinestFESpace());
+  m.AddDomainIntegrator<VectorFEMassIntegrator>();
+  if (!use_mg)
+  {
+    return BuildLevelParOperator<OperType>(m.Assemble(skip_zeros),
+                                           fespaces.GetFinestFESpace());
+  }
+  else
+  {
+    auto m_vec = m.Assemble(fespaces, skip_zeros);
+    auto M_mg = std::make_unique<BaseMultigridOperator<OperType>>(fespaces.GetNumLevels());
+    for (std::size_t l = 0; l < fespaces.GetNumLevels(); l++)
+    {
+      const auto &fespace_l = fespaces.GetFESpaceAtLevel(l);
+      M_mg->AddOperator(BuildLevelParOperator<OperType>(std::move(m_vec[l]), fespace_l));
+    }
+    return M_mg;
+  }
+}
+
+template <typename OperType>
+auto ConfigureLinearSolver(const FiniteElementSpaceHierarchy &fespaces, double tol,
+                           int max_it, int print, bool use_mg)
 {
   // The system matrix for the projection is real, SPD and diagonally dominant.
-  auto pc = std::make_unique<ChebyshevSmoother<OperType>>(comm, 1, mg_smooth_order, 1.0);
-  auto pcg = std::make_unique<CgSolver<OperType>>(comm, print);
+  std::unique_ptr<Solver<OperType>> pc;
+  if (!use_mg)
+  {
+    pc = std::make_unique<JacobiSmoother<OperType>>();
+  }
+  else
+  {
+    auto amg = std::make_unique<BoomerAmgSolver>(1, 1, 0);
+    amg->SetStrengthThresh(0.8);  // More coarsening to save memory
+    const int mg_smooth_order =
+        std::max(fespaces.GetFinestFESpace().GetMaxElementOrder(), 2) +
+        (dynamic_cast<const mfem::RT_FECollection *>(
+             &fespaces.GetFinestFESpace().GetFEColl()) != nullptr);
+    pc = std::make_unique<GeometricMultigridSolver<OperType>>(
+        fespaces.GetFinestFESpace().GetComm(),
+        std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg)),
+        fespaces.GetProlongationOperators(), nullptr, 1, 1, mg_smooth_order, 1.0, 0.0,
+        true);
+  }
+
+  auto pcg =
+      std::make_unique<CgSolver<OperType>>(fespaces.GetFinestFESpace().GetComm(), print);
   pcg->SetInitialGuess(false);
   pcg->SetRelTol(tol);
   pcg->SetAbsTol(std::numeric_limits<double>::epsilon());
@@ -61,24 +113,22 @@ auto ConfigureLinearSolver(MPI_Comm comm, double tol, int max_it, int print,
 
 template <typename VecType>
 FluxProjector<VecType>::FluxProjector(const MaterialOperator &mat_op,
-                                      const FiniteElementSpace &nd_fespace, double tol,
-                                      int max_it, int print)
+                                      const FiniteElementSpaceHierarchy &nd_fespaces,
+                                      double tol, int max_it, int print, bool use_mg)
 {
   BlockTimer bt(Timer::CONSTRUCT_ESTIMATOR);
+  use_mg = use_mg && (nd_fespaces.GetNumLevels() > 1);
+  const auto &nd_fespace = nd_fespaces.GetFinestFESpace();
   {
     // Flux operator is always partially assembled.
     MaterialPropertyCoefficient muinv_func(mat_op.GetAttributeToMaterial(),
                                            mat_op.GetInvPermeability());
     BilinearForm flux(nd_fespace);
     flux.AddDomainIntegrator<MixedVectorCurlIntegrator>(muinv_func);
-    Flux = WrapOperator<OperType>(
-        std::make_unique<ParOperator>(flux.PartialAssemble(), nd_fespace));
+    Flux = BuildLevelParOperator<OperType>(flux.PartialAssemble(), nd_fespace);
   }
-  M = WrapOperator<OperType>(GetMassMatrix(nd_fespace));
-
-  const int mg_smooth_order = std::max(nd_fespace.GetMaxElementOrder(), 2);
-  ksp = ConfigureLinearSolver<OperType>(nd_fespace.GetComm(), tol, max_it, print,
-                                        mg_smooth_order);
+  M = GetMassMatrix<OperType>(nd_fespaces, use_mg);
+  ksp = ConfigureLinearSolver<OperType>(nd_fespaces, tol, max_it, print, use_mg);
   ksp->SetOperators(*M, *M);
 
   rhs.SetSize(nd_fespace.GetTrueVSize());
@@ -88,24 +138,22 @@ FluxProjector<VecType>::FluxProjector(const MaterialOperator &mat_op,
 template <typename VecType>
 FluxProjector<VecType>::FluxProjector(const MaterialOperator &mat_op,
                                       const FiniteElementSpace &h1_fespace,
-                                      const FiniteElementSpace &rt_fespace, double tol,
-                                      int max_it, int print)
+                                      const FiniteElementSpaceHierarchy &rt_fespaces,
+                                      double tol, int max_it, int print, bool use_mg)
 {
   BlockTimer bt(Timer::CONSTRUCT_ESTIMATOR);
+  use_mg = use_mg && (rt_fespaces.GetNumLevels() > 1);
+  const auto &rt_fespace = rt_fespaces.GetFinestFESpace();
   {
     // Flux operator is always partially assembled.
     MaterialPropertyCoefficient epsilon_func(mat_op.GetAttributeToMaterial(),
                                              mat_op.GetPermittivityReal());
     BilinearForm flux(h1_fespace, rt_fespace);
     flux.AddDomainIntegrator<MixedVectorGradientIntegrator>(epsilon_func);
-    Flux = WrapOperator<OperType>(std::make_unique<ParOperator>(
-        flux.PartialAssemble(), h1_fespace, rt_fespace, false));
+    Flux = BuildLevelParOperator<OperType>(flux.PartialAssemble(), h1_fespace, rt_fespace);
   }
-  M = WrapOperator<OperType>(GetMassMatrix(rt_fespace));
-
-  const int mg_smooth_order = std::max(rt_fespace.GetMaxElementOrder(), 2);
-  ksp = ConfigureLinearSolver<OperType>(rt_fespace.GetComm(), tol, max_it, print,
-                                        mg_smooth_order);
+  M = GetMassMatrix<OperType>(rt_fespaces, use_mg);
+  ksp = ConfigureLinearSolver<OperType>(rt_fespaces, tol, max_it, print, use_mg);
   ksp->SetOperators(*M, *M);
 
   rhs.SetSize(rt_fespace.GetTrueVSize());
@@ -123,14 +171,16 @@ void FluxProjector<VecType>::Mult(const VecType &x, VecType &y) const
 }
 
 template <typename VecType>
-CurlFluxErrorEstimator<VecType>::CurlFluxErrorEstimator(const MaterialOperator &mat_op,
-                                                        FiniteElementSpace &nd_fespace,
-                                                        double tol, int max_it, int print)
-  : mat_op(mat_op), nd_fespace(nd_fespace),
-    projector(mat_op, nd_fespace, tol, max_it, print), F(nd_fespace.GetTrueVSize()),
-    F_gf(nd_fespace.GetVSize()), U_gf(nd_fespace.GetVSize())
+CurlFluxErrorEstimator<VecType>::CurlFluxErrorEstimator(
+    const MaterialOperator &mat_op, FiniteElementSpaceHierarchy &nd_fespaces, double tol,
+    int max_it, int print, bool use_mg)
+  : mat_op(mat_op), nd_fespace(nd_fespaces.GetFinestFESpace()),
+    projector(mat_op, nd_fespaces, tol, max_it, print, use_mg), U_gf(nd_fespace.GetVSize()),
+    F(nd_fespace.GetTrueVSize()), F_gf(nd_fespace.GetVSize())
 {
+  U_gf.UseDevice(true);
   F.UseDevice(true);
+  F_gf.UseDevice(true);
 }
 
 template <typename VecType>
@@ -250,16 +300,17 @@ void CurlFluxErrorEstimator<VecType>::AddErrorIndicator(const VecType &U,
 }
 
 GradFluxErrorEstimator::GradFluxErrorEstimator(const MaterialOperator &mat_op,
-                                               FiniteElementSpace &h1_fespace, double tol,
-                                               int max_it, int print)
-  : mat_op(mat_op), h1_fespace(h1_fespace),
-    rt_fec(std::make_unique<mfem::RT_FECollection>(h1_fespace.GetFEColl().GetOrder() - 1,
-                                                   h1_fespace.SpaceDimension())),
-    rt_fespace(std::make_unique<FiniteElementSpace>(h1_fespace.GetMesh(), rt_fec.get())),
-    projector(mat_op, h1_fespace, *rt_fespace, tol, max_it, print),
-    F(rt_fespace->GetTrueVSize()), F_gf(rt_fespace->GetVSize()), U_gf(h1_fespace.GetVSize())
+                                               FiniteElementSpace &h1_fespace,
+                                               FiniteElementSpaceHierarchy &rt_fespaces,
+                                               double tol, int max_it, int print,
+                                               bool use_mg)
+  : mat_op(mat_op), h1_fespace(h1_fespace), rt_fespace(rt_fespaces.GetFinestFESpace()),
+    projector(mat_op, h1_fespace, rt_fespaces, tol, max_it, print, use_mg),
+    U_gf(h1_fespace.GetVSize()), F(rt_fespace.GetTrueVSize()), F_gf(rt_fespace.GetVSize())
 {
+  U_gf.UseDevice(true);
   F.UseDevice(true);
+  F_gf.UseDevice(true);
 }
 
 void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
@@ -270,7 +321,7 @@ void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
   BlockTimer bt(Timer::ESTIMATION);
   projector.Mult(U, F);
   h1_fespace.GetProlongationMatrix()->Mult(U, U_gf);
-  rt_fespace->GetProlongationMatrix()->Mult(F, F_gf);
+  rt_fespace.GetProlongationMatrix()->Mult(F, F_gf);
   U_gf.HostRead();
   F_gf.HostRead();
 
@@ -294,10 +345,10 @@ void GradFluxErrorEstimator::AddErrorIndicator(const Vector &U,
     for (int e = 0; e < mesh.GetNE(); e++)
     {
       const mfem::FiniteElement &h1_fe = *h1_fespace.Get().GetFE(e);
-      const mfem::FiniteElement &rt_fe = *rt_fespace->Get().GetFE(e);
+      const mfem::FiniteElement &rt_fe = *rt_fespace.Get().GetFE(e);
       mesh.GetElementTransformation(e, &T);
       h1_fespace.Get().GetElementDofs(e, h1_dofs);
-      rt_fespace->Get().GetElementDofs(e, rt_dofs);
+      rt_fespace.Get().GetElementDofs(e, rt_dofs);
       Interp.SetSize(rt_fe.GetDof(), V_ip.Size());
       Grad.SetSize(h1_fe.GetDof(), V_ip.Size());
       const int q_order = fem::DefaultIntegrationOrder::Get(T);

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -117,7 +117,6 @@ FluxProjector<VecType>::FluxProjector(const MaterialOperator &mat_op,
                                       double tol, int max_it, int print, bool use_mg)
 {
   BlockTimer bt(Timer::CONSTRUCT_ESTIMATOR);
-  use_mg = use_mg && (nd_fespaces.GetNumLevels() > 1);
   const auto &nd_fespace = nd_fespaces.GetFinestFESpace();
   {
     // Flux operator is always partially assembled.
@@ -142,7 +141,6 @@ FluxProjector<VecType>::FluxProjector(const MaterialOperator &mat_op,
                                       double tol, int max_it, int print, bool use_mg)
 {
   BlockTimer bt(Timer::CONSTRUCT_ESTIMATOR);
-  use_mg = use_mg && (rt_fespaces.GetNumLevels() > 1);
   const auto &rt_fespace = rt_fespaces.GetFinestFESpace();
   {
     // Flux operator is always partially assembled.

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -83,7 +83,9 @@ auto ConfigureLinearSolver(const FiniteElementSpaceHierarchy &fespaces, double t
   std::unique_ptr<Solver<OperType>> pc;
   if (!use_mg)
   {
-    pc = std::make_unique<JacobiSmoother<OperType>>();
+    // Use eigenvalue estimate to compute optimal Jacobi damping parameter.
+    pc = std::make_unique<JacobiSmoother<OperType>>(fespaces.GetFinestFESpace().GetComm(),
+                                                    0.0);
   }
   else
   {
@@ -91,7 +93,7 @@ auto ConfigureLinearSolver(const FiniteElementSpaceHierarchy &fespaces, double t
     amg->SetStrengthThresh(0.8);  // More coarsening to save memory
     if (fespaces.GetNumLevels() > 1)
     {
-      const int mg_smooth_order = 1;  // Basically damped Jacobi smoother
+      const int mg_smooth_order = 2;  // Smooth order independent of FE space order
       pc = std::make_unique<GeometricMultigridSolver<OperType>>(
           fespaces.GetFinestFESpace().GetComm(),
           std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg)),

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -88,11 +88,8 @@ auto ConfigureLinearSolver(const FiniteElementSpaceHierarchy &fespaces, double t
   else
   {
     auto amg = std::make_unique<BoomerAmgSolver>(1, 1, 0);
-    amg->SetStrengthThresh(0.8);  // More coarsening to save memory
-    const int mg_smooth_order =
-        std::max(fespaces.GetFinestFESpace().GetMaxElementOrder(), 2) +
-        (dynamic_cast<const mfem::RT_FECollection *>(
-             &fespaces.GetFinestFESpace().GetFEColl()) != nullptr);
+    amg->SetStrengthThresh(0.8);    // More coarsening to save memory
+    const int mg_smooth_order = 1;  // Basically damped Jacobi smoother
     pc = std::make_unique<GeometricMultigridSolver<OperType>>(
         fespaces.GetFinestFESpace().GetComm(),
         std::make_unique<MfemWrapperSolver<OperType>>(std::move(amg)),

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -42,10 +42,12 @@ private:
   mutable VecType rhs;
 
 public:
-  FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &nd_fespace,
-                double tol, int max_it, int print);
+  FluxProjector(const MaterialOperator &mat_op,
+                const FiniteElementSpaceHierarchy &nd_fespaces, double tol, int max_it,
+                int print, bool use_mg);
   FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &h1_fespace,
-                const FiniteElementSpace &rt_fespace, double tol, int max_it, int print);
+                const FiniteElementSpaceHierarchy &rt_fespaces, double tol, int max_it,
+                int print, bool use_mg);
 
   void Mult(const VecType &x, VecType &y) const;
 };
@@ -65,11 +67,12 @@ class CurlFluxErrorEstimator
   FluxProjector<VecType> projector;
 
   // Temporary vectors for error estimation.
-  mutable VecType F, F_gf, U_gf;
+  mutable VecType U_gf, F, F_gf;
 
 public:
-  CurlFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &nd_fespace,
-                         double tol, int max_it, int print);
+  CurlFluxErrorEstimator(const MaterialOperator &mat_op,
+                         FiniteElementSpaceHierarchy &nd_fespaces, double tol, int max_it,
+                         int print, bool use_mg);
 
   // Compute elemental error indicators given a vector of true DOF and fold into an existing
   // indicator.
@@ -83,22 +86,19 @@ class GradFluxErrorEstimator
   // Reference to material property data (not owned).
   const MaterialOperator &mat_op;
 
-  // Finite element space used to represent U.
-  FiniteElementSpace &h1_fespace;
-
-  // RT collection and space used to represent F.
-  std::unique_ptr<mfem::FiniteElementCollection> rt_fec;
-  std::unique_ptr<FiniteElementSpace> rt_fespace;
+  // Finite element spaces used to represent U and F.
+  FiniteElementSpace &h1_fespace, &rt_fespace;
 
   // Global L2 projection solver.
   FluxProjector<Vector> projector;
 
   // Temporary vectors for error estimation.
-  mutable Vector F, F_gf, U_gf;
+  mutable Vector U_gf, F, F_gf;
 
 public:
   GradFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &h1_fespace,
-                         double tol, int max_it, int print);
+                         FiniteElementSpaceHierarchy &rt_fespaces, double tol, int max_it,
+                         int print, bool use_mg);
 
   // Compute elemental error indicators given a vector of true DOF and fold into an existing
   // indicator.

--- a/palace/linalg/errorestimator.hpp
+++ b/palace/linalg/errorestimator.hpp
@@ -45,7 +45,7 @@ public:
   FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &nd_fespace,
                 double tol, int max_it, int print);
   FluxProjector(const MaterialOperator &mat_op, const FiniteElementSpace &h1_fespace,
-                const FiniteElementSpace &h1d_fespace, double tol, int max_it, int print);
+                const FiniteElementSpace &rt_fespace, double tol, int max_it, int print);
 
   void Mult(const VecType &x, VecType &y) const;
 };
@@ -97,7 +97,7 @@ class GradFluxErrorEstimator
   mutable Vector F, F_gf, U_gf;
 
 public:
-  GradFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &rt_fespace,
+  GradFluxErrorEstimator(const MaterialOperator &mat_op, FiniteElementSpace &h1_fespace,
                          double tol, int max_it, int print);
 
   // Compute elemental error indicators given a vector of true DOF and fold into an existing

--- a/palace/linalg/iterative.cpp
+++ b/palace/linalg/iterative.cpp
@@ -395,10 +395,18 @@ void CgSolver<OperType>::Mult(const VecType &b, VecType &x) const
   beta = linalg::Dot(comm, z, r);
   CheckDot(beta, "PCG preconditioner is not positive definite: (Br, r) = ");
   res = std::sqrt(std::abs(beta));
-  if (this->initial_guess && B)
+  if (this->initial_guess)
   {
-    ApplyB(B, b, p, this->use_timer);
-    auto beta_rhs = linalg::Dot(comm, p, b);
+    ScalarType beta_rhs;
+    if (B)
+    {
+      ApplyB(B, b, p, this->use_timer);
+      beta_rhs = linalg::Dot(comm, p, b);
+    }
+    else
+    {
+      beta_rhs = linalg::Norml2(comm, b);
+    }
     CheckDot(beta_rhs, "PCG preconditioner is not positive definite: (Bb, b) = ");
     initial_res = std::sqrt(std::abs(beta_rhs));
   }

--- a/palace/linalg/jacobi.hpp
+++ b/palace/linalg/jacobi.hpp
@@ -21,11 +21,20 @@ class JacobiSmoother : public Solver<OperType>
   using VecType = typename Solver<OperType>::VecType;
 
 private:
+  // MPI communicator associated with the solver operator and vectors.
+  MPI_Comm comm;
+
   // Inverse diagonal scaling of the operator (real-valued for now).
   VecType dinv;
 
+  // Damping factor and scaling factor for maximum eigenvalue.
+  double omega, sf_max;
+
 public:
-  JacobiSmoother() : Solver<OperType>() {}
+  JacobiSmoother(MPI_Comm comm, double omega = 1.0, double sf_max = 1.0)
+    : Solver<OperType>(), comm(comm), omega(omega), sf_max(sf_max)
+  {
+  }
 
   void SetOperator(const OperType &op) override;
 

--- a/palace/linalg/ksp.cpp
+++ b/palace/linalg/ksp.cpp
@@ -192,7 +192,7 @@ ConfigurePreconditionerSolver(MPI_Comm comm, const IoData &iodata,
 #endif
       break;
     case config::LinearSolverData::Type::JACOBI:
-      pc = std::make_unique<JacobiSmoother<OperType>>();
+      pc = std::make_unique<JacobiSmoother<OperType>>(comm);
       break;
     case config::LinearSolverData::Type::DEFAULT:
       MFEM_ABORT("Unexpected solver type for preconditioner configuration!");

--- a/palace/linalg/solver.hpp
+++ b/palace/linalg/solver.hpp
@@ -90,14 +90,17 @@ public:
   {
   }
 
+  // Access the underlying solver.
+  const mfem::Solver &GetSolver() { return *pc; }
+
+  // Configure whether or not to save the assembled operator.
+  void SetSaveAssembled(bool save) { save_assembled = save; }
+
   void SetInitialGuess(bool guess) override
   {
     Solver<OperType>::SetInitialGuess(guess);
     pc->iterative_mode = guess;
   }
-
-  // Configure whether or not to save the assembled operator.
-  void SetSaveAssembled(bool save) { save_assembled = save; }
 
   void SetOperator(const OperType &op) override;
 

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -125,7 +125,7 @@ void PrintHeader(const mfem::ParFiniteElementSpace &h1_fespace,
                h1_fespace.GetMaxElementOrder(), h1_fespace.GlobalTrueVSize(),
                nd_fespace.GetMaxElementOrder(), nd_fespace.GlobalTrueVSize(),
                rt_fespace.GetMaxElementOrder(), rt_fespace.GlobalTrueVSize(),
-               nd_fespace.GetMaxElementOrder() > BilinearForm::pa_order_threshold
+               (nd_fespace.GetMaxElementOrder() > BilinearForm::pa_order_threshold)
                    ? "Partial"
                    : "Full");
 

--- a/palace/models/laplaceoperator.hpp
+++ b/palace/models/laplaceoperator.hpp
@@ -33,11 +33,14 @@ private:
   std::vector<mfem::Array<int>> dbc_tdof_lists;
 
   // Objects defining the finite element spaces for the electrostatic potential (H1) and
-  // electric field (Nedelec) on the given mesh.
+  // electric field (Nedelec) on the given mesh. The RT spaces are used for error
+  // estimation.
   std::vector<std::unique_ptr<mfem::H1_FECollection>> h1_fecs;
   std::unique_ptr<mfem::ND_FECollection> nd_fec;
+  std::vector<std::unique_ptr<mfem::RT_FECollection>> rt_fecs;
   FiniteElementSpaceHierarchy h1_fespaces;
   AuxiliaryFiniteElementSpace nd_fespace;
+  FiniteElementSpaceHierarchy rt_fespaces;
 
   // Operator for domain material properties.
   MaterialOperator mat_op;
@@ -64,6 +67,10 @@ public:
   const auto &GetH1Space() const { return h1_fespaces.GetFinestFESpace(); }
   auto &GetNDSpace() { return nd_fespace; }
   const auto &GetNDSpace() const { return nd_fespace; }
+  auto &GetRTSpaces() { return rt_fespaces; }
+  const auto &GetRTSpaces() const { return rt_fespaces; }
+  auto &GetRTSpace() { return rt_fespaces.GetFinestFESpace(); }
+  const auto &GetRTSpace() const { return rt_fespaces.GetFinestFESpace(); }
 
   // Access the underlying mesh object.
   const auto &GetMesh() const { return GetH1Space().GetMesh(); }

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -260,66 +260,84 @@ void PostOperator::InitializeDataCollection(const IoData &iodata)
   }
 }
 
-void PostOperator::SetEGridFunction(const ComplexVector &e)
+void PostOperator::SetEGridFunction(const ComplexVector &e, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(HasImag(),
               "SetEGridFunction for complex-valued output called when HasImag() == false!");
   MFEM_VERIFY(E, "Incorrect usage of PostOperator::SetEGridFunction!");
   E->Real().SetFromTrueDofs(e.Real());  // Parallel distribute
   E->Imag().SetFromTrueDofs(e.Imag());
-  E->Real().ExchangeFaceNbrData();  // Ready for parallel comm on shared faces
-  E->Imag().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    E->Real().ExchangeFaceNbrData();  // Ready for parallel comm on shared faces
+    E->Imag().ExchangeFaceNbrData();
+  }
   lumped_port_init = wave_port_init = false;
 }
 
-void PostOperator::SetBGridFunction(const ComplexVector &b)
+void PostOperator::SetBGridFunction(const ComplexVector &b, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(HasImag(),
               "SetBGridFunction for complex-valued output called when HasImag() == false!");
   MFEM_VERIFY(B, "Incorrect usage of PostOperator::SetBGridFunction!");
   B->Real().SetFromTrueDofs(b.Real());  // Parallel distribute
   B->Imag().SetFromTrueDofs(b.Imag());
-  B->Real().ExchangeFaceNbrData();  // Ready for parallel comm on shared faces
-  B->Imag().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    B->Real().ExchangeFaceNbrData();  // Ready for parallel comm on shared faces
+    B->Imag().ExchangeFaceNbrData();
+  }
   lumped_port_init = wave_port_init = false;
 }
 
-void PostOperator::SetEGridFunction(const Vector &e)
+void PostOperator::SetEGridFunction(const Vector &e, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(!HasImag(),
               "SetEGridFunction for real-valued output called when HasImag() == true!");
   MFEM_VERIFY(E, "Incorrect usage of PostOperator::SetEGridFunction!");
   E->Real().SetFromTrueDofs(e);
-  E->Real().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    E->Real().ExchangeFaceNbrData();
+  }
   lumped_port_init = wave_port_init = false;
 }
 
-void PostOperator::SetBGridFunction(const Vector &b)
+void PostOperator::SetBGridFunction(const Vector &b, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(!HasImag(),
               "SetBGridFunction for real-valued output called when HasImag() == true!");
   MFEM_VERIFY(B, "Incorrect usage of PostOperator::SetBGridFunction!");
   B->Real().SetFromTrueDofs(b);
-  B->Real().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    B->Real().ExchangeFaceNbrData();
+  }
   lumped_port_init = wave_port_init = false;
 }
 
-void PostOperator::SetVGridFunction(const Vector &v)
+void PostOperator::SetVGridFunction(const Vector &v, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(!HasImag(),
               "SetVGridFunction for real-valued output called when HasImag() == true!");
   MFEM_VERIFY(V, "Incorrect usage of PostOperator::SetVGridFunction!");
   V->Real().SetFromTrueDofs(v);
-  V->Real().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    V->Real().ExchangeFaceNbrData();
+  }
 }
 
-void PostOperator::SetAGridFunction(const Vector &a)
+void PostOperator::SetAGridFunction(const Vector &a, bool exchange_face_nbr_data)
 {
   MFEM_VERIFY(!HasImag(),
               "SetAGridFunction for real-valued output called when HasImag() == true!");
   MFEM_VERIFY(A, "Incorrect usage of PostOperator::SetAGridFunction!");
   A->Real().SetFromTrueDofs(a);
-  A->Real().ExchangeFaceNbrData();
+  if (exchange_face_nbr_data)
+  {
+    A->Real().ExchangeFaceNbrData();
+  }
 }
 
 void PostOperator::UpdatePorts(const LumpedPortOperator &lumped_port_op, double omega)

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -89,12 +89,12 @@ public:
   // on the true dofs. For the real-valued overload, the electric scalar potential can be
   // specified too for electrostatic simulations. The output mesh and fields are
   // nondimensionalized consistently (B ~ E (L₀ ω₀ E₀⁻¹)).
-  void SetEGridFunction(const ComplexVector &e);
-  void SetBGridFunction(const ComplexVector &b);
-  void SetEGridFunction(const Vector &e);
-  void SetBGridFunction(const Vector &b);
-  void SetVGridFunction(const Vector &v);
-  void SetAGridFunction(const Vector &a);
+  void SetEGridFunction(const ComplexVector &e, bool exchange_face_nbr_data = true);
+  void SetBGridFunction(const ComplexVector &b, bool exchange_face_nbr_data = true);
+  void SetEGridFunction(const Vector &e, bool exchange_face_nbr_data = true);
+  void SetBGridFunction(const Vector &b, bool exchange_face_nbr_data = true);
+  void SetVGridFunction(const Vector &v, bool exchange_face_nbr_data = true);
+  void SetAGridFunction(const Vector &a, bool exchange_face_nbr_data = true);
 
   // Update cached port voltages and currents for lumped and wave port operators.
   void UpdatePorts(const LumpedPortOperator &lumped_port_op,

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -174,7 +174,7 @@ void PrintHeader(const mfem::ParFiniteElementSpace &h1_fespace,
                h1_fespace.GetMaxElementOrder(), h1_fespace.GlobalTrueVSize(),
                nd_fespace.GetMaxElementOrder(), nd_fespace.GlobalTrueVSize(),
                rt_fespace.GetMaxElementOrder(), rt_fespace.GlobalTrueVSize(),
-               nd_fespace.GetMaxElementOrder() > BilinearForm::pa_order_threshold
+               (nd_fespace.GetMaxElementOrder() > BilinearForm::pa_order_threshold)
                    ? "Partial"
                    : "Full");
 

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -206,7 +206,7 @@ double TimeOperator::GetMaxTimeStep() const
 
   // Solver for M⁻¹.
   constexpr double lin_tol = 1.0e-9;
-  constexpr int max_lin_it = 500;
+  constexpr int max_lin_it = 10000;
   CgSolver<Operator> pcg(comm, 0);
   pcg.SetRelTol(lin_tol);
   pcg.SetMaxIter(max_lin_it);

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -70,7 +70,7 @@ public:
       pcg->SetRelTol(iodata.solver.linear.tol);
       pcg->SetAbsTol(std::numeric_limits<double>::epsilon());
       pcg->SetMaxIter(iodata.solver.linear.max_it);
-      auto jac = std::make_unique<JacobiSmoother<Operator>>();
+      auto jac = std::make_unique<JacobiSmoother<Operator>>(comm);
       kspM = std::make_unique<KspSolver>(std::move(pcg), std::move(jac));
       kspM->SetOperators(*M, *M);
     }
@@ -211,13 +211,14 @@ double TimeOperator::GetMaxTimeStep() const
   pcg.SetRelTol(lin_tol);
   pcg.SetMaxIter(max_lin_it);
   pcg.SetOperator(M);
-  JacobiSmoother<Operator> jac;
+  JacobiSmoother<Operator> jac(comm);
   jac.SetOperator(M);
   pcg.SetPreconditioner(jac);
 
-  // Power iteration to estimate largest eigenvalue of undamped system matrix M⁻¹ K.
+  // Power iteration to estimate largest eigenvalue of undamped system matrix M⁻¹ K (can use
+  // Hermitian eigenvalue solver as M, K are SPD).
   ProductOperator op(pcg, K);
-  double lam = linalg::SpectralNorm(comm, op, false);
+  double lam = linalg::SpectralNorm(comm, op, true);
   MFEM_VERIFY(lam > 0.0, "Error during power iteration, λ = " << lam << "!");
   return 2.0 / std::sqrt(lam);
 }

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -1738,6 +1738,7 @@ void LinearSolverData::SetUp(json &solver)
   divfree_max_it = linear->value("DivFreeMaxIts", divfree_max_it);
   estimator_tol = linear->value("EstimatorTol", estimator_tol);
   estimator_max_it = linear->value("EstimatorMaxIts", estimator_max_it);
+  estimator_mg = linear->value("EstimatorMG", estimator_mg);
   gs_orthog_type = linear->value("GSOrthogonalization", gs_orthog_type);
 
   // Cleanup
@@ -1774,6 +1775,7 @@ void LinearSolverData::SetUp(json &solver)
   linear->erase("DivFreeMaxIts");
   linear->erase("EstimatorTol");
   linear->erase("EstimatorMaxIts");
+  linear->erase("EstimatorMG");
   linear->erase("GSOrthogonalization");
   MFEM_VERIFY(linear->empty(),
               "Found an unsupported configuration file keyword under \"Linear\"!\n"
@@ -1810,6 +1812,9 @@ void LinearSolverData::SetUp(json &solver)
   // std::cout << "AMSVector: " << ams_vector << '\n';
   // std::cout << "DivFreeTol: " << divfree_tol << '\n';
   // std::cout << "DivFreeMaxIts: " << divfree_max_it << '\n';
+  // std::cout << "EstimatorTol: " << estimator_tol << '\n';
+  // std::cout << "EstimatorMaxIts: " << estimator_max_its << '\n';
+  // std::cout << "EstimatorMG: " << estimator_mg << '\n';
   // std::cout << "GSOrthogonalization: " << gs_orthog_type << '\n';
 }
 

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -861,7 +861,7 @@ public:
   double estimator_tol = 1.0e-6;
 
   // Maximum number of iterations for solving linear systems in the error estimator.
-  int estimator_max_it = 1000;
+  int estimator_max_it = 10000;
 
   // Use geometric multigrid + AMG for error estimator linear solver preconditioner (instead
   // of just Jacobi).

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -863,6 +863,10 @@ public:
   // Maximum number of iterations for solving linear systems in the error estimator.
   int estimator_max_it = 1000;
 
+  // Use geometric multigrid + AMG for error estimator linear solver preconditioner (instead
+  // of just Jacobi).
+  bool estimator_mg = false;
+
   // Enable different variants of Gram-Schmidt orthogonalization for GMRES/FGMRES iterative
   // solvers and SLEPc eigenvalue solver.
   enum class OrthogType

--- a/scripts/schema/config/solver.json
+++ b/scripts/schema/config/solver.json
@@ -129,6 +129,7 @@
         "DivFreeMaxIts": { "type": "integer", "minimum": 0 },
         "EstimatorTol": { "type": "number", "minimum": 0.0 },
         "EstimatorMaxIts": { "type": "integer", "minimum": 0 },
+        "EstimatorMG": { "type": "boolean" },
         "GSOrthogonalization": { "type": "string" }
       }
     }


### PR DESCRIPTION
For electrostatic problems, PR https://github.com/awslabs/palace/pull/209 made the change from a global vector H1 project to a global RT-space projection, which increased the time spent in the linear solve by a factor of 5 or more. This PR is the result of some experimentation with how to speed up the linear solve associated with error estimation.

The current default is still to use Jacobi-preconditioned CG, but now a runtime option can switch this back to AMG (with matrix-free p-MG when order > 1) for problems where the increased memory overhead is worth the improved convergence rate.