### PR TITLE
Optimize electrostatic and magnetostatic capacitance matrix postprocessing

### DIFF
--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -367,8 +367,8 @@ void BaseSolver::PostprocessDomains(const PostOperator &postop, const std::strin
 
   // Write the field and lumped element energies.
   std::vector<EnergyData> energy_data;
-  energy_data.reserve(postop.GetDomainPostOp().GetDomains().size());
-  for (const auto &[idx, data] : postop.GetDomainPostOp().GetDomains())
+  energy_data.reserve(postop.GetDomainPostOp().M_i.size());
+  for (const auto &[idx, data] : postop.GetDomainPostOp().M_i)
   {
     const double E_elec_i = (E_elec > 0.0) ? postop.GetEFieldEnergy(idx) : 0.0;
     const double E_mag_i = (E_mag > 0.0) ? postop.GetHFieldEnergy(idx) : 0.0;
@@ -449,8 +449,8 @@ void BaseSolver::PostprocessSurfaces(const PostOperator &postop, const std::stri
 
   // Write the Q-factors due to interface dielectric loss.
   std::vector<EpsData> eps_data;
-  eps_data.reserve(postop.GetSurfacePostOp().GetEps().size());
-  for (const auto &[idx, data] : postop.GetSurfacePostOp().GetEps())
+  eps_data.reserve(postop.GetSurfacePostOp().eps_surfs.size());
+  for (const auto &[idx, data] : postop.GetSurfacePostOp().eps_surfs)
   {
     const double pl = postop.GetInterfaceParticipation(idx, E_elec);
     const double tandelta = postop.GetSurfacePostOp().GetInterfaceLossTangent(idx);
@@ -491,8 +491,8 @@ void BaseSolver::PostprocessSurfaces(const PostOperator &postop, const std::stri
 
   // Write the surface capacitance (integrated charge).
   std::vector<CapData> cap_data;
-  cap_data.reserve(postop.GetSurfacePostOp().GetCap().size());
-  for (const auto &[idx, data] : postop.GetSurfacePostOp().GetCap())
+  cap_data.reserve(postop.GetSurfacePostOp().charge_surfs.size());
+  for (const auto &[idx, data] : postop.GetSurfacePostOp().charge_surfs)
   {
     const double Cij = (std::abs(Vinc) > 0.0) ? postop.GetSurfaceCharge(idx) / Vinc : 0.0;
     cap_data.push_back(
@@ -529,8 +529,8 @@ void BaseSolver::PostprocessSurfaces(const PostOperator &postop, const std::stri
 
   // Write the surface inductance (integrated flux).
   std::vector<IndData> ind_data;
-  ind_data.reserve(postop.GetSurfacePostOp().GetInd().size());
-  for (const auto &[idx, data] : postop.GetSurfacePostOp().GetInd())
+  ind_data.reserve(postop.GetSurfacePostOp().flux_surfs.size());
+  for (const auto &[idx, data] : postop.GetSurfacePostOp().flux_surfs)
   {
     const double Mij = (std::abs(Iinc) > 0.0) ? postop.GetSurfaceFlux(idx) / Iinc : 0.0;
     ind_data.push_back(

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -44,7 +44,6 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Right-hand side term and solution vector storage.
   Vector RHS(Grad.Width()), E(Grad.Height());
   std::vector<Vector> V(nstep);
-  std::vector<double> E_elec(nstep);
 
   // Initialize structures for storing and reducing the results of error estimation.
   GradFluxErrorEstimator estimator(
@@ -76,13 +75,13 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     Grad.AddMult(V[step], E, -1.0);
     postop.SetVGridFunction(V[step]);
     postop.SetEGridFunction(E);
-    E_elec[step] = postop.GetEFieldEnergy();
+    double E_elec = postop.GetEFieldEnergy();
     Mpi::Print(" Sol. ||V|| = {:.6e} (||RHS|| = {:.6e})\n",
                linalg::Norml2(laplaceop.GetComm(), V[step]),
                linalg::Norml2(laplaceop.GetComm(), RHS));
     {
       const double J = iodata.DimensionalizeValue(IoData::ValueType::ENERGY, 1.0);
-      Mpi::Print(" Field energy E = {:.3e} J\n", E_elec[step] * J);
+      Mpi::Print(" Field energy E = {:.3e} J\n", E_elec * J);
     }
 
     // Calculate and record the error indicators.
@@ -90,8 +89,7 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     estimator.AddErrorIndicator(V[step], indicator);
 
     // Postprocess field solutions and optionally write solution to disk.
-    Postprocess(postop, step, idx, E_elec[step],
-                (step == nstep - 1) ? &indicator : nullptr);
+    Postprocess(postop, step, idx, E_elec, (step == nstep - 1) ? &indicator : nullptr);
 
     // Next terminal.
     step++;
@@ -100,7 +98,7 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Postprocess the capacitance matrix from the computed field solutions.
   BlockTimer bt1(Timer::POSTPRO);
   SaveMetadata(ksp);
-  PostprocessTerminals(postop, laplaceop.GetSources(), V, E_elec);
+  PostprocessTerminals(postop, laplaceop.GetSources(), V);
   return {indicator, laplaceop.GlobalTrueVSize()};
 }
 
@@ -125,7 +123,7 @@ void ElectrostaticSolver::Postprocess(const PostOperator &postop, int step, int 
 
 void ElectrostaticSolver::PostprocessTerminals(
     PostOperator &postop, const std::map<int, mfem::Array<int>> &terminal_sources,
-    const std::vector<Vector> &V, const std::vector<double> &E_elec) const
+    const std::vector<Vector> &V) const
 {
   // Postprocess the Maxwell capacitance matrix. See p. 97 of the COMSOL AC/DC Module manual
   // for the associated formulas based on the electric field energy based on a unit voltage
@@ -136,33 +134,29 @@ void ElectrostaticSolver::PostprocessTerminals(
   mfem::DenseMatrix C(V.size()), Cm(V.size());
   for (int i = 0; i < C.Height(); i++)
   {
-    // Diagonal: C_ii = 2 U_e(V_i) / V_i².
-    C(i, i) = Cm(i, i) = 2.0 * E_elec[i];
-  }
+    // Diagonal: Cᵢᵢ = 2 Uₑ(Vᵢ) / Vᵢ² = (Vᵢᵀ K Vᵢ) / Vᵢ²
+    auto &V_gf = postop.GetV().Real();
+    auto &D_gf = postop.GetDomainPostOp().D;
+    V_gf.SetFromTrueDofs(V[i]);
+    postop.GetDomainPostOp().M_elec->Mult(V_gf, D_gf);
+    C(i, i) = Cm(i, i) = linalg::Dot<Vector>(postop.GetComm(), V_gf, D_gf);
 
-  // Off-diagonals: C_ij = U_e(V_i + V_j) / (V_i V_j) - 1/2 (V_i/V_j C_ii + V_j/V_i C_jj).
-  Vector Vij(V[0].Size());
-  Vij.UseDevice(true);
-  for (int i = 0; i < C.Height(); i++)
-  {
-    for (int j = 0; j < C.Width(); j++)
+    // Off-diagonals: Cᵢⱼ = Uₑ(Vᵢ + Vⱼ) / (Vᵢ Vⱼ) - 1/2 (Vᵢ/Vⱼ Cᵢᵢ + Vⱼ/Vᵢ Cⱼⱼ)
+    //                    = (Vⱼᵀ K Vᵢ) / (Vᵢ Vⱼ)
+    for (int j = i + 1; j < C.Width(); j++)
     {
-      if (j < i)
-      {
-        // Copy lower triangle from already computed upper triangle.
-        C(i, j) = C(j, i);
-        Cm(i, j) = Cm(j, i);
-        Cm(i, i) -= Cm(i, j);
-      }
-      else if (j > i)
-      {
-        linalg::AXPBYPCZ(1.0, V[i], 1.0, V[j], 0.0, Vij);
-        postop.SetVGridFunction(Vij, false);
-        double Ue = postop.GetEFieldEnergy();
-        C(i, j) = Ue - 0.5 * (C(i, i) + C(j, j));
-        Cm(i, j) = -C(i, j);
-        Cm(i, i) -= Cm(i, j);
-      }
+      V_gf.SetFromTrueDofs(V[j]);
+      C(i, j) = linalg::Dot<Vector>(postop.GetComm(), V_gf, D_gf);
+      Cm(i, j) = -C(i, j);
+      Cm(i, i) -= Cm(i, j);
+    }
+
+    // Copy lower triangle from already computed upper triangle.
+    for (int j = 0; j < i; j++)
+    {
+      C(i, j) = C(j, i);
+      Cm(i, j) = Cm(j, i);
+      Cm(i, i) -= Cm(i, j);
     }
   }
   mfem::DenseMatrix Cinv(C);

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -134,7 +134,7 @@ void ElectrostaticSolver::PostprocessTerminals(
   mfem::DenseMatrix C(V.size()), Cm(V.size());
   for (int i = 0; i < C.Height(); i++)
   {
-    // Diagonal: Cᵢᵢ = 2 Uₑ(Vᵢ) / Vᵢ² = (Vᵢᵀ K Vᵢ) / Vᵢ²
+    // Diagonal: Cᵢᵢ = 2 Uₑ(Vᵢ) / Vᵢ² = (Vᵢᵀ K Vᵢ) / Vᵢ² (with ∀i, Vᵢ = 1)
     auto &V_gf = postop.GetVGridFunction().Real();
     auto &D_gf = postop.GetDomainPostOp().D;
     V_gf.SetFromTrueDofs(V[i]);

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -135,7 +135,7 @@ void ElectrostaticSolver::PostprocessTerminals(
   for (int i = 0; i < C.Height(); i++)
   {
     // Diagonal: Cᵢᵢ = 2 Uₑ(Vᵢ) / Vᵢ² = (Vᵢᵀ K Vᵢ) / Vᵢ²
-    auto &V_gf = postop.GetV().Real();
+    auto &V_gf = postop.GetVGridFunction().Real();
     auto &D_gf = postop.GetDomainPostOp().D;
     V_gf.SetFromTrueDofs(V[i]);
     postop.GetDomainPostOp().M_elec->Mult(V_gf, D_gf);

--- a/palace/drivers/electrostaticsolver.hpp
+++ b/palace/drivers/electrostaticsolver.hpp
@@ -36,8 +36,7 @@ private:
 
   void PostprocessTerminals(PostOperator &postop,
                             const std::map<int, mfem::Array<int>> &terminal_sources,
-                            const std::vector<Vector> &V,
-                            const std::vector<double> &E_elec) const;
+                            const std::vector<Vector> &V) const;
 
   std::pair<ErrorIndicator, long long int>
   Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const override;

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -142,7 +142,7 @@ void MagnetostaticSolver::PostprocessTerminals(PostOperator &postop,
   for (int i = 0; i < M.Height(); i++)
   {
     // Diagonal: Mᵢᵢ = 2 Uₘ(Aᵢ) / Iᵢ² = (Aᵢᵀ K Aᵢ) / Iᵢ²
-    auto &A_gf = postop.GetA().Real();
+    auto &A_gf = postop.GetAGridFunction().Real();
     auto &H_gf = postop.GetDomainPostOp().H;
     A_gf.SetFromTrueDofs(A[i]);
     postop.GetDomainPostOp().M_mag->Mult(A_gf, H_gf);

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -44,7 +44,7 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Source term and solution vector storage.
   Vector RHS(Curl.Width()), B(Curl.Height());
   std::vector<Vector> A(nstep);
-  std::vector<double> I_inc(nstep), E_mag(nstep);
+  std::vector<double> I_inc(nstep);
 
   // Initialize structures for storing and reducing the results of error estimation.
   CurlFluxErrorEstimator<Vector> estimator(
@@ -77,13 +77,13 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     Curl.Mult(A[step], B);
     postop.SetAGridFunction(A[step]);
     postop.SetBGridFunction(B);
-    E_mag[step] = postop.GetHFieldEnergy();
+    double E_mag = postop.GetHFieldEnergy();
     Mpi::Print(" Sol. ||A|| = {:.6e} (||RHS|| = {:.6e})\n",
                linalg::Norml2(curlcurlop.GetComm(), A[step]),
                linalg::Norml2(curlcurlop.GetComm(), RHS));
     {
       const double J = iodata.DimensionalizeValue(IoData::ValueType::ENERGY, 1.0);
-      Mpi::Print(" Field energy H = {:.3e} J\n", E_mag[step] * J);
+      Mpi::Print(" Field energy H = {:.3e} J\n", E_mag * J);
     }
     I_inc[step] = data.GetExcitationCurrent();
 
@@ -92,7 +92,7 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     estimator.AddErrorIndicator(A[step], indicator);
 
     // Postprocess field solutions and optionally write solution to disk.
-    Postprocess(postop, step, idx, I_inc[step], E_mag[step],
+    Postprocess(postop, step, idx, I_inc[step], E_mag,
                 (step == nstep - 1) ? &indicator : nullptr);
 
     // Next source.
@@ -102,7 +102,7 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Postprocess the inductance matrix from the computed field solutions.
   BlockTimer bt1(Timer::POSTPRO);
   SaveMetadata(ksp);
-  PostprocessTerminals(postop, curlcurlop.GetSurfaceCurrentOp(), A, I_inc, E_mag);
+  PostprocessTerminals(postop, curlcurlop.GetSurfaceCurrentOp(), A, I_inc);
   return {indicator, curlcurlop.GlobalTrueVSize()};
 }
 
@@ -129,8 +129,7 @@ void MagnetostaticSolver::Postprocess(const PostOperator &postop, int step, int 
 void MagnetostaticSolver::PostprocessTerminals(PostOperator &postop,
                                                const SurfaceCurrentOperator &surf_j_op,
                                                const std::vector<Vector> &A,
-                                               const std::vector<double> &I_inc,
-                                               const std::vector<double> &E_mag) const
+                                               const std::vector<double> &I_inc) const
 {
   // Postprocess the Maxwell inductance matrix. See p. 97 of the COMSOL AC/DC Module manual
   // for the associated formulas based on the magnetic field energy based on a current
@@ -142,34 +141,30 @@ void MagnetostaticSolver::PostprocessTerminals(PostOperator &postop,
   mfem::DenseMatrix M(A.size()), Mm(A.size());
   for (int i = 0; i < M.Height(); i++)
   {
-    // Diagonal: M_ii = 2 U_m(A_i) / I_i².
-    M(i, i) = Mm(i, i) = 2.0 * E_mag[i] / (I_inc[i] * I_inc[i]);
-  }
+    // Diagonal: Mᵢᵢ = 2 Uₘ(Aᵢ) / Iᵢ² = (Aᵢᵀ K Aᵢ) / Iᵢ²
+    auto &A_gf = postop.GetA().Real();
+    auto &H_gf = postop.GetDomainPostOp().H;
+    A_gf.SetFromTrueDofs(A[i]);
+    postop.GetDomainPostOp().M_mag->Mult(A_gf, H_gf);
+    M(i, i) = Mm(i, i) =
+        linalg::Dot<Vector>(postop.GetComm(), A_gf, H_gf) / (I_inc[i] * I_inc[i]);
 
-  // Off-diagonals: M_ij = U_m(A_i + A_j) / (I_i I_j) - 1/2 (I_i/I_j M_ii + I_j/I_i M_jj).
-  Vector Aij(A[0].Size());
-  Aij.UseDevice(true);
-  for (int i = 0; i < M.Height(); i++)
-  {
-    for (int j = 0; j < M.Width(); j++)
+    // Off-diagonals: Mᵢⱼ = Uₘ(Aᵢ + Aⱼ) / (Iᵢ Iⱼ) - 1/2 (Iᵢ/Iⱼ Mᵢᵢ + Iⱼ/Iᵢ Mⱼⱼ)
+    //                    = (Aⱼᵀ K Aᵢ) / (Iᵢ Iⱼ)
+    for (int j = i + 1; j < M.Width(); j++)
     {
-      if (j < i)
-      {
-        // Copy lower triangle from already computed upper triangle.
-        M(i, j) = M(j, i);
-        Mm(i, j) = Mm(j, i);
-        Mm(i, i) -= Mm(i, j);
-      }
-      else if (j > i)
-      {
-        linalg::AXPBYPCZ(1.0, A[i], 1.0, A[j], 0.0, Aij);
-        postop.SetAGridFunction(Aij, false);
-        double Um = postop.GetHFieldEnergy();
-        M(i, j) = Um / (I_inc[i] * I_inc[j]) -
-                  0.5 * (M(i, i) * I_inc[i] / I_inc[j] + M(j, j) * I_inc[j] / I_inc[i]);
-        Mm(i, j) = -M(i, j);
-        Mm(i, i) -= Mm(i, j);
-      }
+      A_gf.SetFromTrueDofs(A[j]);
+      M(i, j) = linalg::Dot<Vector>(postop.GetComm(), A_gf, H_gf) / (I_inc[i] * I_inc[j]);
+      Mm(i, j) = -M(i, j);
+      Mm(i, i) -= Mm(i, j);
+    }
+
+    // Copy lower triangle from already computed upper triangle.
+    for (int j = 0; j < i; j++)
+    {
+      M(i, j) = M(j, i);
+      Mm(i, j) = Mm(j, i);
+      Mm(i, i) -= Mm(i, j);
     }
   }
   mfem::DenseMatrix Minv(M);

--- a/palace/drivers/magnetostaticsolver.hpp
+++ b/palace/drivers/magnetostaticsolver.hpp
@@ -27,8 +27,8 @@ private:
                    double E_mag, const ErrorIndicator *indicator) const;
 
   void PostprocessTerminals(PostOperator &postop, const SurfaceCurrentOperator &surf_j_op,
-                            const std::vector<Vector> &A, const std::vector<double> &I_inc,
-                            const std::vector<double> &E_mag) const;
+                            const std::vector<Vector> &A,
+                            const std::vector<double> &I_inc) const;
 
   std::pair<ErrorIndicator, long long int>
   Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const override;

--- a/palace/models/domainpostoperator.hpp
+++ b/palace/models/domainpostoperator.hpp
@@ -26,23 +26,19 @@ class MaterialOperator;
 //
 class DomainPostOperator
 {
-private:
+public:
+  // Temporary vectors for inner product calculations.
+  mutable Vector D, H;
+
   // Bilinear forms for computing field energy integrals over domains.
   std::unique_ptr<Operator> M_elec, M_mag;
   std::map<int, std::pair<std::unique_ptr<Operator>, std::unique_ptr<Operator>>> M_i;
 
-  // Temporary vectors for inner product calculations.
-  mutable Vector D, H;
-
-public:
   DomainPostOperator(const IoData &iodata, const MaterialOperator &mat_op,
                      const FiniteElementSpace &nd_fespace,
                      const FiniteElementSpace &rt_fespace);
   DomainPostOperator(const IoData &iodata, const MaterialOperator &mat_op,
                      const FiniteElementSpace &fespace);
-
-  // Access data structures for postprocessing domains.
-  const auto &GetDomains() const { return M_i; }
 
   // Get volume integrals computing the electric or magnetic field energy in the entire
   // domain.

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -96,6 +96,32 @@ public:
   void SetVGridFunction(const Vector &v, bool exchange_face_nbr_data = true);
   void SetAGridFunction(const Vector &a, bool exchange_face_nbr_data = true);
 
+  // Access grid functions for field solutions.
+  auto &GetE()
+  {
+    MFEM_ASSERT(E.has_value(),
+                "Missing GridFunction object when accessing from PostOperator!");
+    return *E;
+  }
+  auto &GetB()
+  {
+    MFEM_ASSERT(B.has_value(),
+                "Missing GridFunction object when accessing from PostOperator!");
+    return *B;
+  }
+  auto &GetV()
+  {
+    MFEM_ASSERT(V.has_value(),
+                "Missing GridFunction object when accessing from PostOperator!");
+    return *V;
+  }
+  auto &GetA()
+  {
+    MFEM_ASSERT(A.has_value(),
+                "Missing GridFunction object when accessing from PostOperator!");
+    return *A;
+  }
+
   // Postprocess the total electric and magnetic field energies in the electric and magnetic
   // fields.
   double GetEFieldEnergy() const;

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -97,25 +97,25 @@ public:
   void SetAGridFunction(const Vector &a, bool exchange_face_nbr_data = true);
 
   // Access grid functions for field solutions.
-  auto &GetE()
+  auto &GetEGridFunction()
   {
     MFEM_ASSERT(E.has_value(),
                 "Missing GridFunction object when accessing from PostOperator!");
     return *E;
   }
-  auto &GetB()
+  auto &GetBGridFunction()
   {
     MFEM_ASSERT(B.has_value(),
                 "Missing GridFunction object when accessing from PostOperator!");
     return *B;
   }
-  auto &GetV()
+  auto &GetVGridFunction()
   {
     MFEM_ASSERT(V.has_value(),
                 "Missing GridFunction object when accessing from PostOperator!");
     return *V;
   }
-  auto &GetA()
+  auto &GetAGridFunction()
   {
     MFEM_ASSERT(A.has_value(),
                 "Missing GridFunction object when accessing from PostOperator!");

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -75,9 +75,6 @@ private:
     GetCoefficient(std::size_t i, const mfem::ParGridFunction &U,
                    const MaterialOperator &mat_op) const override;
   };
-  std::map<int, InterfaceDielectricData> eps_surfs;
-  std::map<int, SurfaceChargeData> charge_surfs;
-  std::map<int, SurfaceFluxData> flux_surfs;
 
   // Reference to material property operator (not owned).
   const MaterialOperator &mat_op;
@@ -90,13 +87,13 @@ private:
                                  const mfem::ParGridFunction &U) const;
 
 public:
+  // Data structures for postprocessing the surface with the given type.
+  std::map<int, InterfaceDielectricData> eps_surfs;
+  std::map<int, SurfaceChargeData> charge_surfs;
+  std::map<int, SurfaceFluxData> flux_surfs;
+
   SurfacePostOperator(const IoData &iodata, const MaterialOperator &mat_op,
                       mfem::ParFiniteElementSpace &h1_fespace);
-
-  // Access data structures for postprocessing the surface with the given type.
-  const auto &GetEps() const { return eps_surfs; }
-  const auto &GetCap() const { return charge_surfs; }
-  const auto &GetInd() const { return flux_surfs; }
 
   // Get surface integrals computing dielectric interface energy, surface charge, or
   // surface magnetic flux.


### PR DESCRIPTION
Reduces the number of matrix-vector products by `N*(N-1)/2` for `N` terminals or current sources. Still requires `N*(N+1)/2` dot products.

Note: Based on https://github.com/awslabs/palace/pull/234