### PR TITLE
Export mesh after cracking pre-processing

### DIFF
--- a/docs/src/config/model.md
+++ b/docs/src/config/model.md
@@ -122,7 +122,7 @@ mesh length units.
   - `"RefineCrackElements" [true]`
   - `"CrackDisplacementFactor" [1.0e-12]`
   - `"AddInterfaceBoundaryElements" [true]`
-  - `"ExportMeshBeforeCrack" [false]`
+  - `"ExportMeshBeforeCracking" [false]`
   - `"ReorientTetMesh" [false]`
   - `"Partitioning" [""]`
   - `"MaxNCLevels" [1]`

--- a/docs/src/config/model.md
+++ b/docs/src/config/model.md
@@ -122,6 +122,7 @@ mesh length units.
   - `"RefineCrackElements" [true]`
   - `"CrackDisplacementFactor" [1.0e-12]`
   - `"AddInterfaceBoundaryElements" [true]`
+  - `"ExportMeshBeforeCrack" [false]`
   - `"ReorientTetMesh" [false]`
   - `"Partitioning" [""]`
   - `"MaxNCLevels" [1]`

--- a/docs/src/config/model.md
+++ b/docs/src/config/model.md
@@ -122,7 +122,7 @@ mesh length units.
   - `"RefineCrackElements" [true]`
   - `"CrackDisplacementFactor" [1.0e-12]`
   - `"AddInterfaceBoundaryElements" [true]`
-  - `"ExportMeshBeforeCracking" [false]`
+  - `"ExportPrerefinedMesh" [false]`
   - `"ReorientTetMesh" [false]`
   - `"Partitioning" [""]`
   - `"MaxNCLevels" [1]`

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -474,6 +474,7 @@ void ModelData::SetUp(json &config)
   refine_crack_elements = model->value("RefineCrackElements", refine_crack_elements);
   crack_displ_factor = model->value("CrackDisplacementFactor", crack_displ_factor);
   add_bdr_elements = model->value("AddInterfaceBoundaryElements", add_bdr_elements);
+  export_mesh_before_crack = model->value("ExportMeshBeforeCrack", export_mesh_before_crack);
   reorient_tet_mesh = model->value("ReorientTetMesh", reorient_tet_mesh);
   partitioning = model->value("Partitioning", partitioning);
   refinement.SetUp(*model);
@@ -491,6 +492,7 @@ void ModelData::SetUp(json &config)
   model->erase("RefineCrackElements");
   model->erase("CrackDisplacementFactor");
   model->erase("AddInterfaceBoundaryElements");
+  model->erase("ExportMeshBeforeCrack");
   model->erase("ReorientTetMesh");
   model->erase("Partitioning");
   model->erase("Refinement");
@@ -513,6 +515,7 @@ void ModelData::SetUp(json &config)
     std::cout << "RefineCrackElements: " << refine_crack_elements << '\n';
     std::cout << "CrackDisplacementFactor: " << crack_displ_factor << '\n';
     std::cout << "AddInterfaceBoundaryElements: " << add_bdr_elements << '\n';
+    std::cout << "ExportMeshBeforeCrack: " << export_mesh_before_crack << '\n';
     std::cout << "ReorientTetMesh: " << reorient_tet_mesh << '\n';
     std::cout << "Partitioning: " << partitioning << '\n';
   }

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -474,8 +474,7 @@ void ModelData::SetUp(json &config)
   refine_crack_elements = model->value("RefineCrackElements", refine_crack_elements);
   crack_displ_factor = model->value("CrackDisplacementFactor", crack_displ_factor);
   add_bdr_elements = model->value("AddInterfaceBoundaryElements", add_bdr_elements);
-  export_mesh_before_crack =
-      model->value("ExportMeshBeforeCracking", export_mesh_before_crack);
+  export_prerefined_mesh = model->value("ExportPrerefinedMesh", export_prerefined_mesh);
   reorient_tet_mesh = model->value("ReorientTetMesh", reorient_tet_mesh);
   partitioning = model->value("Partitioning", partitioning);
   refinement.SetUp(*model);
@@ -493,7 +492,7 @@ void ModelData::SetUp(json &config)
   model->erase("RefineCrackElements");
   model->erase("CrackDisplacementFactor");
   model->erase("AddInterfaceBoundaryElements");
-  model->erase("ExportMeshBeforeCracking");
+  model->erase("ExportPrerefinedMesh");
   model->erase("ReorientTetMesh");
   model->erase("Partitioning");
   model->erase("Refinement");
@@ -516,7 +515,7 @@ void ModelData::SetUp(json &config)
     std::cout << "RefineCrackElements: " << refine_crack_elements << '\n';
     std::cout << "CrackDisplacementFactor: " << crack_displ_factor << '\n';
     std::cout << "AddInterfaceBoundaryElements: " << add_bdr_elements << '\n';
-    std::cout << "ExportMeshBeforeCracking: " << export_mesh_before_crack << '\n';
+    std::cout << "ExportPrerefinedMesh: " << export_prerefined_mesh << '\n';
     std::cout << "ReorientTetMesh: " << reorient_tet_mesh << '\n';
     std::cout << "Partitioning: " << partitioning << '\n';
   }

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -474,7 +474,7 @@ void ModelData::SetUp(json &config)
   refine_crack_elements = model->value("RefineCrackElements", refine_crack_elements);
   crack_displ_factor = model->value("CrackDisplacementFactor", crack_displ_factor);
   add_bdr_elements = model->value("AddInterfaceBoundaryElements", add_bdr_elements);
-  export_mesh_before_crack = model->value("ExportMeshBeforeCrack", export_mesh_before_crack);
+  export_mesh_before_crack = model->value("ExportMeshBeforeCracking", export_mesh_before_crack);
   reorient_tet_mesh = model->value("ReorientTetMesh", reorient_tet_mesh);
   partitioning = model->value("Partitioning", partitioning);
   refinement.SetUp(*model);
@@ -492,7 +492,7 @@ void ModelData::SetUp(json &config)
   model->erase("RefineCrackElements");
   model->erase("CrackDisplacementFactor");
   model->erase("AddInterfaceBoundaryElements");
-  model->erase("ExportMeshBeforeCrack");
+  model->erase("ExportMeshBeforeCracking");
   model->erase("ReorientTetMesh");
   model->erase("Partitioning");
   model->erase("Refinement");
@@ -515,7 +515,7 @@ void ModelData::SetUp(json &config)
     std::cout << "RefineCrackElements: " << refine_crack_elements << '\n';
     std::cout << "CrackDisplacementFactor: " << crack_displ_factor << '\n';
     std::cout << "AddInterfaceBoundaryElements: " << add_bdr_elements << '\n';
-    std::cout << "ExportMeshBeforeCrack: " << export_mesh_before_crack << '\n';
+    std::cout << "ExportMeshBeforeCracking: " << export_mesh_before_crack << '\n';
     std::cout << "ReorientTetMesh: " << reorient_tet_mesh << '\n';
     std::cout << "Partitioning: " << partitioning << '\n';
   }

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -474,7 +474,8 @@ void ModelData::SetUp(json &config)
   refine_crack_elements = model->value("RefineCrackElements", refine_crack_elements);
   crack_displ_factor = model->value("CrackDisplacementFactor", crack_displ_factor);
   add_bdr_elements = model->value("AddInterfaceBoundaryElements", add_bdr_elements);
-  export_mesh_before_crack = model->value("ExportMeshBeforeCracking", export_mesh_before_crack);
+  export_mesh_before_crack =
+      model->value("ExportMeshBeforeCracking", export_mesh_before_crack);
   reorient_tet_mesh = model->value("ReorientTetMesh", reorient_tet_mesh);
   partitioning = model->value("Partitioning", partitioning);
   refinement.SetUp(*model);

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -235,6 +235,9 @@ public:
   // have attached elements on either side with different domain attributes.
   bool add_bdr_elements = true;
 
+  // Export mesh after pre-processing but before cracking.
+  bool export_mesh_before_crack = false;
+
   // Call MFEM's ReorientTetMesh as a check of mesh orientation after partitioning.
   bool reorient_tet_mesh = false;
 

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -236,7 +236,7 @@ public:
   bool add_bdr_elements = true;
 
   // Export mesh after pre-processing but before cracking.
-  bool export_mesh_before_crack = false;
+  bool export_prerefined_mesh = false;
 
   // Call MFEM's ReorientTetMesh as a check of mesh orientation after partitioning.
   bool reorient_tet_mesh = false;

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -60,7 +60,7 @@ std::unordered_map<int, int> CheckMesh(const mfem::Mesh &, const config::Boundar
 // Adding boundary elements for material interfaces and exterior boundaries, and "crack"
 // desired internal boundary elements to disconnect the elements on either side.
 int AddInterfaceBdrElements(const IoData &, std::unique_ptr<mfem::Mesh> &,
-                            std::unordered_map<int, int> &);
+                            std::unordered_map<int, int> &, MPI_Comm comm);
 
 // Generate element-based mesh partitioning, using either a provided file or METIS.
 std::unique_ptr<int[]> GetMeshPartitioning(const mfem::Mesh &, int,
@@ -198,7 +198,7 @@ std::unique_ptr<mfem::ParMesh> ReadMesh(const IoData &iodata, MPI_Comm comm)
     {
       // Split all internal (non periodic) boundary elements for boundary attributes where
       // BC are applied (not just postprocessing).
-      while (AddInterfaceBdrElements(iodata, smesh, face_to_be) != 1)
+      while (AddInterfaceBdrElements(iodata, smesh, face_to_be, comm) != 1)
       {
         // May require multiple calls due to early exit/retry approach.
       }
@@ -2791,7 +2791,7 @@ struct UnorderedPairHasher
 };
 
 int AddInterfaceBdrElements(const IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_mesh,
-                            std::unordered_map<int, int> &face_to_be)
+                            std::unordered_map<int, int> &face_to_be, MPI_Comm comm)
 {
   // Return if nothing to do. Otherwise, count vertices and boundary elements to add.
   if (iodata.boundaries.attributes.empty() && !iodata.model.add_bdr_elements)
@@ -3116,6 +3116,16 @@ int AddInterfaceBdrElements(const IoData &iodata, std::unique_ptr<mfem::Mesh> &o
       Mpi::Print("Added {:d} boundary elements for material interfaces to the mesh\n",
                  new_nbe_int);
     }
+  }
+
+  // Export mesh after pre-processing, before cracking boundary elements.
+  if (iodata.model.export_mesh_before_crack && Mpi::Root(comm))
+  {
+    auto pos = iodata.model.mesh.find_last_of(".");
+    std::string meshfile = iodata.model.mesh.substr(0, pos) + "_preprocessed.mesh";
+    std::ofstream fo(meshfile);
+    fo.precision(MSH_FLT_PRECISION);
+    orig_mesh->Print(fo);
   }
 
   // Create the new mesh. We can't just add the new vertices and boundary elements to the

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -3119,7 +3119,7 @@ int AddInterfaceBdrElements(const IoData &iodata, std::unique_ptr<mfem::Mesh> &o
   }
 
   // Export mesh after pre-processing, before cracking boundary elements.
-  if (iodata.model.export_mesh_before_crack && Mpi::Root(comm))
+  if (iodata.model.export_prerefined_mesh && Mpi::Root(comm))
   {
     auto pos = iodata.model.mesh.find_last_of(".");
     std::string meshfile = iodata.model.mesh.substr(0, pos) + "_preprocessed.mesh";

--- a/scripts/schema/config/model.json
+++ b/scripts/schema/config/model.json
@@ -18,7 +18,7 @@
     "RefineCrackElements": { "type": "boolean" },
     "CrackDisplacementFactor": { "type": "number", "inclusiveMinimum": 0.0 },
     "AddInterfaceBoundaryElements": { "type": "boolean" },
-    "ExportMeshBeforeCrack": { "type": "boolean" },
+    "ExportPrerefinedMesh": { "type": "boolean" },
     "ReorientTetMesh": { "type": "boolean" },
     "Partitioning": { "type": "string" },
     "Refinement":

--- a/scripts/schema/config/model.json
+++ b/scripts/schema/config/model.json
@@ -18,6 +18,7 @@
     "RefineCrackElements": { "type": "boolean" },
     "CrackDisplacementFactor": { "type": "number", "inclusiveMinimum": 0.0 },
     "AddInterfaceBoundaryElements": { "type": "boolean" },
+    "ExportMeshBeforeCrack": { "type": "boolean" },
     "ReorientTetMesh": { "type": "boolean" },
     "Partitioning": { "type": "string" },
     "Refinement":


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->

Palace does some pre-processing of the mesh to enable mesh cracking. To enable comparative studies on the same mesh whether mesh cracking is used or not, users may want an option to export this mesh after pre-processing, before cracking, for use with other configurations.

