### PR TITLE
Force link of pkgconf to new version on mac OS runners

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew unlink pkg-config@0.29.2
           brew install pkg-config
 
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Mac OS CI failing due to pkg config not updating on the new runners. See https://github.com/awslabs/palace/actions/runs/11977558035/job/33395703593?pr=272