### PR TITLE
London Equation bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format of this changelog is based on
   - Added an option to use the complex-valued system matrix for the coarse level solve (sparse
     direct solve) instead of the real-valued approximation. This can be specified with
     `config["Solver"]["Linear"]["ComplexCoarseSolve"]`.
+  - Fix bug in London equation implementation where a curl-curl term was added to the
+    stiffness operator instead of a mass term.
 
 ## [0.13.0] - 2024-05-20
 

--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -432,10 +432,14 @@ iterative solver choices, and the default choice depends on the iterative solver
   - `"Default"`
 
 `"DivFreeTol" [1.0e-12]` :  Relative tolerance for divergence-free cleaning used in the
-eigenmode simulation type.
+eigenmode simulation type. Ignored if non-zero
+[`config["Domains"]["Materials"]["LondonDepth"]`](domains.md##domains%5B%22Materials%22%5D%5B%22LondonDepth%22%5D)
+is detected.
 
 `"DivFreeMaxIts" [1000]` :  Maximum number of iterations for divergence-free cleaning use in
-the eigenmode simulation type.
+the eigenmode simulation type. Ignored if non-zero
+[`config["Domains"]["Materials"]["LondonDepth"]`](domains.md##domains%5B%22Materials%22%5D%5B%22LondonDepth%22%5D)
+is detected.
 
 `"EstimatorTol" [1.0e-6]` :  Relative tolerance for flux projection used in the
 error estimate calculation.

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -154,7 +154,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // Construct a divergence-free projector so the eigenvalue solve is performed in the space
   // orthogonal to the zero eigenvalues of the stiffness matrix.
   std::unique_ptr<DivFreeSolver<ComplexVector>> divfree;
-  if (iodata.solver.linear.divfree_max_it > 0)
+  if (iodata.solver.linear.divfree_max_it > 0 && !space_op.GetMaterialOp().HasLondonDepth())
   {
     Mpi::Print(" Configuring divergence-free projection\n");
     constexpr int divfree_verbose = 0;

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -821,7 +821,7 @@ void SpaceOperator::AddStiffnessCoefficients(double coeff, MaterialPropertyCoeff
   // Contribution for London superconductors.
   if (mat_op.HasLondonDepth())
   {
-    df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvLondonDepth(), coeff);
+    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvLondonDepth(), coeff);
   }
 }
 


### PR DESCRIPTION
The London equation implementation has an issue where the london depth is added as a curlcurl term, where it should have been added as a mass term. This was due to a typo where `df` was used instead of `f`. The effect of the London equation is to make a reaction-diffusion (second order) boundary layer in the London region, which is independent of driving frequency, hence needing the mass term. The magnetic boundary layer effect was confirmed after this fix.

Additionally to get good results requires disabling the divergence free cleaner, as the mass term results in a change to the nullspace of the stiffness matrix. 
![image (18)](https://github.com/user-attachments/assets/99490494-bcf0-44bb-9cf6-62c7412056d9)