### PR TITLE
Fix oriented bounding box calculation for lumped ports, in preparation for #261

### DIFF
--- a/docs/src/guide/boundaries.md
+++ b/docs/src/guide/boundaries.md
@@ -87,10 +87,7 @@ reference.
     Note that a single lumped port (given by a single integer `"Index"`) can be made up of
     multiple boundary attributes in the mesh in order to model, for example, a multielement
     lumped port. To use this functionality, use the `"Elements"` object under
-    [`"LumpedPort"`](../config/boundaries.md#boundaries%5B%22LumpedPort%22%5D). Also, each
-    element of a lumped port boundary must be _planar_. Combining multiple planar boundaries
-    into a single port `"Index"` via the multielement lumped port achieves the same effect
-    as if the single element lumped port was made up of boundaries which were not coplanar.
+    [`"LumpedPort"`](../config/boundaries.md#boundaries%5B%22LumpedPort%22%5D).
 
   - [`config["Boundaries"]["WavePort"]`](../config/boundaries.md#boundaries%5B%22WavePort%22%5D) :
     Numeric wave ports are available for frequency domain driven simulations. In this case,

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -182,7 +182,7 @@ inline double GetDistanceFromPoint(const mfem::ParMesh &mesh, int attr, bool bdr
 }
 
 // Helper function to compute the average surface normal for all elements with the given
-// attribute.
+// attributes.
 mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, const mfem::Array<int> &marker,
                               bool average = true);
 
@@ -201,6 +201,28 @@ inline mfem::Vector GetSurfaceNormal(const mfem::ParMesh &mesh, bool average = t
   const bool bdr = (mesh.Dimension() == mesh.SpaceDimension());
   const auto &attributes = bdr ? mesh.bdr_attributes : mesh.attributes;
   return GetSurfaceNormal(mesh, AttrToMarker(attributes.Max(), attributes), average);
+}
+
+// Helper functions to compute the volume or area for all domain or boundary elements with
+// the given attributes.
+double GetSurfaceArea(const mfem::ParMesh &mesh, const mfem::Array<int> &marker);
+
+inline double GetSurfaceArea(const mfem::ParMesh &mesh, int attr)
+{
+  mfem::Array<int> marker(mesh.bdr_attributes.Max());
+  marker = 0;
+  marker[attr - 1] = 1;
+  return GetSurfaceArea(mesh, marker);
+}
+
+double GetVolume(const mfem::ParMesh &mesh, const mfem::Array<int> &marker);
+
+inline double GetVolume(const mfem::ParMesh &mesh, int attr)
+{
+  mfem::Array<int> marker(mesh.attributes.Max());
+  marker = 0;
+  marker[attr - 1] = 1;
+  return GetVolume(mesh, marker);
 }
 
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from


### PR DESCRIPTION
Very minor perturbations to a perfect quadrilateral or rectangular prism caused the entire algorithm to fail and led to failed `MFEM_VERIFY` statements for the direction in `UniformElementData`'s constructor.