### PR TITLE
Style fix with updated clang-format for CI

### DIFF
--- a/palace/utils/meshio.cpp
+++ b/palace/utils/meshio.cpp
@@ -330,7 +330,8 @@ void WriteGmsh(std::ostream &buffer, const std::vector<double> &node_coords,
                const bool use_lo_type)
 {
   // Write the Gmsh file header (version 2.2).
-  buffer << "$MeshFormat\n2.2 " <<
+  buffer << "$MeshFormat\n2.2 "
+         <<
 #if defined(GMSH_BIN)
       "1 " <<
 #else


### PR DESCRIPTION
Updating `clang-format` v18 minor versions seems to have introduced a needed style fix.