### PR TITLE
Relax requirements for invalid boundary attributes specified for certain boundary conditions

### DIFF
--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -51,10 +51,10 @@ CurlCurlOperator::CurlCurlOperator(const IoData &iodata,
 mfem::Array<int> CurlCurlOperator::SetUpBoundaryProperties(const IoData &iodata,
                                                            const mfem::ParMesh &mesh)
 {
+  // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   if (!iodata.boundaries.pec.empty())
   {
-    // Check that boundary attributes have been specified correctly.
     mfem::Array<int> bdr_attr_marker(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -49,10 +49,10 @@ LaplaceOperator::LaplaceOperator(const IoData &iodata,
 mfem::Array<int> LaplaceOperator::SetUpBoundaryProperties(const IoData &iodata,
                                                           const mfem::ParMesh &mesh)
 {
+  // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   if (!iodata.boundaries.pec.empty() || !iodata.boundaries.lumpedport.empty())
   {
-    // Check that boundary attributes have been specified correctly.
     mfem::Array<int> bdr_attr_marker(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -60,10 +60,10 @@ SpaceOperator::SpaceOperator(const IoData &iodata,
 mfem::Array<int> SpaceOperator::SetUpBoundaryProperties(const IoData &iodata,
                                                         const mfem::ParMesh &mesh)
 {
+  // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   if (!iodata.boundaries.pec.empty())
   {
-    // Check that boundary attributes have been specified correctly.
     mfem::Array<int> bdr_attr_marker(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -57,12 +57,13 @@ ElementTypeInfo CheckElements(const mfem::Mesh &mesh);
 // attribute numbers are present in the list array. In the special case when list has a
 // single entry equal to -1 the marker array will contain all ones.
 template <typename T>
-void AttrToMarker(int max_attr, const T &attr_list, mfem::Array<int> &marker);
+void AttrToMarker(int max_attr, const T &attr_list, mfem::Array<int> &marker,
+                  bool skip_invalid = false);
 template <typename T>
-mfem::Array<int> AttrToMarker(int max_attr, const T &attr_list)
+mfem::Array<int> AttrToMarker(int max_attr, const T &attr_list, bool skip_invalid = false)
 {
   mfem::Array<int> marker;
-  AttrToMarker(max_attr, attr_list, marker);
+  AttrToMarker(max_attr, attr_list, marker, skip_invalid);
   return marker;
 }
 


### PR DESCRIPTION
Farfield/absorbing boundary conditions and boundary postprocessing can just warn and and ignore invalid boundary attributes. This doesn't pose too much of a risk for users and warnings are sufficiently visible in the log file. This is a usability improvement when copy-pasting large numbers of boundary attributes for models when some domains may not be meshed or may be removed due to no material properties being specified.