### PR TITLE
Fix intel oneapi versions to 2024.2.1

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -118,8 +118,8 @@ jobs:
       - name: Configure Intel oneAPI compiler
         if: matrix.compiler == 'intel'
         run: |
-          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
-                                  intel-oneapi-compiler-fortran
+          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp=2024.2.1-1079 \
+                                  intel-oneapi-compiler-fortran=2024.2.1-1079
 
       - name: Install math libraries (OpenBLAS)
         if: matrix.math-libs == 'openblas'
@@ -133,7 +133,7 @@ jobs:
       - name: Install math libraries (Intel oneAPI MKL)
         if: matrix.math-libs == 'intelmkl'
         run: |
-          sudo apt-get install -y intel-oneapi-mkl intel-oneapi-mkl-devel
+          sudo apt-get install -y intel-oneapi-mkl=2024.2.2-15 intel-oneapi-mkl-devel=2024.2.2-15
 
       - name: Install math libraries (AOCL)
         if: matrix.math-libs == 'aocl'

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Configure Intel oneAPI compiler
         if: matrix.compiler == 'intel'
         run: |
-          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
-                                  intel-oneapi-compiler-fortran
+          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp=2024.2.1-1079 \
+                                  intel-oneapi-compiler-fortran=2024.2.1-1079
 
       - uses: vsoch/spack-package-action/install@main
 


### PR DESCRIPTION
There is an internal compiler error in 2025.0 for the fortran compiler. This prevents STRUMPACK from building in CI, see https://github.com/awslabs/palace/pull/293. This change fixes the version to the previously work 2024.2.1 until a patch for 2025 is released.

Future removal of this rollback is documented in https://github.com/awslabs/palace/issues/295.