### PR TITLE
Fix timer value of `Timer::TOTAL` for AMR simulations

### DIFF
--- a/palace/utils/timer.hpp
+++ b/palace/utils/timer.hpp
@@ -108,7 +108,14 @@ public:
   // Record a timing step by adding a duration, without lapping; optionally, count it.
   Duration MarkTime(Index idx, Duration time, bool count_it = true)
   {
-    data[idx] = time + ((idx != Timer::TOTAL) ? data[idx] : 0.0);
+    if (idx == Timer::TOTAL)
+    {
+      data[idx] = time;
+    }
+    else
+    {
+      data[idx] += time;
+    }
     counts[idx] += count_it;
     return data[idx];
   }

--- a/palace/utils/timer.hpp
+++ b/palace/utils/timer.hpp
@@ -99,18 +99,18 @@ public:
   // Return the time elapsed since timer creation.
   Duration TimeFromStart() const { return Now() - start_time; }
 
-  // Save a timing step by adding a duration, without lapping; optionally, count it.
-  Duration SaveTime(Index idx, Duration time, bool count_it = true)
-  {
-    data[idx] += time;
-    counts[idx] += count_it;
-    return data[idx];
-  }
-
   // Lap and record a timing step.
   Duration MarkTime(Index idx, bool count_it = true)
   {
-    return SaveTime(idx, Lap(), count_it);
+    return MarkTime(idx, Lap(), count_it);
+  }
+
+  // Record a timing step by adding a duration, without lapping; optionally, count it.
+  Duration MarkTime(Index idx, Duration time, bool count_it = true)
+  {
+    data[idx] = time + ((idx != Timer::TOTAL) ? data[idx] : 0.0);
+    counts[idx] += count_it;
+    return data[idx];
   }
 
   // Provide map-like read-only access to the timing data.
@@ -186,7 +186,7 @@ public:
       timer.MarkTime(stack.top());
       stack.pop();
     }
-    timer.SaveTime(Timer::TOTAL, timer.TimeFromStart());
+    timer.MarkTime(Timer::TOTAL, timer.TimeFromStart());
 
     // Reduce timing data.
     std::vector<double> data_min, data_max, data_avg;


### PR DESCRIPTION
Fix after https://github.com/awslabs/palace/pull/212. The total time value for AMR simulations, when reduction is performed more than once, was previously double counting and printing an incorrect value.