### PR TITLE
Add missing error for unsupported set-up configurations early

### DIFF
--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -239,6 +239,11 @@ void IoData::CheckConfiguration()
       Mpi::Warning(
           "Eigenmode problem type does not support wave port boundary conditions!\n");
     }
+    if (!boundaries.farfield.empty() && boundaries.farfield.order > 1)
+    {
+      Mpi::Warning("Eigenmode problem type does not support absorbing boundary conditions "
+                   "with order > 1!\n");
+    }
   }
   else if (problem.type == config::ProblemData::Type::ELECTROSTATIC)
   {
@@ -312,6 +317,11 @@ void IoData::CheckConfiguration()
     {
       Mpi::Warning(
           "Transient problem type does not support wave port boundary conditions!\n");
+    }
+    if (!boundaries.farfield.empty() && boundaries.farfield.order > 1)
+    {
+      Mpi::Warning("Transient problem type does not support absorbing boundary conditions "
+                   "with order > 1!\n");
     }
   }
 


### PR DESCRIPTION
Higher order far-field boundary conditions are only supported in driven system, since like wave-ports they have a non LRC frequency dependance. Technically, this is enforced when building the matrices here:

https://github.com/awslabs/palace/blob/78043460e7dca7fcf0b57349477da69a8771cde6/palace/models/farfieldboundaryoperator.cpp#L83

It would be nice to enforce this along with all similar conditions in the config options. (e.g. we enforce no farfield be for the DC simulations in config).

PR is trivial, but would be nice for a second pair of eyes to double check logic / bool condition is correct.