### PR TITLE
Fix divergence cleaning when a model has no real boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format of this changelog is based on
     (`config["Boundaries"]["Conductivity"]`) are automatically marked as PEC for the wave
     port mode solve (previously these were marked as PMC unless specified under
     `"WavePortPEC"`).
+  - Fixed a bug in divergence-free projection for problems without essential or mixed
+    boundary conditions.
 
 ## [0.13.0] - 2024-05-20
 

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -50,7 +50,7 @@ DivFreeSolver<VecType>::DivFreeSolver(
 {
   BlockTimer bt(Timer::DIV_FREE);
 
-  // If no boundaries on the mesh have been marked, add a single degree of freedo
+  // If no boundaries on the mesh have been marked, add a single degree of freedom
   // constraint so the system for the projection is not singular. This amounts to enforcing
   // a scalar potential of 0 at a point in space if it is otherwise completely
   // unconstrained.

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -49,6 +49,42 @@ DivFreeSolver<VecType>::DivFreeSolver(
     int print)
 {
   BlockTimer bt(Timer::DIV_FREE);
+
+  // If no boundaries on the mesh have been marked, add a single degree of freedo
+  // constraint so the system for the projection is not singular. This amounts to enforcing
+  // a scalar potential of 0 at a point in space if it is otherwise completely
+  // unconstrained.
+  const auto *ptr_h1_bdr_tdof_lists = &h1_bdr_tdof_lists;
+  {
+    MFEM_VERIFY(
+        !h1_bdr_tdof_lists.empty(),
+        "Unexpected empty list of boundary true dofs for finite element space hierarchy!");
+    HYPRE_BigInt coarse_bdr_tdofs = h1_bdr_tdof_lists[0].Size();
+    MPI_Comm comm = h1_fespaces.GetFESpaceAtLevel(0).GetComm();
+    Mpi::GlobalSum(1, &coarse_bdr_tdofs, comm);
+    if (coarse_bdr_tdofs == 0)
+    {
+      MPI_Comm split_comm = MPI_COMM_NULL;
+      int color = (h1_fespaces.GetFESpaceAtLevel(0).GetTrueVSize() > 0) ? 0 : MPI_UNDEFINED;
+      MPI_Comm_split(comm, color, Mpi::Rank(comm), &split_comm);
+      if (split_comm != MPI_COMM_NULL && Mpi::Root(split_comm))
+      {
+        aux_tdof_lists.reserve(h1_fespaces.GetNumLevels());
+        for (std::size_t l = 0; l < h1_fespaces.GetNumLevels(); l++)
+        {
+          auto &tdof_list = aux_tdof_lists.emplace_back(1);
+          tdof_list[0] = 0;
+        }
+        ptr_h1_bdr_tdof_lists = &aux_tdof_lists;
+      }
+      if (split_comm != MPI_COMM_NULL)
+      {
+        MPI_Comm_free(&split_comm);
+      }
+    }
+  }
+
+  // Create the mass and weak divergence operators for divergence-free projection.
   MaterialPropertyCoefficient epsilon_func(mat_op.GetAttributeToMaterial(),
                                            mat_op.GetPermittivityReal());
   {
@@ -63,7 +99,8 @@ DivFreeSolver<VecType>::DivFreeSolver(
     {
       const auto &h1_fespace_l = h1_fespaces.GetFESpaceAtLevel(l);
       auto M_l = BuildLevelParOperator<OperType>(std::move(m_vec[l]), h1_fespace_l);
-      M_l->SetEssentialTrueDofs(h1_bdr_tdof_lists[l], Operator::DiagonalPolicy::DIAG_ONE);
+      M_l->SetEssentialTrueDofs((*ptr_h1_bdr_tdof_lists)[l],
+                                Operator::DiagonalPolicy::DIAG_ONE);
       if (l == h1_fespaces.GetNumLevels() - 1)
       {
         bdr_tdof_list_M = M_l->GetEssentialTrueDofs();

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -64,9 +64,11 @@ DivFreeSolver<VecType>::DivFreeSolver(
     Mpi::GlobalSum(1, &coarse_bdr_tdofs, comm);
     if (coarse_bdr_tdofs == 0)
     {
-      int root = (h1_fespaces.GetFESpaceAtLevel(0).GetTrueVSize() == 0) ? Mpi::Size(comm) : Mpi::Rank(comm);
+      int root = (h1_fespaces.GetFESpaceAtLevel(0).GetTrueVSize() == 0) ? Mpi::Size(comm)
+                                                                        : Mpi::Rank(comm);
       Mpi::GlobalMin(1, &root, comm);
-      MFEM_VERIFY(root < Mpi::Size(comm), "No root process found for single true dof constraint!");
+      MFEM_VERIFY(root < Mpi::Size(comm),
+                  "No root process found for single true dof constraint!");
       if (root == Mpi::Rank(comm))
       {
         aux_tdof_lists.reserve(h1_fespaces.GetNumLevels());

--- a/palace/linalg/divfree.hpp
+++ b/palace/linalg/divfree.hpp
@@ -43,6 +43,11 @@ private:
   const Operator *Grad;
   const mfem::Array<int> *bdr_tdof_list_M;
 
+  // Optional storage for homogeneous Dirichlet boundary condition on a single true dof,
+  // used when the input array of H1 boundary dofs is empty to prevent the Poisson operator
+  // from being singular.
+  std::vector<mfem::Array<int>> aux_tdof_lists;
+
   // Linear solver for the projected linear system (Gᵀ M G) y = x.
   std::unique_ptr<BaseKspSolver<OperType>> ksp;
 


### PR DESCRIPTION
This avoids solving a singular Laplace problem when calculating the scalar potential for a model with no real boundaries. For example, this can be observed by printing the output of divergence-free projection linear solve for the cavity example with PMC boundaries. After this PR, the divergence-free solves actually converge normally in a few iterations and the eigensolve converges as well.

Correctly handles the case of some subdomains having potentially no true dofs and just enforces a potential = 0 on the processor of lowest rank with some non-zero number of local true dofs.