### PR TITLE
Fix arg error in rings/mesh.jl

### DIFF
--- a/examples/rings/mesh/mesh.jl
+++ b/examples/rings/mesh/mesh.jl
@@ -38,7 +38,7 @@ function generate_ring_mesh(;
     outer_radius                       = 100.0,
     rot_center::AbstractVector{<:Real} = [0.0, 0.0, 0.0],
     rot_axis::AbstractVector{<:Real}   = [0.0, 0.0, 1.0],
-    rot_θ::Real                        = π / 2,
+    rot_θ::Real                        = π / 6,
     verbose::Integer                   = 5,
     gui::Bool                          = false
 )
@@ -148,8 +148,17 @@ function generate_ring_mesh(;
     )
 
     # Apply a rotation transformation to all entities in the model
-    ra ./= norm(ra)
-    kernel.rotate(kernel.getEntities(), rc[1], rc[2], rc[3], ra[1], ra[2], ra[3], θ)
+    rot_axis ./= norm(rot_axis)
+    kernel.rotate(
+        kernel.getEntities(),
+        rot_center[1],
+        rot_center[2],
+        rot_center[3],
+        rot_axis[1],
+        rot_axis[2],
+        rot_axis[3],
+        rot_θ
+    )
 
     kernel.synchronize()
 


### PR DESCRIPTION
The default arguments in `rings/mesh.jl` were not being used. Additionally the default value for `rot_θ` did not match the value used in the configuration file.