### PR TITLE
Bug fix for boundary postprocessing from #240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## In progress
+
+  - Fixed a small regression bug for boundary postprocessing when specifying
+    `"Side": "LargerRefractiveIndex"`, introduced as part of v0.13.0.
+
 ## [0.13.0] - 2024-05-20
 
   - Changed default value of `config["Solver"]["PartialAssemblyOrder"]` in order to activate

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -410,7 +410,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MA>::Eval(
   }
 
   // Metal-air interface: 0.5 * t / ε_MA * |E_n|² .
-  return 0.5 * t_i / epsilon_i * Vn2;
+  return 0.5 * (t_i / epsilon_i) * Vn2;
 }
 
 template <>
@@ -435,7 +435,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MS>::Eval(
   }
 
   // Metal-substrate interface: 0.5 * t / ε_MS * |(ε_S E)_n|² .
-  return 0.5 * t_i / epsilon_i * Vn2;
+  return 0.5 * (t_i / epsilon_i) * Vn2;
 }
 
 template <>
@@ -461,7 +461,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::SA>::Eval(
   }
 
   // Substrate-air interface: 0.5 * t * (ε_SA * |E_t|² + 1 / ε_SA * |E_n|²) .
-  return 0.5 * t_i * (epsilon_i * Vt2 + Vn2 / epsilon_i);
+  return 0.5 * t_i * ((epsilon_i * Vt2) + (Vn2 / epsilon_i));
 }
 
 // Helper for EnergyDensityCoefficient.

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -60,9 +60,11 @@ protected:
     // For interior faces, compute the value on the side where the speed of light is larger
     // (refractive index is smaller, typically should choose the vacuum side). For cases
     // where the speeds are the same, use element 1.
-    return (FET.Elem2 && side_n_min &&
-            mat_op.GetLightSpeedMax(FET.Elem2->Attribute) >
-                mat_op.GetLightSpeedMax(FET.Elem1->Attribute));
+    return (FET.Elem2 &&
+            ((side_n_min && mat_op.GetLightSpeedMax(FET.Elem2->Attribute) >
+                                mat_op.GetLightSpeedMax(FET.Elem1->Attribute)) ||
+             (!side_n_min && mat_op.GetLightSpeedMax(FET.Elem2->Attribute) <
+                                 mat_op.GetLightSpeedMax(FET.Elem1->Attribute))));
   }
 
 public:


### PR DESCRIPTION
As part of https://github.com/awslabs/palace/pull/240, using `"Side": "LargerRefractiveIndex"` was not handled correctly. This caused regressions for some meshes with internal boundaries, but was not caught by the CI tests because the meshes for the CPW test which should have tested this were a special case that happened to still give the correct result.