### PR TITLE
Fix bounding ball calculation for coaxial lumped ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format of this changelog is based on
   - Fixed a bug when computing the energy associated with lumped elements with more than
     one nonzero R, L, or C. This also affects the inductive EPR for lumped inductors with
     and associated parallel capacitance.
+  - Fixed a bug for coaxial lumped ports which led to incorrect extraction of the geometric
+    parameters, especially when coarsely-meshed or non-axis-aligned.
 
 ## [0.12.0] - 2023-12-21
 

--- a/palace/fem/lumpedelement.cpp
+++ b/palace/fem/lumpedelement.cpp
@@ -116,8 +116,8 @@ CoaxialElementData::CoaxialElementData(const std::array<double, 3> &input_dir,
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
   auto bounding_ball = mesh::GetBoundingBall(mesh, attr_marker, true);
-  MFEM_VERIFY(bounding_ball.planar,
-              "Boundary elements must be coplanar to define a coaxial lumped element!");
+  // MFEM_VERIFY(bounding_ball.planar,
+  //             "Boundary elements must be coplanar to define a coaxial lumped element!");
 
   // Direction of the excitation as +/-r̂.
   direction = (input_dir[0] > 0);
@@ -131,6 +131,22 @@ CoaxialElementData::CoaxialElementData(const std::array<double, 3> &input_dir,
               "Coaxial element boundary is not defined correctly (radius "
                   << r_outer << ", area " << A << ")!");
   r_inner = std::sqrt(std::pow(r_outer, 2) - A / M_PI);
+
+
+
+
+  // XX TODO WIP...
+  const auto &center = bounding_ball.center;
+  const auto &lengths = bounding_ball.Lengths();
+  std::cout << "\norigin: " << center[0] << ", " << center[1] << ", " << center[2]
+            << "\n\n";
+  std::cout << "\nlengths: " << lengths[0] << ", " << lengths[1] << ", " << lengths[2]
+            << "\n\n";
+  std::cout << "\nr_outer: " << r_outer << "\n\n";
+  std::cout << "\nr_inner: " << r_inner << "\n\n";
+
+
+
 }
 
 std::unique_ptr<mfem::VectorCoefficient>

--- a/palace/fem/lumpedelement.cpp
+++ b/palace/fem/lumpedelement.cpp
@@ -116,8 +116,8 @@ CoaxialElementData::CoaxialElementData(const std::array<double, 3> &input_dir,
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
   auto bounding_ball = mesh::GetBoundingBall(mesh, attr_marker, true);
-  // MFEM_VERIFY(bounding_ball.planar,
-  //             "Boundary elements must be coplanar to define a coaxial lumped element!");
+  MFEM_VERIFY(bounding_ball.planar,
+              "Boundary elements must be coplanar to define a coaxial lumped element!");
 
   // Direction of the excitation as +/-r̂.
   direction = (input_dir[0] > 0);
@@ -131,22 +131,6 @@ CoaxialElementData::CoaxialElementData(const std::array<double, 3> &input_dir,
               "Coaxial element boundary is not defined correctly (radius "
                   << r_outer << ", area " << A << ")!");
   r_inner = std::sqrt(std::pow(r_outer, 2) - A / M_PI);
-
-
-
-
-  // XX TODO WIP...
-  const auto &center = bounding_ball.center;
-  const auto &lengths = bounding_ball.Lengths();
-  std::cout << "\norigin: " << center[0] << ", " << center[1] << ", " << center[2]
-            << "\n\n";
-  std::cout << "\nlengths: " << lengths[0] << ", " << lengths[1] << ", " << lengths[2]
-            << "\n\n";
-  std::cout << "\nr_outer: " << r_outer << "\n\n";
-  std::cout << "\nr_inner: " << r_inner << "\n\n";
-
-
-
 }
 
 std::unique_ptr<mfem::VectorCoefficient>

--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <mfem.hpp>
-#include "utils/geodata.hpp"
 
 namespace palace
 {
@@ -37,9 +36,6 @@ public:
 class UniformElementData : public LumpedElementData
 {
 private:
-  // Bounding box defining the rectangular lumped port.
-  mesh::BoundingBox bounding_box;
-
   // Cartesian vector specifying signed direction of incident field.
   mfem::Vector direction;
 
@@ -61,21 +57,21 @@ public:
 class CoaxialElementData : public LumpedElementData
 {
 private:
-  // Bounding ball defined by boundary element.
-  mesh::BoundingBall bounding_ball;
+  // Sign of incident field, +1 for +r̂, -1 for -r̂.
+  double direction;
 
-  // Sign of incident field, +r̂ if true.
-  bool sign;
+  // Origin of the coaxial annulus.
+  mfem::Vector origin;
 
-  // Inner radius of coaxial annulus.
-  double ra;
+  // Outer and inner radii of coaxial annulus.
+  double r_outer, r_inner;
 
 public:
-  CoaxialElementData(const std::array<double, 3> &direction,
+  CoaxialElementData(const std::array<double, 3> &input_dir,
                      const mfem::Array<int> &attr_list,
                      mfem::ParFiniteElementSpace &fespace);
 
-  double GetGeometryLength() const override { return std::log(bounding_ball.radius / ra); }
+  double GetGeometryLength() const override { return std::log(r_outer / r_inner); }
   double GetGeometryWidth() const override { return 2.0 * M_PI; }
 
   std::unique_ptr<mfem::VectorCoefficient>

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1034,7 +1034,7 @@ BoundingBall SphereFromPoints(const std::vector<std::size_t> &indices,
   const Eigen::Vector3d AB = vertices[indices[1]] - vertices[indices[0]];
   const Eigen::Vector3d AC = vertices[indices[2]] - vertices[indices[0]];
   const Eigen::Vector3d ABAC = AB.cross(AC);
-  Eigen::Vector3d AD;
+  Eigen::Vector3d AD = Eigen::Vector3d::Zero();
   if (!ball.planar)
   {
     AD = vertices[indices[3]] - vertices[indices[0]];

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <limits>
-#include <list>
 #include <map>
 #include <numeric>
 #include <random>

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -781,7 +781,7 @@ int CollectPointCloudOnRoot(const mfem::ParMesh &mesh, const mfem::Array<int> &m
   }
   else
   {
-    // Nonlinear mesh, need to process point matrices.
+    // Curved mesh, need to process point matrices.
     const int ref = mesh.GetNodes()->FESpace()->GetMaxElementOrder();
     mfem::DenseMatrix pointmat;  // 3 x N
     mfem::IsoparametricTransformation T;

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1152,22 +1152,6 @@ BoundingBox BoundingBallFromPointCloud(MPI_Comm comm,
       p_1 = std::max_element(vertices.begin(), vertices.end(),
                              [p_2](const Eigen::Vector3d &x, const Eigen::Vector3d &y)
                              { return (x - *p_2).norm() < (y - *p_2).norm(); });
-
-
-      // //XX TODO
-      // auto p_test = std::max_element(vertices.begin(), vertices.end(),
-      //                              [p_1](const Eigen::Vector3d &x, const Eigen::Vector3d &y)
-      //                              { return (x - *p_1).norm() < (y - *p_1).norm(); });
-      // MFEM_ASSERT(p_test == p_2, "p_1 and p_2 must be mutually opposing points!");
-
-
-      // MFEM_ASSERT(std::max_element(vertices.begin(), vertices.end(),
-      //                              [p_1](const Eigen::Vector3d &x, const Eigen::Vector3d &y)
-      //                              { return (x - *p_1).norm() < (y - *p_1).norm(); }) ==
-      //                 p_2,
-      //             "p_1 and p_2 must be mutually opposing points!");
-
-
       auto p_12 = 0.5 * (*p_1 + *p_2);
       auto p_3 =
           std::max_element(vertices.begin(), vertices.end(),
@@ -1231,19 +1215,6 @@ BoundingBox GetBoundingBall(const mfem::ParMesh &mesh, const mfem::Array<int> &m
 {
   std::vector<Eigen::Vector3d> vertices;
   int dominant_rank = CollectPointCloudOnRoot(mesh, marker, bdr, vertices);
-
-
-
-  //XX TODO WIP FOR TEST...
-  bool neg = false;
-  for (auto &v : vertices)
-  {
-    v[0] += 0.1 * (neg ? -1.0 : 1.0);
-    neg = !neg;
-  }
-
-
-
   return BoundingBallFromPointCloud(mesh.GetComm(), vertices, dominant_rank);
 }
 

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1143,7 +1143,7 @@ BoundingBox BoundingBallFromPointCloud(MPI_Comm comm,
                              [p_2](const Eigen::Vector3d &x, const Eigen::Vector3d &y)
                              { return (x - *p_2).norm() < (y - *p_2).norm(); });
 
-      // Find the p_3 as the vertex furthest from the initial axis.
+      // Find the next point as the vertex furthest from the initial axis.
       const Eigen::Vector3d n_1 = (*p_2 - *p_1).normalized();
       auto p_3 = std::max_element(vertices.begin(), vertices.end(),
                                   [&](const auto &x, const auto &y) {

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -92,18 +92,23 @@ struct BoundingBox
   // Compute the area of the bounding box spanned by the first two normals.
   double Area() const;
 
-  // Compute the volume of a 3D bounding box. Returns zero if planar.
+  // Compute the volume of the 3D bounding box. Returns zero if planar.
   double Volume() const;
 
-  // Compute the lengths of each axis.
+  // Compute the lengths along each axis.
   std::array<double, 3> Lengths() const;
 
-  // Compute the deviation in degrees of a vector from each of the normal directions.
+  // Compute the deviation in degrees of a vector from each of the axis directions.
   std::array<double, 3> Deviation(const std::array<double, 3> &direction) const;
 };
 
 // Helper functions for computing bounding boxes from a mesh and markers. These do not need
-// to be axis-aligned.
+// to be axis-aligned. Note: This function only returns an oriented bounding box for points
+// which exactly form a rectangle or rectangular prism. For other shapes, the result is less
+// predictable. For shapes where the convex hull is a circle or sphere, the convex hull
+// is the circumscribed sphere of the resulting box, or equivalently the box is inscribed by
+// the convex hull. It is thus clearly not a bounding box but can be useful to compute
+// nonetheless.
 BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                            bool bdr);
 BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr);

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -67,7 +67,8 @@ mfem::Array<int> AttrToMarker(int max_attr, const T &attr_list, bool skip_invali
   return marker;
 }
 
-// Helper function to construct the bounding box for all elements with the given attribute.
+// Helper function to construct the axis-aligned bounding box for all elements with the
+// given attribute.
 void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                                bool bdr, mfem::Vector &min, mfem::Vector &max);
 void GetAxisAlignedBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr,
@@ -101,31 +102,8 @@ struct BoundingBox
   std::array<double, 3> Deviation(const std::array<double, 3> &direction) const;
 };
 
-// Struct describing a bounding ball in terms of a center and radius. If a ball is two
-// dimensional, additionally provides a normal to the plane.
-struct BoundingBall
-{
-  // The centroid of the ball.
-  std::array<double, 3> center;
-
-  // The radius of the ball from the center.
-  double radius;
-
-  // If the ball is two dimensional, the normal defining the planar surface. Zero magnitude
-  // if a sphere.
-  std::array<double, 3> planar_normal;
-
-  // Whether or not this bounding ball is two dimensional.
-  bool planar;
-
-  // Compute the area of the bounding box spanned by the first two normals.
-  double Area() const { return M_PI * std::pow(radius, 2.0); }
-
-  // Compute the volume of a 3D bounding box. Returns zero if planar.
-  double Volume() const { return planar ? 0.0 : (4 * M_PI / 3) * std::pow(radius, 3.0); }
-};
-
-// Helper functions for computing bounding boxes from a mesh and markers.
+// Helper functions for computing bounding boxes from a mesh and markers. These do not need
+// to be axis-aligned.
 BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                            bool bdr);
 BoundingBox GetBoundingBox(const mfem::ParMesh &mesh, int attr, bool bdr);
@@ -135,12 +113,6 @@ double GetProjectedLength(const mfem::ParMesh &mesh, const mfem::Array<int> &mar
                           bool bdr, const std::array<double, 3> &dir);
 double GetProjectedLength(const mfem::ParMesh &mesh, int attr, bool bdr,
                           const std::array<double, 3> &dir);
-
-// Given a mesh and a marker, compute the diameter of a bounding circle/sphere, assuming
-// that the extrema points are in the marked group.
-BoundingBall GetBoundingBall(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
-                             bool bdr);
-BoundingBall GetBoundingBall(const mfem::ParMesh &mesh, int attr, bool bdr);
 
 // Helper function to compute the average surface normal for all elements with the given
 // attribute.


### PR DESCRIPTION
Previously, for coaxial lumped ports with particularly coarse meshes, the following assertion would fail in `geodata.cpp`'s `BoundingBallFromPointCloud`:

```
MFEM_VERIFY(std::abs(PerpendicularDistance({delta}, perp) - ball.radius) <=
                rel_tol * ball.radius,
            "Furthest point perpendicular must be on the exterior of the ball: "
                << PerpendicularDistance({delta}, perp) << " vs. " << ball.radius
                << "!");
```

This PR improves the bounding ball algorithm to avoid this error (and is a simpler algorithm). We now just compute the ball origin as the average of all points and radial direction as the point furthest from the centroid. The rest of the algorithm is unchanged.

Here is an example second-order mesh which was causing problems prior to this PR:

![Screenshot 2024-05-06 at 4 14 13 PM](https://github.com/awslabs/palace/assets/26631700/a558e0d5-bac7-4ab8-8812-5adf9aee9bc7)