### PR TITLE
Revisiting boundary condition warning messages from #224

### DIFF
--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -3,6 +3,7 @@
 
 #include "curlcurloperator.hpp"
 
+#include <set>
 #include "fem/bilinearform.hpp"
 #include "fem/coefficient.hpp"
 #include "fem/integrator.hpp"
@@ -43,7 +44,6 @@ CurlCurlOperator::CurlCurlOperator(const IoData &iodata,
   if (dbc_attr.Size())
   {
     Mpi::Print("\nConfiguring Dirichlet BC at attributes:\n");
-    std::sort(dbc_attr.begin(), dbc_attr.end());
     utils::PrettyPrint(dbc_attr);
   }
 }
@@ -61,24 +61,25 @@ mfem::Array<int> CurlCurlOperator::SetUpBoundaryProperties(const IoData &iodata,
     {
       bdr_attr_marker[attr - 1] = 1;
     }
-    bool first = true;
+    std::set<int> bdr_warn_list;
     for (auto attr : iodata.boundaries.pec.attributes)
     {
       // MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
       //             "PEC boundary attribute tags must be non-negative and correspond to "
       //             "attributes in the mesh!");
-      // MFEM_VERIFY(bdr_attr_marker[attr-1],
+      // MFEM_VERIFY(bdr_attr_marker[attr - 1],
       //             "Unknown PEC boundary attribute " << attr << "!");
       if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
       {
-        if (first)
-        {
-          Mpi::Print("\n");
-          first = false;
-        }
-        Mpi::Warning("Unknown PEC boundary attribute {:d}!\nSolver will just ignore it!\n",
-                     attr);
+        bdr_warn_list.insert(attr);
       }
+    }
+    if (!bdr_warn_list.empty())
+    {
+      Mpi::Print("\n");
+      Mpi::Warning("Unknown PEC boundary attributes!\nSolver will just ignore them!");
+      utils::PrettyPrint(bdr_warn_list, "Boundary attribute list:");
+      Mpi::Print("\n");
     }
   }
 

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -53,9 +53,10 @@ mfem::Array<int> CurlCurlOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.pec.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)
     {
@@ -69,7 +70,7 @@ mfem::Array<int> CurlCurlOperator::SetUpBoundaryProperties(const IoData &iodata,
       //             "attributes in the mesh!");
       // MFEM_VERIFY(bdr_attr_marker[attr - 1],
       //             "Unknown PEC boundary attribute " << attr << "!");
-      if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         bdr_warn_list.insert(attr);
       }
@@ -88,7 +89,7 @@ mfem::Array<int> CurlCurlOperator::SetUpBoundaryProperties(const IoData &iodata,
   dbc_bcs.Reserve(static_cast<int>(iodata.boundaries.pec.attributes.size()));
   for (auto attr : iodata.boundaries.pec.attributes)
   {
-    if (attr <= 0 || attr > bdr_attr_max)
+    if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
     {
       continue;  // Can just ignore if wrong
     }

--- a/palace/models/farfieldboundaryoperator.cpp
+++ b/palace/models/farfieldboundaryoperator.cpp
@@ -34,9 +34,10 @@ FarfieldBoundaryOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that impedance boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.farfield.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)
     {
@@ -50,7 +51,7 @@ FarfieldBoundaryOperator::SetUpBoundaryProperties(const IoData &iodata,
       //             " "to attributes in the mesh!");
       // MFEM_VERIFY(bdr_attr_marker[attr - 1],
       //             "Unknown absorbing boundary attribute " << attr << "!");
-      if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         bdr_warn_list.insert(attr);
       }
@@ -73,7 +74,7 @@ FarfieldBoundaryOperator::SetUpBoundaryProperties(const IoData &iodata,
   farfield_bcs.Reserve(static_cast<int>(iodata.boundaries.farfield.attributes.size()));
   for (auto attr : iodata.boundaries.farfield.attributes)
   {
-    if (attr <= 0 || attr > bdr_attr_max)
+    if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
     {
       continue;  // Can just ignore if wrong
     }

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -51,9 +51,10 @@ mfem::Array<int> LaplaceOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.pec.empty() || !iodata.boundaries.lumpedport.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)
     {
@@ -67,7 +68,7 @@ mfem::Array<int> LaplaceOperator::SetUpBoundaryProperties(const IoData &iodata,
       //             " attributes in the mesh!");
       // MFEM_VERIFY(bdr_attr_marker[attr - 1],
       //             "Unknown ground boundary attribute " << attr << "!");
-      if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         bdr_warn_list.insert(attr);
       }
@@ -102,7 +103,7 @@ mfem::Array<int> LaplaceOperator::SetUpBoundaryProperties(const IoData &iodata,
                   static_cast<int>(iodata.boundaries.lumpedport.size()));
   for (auto attr : iodata.boundaries.pec.attributes)
   {
-    if (attr <= 0 || attr > bdr_attr_max)
+    if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
     {
       continue;  // Can just ignore if wrong
     }

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -66,9 +66,10 @@ mfem::Array<int> SpaceOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.pec.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     for (auto attr : mesh.bdr_attributes)
     {
@@ -82,7 +83,7 @@ mfem::Array<int> SpaceOperator::SetUpBoundaryProperties(const IoData &iodata,
       //             "attributes in the mesh!");
       // MFEM_VERIFY(bdr_attr_marker[attr - 1],
       //             "Unknown PEC boundary attribute " << attr << "!");
-      if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         bdr_warn_list.insert(attr);
       }
@@ -101,7 +102,7 @@ mfem::Array<int> SpaceOperator::SetUpBoundaryProperties(const IoData &iodata,
   dbc_bcs.Reserve(static_cast<int>(iodata.boundaries.pec.attributes.size()));
   for (auto attr : iodata.boundaries.pec.attributes)
   {
-    if (attr <= 0 || attr > bdr_attr_max)
+    if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
     {
       continue;  // Can just ignore if wrong
     }

--- a/palace/models/surfaceconductivityoperator.cpp
+++ b/palace/models/surfaceconductivityoperator.cpp
@@ -3,10 +3,12 @@
 
 #include "surfaceconductivityoperator.hpp"
 
+#include <set>
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
 #include "utils/iodata.hpp"
+#include "utils/prettyprint.hpp"
 
 namespace palace
 {
@@ -27,9 +29,9 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
                                                           const mfem::ParMesh &mesh)
 {
   // Check that conductivity boundary attributes have been specified correctly.
+  int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   if (!iodata.boundaries.conductivity.empty())
   {
-    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
     mfem::Array<int> bdr_attr_marker(bdr_attr_max), conductivity_marker(bdr_attr_max);
     bdr_attr_marker = 0;
     conductivity_marker = 0;
@@ -37,21 +39,34 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
     {
       bdr_attr_marker[attr - 1] = 1;
     }
+    std::set<int> bdr_warn_list;
     for (const auto &data : iodata.boundaries.conductivity)
     {
       for (auto attr : data.attributes)
       {
-        MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
-                    "Conductivity boundary attribute tags must be non-negative and "
-                    "correspond to attributes in the mesh!");
-        MFEM_VERIFY(bdr_attr_marker[attr - 1],
-                    "Unknown conductivity boundary attribute " << attr << "!");
         MFEM_VERIFY(!conductivity_marker[attr - 1],
                     "Multiple definitions of conductivity boundary properties for boundary "
                     "attribute "
                         << attr << "!");
         conductivity_marker[attr - 1] = 1;
+        // MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
+        //             "Conductivity boundary attribute tags must be non-negative and "
+        //             "correspond to attributes in the mesh!");
+        // MFEM_VERIFY(bdr_attr_marker[attr - 1],
+        //             "Unknown conductivity boundary attribute " << attr << "!");
+        if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+        {
+          bdr_warn_list.insert(attr);
+        }
       }
+    }
+    if (!bdr_warn_list.empty())
+    {
+      Mpi::Print("\n");
+      Mpi::Warning(
+          "Unknown conductivity boundary attributes!\nSolver will just ignore them!");
+      utils::PrettyPrint(bdr_warn_list, "Boundary attribute list:");
+      Mpi::Print("\n");
     }
   }
 
@@ -74,7 +89,15 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
       // side.
       bdr.h *= 2.0;
     }
-    bdr.attr_list.Append(data.attributes.data(), data.attributes.size());
+    bdr.attr_list.Reserve(static_cast<int>(data.attributes.size()));
+    for (auto attr : data.attributes)
+    {
+      if (attr <= 0 || attr > bdr_attr_max)
+      {
+        continue;  // Can just ignore if wrong
+      }
+      bdr.attr_list.Append(attr);
+    }
   }
   MFEM_VERIFY(boundaries.empty() ||
                   iodata.problem.type == config::ProblemData::Type::DRIVEN,

--- a/palace/models/surfaceconductivityoperator.cpp
+++ b/palace/models/surfaceconductivityoperator.cpp
@@ -30,9 +30,11 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that conductivity boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.conductivity.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max), conductivity_marker(bdr_attr_max);
+    mfem::Array<int> conductivity_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     conductivity_marker = 0;
     for (auto attr : mesh.bdr_attributes)
@@ -54,7 +56,7 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
         //             "correspond to attributes in the mesh!");
         // MFEM_VERIFY(bdr_attr_marker[attr - 1],
         //             "Unknown conductivity boundary attribute " << attr << "!");
-        if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+        if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
         {
           bdr_warn_list.insert(attr);
         }
@@ -92,7 +94,7 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
     bdr.attr_list.Reserve(static_cast<int>(data.attributes.size()));
     for (auto attr : data.attributes)
     {
-      if (attr <= 0 || attr > bdr_attr_max)
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         continue;  // Can just ignore if wrong
       }

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -28,9 +28,11 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
 {
   // Check that impedance boundary attributes have been specified correctly.
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker;
   if (!iodata.boundaries.impedance.empty())
   {
-    mfem::Array<int> bdr_attr_marker(bdr_attr_max), impedance_marker(bdr_attr_max);
+    mfem::Array<int> impedance_marker(bdr_attr_max);
+    bdr_attr_marker.SetSize(bdr_attr_max);
     bdr_attr_marker = 0;
     impedance_marker = 0;
     for (auto attr : mesh.bdr_attributes)
@@ -52,7 +54,7 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
         //             correspond " "to attributes in the mesh!");
         // MFEM_VERIFY(bdr_attr_marker[attr - 1],
         //             "Unknown impedance boundary attribute " << attr << "!");
-        if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+        if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
         {
           bdr_warn_list.insert(attr);
         }
@@ -80,7 +82,7 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
     bdr.attr_list.Reserve(static_cast<int>(data.attributes.size()));
     for (auto attr : data.attributes)
     {
-      if (attr <= 0 || attr > bdr_attr_max)
+      if (attr <= 0 || attr > bdr_attr_max || !bdr_attr_marker[attr - 1])
       {
         continue;  // Can just ignore if wrong
       }

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -3,10 +3,12 @@
 
 #include "surfaceimpedanceoperator.hpp"
 
+#include <set>
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
 #include "utils/iodata.hpp"
+#include "utils/prettyprint.hpp"
 
 namespace palace
 {
@@ -25,9 +27,9 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
                                                        const mfem::ParMesh &mesh)
 {
   // Check that impedance boundary attributes have been specified correctly.
+  int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   if (!iodata.boundaries.impedance.empty())
   {
-    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
     mfem::Array<int> bdr_attr_marker(bdr_attr_max), impedance_marker(bdr_attr_max);
     bdr_attr_marker = 0;
     impedance_marker = 0;
@@ -35,21 +37,33 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
     {
       bdr_attr_marker[attr - 1] = 1;
     }
+    std::set<int> bdr_warn_list;
     for (const auto &data : iodata.boundaries.impedance)
     {
       for (auto attr : data.attributes)
       {
-        MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
-                    "Impedance boundary attribute tags must be non-negative and correspond "
-                    "to attributes in the mesh!");
-        MFEM_VERIFY(bdr_attr_marker[attr - 1],
-                    "Unknown impedance boundary attribute " << attr << "!");
         MFEM_VERIFY(
             !impedance_marker[attr - 1],
             "Multiple definitions of impedance boundary properties for boundary attribute "
                 << attr << "!");
         impedance_marker[attr - 1] = 1;
+        // MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
+        //             "Impedance boundary attribute tags must be non-negative and
+        //             correspond " "to attributes in the mesh!");
+        // MFEM_VERIFY(bdr_attr_marker[attr - 1],
+        //             "Unknown impedance boundary attribute " << attr << "!");
+        if (attr <= 0 || attr > bdr_attr_marker.Size() || !bdr_attr_marker[attr - 1])
+        {
+          bdr_warn_list.insert(attr);
+        }
       }
+    }
+    if (!bdr_warn_list.empty())
+    {
+      Mpi::Print("\n");
+      Mpi::Warning("Unknown impedance boundary attributes!\nSolver will just ignore them!");
+      utils::PrettyPrint(bdr_warn_list, "Boundary attribute list:");
+      Mpi::Print("\n");
     }
   }
 
@@ -63,7 +77,15 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(const IoData &iodata,
     bdr.Rs = data.Rs;
     bdr.Ls = data.Ls;
     bdr.Cs = data.Cs;
-    bdr.attr_list.Append(data.attributes.data(), data.attributes.size());
+    bdr.attr_list.Reserve(static_cast<int>(data.attributes.size()));
+    for (auto attr : data.attributes)
+    {
+      if (attr <= 0 || attr > bdr_attr_max)
+      {
+        continue;  // Can just ignore if wrong
+      }
+      bdr.attr_list.Append(attr);
+    }
   }
 }
 

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -45,7 +45,8 @@ private:
     bool two_sided;
     mfem::Vector center;
 
-    SurfaceFluxData(const config::SurfaceFluxData &data, const mfem::ParMesh &mesh);
+    SurfaceFluxData(const config::SurfaceFluxData &data, const mfem::ParMesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker);
 
     std::unique_ptr<mfem::Coefficient> GetCoefficient(const mfem::ParGridFunction *E,
                                                       const mfem::ParGridFunction *B,
@@ -58,7 +59,8 @@ private:
     bool side_n_min;
 
     InterfaceDielectricData(const config::InterfaceDielectricData &data,
-                            const mfem::ParMesh &mesh);
+                            const mfem::ParMesh &mesh,
+                            const mfem::Array<int> &bdr_attr_marker);
 
     std::unique_ptr<mfem::Coefficient> GetCoefficient(const GridFunction &E,
                                                       const MaterialOperator &mat_op) const;

--- a/palace/utils/communication.hpp
+++ b/palace/utils/communication.hpp
@@ -5,6 +5,7 @@
 #define PALACE_UTILS_COMMUNICATION_HPP
 
 #include <complex>
+#include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
@@ -357,7 +358,7 @@ public:
   template <typename... T>
   static void Warning(MPI_Comm comm, fmt::format_string<T...> fmt, T &&...args)
   {
-    Print(comm, "\nWarning!\n");
+    Print(comm, "\n{}\n", fmt::styled("--> Warning!", fmt::fg(fmt::color::yellow)));
     Print(comm, fmt, std::forward<T>(args)...);
     Print(comm, "\n");
   }

--- a/palace/utils/prettyprint.hpp
+++ b/palace/utils/prettyprint.hpp
@@ -20,7 +20,7 @@ namespace palace::utils
 namespace internal
 {
 
-constexpr std::size_t max_width = 60;
+constexpr std::size_t max_width = 80;
 
 template <typename T>
 inline std::size_t GetSize(const T &v)


### PR DESCRIPTION
- Add surface impedance and surface conductivity BCs to allow invalid attributes, following https://github.com/awslabs/palace/pull/224.
- Fix invalid BC warning messages to be more concise.
- Update `Mpi::Warning` color to highlight warnings and increase column width for `PrettyPrint` to 80 characters from 60.

Note: Based on https://github.com/awslabs/palace/pull/242