### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -88,7 +88,7 @@ jobs:
             export FC=gfortran-12
           fi
           if [[ "${{ matrix.math-libs }}" == 'openblas' ]]; then
-            export OPENBLAS_DIR=/opt/homebrew/opt/openblas
+            export OPENBLAS_DIR=$(brew --prefix openblas)
           fi
           export NUM_PROC_BUILD=$(nproc 2> /dev/null || sysctl -n hw.ncpu)
           if [[ "$NUM_PROC_BUILD" -gt "$NUM_PROC_BUILD_MAX" ]]; then

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -43,7 +43,7 @@ jobs:
             with-solver: strumpack
             with-eigensolver: slepc
 
-    runs-on: macos-latest-xl
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -53,6 +53,10 @@ jobs:
         run: |
           brew install pkg-config
 
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
       - name: Configure Open MPI
         if: matrix.mpi == 'openmpi'
         run: |

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -84,7 +84,7 @@ jobs:
             export FC=gfortran-12
           fi
           if [[ "${{ matrix.math-libs }}" == 'openblas' ]]; then
-            export OPENBLAS_DIR=/usr/local/opt/openblas
+            export OPENBLAS_DIR=/opt/homebrew/opt/openblas
           fi
           export NUM_PROC_BUILD=$(nproc 2> /dev/null || sysctl -n hw.ncpu)
           if [[ "$NUM_PROC_BUILD" -gt "$NUM_PROC_BUILD_MAX" ]]; then

--- a/cmake/ExternalBLASLAPACK.cmake
+++ b/cmake/ExternalBLASLAPACK.cmake
@@ -163,6 +163,13 @@ else()
   else()
     set(OPENBLAS_DIR)
   endif()
+
+  if(NOT OPENBLAS_DIR STREQUAL "")
+    # If OpenBLAS was found set the vendor to avoid conflict with Accelerate on Darwin
+    set(BLA_VENDOR "OpenBLAS")
+    message(STATUS "Using BLAS/LAPACK from OpenBLAS")
+  endif()
+
   list(APPEND CMAKE_PREFIX_PATH ${OPENBLAS_DIR})
   find_package(BLAS REQUIRED)
   find_package(LAPACK REQUIRED)

--- a/cmake/ExternalBLASLAPACK.cmake
+++ b/cmake/ExternalBLASLAPACK.cmake
@@ -162,14 +162,13 @@ else()
     set(OPENBLAS_DIR $ENV{OPENBLAS_ROOT})
   else()
     set(OPENBLAS_DIR)
+    message(STATUS "Using BLAS/LAPACK located by CMake")
   endif()
 
   if(NOT OPENBLAS_DIR STREQUAL "")
     # If OpenBLAS was found set the vendor to avoid conflict with Accelerate on Darwin
     set(BLA_VENDOR "OpenBLAS")
     message(STATUS "Using BLAS/LAPACK from OpenBLAS")
-  else()
-    message(STATUS "Using BLAS/LAPACK located by CMake")
   endif()
 
   list(APPEND CMAKE_PREFIX_PATH ${OPENBLAS_DIR})

--- a/cmake/ExternalBLASLAPACK.cmake
+++ b/cmake/ExternalBLASLAPACK.cmake
@@ -168,6 +168,8 @@ else()
     # If OpenBLAS was found set the vendor to avoid conflict with Accelerate on Darwin
     set(BLA_VENDOR "OpenBLAS")
     message(STATUS "Using BLAS/LAPACK from OpenBLAS")
+  else()
+    message(STATUS "Using BLAS/LAPACK located by CMake")
   endif()
 
   list(APPEND CMAKE_PREFIX_PATH ${OPENBLAS_DIR})
@@ -188,7 +190,6 @@ else()
     PATH_SUFFIXES include include/openblas
     REQUIRED
   )
-  message(STATUS "Using BLAS/LAPACK located by CMake")
 endif()
 
 # Save variables to cache

--- a/cmake/ExternalHYPRE.cmake
+++ b/cmake/ExternalHYPRE.cmake
@@ -44,7 +44,7 @@ if(NOT CMAKE_C_COMPILER STREQUAL MPI_C_COMPILER)
     set(HYPRE_CXXFLAGS "${HYPRE_CXXFLAGS} -I${INCLUDE_DIR}")
   endforeach()
   string(REPLACE ";" " " HYPRE_MPI_LIBRARIES "${MPI_C_LIBRARIES}")
-  set(HYPRE_LDFLAGS "${HYPRE_LDFLAGS} ${HYPRE_MPI_LIBRARIES}")
+  set(HYPRE_LDFLAGS "${HYPRE_LDFLAGS} ${HYPRE_MPI_LIBRARIES} -lm")
 endif()
 
 # Use Autotools build instead of CMake for HIP support


### PR DESCRIPTION
In some macos github action builds:
```
[build-and-test-macos (gcc, openmpi, openblas, static, int64, openmp, superlu, arpack)](https://github.com/awslabs/palace/actions/runs/11825573260/job/32994205616#step:4:17)
You are using macOS 12.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```
Looks like the github action runners `macos-latest-xl` might've been moved to `macos-latest-large`. Should probably add an m1 build to the CI.