### PR TITLE
Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiling with CUDA

### DIFF
--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -378,6 +378,13 @@ else()
   endforeach()
 endif()
 
+# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiled with CUDA
+if(PALACE_WITH_CUDA)
+  set(MFEM_TEST_COMMAND "")
+else()
+  set(MFEM_TEST_COMMAND "${CMAKE_MAKE_PROGRAM} ex1 ex1p")
+endif()
+
 string(REPLACE ";" "; " MFEM_OPTIONS_PRINT "${MFEM_OPTIONS}")
 message(STATUS "MFEM_OPTIONS: ${MFEM_OPTIONS_PRINT}")
 
@@ -405,5 +412,5 @@ ExternalProject_Add(mfem
     git clean -fd &&
     git apply "${MFEM_PATCH_FILES}"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} <SOURCE_DIR> "${MFEM_OPTIONS}"
-  TEST_COMMAND      ${CMAKE_MAKE_PROGRAM} ex1 ex1p
+  TEST_COMMAND      ${MFEM_TEST_COMMAND}
 )

--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -378,7 +378,7 @@ else()
   endforeach()
 endif()
 
-# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiled with CUDA
+# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiling with CUDA
 if(PALACE_WITH_CUDA)
   set(MFEM_TEST_COMMAND "")
 else()

--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -382,7 +382,7 @@ endif()
 if(PALACE_WITH_CUDA)
   set(MFEM_TEST_COMMAND "")
 else()
-  set(MFEM_TEST_COMMAND "${CMAKE_MAKE_PROGRAM} ex1 ex1p")
+  set(MFEM_TEST_COMMAND ${CMAKE_MAKE_PROGRAM} ex1 ex1p)
 endif()
 
 string(REPLACE ";" "; " MFEM_OPTIONS_PRINT "${MFEM_OPTIONS}")

--- a/palace/CMakeLists.txt
+++ b/palace/CMakeLists.txt
@@ -54,7 +54,7 @@ if(PALACE_WITH_ARPACK)
   enable_language(Fortran)
 endif()
 
-# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiled with CUDA
+# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiling with CUDA
 if(PALACE_WITH_CUDA)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto")

--- a/palace/CMakeLists.txt
+++ b/palace/CMakeLists.txt
@@ -54,6 +54,12 @@ if(PALACE_WITH_ARPACK)
   enable_language(Fortran)
 endif()
 
+# Avoid "Error: symbol `fatbinData' is already defined" caused by LTO when compiled with CUDA
+if(PALACE_WITH_CUDA)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto")
+endif()
+
 # Enable CUDA/HIP if required
 if(PALACE_WITH_CUDA AND PALACE_WITH_HIP)
   message(FATAL_ERROR "PALACE_WITH_CUDA is not compatible with PALACE_WITH_HIP")


### PR DESCRIPTION
Refer to the issue at https://github.com/awslabs/palace/issues/256, https://github.com/awslabs/palace/issues/340.

When attempting to build the palace application with CUDA support on Ubuntu 22.04, I encountered the same problem on two separate occasions:

1. In the test step of MFEM.
2. At the final build stage of palace

This issue can be resolved by taking two specific actions. First, when building with CUDA, I disable the test step of MFEM. Second, I add the appropriate CMake option during the final build step.
The following code snippet demonstrates how to add the necessary CMake option:

```
if(PALACE_WITH_CUDA)
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto")
endif()
```