### PR TITLE
Fix compiler spec in GitHub workflow to work with `spack@v1.x`

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
           # Build and install
-          PALACE_SPEC="local.palace@develop%${{ matrix.compiler }}$GPU_VARIANT ^${{ matrix.mpi }}"
+          PALACE_SPEC="local.palace@develop$GPU_VARIANT ^${{ matrix.mpi }} %${{ matrix.compiler }}"
           PALACE_SPEC="$PALACE_SPEC ^petsc~hdf5 ^intel-oneapi-mkl"
           spack spec $PALACE_SPEC
           spack dev-build $PALACE_SPEC


### PR DESCRIPTION
Currently main pipelines are failing to build palace due to changes that were made in `spack@v1.x`. This moved compilers into a package instead of a compiler explicitly, and so hence this also changed how the spec syntax handles packages.