### PR TITLE
Snake case consistency

### DIFF
--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -108,8 +108,8 @@ various possible postprocessed scalar and vector are:
   - Magnetic flux density: `B`, `B_real`, and `B_imag`
   - Electric potential: `V`
   - Magnetic vector potential : `A`, `A_real`, and `A_imag`
-  - Electric energy density : `Ue`
-  - Magnetic energy density : `Um`
+  - Electric energy density : `U_e`
+  - Magnetic energy density : `U_m`
   - Poynting vector: `S`
 
 Also, at the final step of the simulation the following element-wise quantities are written
@@ -126,8 +126,8 @@ located in the same `paraview/` directory, with suffix `_boundary`.
 The boundary data collection includes the 3D field values sampled on the boundary mesh as
 well as:
 
-  - Surface charge density: `Qs`, `Q_real`, `Qs_imag`
-  - Surface current density: `Js`, `Js_real`, `Js_imag`
+  - Surface charge density: `Q_s`, `Q_s_real`, `Q_s_imag`
+  - Surface current density: `J_s`, `J_s_real`, `J_s_imag`
 
 ## Adaptive mesh refinement
 

--- a/palace/drivers/basesolver.hpp
+++ b/palace/drivers/basesolver.hpp
@@ -53,23 +53,23 @@ protected:
   }
 
   // Common domain postprocessing for all simulation types.
-  void PostprocessDomains(const PostOperator &postop, const std::string &name, int step,
+  void PostprocessDomains(const PostOperator &post_op, const std::string &name, int step,
                           double time, double E_elec, double E_mag, double E_cap,
                           double E_ind) const;
 
   // Common surface postprocessing for all simulation types.
-  void PostprocessSurfaces(const PostOperator &postop, const std::string &name, int step,
+  void PostprocessSurfaces(const PostOperator &post_op, const std::string &name, int step,
                            double time, double E_elec, double E_mag) const;
 
   // Common probe postprocessing for all simulation types.
-  void PostprocessProbes(const PostOperator &postop, const std::string &name, int step,
+  void PostprocessProbes(const PostOperator &post_op, const std::string &name, int step,
                          double time) const;
 
   // Common field visualization postprocessing for all simulation types.
-  void PostprocessFields(const PostOperator &postop, int step, double time) const;
+  void PostprocessFields(const PostOperator &post_op, int step, double time) const;
 
   // Common error indicator postprocessing for all simulation types.
-  void PostprocessErrorIndicator(const PostOperator &postop,
+  void PostprocessErrorIndicator(const PostOperator &post_op,
                                  const ErrorIndicator &indicator, bool fields) const;
 
   // Performs a solve using the mesh sequence, then reports error indicators and the number

--- a/palace/drivers/drivensolver.hpp
+++ b/palace/drivers/drivensolver.hpp
@@ -27,26 +27,26 @@ class DrivenSolver : public BaseSolver
 private:
   int GetNumSteps(double start, double end, double delta) const;
 
-  ErrorIndicator SweepUniform(SpaceOperator &spaceop, PostOperator &postop, int nstep,
+  ErrorIndicator SweepUniform(SpaceOperator &space_op, PostOperator &post_op, int n_step,
                               int step0, double omega0, double delta_omega) const;
 
-  ErrorIndicator SweepAdaptive(SpaceOperator &spaceop, PostOperator &postop, int nstep,
+  ErrorIndicator SweepAdaptive(SpaceOperator &space_op, PostOperator &post_op, int n_step,
                                int step0, double omega0, double delta_omega) const;
 
-  void Postprocess(const PostOperator &postop, const LumpedPortOperator &lumped_port_op,
+  void Postprocess(const PostOperator &post_op, const LumpedPortOperator &lumped_port_op,
                    const WavePortOperator &wave_port_op,
                    const SurfaceCurrentOperator &surf_j_op, int step, double omega,
                    double E_elec, double E_mag, const ErrorIndicator *indicator) const;
 
-  void PostprocessCurrents(const PostOperator &postop,
+  void PostprocessCurrents(const PostOperator &post_op,
                            const SurfaceCurrentOperator &surf_j_op, int step,
                            double omega) const;
 
-  void PostprocessPorts(const PostOperator &postop,
+  void PostprocessPorts(const PostOperator &post_op,
                         const LumpedPortOperator &lumped_port_op, int step,
                         double omega) const;
 
-  void PostprocessSParameters(const PostOperator &postop,
+  void PostprocessSParameters(const PostOperator &post_op,
                               const LumpedPortOperator &lumped_port_op,
                               const WavePortOperator &wave_port_op, int step,
                               double omega) const;

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -542,7 +542,7 @@ void EigenSolver::PostprocessPorts(const PostOperator &postop,
 
 void EigenSolver::PostprocessEPR(const PostOperator &postop,
                                  const LumpedPortOperator &lumped_port_op, int i,
-                                 std::complex<double> omega, double Em) const
+                                 std::complex<double> omega, double E_m) const
 {
   // If ports have been specified in the model, compute the corresponding energy-
   // participation ratios (EPR) and write out to disk.
@@ -558,7 +558,7 @@ void EigenSolver::PostprocessEPR(const PostOperator &postop,
   {
     if (std::abs(data.L) > 0.0)
     {
-      const double pj = postop.GetInductorParticipation(lumped_port_op, idx, Em);
+      const double pj = postop.GetInductorParticipation(lumped_port_op, idx, E_m);
       epr_L_data.push_back({idx, pj});
     }
   }
@@ -598,7 +598,7 @@ void EigenSolver::PostprocessEPR(const PostOperator &postop,
   {
     if (std::abs(data.R) > 0.0)
     {
-      const double Kl = postop.GetExternalKappa(lumped_port_op, idx, Em);
+      const double Kl = postop.GetExternalKappa(lumped_port_op, idx, E_m);
       const double Ql = (Kl == 0.0) ? mfem::infinity() : omega.real() / std::abs(Kl);
       epr_IO_data.push_back(
           {idx, Ql, iodata.DimensionalizeValue(IoData::ValueType::FREQUENCY, Kl)});

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -32,15 +32,15 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // values for the mass matrix PEC dof shift the Dirichlet eigenvalues out of the
   // computational range. The damping matrix may be nullptr.
   BlockTimer bt0(Timer::CONSTRUCT);
-  SpaceOperator spaceop(iodata, mesh);
-  auto K = spaceop.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
-  auto C = spaceop.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
-  auto M = spaceop.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
-  const auto &Curl = spaceop.GetCurlMatrix();
-  SaveMetadata(spaceop.GetNDSpaces());
+  SpaceOperator space_op(iodata, mesh);
+  auto K = space_op.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
+  auto C = space_op.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+  auto M = space_op.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+  const auto &Curl = space_op.GetCurlMatrix();
+  SaveMetadata(space_op.GetNDSpaces());
 
   // Configure objects for postprocessing.
-  PostOperator postop(iodata, spaceop, "eigenmode");
+  PostOperator post_op(iodata, space_op, "eigenmode");
   ComplexVector E(Curl.Width()), B(Curl.Height());
   E.UseDevice(true);
   B.UseDevice(true);
@@ -84,12 +84,12 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     Mpi::Print("\nConfiguring ARPACK eigenvalue solver:\n");
     if (C)
     {
-      eigen = std::make_unique<arpack::ArpackPEPSolver>(spaceop.GetComm(),
+      eigen = std::make_unique<arpack::ArpackPEPSolver>(space_op.GetComm(),
                                                         iodata.problem.verbose);
     }
     else
     {
-      eigen = std::make_unique<arpack::ArpackEPSSolver>(spaceop.GetComm(),
+      eigen = std::make_unique<arpack::ArpackEPSSolver>(space_op.GetComm(),
                                                         iodata.problem.verbose);
     }
 #endif
@@ -103,20 +103,20 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     {
       if (!iodata.solver.eigenmode.pep_linear)
       {
-        slepc = std::make_unique<slepc::SlepcPEPSolver>(spaceop.GetComm(),
+        slepc = std::make_unique<slepc::SlepcPEPSolver>(space_op.GetComm(),
                                                         iodata.problem.verbose);
         slepc->SetType(slepc::SlepcEigenvalueSolver::Type::TOAR);
       }
       else
       {
-        slepc = std::make_unique<slepc::SlepcPEPLinearSolver>(spaceop.GetComm(),
+        slepc = std::make_unique<slepc::SlepcPEPLinearSolver>(space_op.GetComm(),
                                                               iodata.problem.verbose);
         slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
       }
     }
     else
     {
-      slepc = std::make_unique<slepc::SlepcEPSSolver>(spaceop.GetComm(),
+      slepc = std::make_unique<slepc::SlepcEPSSolver>(space_op.GetComm(),
                                                       iodata.problem.verbose);
       slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
     }
@@ -151,11 +151,11 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   if (iodata.solver.eigenmode.mass_orthog)
   {
     Mpi::Print(" Basis uses M-inner product\n");
-    KM = spaceop.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
+    KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
     eigen->SetBMat(*KM);
 
     // Mpi::Print(" Basis uses (K + M)-inner product\n");
-    // KM = spaceop.GetInnerProductMatrix(1.0, 1.0, K.get(), M.get());
+    // KM = space_op.GetInnerProductMatrix(1.0, 1.0, K.get(), M.get());
     // eigen->SetBMat(*KM);
   }
 
@@ -167,8 +167,8 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     Mpi::Print(" Configuring divergence-free projection\n");
     constexpr int divfree_verbose = 0;
     divfree = std::make_unique<DivFreeSolver<ComplexVector>>(
-        spaceop.GetMaterialOp(), spaceop.GetNDSpace(), spaceop.GetH1Spaces(),
-        spaceop.GetAuxBdrTDofLists(), iodata.solver.linear.divfree_tol,
+        space_op.GetMaterialOp(), space_op.GetNDSpace(), space_op.GetH1Spaces(),
+        space_op.GetAuxBdrTDofLists(), iodata.solver.linear.divfree_tol,
         iodata.solver.linear.divfree_max_it, divfree_verbose);
     eigen->SetDivFreeProjector(*divfree);
   }
@@ -181,12 +181,12 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     if (iodata.solver.eigenmode.init_v0_const)
     {
       Mpi::Print(" Using constant starting vector\n");
-      spaceop.GetConstantInitialVector(v0);
+      space_op.GetConstantInitialVector(v0);
     }
     else
     {
       Mpi::Print(" Using random starting vector\n");
-      spaceop.GetRandomInitialVector(v0);
+      space_op.GetRandomInitialVector(v0);
     }
     if (divfree)
     {
@@ -195,7 +195,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     eigen->SetInitialSpace(v0);  // Copies the vector
 
     // Debug
-    // const auto &Grad = spaceop.GetGradMatrix();
+    // const auto &Grad = space_op.GetGradMatrix();
     // ComplexVector r0(Grad->Width());
     // r0.UseDevice(true);
     // Grad.MultTranspose(v0.Real(), r0.Real());
@@ -248,13 +248,13 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // (K - σ² M) or P(iσ) = (K + iσ C - σ² M) during the eigenvalue solve. The
   // preconditioner for complex linear systems is constructed from a real approximation
   // to the complex system matrix.
-  auto A = spaceop.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * target,
-                                   std::complex<double>(-target * target, 0.0), K.get(),
-                                   C.get(), M.get());
-  auto P = spaceop.GetPreconditionerMatrix<ComplexOperator>(1.0, target, -target * target,
-                                                            target);
-  auto ksp = std::make_unique<ComplexKspSolver>(iodata, spaceop.GetNDSpaces(),
-                                                &spaceop.GetH1Spaces());
+  auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * target,
+                                    std::complex<double>(-target * target, 0.0), K.get(),
+                                    C.get(), M.get());
+  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(1.0, target, -target * target,
+                                                             target);
+  auto ksp = std::make_unique<ComplexKspSolver>(iodata, space_op.GetNDSpaces(),
+                                                &space_op.GetH1Spaces());
   ksp->SetOperators(*A, *P);
   eigen->SetLinearSolver(*ksp);
 
@@ -276,7 +276,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Calculate and record the error indicators, and postprocess the results.
   Mpi::Print("\nComputing solution error estimates and performing postprocessing\n");
   TimeDependentFluxErrorEstimator<ComplexVector> estimator(
-      spaceop.GetMaterialOp(), spaceop.GetNDSpaces(), spaceop.GetRTSpaces(),
+      space_op.GetMaterialOp(), space_op.GetNDSpaces(), space_op.GetRTSpaces(),
       iodata.solver.linear.estimator_tol, iodata.solver.linear.estimator_max_it, 0,
       iodata.solver.linear.estimator_mg);
   ErrorIndicator indicator;
@@ -284,7 +284,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   {
     // Normalize the finalized eigenvectors with respect to mass matrix (unit electric field
     // energy) even if they are not computed to be orthogonal with respect to it.
-    KM = spaceop.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
+    KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
     eigen->SetBMat(*KM);
     eigen->RescaleEigenvectors(num_conv);
   }
@@ -312,11 +312,11 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     Curl.Mult(E.Real(), B.Real());
     Curl.Mult(E.Imag(), B.Imag());
     B *= -1.0 / (1i * omega);
-    postop.SetEGridFunction(E);
-    postop.SetBGridFunction(B);
-    postop.UpdatePorts(spaceop.GetLumpedPortOp(), omega.real());
-    const double E_elec = postop.GetEFieldEnergy();
-    const double E_mag = postop.GetHFieldEnergy();
+    post_op.SetEGridFunction(E);
+    post_op.SetBGridFunction(B);
+    post_op.UpdatePorts(space_op.GetLumpedPortOp(), omega.real());
+    const double E_elec = post_op.GetEFieldEnergy();
+    const double E_mag = post_op.GetHFieldEnergy();
 
     // Calculate and record the error indicators.
     if (i < iodata.solver.eigenmode.n)
@@ -325,14 +325,14 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     }
 
     // Postprocess the mode.
-    Postprocess(postop, spaceop.GetLumpedPortOp(), i, omega, error_bkwd, error_abs,
+    Postprocess(post_op, space_op.GetLumpedPortOp(), i, omega, error_bkwd, error_abs,
                 num_conv, E_elec, E_mag,
                 (i == iodata.solver.eigenmode.n - 1) ? &indicator : nullptr);
   }
-  return {indicator, spaceop.GlobalTrueVSize()};
+  return {indicator, space_op.GlobalTrueVSize()};
 }
 
-void EigenSolver::Postprocess(const PostOperator &postop,
+void EigenSolver::Postprocess(const PostOperator &post_op,
                               const LumpedPortOperator &lumped_port_op, int i,
                               std::complex<double> omega, double error_bkwd,
                               double error_abs, int num_conv, double E_elec, double E_mag,
@@ -340,22 +340,22 @@ void EigenSolver::Postprocess(const PostOperator &postop,
 {
   // The internal GridFunctions for PostOperator have already been set from the E and B
   // solutions in the main loop over converged eigenvalues.
-  const double E_cap = postop.GetLumpedCapacitorEnergy(lumped_port_op);
-  const double E_ind = postop.GetLumpedInductorEnergy(lumped_port_op);
+  const double E_cap = post_op.GetLumpedCapacitorEnergy(lumped_port_op);
+  const double E_ind = post_op.GetLumpedInductorEnergy(lumped_port_op);
   PostprocessEigen(i, omega, error_bkwd, error_abs, num_conv);
-  PostprocessPorts(postop, lumped_port_op, i);
-  PostprocessEPR(postop, lumped_port_op, i, omega, E_elec + E_cap);
-  PostprocessDomains(postop, "m", i, i + 1, E_elec, E_mag, E_cap, E_ind);
-  PostprocessSurfaces(postop, "m", i, i + 1, E_elec + E_cap, E_mag + E_ind);
-  PostprocessProbes(postop, "m", i, i + 1);
+  PostprocessPorts(post_op, lumped_port_op, i);
+  PostprocessEPR(post_op, lumped_port_op, i, omega, E_elec + E_cap);
+  PostprocessDomains(post_op, "m", i, i + 1, E_elec, E_mag, E_cap, E_ind);
+  PostprocessSurfaces(post_op, "m", i, i + 1, E_elec + E_cap, E_mag + E_ind);
+  PostprocessProbes(post_op, "m", i, i + 1);
   if (i < iodata.solver.eigenmode.n_post)
   {
-    PostprocessFields(postop, i, i + 1);
+    PostprocessFields(post_op, i, i + 1);
     Mpi::Print(" Wrote mode {:d} to disk\n", i + 1);
   }
   if (indicator)
   {
-    PostprocessErrorIndicator(postop, *indicator, iodata.solver.eigenmode.n_post > 0);
+    PostprocessErrorIndicator(post_op, *indicator, iodata.solver.eigenmode.n_post > 0);
   }
 }
 
@@ -450,7 +450,7 @@ void EigenSolver::PostprocessEigen(int i, std::complex<double> omega, double err
   }
 }
 
-void EigenSolver::PostprocessPorts(const PostOperator &postop,
+void EigenSolver::PostprocessPorts(const PostOperator &post_op,
                                    const LumpedPortOperator &lumped_port_op, int i) const
 {
   // Postprocess the frequency domain lumped port voltages and currents (complex magnitude
@@ -463,8 +463,8 @@ void EigenSolver::PostprocessPorts(const PostOperator &postop,
   port_data.reserve(lumped_port_op.Size());
   for (const auto &[idx, data] : lumped_port_op)
   {
-    const std::complex<double> V_i = postop.GetPortVoltage(lumped_port_op, idx);
-    const std::complex<double> I_i = postop.GetPortCurrent(lumped_port_op, idx);
+    const std::complex<double> V_i = post_op.GetPortVoltage(lumped_port_op, idx);
+    const std::complex<double> I_i = post_op.GetPortCurrent(lumped_port_op, idx);
     port_data.push_back({idx, iodata.DimensionalizeValue(IoData::ValueType::VOLTAGE, V_i),
                          iodata.DimensionalizeValue(IoData::ValueType::CURRENT, I_i)});
   }
@@ -540,7 +540,7 @@ void EigenSolver::PostprocessPorts(const PostOperator &postop,
   }
 }
 
-void EigenSolver::PostprocessEPR(const PostOperator &postop,
+void EigenSolver::PostprocessEPR(const PostOperator &post_op,
                                  const LumpedPortOperator &lumped_port_op, int i,
                                  std::complex<double> omega, double E_m) const
 {
@@ -558,7 +558,7 @@ void EigenSolver::PostprocessEPR(const PostOperator &postop,
   {
     if (std::abs(data.L) > 0.0)
     {
-      const double pj = postop.GetInductorParticipation(lumped_port_op, idx, E_m);
+      const double pj = post_op.GetInductorParticipation(lumped_port_op, idx, E_m);
       epr_L_data.push_back({idx, pj});
     }
   }
@@ -598,7 +598,7 @@ void EigenSolver::PostprocessEPR(const PostOperator &postop,
   {
     if (std::abs(data.R) > 0.0)
     {
-      const double Kl = postop.GetExternalKappa(lumped_port_op, idx, E_m);
+      const double Kl = post_op.GetExternalKappa(lumped_port_op, idx, E_m);
       const double Ql = (Kl == 0.0) ? mfem::infinity() : omega.real() / std::abs(Kl);
       epr_IO_data.push_back(
           {idx, Ql, iodata.DimensionalizeValue(IoData::ValueType::FREQUENCY, Kl)});

--- a/palace/drivers/eigensolver.hpp
+++ b/palace/drivers/eigensolver.hpp
@@ -35,7 +35,7 @@ private:
                         const LumpedPortOperator &lumped_port_op, int i) const;
 
   void PostprocessEPR(const PostOperator &postop, const LumpedPortOperator &lumped_port_op,
-                      int i, std::complex<double> omega, double Em) const;
+                      int i, std::complex<double> omega, double E_m) const;
 
   std::pair<ErrorIndicator, long long int>
   Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const override;

--- a/palace/drivers/eigensolver.hpp
+++ b/palace/drivers/eigensolver.hpp
@@ -23,7 +23,7 @@ class PostOperator;
 class EigenSolver : public BaseSolver
 {
 private:
-  void Postprocess(const PostOperator &postop, const LumpedPortOperator &lumped_port_op,
+  void Postprocess(const PostOperator &post_op, const LumpedPortOperator &lumped_port_op,
                    int i, std::complex<double> omega, double error_bkwd, double error_abs,
                    int num_conv, double E_elec, double E_mag,
                    const ErrorIndicator *indicator) const;
@@ -31,10 +31,10 @@ private:
   void PostprocessEigen(int i, std::complex<double> omega, double error_bkwd,
                         double error_abs, int num_conv) const;
 
-  void PostprocessPorts(const PostOperator &postop,
+  void PostprocessPorts(const PostOperator &post_op,
                         const LumpedPortOperator &lumped_port_op, int i) const;
 
-  void PostprocessEPR(const PostOperator &postop, const LumpedPortOperator &lumped_port_op,
+  void PostprocessEPR(const PostOperator &post_op, const LumpedPortOperator &lumped_port_op,
                       int i, std::complex<double> omega, double E_m) const;
 
   std::pair<ErrorIndicator, long long int>

--- a/palace/drivers/electrostaticsolver.hpp
+++ b/palace/drivers/electrostaticsolver.hpp
@@ -31,10 +31,10 @@ class PostOperator;
 class ElectrostaticSolver : public BaseSolver
 {
 private:
-  void Postprocess(const PostOperator &postop, int step, int idx, double E_elec,
+  void Postprocess(const PostOperator &post_op, int step, int idx, double E_elec,
                    const ErrorIndicator *indicator) const;
 
-  void PostprocessTerminals(PostOperator &postop,
+  void PostprocessTerminals(PostOperator &post_op,
                             const std::map<int, mfem::Array<int>> &terminal_sources,
                             const std::vector<Vector> &V) const;
 

--- a/palace/drivers/magnetostaticsolver.hpp
+++ b/palace/drivers/magnetostaticsolver.hpp
@@ -23,10 +23,10 @@ class SurfaceCurrentOperator;
 class MagnetostaticSolver : public BaseSolver
 {
 private:
-  void Postprocess(const PostOperator &postop, int step, int idx, double I_inc,
+  void Postprocess(const PostOperator &post_op, int step, int idx, double I_inc,
                    double E_mag, const ErrorIndicator *indicator) const;
 
-  void PostprocessTerminals(PostOperator &postop, const SurfaceCurrentOperator &surf_j_op,
+  void PostprocessTerminals(PostOperator &post_op, const SurfaceCurrentOperator &surf_j_op,
                             const std::vector<Vector> &A,
                             const std::vector<double> &I_inc) const;
 

--- a/palace/drivers/transientsolver.hpp
+++ b/palace/drivers/transientsolver.hpp
@@ -28,16 +28,16 @@ private:
 
   int GetNumSteps(double start, double end, double delta) const;
 
-  void Postprocess(const PostOperator &postop, const LumpedPortOperator &lumped_port_op,
+  void Postprocess(const PostOperator &post_op, const LumpedPortOperator &lumped_port_op,
                    const SurfaceCurrentOperator &surf_j_op, int step, double t,
                    double J_coef, double E_elec, double E_mag,
                    const ErrorIndicator *indicator) const;
 
-  void PostprocessCurrents(const PostOperator &postop,
+  void PostprocessCurrents(const PostOperator &post_op,
                            const SurfaceCurrentOperator &surf_j_op, int step, double t,
                            double J_coef) const;
 
-  void PostprocessPorts(const PostOperator &postop,
+  void PostprocessPorts(const PostOperator &post_op,
                         const LumpedPortOperator &lumped_port_op, int step, double t,
                         double J_coef) const;
 

--- a/palace/fem/lumpedelement.cpp
+++ b/palace/fem/lumpedelement.cpp
@@ -99,10 +99,10 @@ UniformElementData::UniformElementData(const std::array<double, 3> &input_dir,
 }
 
 std::unique_ptr<mfem::VectorCoefficient>
-UniformElementData::GetModeCoefficient(double coef) const
+UniformElementData::GetModeCoefficient(double coeff) const
 {
   mfem::Vector source = direction;
-  source *= coef;
+  source *= coeff;
   return std::make_unique<RestrictedVectorCoefficient<mfem::VectorConstantCoefficient>>(
       attr_list, source);
 }
@@ -134,16 +134,16 @@ CoaxialElementData::CoaxialElementData(const std::array<double, 3> &input_dir,
 }
 
 std::unique_ptr<mfem::VectorCoefficient>
-CoaxialElementData::GetModeCoefficient(double coef) const
+CoaxialElementData::GetModeCoefficient(double coeff) const
 {
-  coef *= direction;
+  coeff *= direction;
   mfem::Vector x0(origin);
-  auto Source = [coef, x0](const mfem::Vector &x, mfem::Vector &f) -> void
+  auto Source = [coeff, x0](const mfem::Vector &x, mfem::Vector &f) -> void
   {
     f = x;
     f -= x0;
     double oor = 1.0 / f.Norml2();
-    f *= coef * oor * oor;
+    f *= coeff * oor * oor;
   };
   return std::make_unique<RestrictedVectorCoefficient<mfem::VectorFunctionCoefficient>>(
       attr_list, x0.Size(), Source);

--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -30,7 +30,7 @@ public:
   virtual double GetGeometryWidth() const = 0;
 
   virtual std::unique_ptr<mfem::VectorCoefficient>
-  GetModeCoefficient(double coef = 1.0) const = 0;
+  GetModeCoefficient(double coeff = 1.0) const = 0;
 };
 
 class UniformElementData : public LumpedElementData
@@ -51,7 +51,7 @@ public:
   double GetGeometryWidth() const override { return w; }
 
   std::unique_ptr<mfem::VectorCoefficient>
-  GetModeCoefficient(double coef = 1.0) const override;
+  GetModeCoefficient(double coeff = 1.0) const override;
 };
 
 class CoaxialElementData : public LumpedElementData
@@ -75,7 +75,7 @@ public:
   double GetGeometryWidth() const override { return 2.0 * M_PI; }
 
   std::unique_ptr<mfem::VectorCoefficient>
-  GetModeCoefficient(double coef = 1.0) const override;
+  GetModeCoefficient(double coeff = 1.0) const override;
 };
 
 }  // namespace palace

--- a/palace/models/farfieldboundaryoperator.cpp
+++ b/palace/models/farfieldboundaryoperator.cpp
@@ -84,7 +84,7 @@ FarfieldBoundaryOperator::SetUpBoundaryProperties(const IoData &iodata,
   return farfield_bcs;
 }
 
-void FarfieldBoundaryOperator::AddDampingBdrCoefficients(double coef,
+void FarfieldBoundaryOperator::AddDampingBdrCoefficients(double coeff,
                                                          MaterialPropertyCoefficient &fb)
 {
   // First-order absorbing boundary condition.
@@ -94,7 +94,7 @@ void FarfieldBoundaryOperator::AddDampingBdrCoefficients(double coef,
                                            mat_op.GetInvImpedance());
     invz0_func.RestrictCoefficient(mat_op.GetCeedBdrAttributes(farfield_attr));
     fb.AddCoefficient(invz0_func.GetAttributeToMaterial(),
-                      invz0_func.GetMaterialProperties(), coef);
+                      invz0_func.GetMaterialProperties(), coeff);
   }
 }
 

--- a/palace/models/farfieldboundaryoperator.hpp
+++ b/palace/models/farfieldboundaryoperator.hpp
@@ -42,7 +42,7 @@ public:
 
   // Add contributions to system matrices from first- or second-order absorbing boundary
   // condition.
-  void AddDampingBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
+  void AddDampingBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
   void AddExtraSystemBdrCoefficients(double omega, MaterialPropertyCoefficient &dfbr,
                                      MaterialPropertyCoefficient &dfbi);
 };

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -570,7 +570,7 @@ mfem::Array<int> LumpedPortOperator::GetCsAttrList() const
   return attr_list;
 }
 
-void LumpedPortOperator::AddStiffnessBdrCoefficients(double coef,
+void LumpedPortOperator::AddStiffnessBdrCoefficients(double coeff,
                                                      MaterialPropertyCoefficient &fb)
 {
   // Add lumped inductor boundaries to the bilinear form.
@@ -586,13 +586,13 @@ void LumpedPortOperator::AddStiffnessBdrCoefficients(double coef,
       {
         const double Ls = data.L * data.GetToSquare(*elem);
         fb.AddMaterialProperty(data.mat_op.GetCeedBdrAttributes(elem->GetAttrList()),
-                               coef / Ls);
+                               coeff / Ls);
       }
     }
   }
 }
 
-void LumpedPortOperator::AddDampingBdrCoefficients(double coef,
+void LumpedPortOperator::AddDampingBdrCoefficients(double coeff,
                                                    MaterialPropertyCoefficient &fb)
 {
   // Add lumped resistor boundaries to the bilinear form.
@@ -608,13 +608,13 @@ void LumpedPortOperator::AddDampingBdrCoefficients(double coef,
       {
         const double Rs = data.R * data.GetToSquare(*elem);
         fb.AddMaterialProperty(data.mat_op.GetCeedBdrAttributes(elem->GetAttrList()),
-                               coef / Rs);
+                               coeff / Rs);
       }
     }
   }
 }
 
-void LumpedPortOperator::AddMassBdrCoefficients(double coef,
+void LumpedPortOperator::AddMassBdrCoefficients(double coeff,
                                                 MaterialPropertyCoefficient &fb)
 {
   // Add lumped capacitance boundaries to the bilinear form.
@@ -630,7 +630,7 @@ void LumpedPortOperator::AddMassBdrCoefficients(double coef,
       {
         const double Cs = data.C / data.GetToSquare(*elem);
         fb.AddMaterialProperty(data.mat_op.GetCeedBdrAttributes(elem->GetAttrList()),
-                               coef * Cs);
+                               coeff * Cs);
       }
     }
   }

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -112,9 +112,9 @@ public:
 
   // Add contributions to system matrices from lumped elements with nonzero inductance,
   // resistance, and/or capacitance.
-  void AddStiffnessBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddDampingBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddMassBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
+  void AddStiffnessBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddDampingBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddMassBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
 
   // Add contributions to the right-hand side source term vector for an incident field at
   // excited port boundaries, -U_inc/(iω) for the real version (versus the full -U_inc for

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -54,23 +54,23 @@ PostOperator::PostOperator(const IoData &iodata, SpaceOperator &spaceop,
 {
   bool side_n_min = (iodata.boundaries.postpro.side ==
                      config::InterfaceDielectricData::Side::SMALLER_REF_INDEX);
-  Ue = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(*E, mat_op,
-                                                                               side_n_min);
-  Um = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(*B, mat_op,
-                                                                               side_n_min);
+  U_e = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(*E, mat_op,
+                                                                                side_n_min);
+  U_m = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(*B, mat_op,
+                                                                                side_n_min);
   S = std::make_unique<PoyntingVectorCoefficient>(*E, *B, mat_op, side_n_min);
 
-  Esr = std::make_unique<BdrFieldVectorCoefficient>(E->Real(), mat_op, side_n_min);
-  Bsr = std::make_unique<BdrFieldVectorCoefficient>(B->Real(), mat_op, side_n_min);
-  Jsr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Real(), mat_op);
-  Qsr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
+  E_sr = std::make_unique<BdrFieldVectorCoefficient>(E->Real(), mat_op, side_n_min);
+  B_sr = std::make_unique<BdrFieldVectorCoefficient>(B->Real(), mat_op, side_n_min);
+  J_sr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Real(), mat_op);
+  Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
       &E->Real(), nullptr, mat_op, true, mfem::Vector());
   if (HasImag())
   {
-    Esi = std::make_unique<BdrFieldVectorCoefficient>(E->Imag(), mat_op, side_n_min);
-    Bsi = std::make_unique<BdrFieldVectorCoefficient>(B->Imag(), mat_op, side_n_min);
-    Jsi = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Imag(), mat_op);
-    Qsi = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
+    E_si = std::make_unique<BdrFieldVectorCoefficient>(E->Imag(), mat_op, side_n_min);
+    B_si = std::make_unique<BdrFieldVectorCoefficient>(B->Imag(), mat_op, side_n_min);
+    J_si = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Imag(), mat_op);
+    Q_si = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
         &E->Imag(), nullptr, mat_op, true, mfem::Vector());
   }
 
@@ -104,12 +104,12 @@ PostOperator::PostOperator(const IoData &iodata, LaplaceOperator &laplaceop,
   // etc.), since only V and E fields are supplied.
   bool side_n_min = (iodata.boundaries.postpro.side ==
                      config::InterfaceDielectricData::Side::SMALLER_REF_INDEX);
-  Ue = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(*E, mat_op,
-                                                                               side_n_min);
+  U_e = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(*E, mat_op,
+                                                                                side_n_min);
 
-  Esr = std::make_unique<BdrFieldVectorCoefficient>(E->Real(), mat_op, side_n_min);
-  Vs = std::make_unique<BdrFieldCoefficient>(V->Real(), mat_op, side_n_min);
-  Qsr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
+  E_sr = std::make_unique<BdrFieldVectorCoefficient>(E->Real(), mat_op, side_n_min);
+  V_s = std::make_unique<BdrFieldCoefficient>(V->Real(), mat_op, side_n_min);
+  Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
       &E->Real(), nullptr, mat_op, true, mfem::Vector());
 
   // Initialize data collection objects.
@@ -134,12 +134,12 @@ PostOperator::PostOperator(const IoData &iodata, CurlCurlOperator &curlcurlop,
   // etc.), since only the B field is supplied.
   bool side_n_min = (iodata.boundaries.postpro.side ==
                      config::InterfaceDielectricData::Side::SMALLER_REF_INDEX);
-  Um = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(*B, mat_op,
-                                                                               side_n_min);
+  U_m = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(*B, mat_op,
+                                                                                side_n_min);
 
-  Bsr = std::make_unique<BdrFieldVectorCoefficient>(B->Real(), mat_op, side_n_min);
-  As = std::make_unique<BdrFieldVectorCoefficient>(A->Real(), mat_op, side_n_min);
-  Jsr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Real(), mat_op);
+  B_sr = std::make_unique<BdrFieldVectorCoefficient>(B->Real(), mat_op, side_n_min);
+  A_s = std::make_unique<BdrFieldVectorCoefficient>(A->Real(), mat_op, side_n_min);
+  J_sr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(B->Real(), mat_op);
 
   // Initialize data collection objects.
   InitializeDataCollection(iodata);
@@ -185,13 +185,13 @@ void PostOperator::InitializeDataCollection(const IoData &iodata)
     {
       paraview.RegisterField("E_real", &E->Real());
       paraview.RegisterField("E_imag", &E->Imag());
-      paraview_bdr.RegisterVCoeffField("E_real", Esr.get());
-      paraview_bdr.RegisterVCoeffField("E_imag", Esi.get());
+      paraview_bdr.RegisterVCoeffField("E_real", E_sr.get());
+      paraview_bdr.RegisterVCoeffField("E_imag", E_si.get());
     }
     else
     {
       paraview.RegisterField("E", &E->Real());
-      paraview_bdr.RegisterVCoeffField("E", Esr.get());
+      paraview_bdr.RegisterVCoeffField("E", E_sr.get());
     }
   }
   if (B)
@@ -200,37 +200,37 @@ void PostOperator::InitializeDataCollection(const IoData &iodata)
     {
       paraview.RegisterField("B_real", &B->Real());
       paraview.RegisterField("B_imag", &B->Imag());
-      paraview_bdr.RegisterVCoeffField("B_real", Bsr.get());
-      paraview_bdr.RegisterVCoeffField("B_imag", Bsi.get());
+      paraview_bdr.RegisterVCoeffField("B_real", B_sr.get());
+      paraview_bdr.RegisterVCoeffField("B_imag", B_si.get());
     }
     else
     {
       paraview.RegisterField("B", &B->Real());
-      paraview_bdr.RegisterVCoeffField("B", Bsr.get());
+      paraview_bdr.RegisterVCoeffField("B", B_sr.get());
     }
   }
   if (V)
   {
     paraview.RegisterField("V", &V->Real());
-    paraview_bdr.RegisterCoeffField("V", Vs.get());
+    paraview_bdr.RegisterCoeffField("V", V_s.get());
   }
   if (A)
   {
     paraview.RegisterField("A", &A->Real());
-    paraview_bdr.RegisterVCoeffField("A", As.get());
+    paraview_bdr.RegisterVCoeffField("A", A_s.get());
   }
 
   // Extract energy density field for electric field energy 1/2 Dᴴ E or magnetic field
   // energy 1/2 Hᴴ B. Also Poynting vector S = E x H⋆.
-  if (Ue)
+  if (U_e)
   {
-    paraview.RegisterCoeffField("Ue", Ue.get());
-    paraview_bdr.RegisterCoeffField("Ue", Ue.get());
+    paraview.RegisterCoeffField("U_e", U_e.get());
+    paraview_bdr.RegisterCoeffField("U_e", U_e.get());
   }
-  if (Um)
+  if (U_m)
   {
-    paraview.RegisterCoeffField("Um", Um.get());
-    paraview_bdr.RegisterCoeffField("Um", Um.get());
+    paraview.RegisterCoeffField("U_m", U_m.get());
+    paraview_bdr.RegisterCoeffField("U_m", U_m.get());
   }
   if (S)
   {
@@ -241,28 +241,28 @@ void PostOperator::InitializeDataCollection(const IoData &iodata)
   // Extract surface charge from normally discontinuous ND E-field. Also extract surface
   // currents from tangentially discontinuous RT B-field The surface charge and surface
   // currents are single-valued at internal boundaries.
-  if (Qsr)
+  if (Q_sr)
   {
     if (HasImag())
     {
-      paraview_bdr.RegisterCoeffField("Qs_real", Qsr.get());
-      paraview_bdr.RegisterCoeffField("Qs_imag", Qsi.get());
+      paraview_bdr.RegisterCoeffField("Q_s_real", Q_sr.get());
+      paraview_bdr.RegisterCoeffField("Q_s_imag", Q_si.get());
     }
     else
     {
-      paraview_bdr.RegisterCoeffField("Qs", Qsr.get());
+      paraview_bdr.RegisterCoeffField("Q_s", Q_sr.get());
     }
   }
-  if (Jsr)
+  if (J_sr)
   {
     if (HasImag())
     {
-      paraview_bdr.RegisterVCoeffField("Js_real", Jsr.get());
-      paraview_bdr.RegisterVCoeffField("Js_imag", Jsi.get());
+      paraview_bdr.RegisterVCoeffField("J_s_real", J_sr.get());
+      paraview_bdr.RegisterVCoeffField("J_s_imag", J_si.get());
     }
     else
     {
-      paraview_bdr.RegisterVCoeffField("Js", Jsr.get());
+      paraview_bdr.RegisterVCoeffField("J_s", J_sr.get());
     }
   }
 
@@ -414,7 +414,7 @@ std::complex<double> PostOperator::GetSurfaceFlux(int idx) const
   return surf_post_op.GetSurfaceFlux(idx, E.get(), B.get());
 }
 
-double PostOperator::GetInterfaceParticipation(int idx, double Em) const
+double PostOperator::GetInterfaceParticipation(int idx, double E_m) const
 {
   // Compute the surface dielectric participation ratio and associated quality factor for
   // the material interface given by index idx. We have:
@@ -422,7 +422,7 @@ double PostOperator::GetInterfaceParticipation(int idx, double Em) const
   // with:
   //          p_mj = 1/2 t_j Re{∫_{Γ_j} (ε_j E_m)ᴴ E_m dS} /(E_elec + E_cap).
   MFEM_VERIFY(E, "Surface Q not defined, no electric field solution found!");
-  return surf_post_op.GetInterfaceElectricFieldEnergy(idx, *E) / Em;
+  return surf_post_op.GetInterfaceElectricFieldEnergy(idx, *E) / E_m;
 }
 
 void PostOperator::UpdatePorts(const LumpedPortOperator &lumped_port_op, double omega)
@@ -497,9 +497,9 @@ double PostOperator::GetLumpedInductorEnergy(const LumpedPortOperator &lumped_po
   {
     if (std::abs(data.L) > 0.0)
     {
-      std::complex<double> Ij =
+      std::complex<double> I_j =
           GetPortCurrent(lumped_port_op, idx, LumpedPortData::Branch::L);
-      U += 0.5 * std::abs(data.L) * std::real(Ij * std::conj(Ij));
+      U += 0.5 * std::abs(data.L) * std::real(I_j * std::conj(I_j));
     }
   }
   return U;
@@ -515,8 +515,8 @@ PostOperator::GetLumpedCapacitorEnergy(const LumpedPortOperator &lumped_port_op)
   {
     if (std::abs(data.C) > 0.0)
     {
-      std::complex<double> Vj = GetPortVoltage(lumped_port_op, idx);
-      U += 0.5 * std::abs(data.C) * std::real(Vj * std::conj(Vj));
+      std::complex<double> V_j = GetPortVoltage(lumped_port_op, idx);
+      U += 0.5 * std::abs(data.C) * std::real(V_j * std::conj(V_j));
     }
   }
   return U;
@@ -534,17 +534,17 @@ std::complex<double> PostOperator::GetSParameter(const LumpedPortOperator &lumpe
               "Lumped port index " << source_idx << " is not marked for excitation!");
   MFEM_VERIFY(it != lumped_port_vi.end(),
               "Could not find lumped port when calculating port S-parameters!");
-  std::complex<double> Sij = it->second.S;
+  std::complex<double> S_ij = it->second.S;
   if (idx == source_idx)
   {
-    Sij.real(Sij.real() - 1.0);
+    S_ij.real(S_ij.real() - 1.0);
   }
   // Generalized S-parameters if the ports are resistive (avoids divide-by-zero).
   if (std::abs(data.R) > 0.0)
   {
-    Sij *= std::sqrt(src_data.R / data.R);
+    S_ij *= std::sqrt(src_data.R / data.R);
   }
-  return Sij;
+  return S_ij;
 }
 
 std::complex<double> PostOperator::GetSParameter(const WavePortOperator &wave_port_op,
@@ -560,16 +560,16 @@ std::complex<double> PostOperator::GetSParameter(const WavePortOperator &wave_po
               "Wave port index " << source_idx << " is not marked for excitation!");
   MFEM_VERIFY(it != wave_port_vi.end(),
               "Could not find wave port when calculating port S-parameters!");
-  std::complex<double> Sij = it->second.S;
+  std::complex<double> S_ij = it->second.S;
   if (idx == source_idx)
   {
-    Sij.real(Sij.real() - 1.0);
+    S_ij.real(S_ij.real() - 1.0);
   }
   // Port de-embedding: S_demb = S exp(ikₙᵢ dᵢ) exp(ikₙⱼ dⱼ) (distance offset is default 0
   // unless specified).
-  Sij *= std::exp(1i * src_data.kn0 * src_data.d_offset);
-  Sij *= std::exp(1i * data.kn0 * data.d_offset);
-  return Sij;
+  S_ij *= std::exp(1i * src_data.kn0 * src_data.d_offset);
+  S_ij *= std::exp(1i * data.kn0 * data.d_offset);
+  return S_ij;
 }
 
 std::complex<double> PostOperator::GetPortPower(const LumpedPortOperator &lumped_port_op,
@@ -640,24 +640,25 @@ std::complex<double> PostOperator::GetPortCurrent(const WavePortOperator &wave_p
 }
 
 double PostOperator::GetInductorParticipation(const LumpedPortOperator &lumped_port_op,
-                                              int idx, double Em) const
+                                              int idx, double E_m) const
 {
   // Compute energy-participation ratio of junction given by index idx for the field mode.
   // We first get the port line voltage, and use lumped port circuit impedance to get peak
-  // current through the inductor: I_mj = V_mj / Z_mj,  Z_mj = i ω_m L_j. Em is the total
+  // current through the inductor: I_mj = V_mj / Z_mj,  Z_mj = i ω_m L_j. E_m is the total
   // energy in mode m: E_m = E_elec + E_cap = E_mag + E_ind. The signed EPR for a lumped
   // inductive element is computed as:
   //                            p_mj = 1/2 L_j I_mj² / E_m.
   // An element with no assigned inductance will be treated as having zero admittance and
   // thus zero current.
   const LumpedPortData &data = lumped_port_op.GetPort(idx);
-  std::complex<double> Imj = GetPortCurrent(lumped_port_op, idx, LumpedPortData::Branch::L);
-  return std::copysign(0.5 * std::abs(data.L) * std::real(Imj * std::conj(Imj)) / Em,
-                       Imj.real());  // mean(I²) = (I_r² + I_i²) / 2
+  std::complex<double> I_mj =
+      GetPortCurrent(lumped_port_op, idx, LumpedPortData::Branch::L);
+  return std::copysign(0.5 * std::abs(data.L) * std::real(I_mj * std::conj(I_mj)) / E_m,
+                       I_mj.real());  // mean(I²) = (I_r² + I_i²) / 2
 }
 
 double PostOperator::GetExternalKappa(const LumpedPortOperator &lumped_port_op, int idx,
-                                      double Em) const
+                                      double E_m) const
 {
   // Compute participation ratio of external ports (given as any port boundary with nonzero
   // resistance). Currently no reactance of the ports is supported. The κ of the port
@@ -666,9 +667,10 @@ double PostOperator::GetExternalKappa(const LumpedPortOperator &lumped_port_op, 
   // from which the mode coupling quality factor is computed as:
   //                              Q_mj = ω_m / κ_mj.
   const LumpedPortData &data = lumped_port_op.GetPort(idx);
-  std::complex<double> Imj = GetPortCurrent(lumped_port_op, idx, LumpedPortData::Branch::R);
-  return std::copysign(0.5 * std::abs(data.R) * std::real(Imj * std::conj(Imj)) / Em,
-                       Imj.real());  // mean(I²) = (I_r² + I_i²) / 2
+  std::complex<double> I_mj =
+      GetPortCurrent(lumped_port_op, idx, LumpedPortData::Branch::R);
+  return std::copysign(0.5 * std::abs(data.R) * std::real(I_mj * std::conj(I_mj)) / E_m,
+                       I_mj.real());  // mean(I²) = (I_r² + I_i²) / 2
 }
 
 namespace

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -45,8 +45,8 @@ private:
 
   // Objects for grid function postprocessing from the FE solution.
   mutable std::unique_ptr<GridFunction> E, B, V, A;
-  std::unique_ptr<mfem::VectorCoefficient> S, Esr, Esi, Bsr, Bsi, As, Jsr, Jsi;
-  std::unique_ptr<mfem::Coefficient> Ue, Um, Vs, Qsr, Qsi;
+  std::unique_ptr<mfem::VectorCoefficient> S, E_sr, E_si, B_sr, B_si, A_s, J_sr, J_si;
+  std::unique_ptr<mfem::Coefficient> U_e, U_m, V_s, Q_sr, Q_si;
 
   // Wave port boundary mode field postprocessing.
   struct WavePortFieldData
@@ -133,7 +133,7 @@ public:
 
   // Postprocess the partitipation ratio for interface lossy dielectric losses in the
   // electric field mode.
-  double GetInterfaceParticipation(int idx, double Em) const;
+  double GetInterfaceParticipation(int idx, double E_m) const;
 
   // Update cached port voltages and currents for lumped and wave port operators.
   void UpdatePorts(const LumpedPortOperator &lumped_port_op,
@@ -173,11 +173,11 @@ public:
 
   // Postprocess the EPR for the electric field solution and lumped port index.
   double GetInductorParticipation(const LumpedPortOperator &lumped_port_op, int idx,
-                                  double Em) const;
+                                  double E_m) const;
 
   // Postprocess the coupling rate for radiative loss to the given I-O port index.
   double GetExternalKappa(const LumpedPortOperator &lumped_port_op, int idx,
-                          double Em) const;
+                          double E_m) const;
 
   // Write to disk the E- and B-fields extracted from the solution vectors. Note that fields
   // are not redimensionalized, to do so one needs to compute: B <= B * (μ₀ H₀), E <= E *

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -71,9 +71,10 @@ private:
   void InitializeDataCollection(const IoData &iodata);
 
 public:
-  PostOperator(const IoData &iodata, SpaceOperator &spaceop, const std::string &name);
-  PostOperator(const IoData &iodata, LaplaceOperator &laplaceop, const std::string &name);
-  PostOperator(const IoData &iodata, CurlCurlOperator &curlcurlop, const std::string &name);
+  PostOperator(const IoData &iodata, SpaceOperator &space_op, const std::string &name);
+  PostOperator(const IoData &iodata, LaplaceOperator &laplace_op, const std::string &name);
+  PostOperator(const IoData &iodata, CurlCurlOperator &curlcurl_op,
+               const std::string &name);
 
   // Access to surface and domain postprocessing objects.
   const auto &GetSurfacePostOp() const { return surf_post_op; }

--- a/palace/models/romoperator.hpp
+++ b/palace/models/romoperator.hpp
@@ -26,7 +26,7 @@ class RomOperator
 {
 private:
   // Reference to HDM discretization (not owned).
-  SpaceOperator &spaceop;
+  SpaceOperator &space_op;
 
   // HDM system matrices and excitation RHS.
   std::unique_ptr<ComplexOperator> K, M, C, A2;
@@ -55,7 +55,7 @@ private:
   std::vector<double> z;
 
 public:
-  RomOperator(const IoData &iodata, SpaceOperator &spaceop, int max_size);
+  RomOperator(const IoData &iodata, SpaceOperator &space_op, int max_size);
 
   // Return the HDM linear solver.
   const ComplexKspSolver &GetLinearSolver() const { return *ksp; }

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -810,69 +810,70 @@ std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(double a0, doub
   return B;
 }
 
-void SpaceOperator::AddStiffnessCoefficients(double coef, MaterialPropertyCoefficient &df,
+void SpaceOperator::AddStiffnessCoefficients(double coeff, MaterialPropertyCoefficient &df,
                                              MaterialPropertyCoefficient &f)
 {
   // Contribution from material permeability.
-  df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvPermeability(), coef);
+  df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvPermeability(), coeff);
 
   // Contribution for London superconductors.
   if (mat_op.HasLondonDepth())
   {
-    df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvLondonDepth(), coef);
+    df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvLondonDepth(), coeff);
   }
 }
 
-void SpaceOperator::AddStiffnessBdrCoefficients(double coef,
+void SpaceOperator::AddStiffnessBdrCoefficients(double coeff,
                                                 MaterialPropertyCoefficient &fb)
 {
   // Robin BC contributions due to surface impedance and lumped ports (inductance).
-  surf_z_op.AddStiffnessBdrCoefficients(coef, fb);
-  lumped_port_op.AddStiffnessBdrCoefficients(coef, fb);
+  surf_z_op.AddStiffnessBdrCoefficients(coeff, fb);
+  lumped_port_op.AddStiffnessBdrCoefficients(coeff, fb);
 }
 
-void SpaceOperator::AddDampingCoefficients(double coef, MaterialPropertyCoefficient &f)
+void SpaceOperator::AddDampingCoefficients(double coeff, MaterialPropertyCoefficient &f)
 {
   // Contribution for domain conductivity.
   if (mat_op.HasConductivity())
   {
-    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetConductivity(), coef);
+    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetConductivity(), coeff);
   }
 }
 
-void SpaceOperator::AddDampingBdrCoefficients(double coef, MaterialPropertyCoefficient &fb)
+void SpaceOperator::AddDampingBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb)
 {
   // Robin BC contributions due to surface impedance, lumped ports, and absorbing
   // boundaries (resistance).
-  farfield_op.AddDampingBdrCoefficients(coef, fb);
-  surf_z_op.AddDampingBdrCoefficients(coef, fb);
-  lumped_port_op.AddDampingBdrCoefficients(coef, fb);
+  farfield_op.AddDampingBdrCoefficients(coeff, fb);
+  surf_z_op.AddDampingBdrCoefficients(coeff, fb);
+  lumped_port_op.AddDampingBdrCoefficients(coeff, fb);
 }
 
-void SpaceOperator::AddRealMassCoefficients(double coef, MaterialPropertyCoefficient &f)
+void SpaceOperator::AddRealMassCoefficients(double coeff, MaterialPropertyCoefficient &f)
 {
-  f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityReal(), coef);
+  f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityReal(), coeff);
 }
 
-void SpaceOperator::AddRealMassBdrCoefficients(double coef, MaterialPropertyCoefficient &fb)
+void SpaceOperator::AddRealMassBdrCoefficients(double coeff,
+                                               MaterialPropertyCoefficient &fb)
 {
   // Robin BC contributions due to surface impedance and lumped ports (capacitance).
-  surf_z_op.AddMassBdrCoefficients(coef, fb);
-  lumped_port_op.AddMassBdrCoefficients(coef, fb);
+  surf_z_op.AddMassBdrCoefficients(coeff, fb);
+  lumped_port_op.AddMassBdrCoefficients(coeff, fb);
 }
 
-void SpaceOperator::AddImagMassCoefficients(double coef, MaterialPropertyCoefficient &f)
+void SpaceOperator::AddImagMassCoefficients(double coeff, MaterialPropertyCoefficient &f)
 {
   // Contribution for loss tangent: ε -> ε * (1 - i tan(δ)).
   if (mat_op.HasLossTangent())
   {
-    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityImag(), coef);
+    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityImag(), coeff);
   }
 }
 
-void SpaceOperator::AddAbsMassCoefficients(double coef, MaterialPropertyCoefficient &f)
+void SpaceOperator::AddAbsMassCoefficients(double coeff, MaterialPropertyCoefficient &f)
 {
-  f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityAbs(), coef);
+  f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityAbs(), coeff);
 }
 
 void SpaceOperator::AddExtraSystemBdrCoefficients(double omega,

--- a/palace/models/spaceoperator.hpp
+++ b/palace/models/spaceoperator.hpp
@@ -65,15 +65,15 @@ private:
 
   // Helper functions for building the bilinear forms corresponding to the discretized
   // operators in Maxwell's equations.
-  void AddStiffnessCoefficients(double coef, MaterialPropertyCoefficient &df,
+  void AddStiffnessCoefficients(double coeff, MaterialPropertyCoefficient &df,
                                 MaterialPropertyCoefficient &f);
-  void AddStiffnessBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddDampingCoefficients(double coef, MaterialPropertyCoefficient &f);
-  void AddDampingBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddRealMassCoefficients(double coef, MaterialPropertyCoefficient &f);
-  void AddRealMassBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddImagMassCoefficients(double coef, MaterialPropertyCoefficient &f);
-  void AddAbsMassCoefficients(double coef, MaterialPropertyCoefficient &f);
+  void AddStiffnessBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddDampingCoefficients(double coeff, MaterialPropertyCoefficient &f);
+  void AddDampingBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddRealMassCoefficients(double coeff, MaterialPropertyCoefficient &f);
+  void AddRealMassBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddImagMassCoefficients(double coeff, MaterialPropertyCoefficient &f);
+  void AddAbsMassCoefficients(double coeff, MaterialPropertyCoefficient &f);
   void AddExtraSystemBdrCoefficients(double omega, MaterialPropertyCoefficient &dfbr,
                                      MaterialPropertyCoefficient &dfbi,
                                      MaterialPropertyCoefficient &fbr,

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -174,7 +174,7 @@ mfem::Array<int> SurfaceImpedanceOperator::GetCsAttrList() const
   return attr_list;
 }
 
-void SurfaceImpedanceOperator::AddStiffnessBdrCoefficients(double coef,
+void SurfaceImpedanceOperator::AddStiffnessBdrCoefficients(double coeff,
                                                            MaterialPropertyCoefficient &fb)
 {
   // Lumped inductor boundaries.
@@ -182,12 +182,12 @@ void SurfaceImpedanceOperator::AddStiffnessBdrCoefficients(double coef,
   {
     if (std::abs(bdr.Ls) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coef / bdr.Ls);
+      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff / bdr.Ls);
     }
   }
 }
 
-void SurfaceImpedanceOperator::AddDampingBdrCoefficients(double coef,
+void SurfaceImpedanceOperator::AddDampingBdrCoefficients(double coeff,
                                                          MaterialPropertyCoefficient &fb)
 {
   // Lumped resistor boundaries.
@@ -195,12 +195,12 @@ void SurfaceImpedanceOperator::AddDampingBdrCoefficients(double coef,
   {
     if (std::abs(bdr.Rs) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coef / bdr.Rs);
+      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff / bdr.Rs);
     }
   }
 }
 
-void SurfaceImpedanceOperator::AddMassBdrCoefficients(double coef,
+void SurfaceImpedanceOperator::AddMassBdrCoefficients(double coeff,
                                                       MaterialPropertyCoefficient &fb)
 {
   // Lumped capacitor boundaries.
@@ -208,7 +208,7 @@ void SurfaceImpedanceOperator::AddMassBdrCoefficients(double coef,
   {
     if (std::abs(bdr.Cs) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coef * bdr.Cs);
+      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff * bdr.Cs);
     }
   }
 }

--- a/palace/models/surfaceimpedanceoperator.hpp
+++ b/palace/models/surfaceimpedanceoperator.hpp
@@ -48,9 +48,9 @@ public:
   // Add contributions to system matrices from impedance boundaries with nonzero inductance,
   // resistance, and/or capacitance. For boundaries with more than R/L/C, impedances add in
   // parallel.
-  void AddStiffnessBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddDampingBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
-  void AddMassBdrCoefficients(double coef, MaterialPropertyCoefficient &fb);
+  void AddStiffnessBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddDampingBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
+  void AddMassBdrCoefficients(double coeff, MaterialPropertyCoefficient &fb);
 };
 
 }  // namespace palace

--- a/palace/models/timeoperator.hpp
+++ b/palace/models/timeoperator.hpp
@@ -36,7 +36,7 @@ private:
   const Operator *Curl;
 
 public:
-  TimeOperator(const IoData &iodata, SpaceOperator &spaceop,
+  TimeOperator(const IoData &iodata, SpaceOperator &space_op,
                std::function<double(double)> &dJ_coef);
 
   // Access solution vectors for E- and B-fields.

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -357,7 +357,7 @@ void RefinementData::SetUp(json &model)
       MFEM_VERIFY(bbmin->is_array() && bbmin->is_array(),
                   "config[\"Refinement\"][\"Boxes\"][\"BoundingBoxMin/Max\"] should "
                   "specify an array in the configuration file!");
-      BoxRefinementData &data = boxlist.emplace_back();
+      BoxRefinementData &data = box_list.emplace_back();
       data.ref_levels = it->at("Levels");                // Required
       data.bbmin = bbmin->get<std::array<double, 3>>();  // Required
       data.bbmax = bbmax->get<std::array<double, 3>>();  // Required
@@ -396,7 +396,7 @@ void RefinementData::SetUp(json &model)
       MFEM_VERIFY(ctr->is_array(),
                   "config[\"Refinement\"][\"Spheres\"][\"Center\"] should specify "
                   "an array in the configuration file!");
-      SphereRefinementData &data = spherelist.emplace_back();
+      SphereRefinementData &data = sphere_list.emplace_back();
       data.ref_levels = it->at("Levels");               // Required
       data.r = it->at("Radius");                        // Required
       data.center = ctr->get<std::array<double, 3>>();  // Required

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -173,17 +173,17 @@ public:
 
 private:
   // Refinement data for mesh regions.
-  std::vector<BoxRefinementData> boxlist = {};
-  std::vector<SphereRefinementData> spherelist = {};
+  std::vector<BoxRefinementData> box_list = {};
+  std::vector<SphereRefinementData> sphere_list = {};
 
 public:
-  auto &GetBox(int i) { return boxlist[i]; }
-  const auto &GetBoxes() const { return boxlist; }
-  auto &GetBoxes() { return boxlist; }
+  auto &GetBox(int i) { return box_list[i]; }
+  const auto &GetBoxes() const { return box_list; }
+  auto &GetBoxes() { return box_list; }
 
-  auto &GetSphere(int i) { return spherelist[i]; }
-  const auto &GetSpheres() const { return spherelist; }
-  auto &GetSpheres() { return spherelist; }
+  auto &GetSphere(int i) { return sphere_list[i]; }
+  const auto &GetSpheres() const { return sphere_list; }
+  auto &GetSpheres() { return sphere_list; }
 
   void SetUp(json &model);
 };


### PR DESCRIPTION
We have slowly moved towards consistent use of snake case across all variable naming, especially in the higher level classes and functions where variable names are longer and more descriptive. Though not explicitly enforced in the developer documentation or in PR reviews, this PR goes through some old code and updates variable names to be match the guidance.

The same change is also made for some output variables, namely the field names in the ParaView visualization files.

One name left unchanged is `iodata`, which could/should be renamed to `io_data`. I didn't have particular feelings either way, but if changing it is preferable I can make that change here as well.

Note: Based on https://github.com/awslabs/palace/pull/240