### PR TITLE
Remove pkg-config unlink

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew unlink pkg-config@0.29.2
           brew install pkg-config
 
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
The macos runner broke on unlinking pkg-config again.