### PR TITLE
Move enums from config into labels.hpp

### DIFF
--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -70,7 +70,7 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &space_op,
 {
   // Initialize postprocessing for measurement and printers.
   // Initialize write directory with default path; will be changed if multiple excitations.
-  PostOperator<config::ProblemData::Type::DRIVEN> post_op(iodata, space_op);
+  PostOperator<ProblemType::DRIVEN> post_op(iodata, space_op);
   auto excitation_helper = space_op.GetPortExcitations();
 
   // Construct the system matrices defining the linear operator. PEC boundaries are handled
@@ -186,7 +186,7 @@ ErrorIndicator DrivenSolver::SweepAdaptive(SpaceOperator &space_op,
                                            const std::vector<double> &omega_sample) const
 {
   // Initialize postprocessing for measurement and printers.
-  PostOperator<config::ProblemData::Type::DRIVEN> post_op(iodata, space_op);
+  PostOperator<ProblemType::DRIVEN> post_op(iodata, space_op);
   auto excitation_helper = space_op.GetPortExcitations();
 
   // Configure PROM parameters if not specified.

--- a/palace/drivers/drivensolver.hpp
+++ b/palace/drivers/drivensolver.hpp
@@ -14,7 +14,7 @@ namespace palace
 
 class ErrorIndicator;
 class Mesh;
-template <config::ProblemData::Type>
+template <ProblemType>
 class PostOperator;
 class SpaceOperator;
 

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -52,28 +52,28 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   //         (K + λ C + λ² M) u = 0    or    K u = -λ² M u
   // with λ = iω. In general, the system matrices are complex and symmetric.
   std::unique_ptr<EigenvalueSolver> eigen;
-  EigenSolverType type = iodata.solver.eigenmode.type;
+  EigenSolverBackend type = iodata.solver.eigenmode.type;
 #if defined(PALACE_WITH_ARPACK) && defined(PALACE_WITH_SLEPC)
-  if (type == EigenSolverType::DEFAULT)
+  if (type == EigenSolverBackend::DEFAULT)
   {
-    type = EigenSolverType::SLEPC;
+    type = EigenSolverBackend::SLEPC;
   }
 #elif defined(PALACE_WITH_ARPACK)
-  if (iodata.solver.eigenmode.type == EigenSolverType::SLEPC)
+  if (iodata.solver.eigenmode.type == EigenSolverBackend::SLEPC)
   {
     Mpi::Warning("SLEPc eigensolver not available, using ARPACK!\n");
   }
-  type = EigenSolverType::ARPACK;
+  type = EigenSolverBackend::ARPACK;
 #elif defined(PALACE_WITH_SLEPC)
-  if (iodata.solver.eigenmode.type == EigenSolverType::ARPACK)
+  if (iodata.solver.eigenmode.type == EigenSolverBackend::ARPACK)
   {
     Mpi::Warning("ARPACK eigensolver not available, using SLEPc!\n");
   }
-  type = EigenSolverType::SLEPC;
+  type = EigenSolverBackend::SLEPC;
 #else
 #error "Eigenmode solver requires building with ARPACK or SLEPc!"
 #endif
-  if (type == EigenSolverType::ARPACK)
+  if (type == EigenSolverBackend::ARPACK)
   {
 #if defined(PALACE_WITH_ARPACK)
     Mpi::Print("\nConfiguring ARPACK eigenvalue solver:\n");
@@ -89,7 +89,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     }
 #endif
   }
-  else  // EigenSolverType::SLEPC
+  else  // EigenSolverBackend::SLEPC
   {
 #if defined(PALACE_WITH_SLEPC)
     Mpi::Print("\nConfiguring SLEPc eigenvalue solver:\n");
@@ -220,7 +220,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   {
     // Search for eigenvalues closest to λ = iσ.
     eigen->SetShiftInvert(1i * target);
-    if (type == EigenSolverType::ARPACK)
+    if (type == EigenSolverBackend::ARPACK)
     {
       // ARPACK searches based on eigenvalues of the transformed problem. The eigenvalue
       // 1 / (λ - σ) will be a large-magnitude negative imaginary number for an eigenvalue
@@ -236,7 +236,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   {
     // Linear EVP has eigenvalues μ = -λ² = ω². Search for eigenvalues closest to μ = σ².
     eigen->SetShiftInvert(target * target);
-    if (type == EigenSolverType::ARPACK)
+    if (type == EigenSolverBackend::ARPACK)
     {
       // ARPACK searches based on eigenvalues of the transformed problem. 1 / (μ - σ²)
       // will be a large-magnitude positive real number for an eigenvalue μ with frequency

--- a/palace/drivers/electrostaticsolver.cpp
+++ b/palace/drivers/electrostaticsolver.cpp
@@ -37,7 +37,7 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
   // Terminal indices are the set of boundaries over which to compute the capacitance
   // matrix. Terminal boundaries are aliases for ports.
-  PostOperator<config::ProblemData::Type::ELECTROSTATIC> post_op(iodata, laplace_op);
+  PostOperator<ProblemType::ELECTROSTATIC> post_op(iodata, laplace_op);
   int n_step = static_cast<int>(laplace_op.GetSources().size());
   MFEM_VERIFY(n_step > 0, "No terminal boundaries specified for electrostatic simulation!");
 
@@ -98,7 +98,7 @@ ElectrostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 }
 
 void ElectrostaticSolver::PostprocessTerminals(
-    PostOperator<config::ProblemData::Type::ELECTROSTATIC> &post_op,
+    PostOperator<ProblemType::ELECTROSTATIC> &post_op,
     const std::map<int, mfem::Array<int>> &terminal_sources,
     const std::vector<Vector> &V) const
 {

--- a/palace/drivers/electrostaticsolver.hpp
+++ b/palace/drivers/electrostaticsolver.hpp
@@ -24,7 +24,7 @@ namespace palace
 
 class ErrorIndicator;
 class Mesh;
-template <config::ProblemData::Type>
+template <ProblemType>
 class PostOperator;
 
 //
@@ -33,7 +33,7 @@ class PostOperator;
 class ElectrostaticSolver : public BaseSolver
 {
 private:
-  void PostprocessTerminals(PostOperator<config::ProblemData::Type::ELECTROSTATIC> &post_op,
+  void PostprocessTerminals(PostOperator<ProblemType::ELECTROSTATIC> &post_op,
                             const std::map<int, mfem::Array<int>> &terminal_sources,
                             const std::vector<Vector> &V) const;
 

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -36,7 +36,7 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   ksp.SetOperators(*K, *K);
 
   // Terminal indices are the set of boundaries over which to compute the inductance matrix.
-  PostOperator<config::ProblemData::Type::MAGNETOSTATIC> post_op(iodata, curlcurl_op);
+  PostOperator<ProblemType::MAGNETOSTATIC> post_op(iodata, curlcurl_op);
   int n_step = static_cast<int>(curlcurl_op.GetSurfaceCurrentOp().Size());
   MFEM_VERIFY(n_step > 0,
               "No surface current boundaries specified for magnetostatic simulation!");
@@ -103,7 +103,7 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 }
 
 void MagnetostaticSolver::PostprocessTerminals(
-    PostOperator<config::ProblemData::Type::MAGNETOSTATIC> &post_op,
+    PostOperator<ProblemType::MAGNETOSTATIC> &post_op,
     const SurfaceCurrentOperator &surf_j_op, const std::vector<Vector> &A,
     const std::vector<double> &I_inc) const
 {

--- a/palace/drivers/magnetostaticsolver.hpp
+++ b/palace/drivers/magnetostaticsolver.hpp
@@ -15,7 +15,7 @@ namespace palace
 
 class ErrorIndicator;
 class Mesh;
-template <config::ProblemData::Type>
+template <ProblemType>
 class PostOperator;
 class SurfaceCurrentOperator;
 
@@ -25,7 +25,7 @@ class SurfaceCurrentOperator;
 class MagnetostaticSolver : public BaseSolver
 {
 private:
-  void PostprocessTerminals(PostOperator<config::ProblemData::Type::MAGNETOSTATIC> &post_op,
+  void PostprocessTerminals(PostOperator<ProblemType::MAGNETOSTATIC> &post_op,
                             const SurfaceCurrentOperator &surf_j_op,
                             const std::vector<Vector> &A,
                             const std::vector<double> &I_inc) const;

--- a/palace/drivers/transientsolver.cpp
+++ b/palace/drivers/transientsolver.cpp
@@ -112,11 +112,10 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
     MFEM_VERIFY(data.pulse_tau > 0.0,
                 "Excitation width is missing for transient simulation!");
   }
-  const double delay =
-      (type == Excitation::GAUSSIAN || type == Excitation::DIFF_GAUSSIAN ||
-       type == Excitation::MOD_GAUSSIAN)
-          ? 4.5 * data.pulse_tau
-          : 0.0;
+  const double delay = (type == Excitation::GAUSSIAN || type == Excitation::DIFF_GAUSSIAN ||
+                        type == Excitation::MOD_GAUSSIAN)
+                           ? 4.5 * data.pulse_tau
+                           : 0.0;
   switch (type)
   {
     case Excitation::SINUSOIDAL:

--- a/palace/drivers/transientsolver.cpp
+++ b/palace/drivers/transientsolver.cpp
@@ -100,26 +100,26 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
   using namespace excitations;
   using F = std::function<double(double)>;
   const config::TransientSolverData &data = iodata.solver.transient;
-  const ExcitationType &type = data.excitation;
-  if (type == ExcitationType::SINUSOIDAL || type == ExcitationType::MOD_GAUSSIAN)
+  const Excitation &type = data.excitation;
+  if (type == Excitation::SINUSOIDAL || type == Excitation::MOD_GAUSSIAN)
   {
     MFEM_VERIFY(data.pulse_f > 0.0,
                 "Excitation frequency is missing for transient simulation!");
   }
-  if (type == ExcitationType::GAUSSIAN || type == ExcitationType::DIFF_GAUSSIAN ||
-      type == ExcitationType::MOD_GAUSSIAN || type == ExcitationType::SMOOTH_STEP)
+  if (type == Excitation::GAUSSIAN || type == Excitation::DIFF_GAUSSIAN ||
+      type == Excitation::MOD_GAUSSIAN || type == Excitation::SMOOTH_STEP)
   {
     MFEM_VERIFY(data.pulse_tau > 0.0,
                 "Excitation width is missing for transient simulation!");
   }
   const double delay =
-      (type == ExcitationType::GAUSSIAN || type == ExcitationType::DIFF_GAUSSIAN ||
-       type == ExcitationType::MOD_GAUSSIAN)
+      (type == Excitation::GAUSSIAN || type == Excitation::DIFF_GAUSSIAN ||
+       type == Excitation::MOD_GAUSSIAN)
           ? 4.5 * data.pulse_tau
           : 0.0;
   switch (type)
   {
-    case ExcitationType::SINUSOIDAL:
+    case Excitation::SINUSOIDAL:
       if (dot)
       {
         return F{[=](double t) { return dpulse_sinusoidal(t, data.pulse_f, delay); }};
@@ -129,7 +129,7 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
         return F{[=](double t) { return pulse_sinusoidal(t, data.pulse_f, delay); }};
       }
       break;
-    case ExcitationType::GAUSSIAN:
+    case Excitation::GAUSSIAN:
       if (dot)
       {
         return F{[=](double t) { return dpulse_gaussian(t, data.pulse_tau, delay); }};
@@ -139,7 +139,7 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
         return F{[=](double t) { return pulse_gaussian(t, data.pulse_tau, delay); }};
       }
       break;
-    case ExcitationType::DIFF_GAUSSIAN:
+    case Excitation::DIFF_GAUSSIAN:
       if (dot)
       {
         return F{[=](double t) { return dpulse_gaussian_diff(t, data.pulse_tau, delay); }};
@@ -149,7 +149,7 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
         return F{[=](double t) { return pulse_gaussian_diff(t, data.pulse_tau, delay); }};
       }
       break;
-    case ExcitationType::MOD_GAUSSIAN:
+    case Excitation::MOD_GAUSSIAN:
       if (dot)
       {
         return F{[=](double t)
@@ -161,7 +161,7 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
                  { return pulse_gaussian_mod(t, data.pulse_f, data.pulse_tau, delay); }};
       }
       break;
-    case ExcitationType::RAMP_STEP:
+    case Excitation::RAMP_STEP:
       if (dot)
       {
         return F{[=](double t) { return dpulse_ramp(t, data.pulse_tau, delay); }};
@@ -171,7 +171,7 @@ std::function<double(double)> TransientSolver::GetTimeExcitation(bool dot) const
         return F{[=](double t) { return pulse_ramp(t, data.pulse_tau, delay); }};
       }
       break;
-    case ExcitationType::SMOOTH_STEP:
+    case Excitation::SMOOTH_STEP:
       if (dot)
       {
         return F{[=](double t) { return dpulse_smootherstep(t, data.pulse_tau, delay); }};

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -270,7 +270,7 @@ inline void BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>::GetLocalFlux(
 // and subtrate-air interfaces following:
 //   J. Wenner et al., Surface loss simulations of superconducting coplanar waveguide
 //     resonators, Appl. Phys. Lett. (2011).
-template <InterfaceDielectricType Type>
+template <InterfaceDielectric Type>
 class InterfaceDielectricCoefficient : public mfem::Coefficient,
                                        public BdrGridFunctionCoefficient
 {
@@ -339,7 +339,7 @@ public:
 };
 
 template <>
-inline double InterfaceDielectricCoefficient<InterfaceDielectricType::DEFAULT>::Eval(
+inline double InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution. Don't use lightspeed detection for differentiating side.
@@ -371,7 +371,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::DEFAULT>::
 }
 
 template <>
-inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MA>::Eval(
+inline double InterfaceDielectricCoefficient<InterfaceDielectric::MA>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution on air (vacuum) side and neighboring element attribute.
@@ -397,7 +397,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MA>::Eval(
 }
 
 template <>
-inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MS>::Eval(
+inline double InterfaceDielectricCoefficient<InterfaceDielectric::MS>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution on substrate side and neighboring element attribute.
@@ -426,7 +426,7 @@ inline double InterfaceDielectricCoefficient<InterfaceDielectricType::MS>::Eval(
 }
 
 template <>
-inline double InterfaceDielectricCoefficient<InterfaceDielectricType::SA>::Eval(
+inline double InterfaceDielectricCoefficient<InterfaceDielectric::SA>::Eval(
     mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip)
 {
   // Get single-sided solution on air side and neighboring element attribute.

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -12,6 +12,7 @@
 #include "fem/gridfunction.hpp"
 #include "models/materialoperator.hpp"
 #include "utils/geodata.hpp"
+#include "utils/labels.hpp"
 
 // XX TODO: Add bulk element Eval() overrides to speed up postprocessing (also needed in
 //          mfem::DataCollection classes.
@@ -145,14 +146,6 @@ public:
   }
 };
 
-// Helper for BdrSurfaceFluxCoefficient.
-enum class SurfaceFluxType
-{
-  ELECTRIC,
-  MAGNETIC,
-  POWER
-};
-
 // Computes the flux Φₛ = F ⋅ n with F = B or ε D on interior boundary elements using B or
 // E given as a vector grid function. For a two-sided internal boundary, the contributions
 // from both sides can either add or be averaged.
@@ -269,15 +262,6 @@ inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::POWER>::GetLocalFlux(
   V.SetSize(W1.Size());
   Cross3(W1, W2, V);
 }
-
-// Helper for InterfaceDielectricCoefficient.
-enum class InterfaceDielectricType
-{
-  DEFAULT,
-  MA,
-  MS,
-  SA
-};
 
 // Computes a single-valued α Eᵀ E on boundaries from E given as a vector grid function.
 // Uses the neighbor element on a user specified side to compute a single-sided value for

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -149,7 +149,7 @@ public:
 // Computes the flux Φₛ = F ⋅ n with F = B or ε D on interior boundary elements using B or
 // E given as a vector grid function. For a two-sided internal boundary, the contributions
 // from both sides can either add or be averaged.
-template <SurfaceFluxType Type>
+template <SurfaceFlux Type>
 class BdrSurfaceFluxCoefficient : public mfem::Coefficient,
                                   public BdrGridFunctionCoefficient
 {
@@ -170,8 +170,8 @@ public:
       E(E), B(B), mat_op(mat_op), two_sided(two_sided), x0(x0)
   {
     MFEM_VERIFY(
-        (E || (Type != SurfaceFluxType::ELECTRIC && Type != SurfaceFluxType::POWER)) &&
-            (B || (Type != SurfaceFluxType::MAGNETIC && Type != SurfaceFluxType::POWER)),
+        (E || (Type != SurfaceFlux::ELECTRIC && Type != SurfaceFlux::POWER)) &&
+            (B || (Type != SurfaceFlux::MAGNETIC && Type != SurfaceFlux::POWER)),
         "Missing E or B field grid function for surface flux coefficient!");
   }
 
@@ -231,7 +231,7 @@ public:
 };
 
 template <>
-inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>::GetLocalFlux(
+inline void BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>::GetLocalFlux(
     mfem::ElementTransformation &T, mfem::Vector &V) const
 {
   // Flux D.
@@ -242,7 +242,7 @@ inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>::GetLocalFlux(
 }
 
 template <>
-inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::MAGNETIC>::GetLocalFlux(
+inline void BdrSurfaceFluxCoefficient<SurfaceFlux::MAGNETIC>::GetLocalFlux(
     mfem::ElementTransformation &T, mfem::Vector &V) const
 {
   // Flux B.
@@ -250,7 +250,7 @@ inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::MAGNETIC>::GetLocalFlux(
 }
 
 template <>
-inline void BdrSurfaceFluxCoefficient<SurfaceFluxType::POWER>::GetLocalFlux(
+inline void BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>::GetLocalFlux(
     mfem::ElementTransformation &T, mfem::Vector &V) const
 {
   // Flux E x H = E x μ⁻¹ B.

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -169,10 +169,9 @@ public:
                                                         : *B->ParFESpace()->GetParMesh()),
       E(E), B(B), mat_op(mat_op), two_sided(two_sided), x0(x0)
   {
-    MFEM_VERIFY(
-        (E || (Type != SurfaceFlux::ELECTRIC && Type != SurfaceFlux::POWER)) &&
-            (B || (Type != SurfaceFlux::MAGNETIC && Type != SurfaceFlux::POWER)),
-        "Missing E or B field grid function for surface flux coefficient!");
+    MFEM_VERIFY((E || (Type != SurfaceFlux::ELECTRIC && Type != SurfaceFlux::POWER)) &&
+                    (B || (Type != SurfaceFlux::MAGNETIC && Type != SurfaceFlux::POWER)),
+                "Missing E or B field grid function for surface flux coefficient!");
   }
 
   double Eval(mfem::ElementTransformation &T, const mfem::IntegrationPoint &ip) override
@@ -250,8 +249,9 @@ inline void BdrSurfaceFluxCoefficient<SurfaceFlux::MAGNETIC>::GetLocalFlux(
 }
 
 template <>
-inline void BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>::GetLocalFlux(
-    mfem::ElementTransformation &T, mfem::Vector &V) const
+inline void
+BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>::GetLocalFlux(mfem::ElementTransformation &T,
+                                                            mfem::Vector &V) const
 {
   // Flux E x H = E x μ⁻¹ B.
   double W1_data[3], W2_data[3];

--- a/palace/fem/multigrid.hpp
+++ b/palace/fem/multigrid.hpp
@@ -23,8 +23,7 @@ namespace palace::fem
 template <typename FECollection>
 inline std::vector<std::unique_ptr<FECollection>>
 ConstructFECollections(int p, int dim, int mg_max_levels,
-                       config::LinearSolverData::MultigridCoarsenType mg_coarsen_type,
-                       bool mat_lor)
+                       MultigridCoarsening mg_coarsen_type, bool mat_lor)
 {
   // If the solver will use a LOR preconditioner, we need to construct with a specific basis
   // type.
@@ -60,10 +59,10 @@ ConstructFECollections(int p, int dim, int mg_max_levels,
     }
     switch (mg_coarsen_type)
     {
-      case config::LinearSolverData::MultigridCoarsenType::LINEAR:
+      case MultigridCoarsening::LINEAR:
         p--;
         break;
-      case config::LinearSolverData::MultigridCoarsenType::LOGARITHMIC:
+      case MultigridCoarsening::LOGARITHMIC:
         p = (p + pmin) / 2;
         break;
     }

--- a/palace/fem/multigrid.hpp
+++ b/palace/fem/multigrid.hpp
@@ -22,8 +22,8 @@ namespace palace::fem
 // Construct sequence of FECollection objects.
 template <typename FECollection>
 inline std::vector<std::unique_ptr<FECollection>>
-ConstructFECollections(int p, int dim, int mg_max_levels,
-                       MultigridCoarsening mg_coarsen_type, bool mat_lor)
+ConstructFECollections(int p, int dim, int mg_max_levels, MultigridCoarsening mg_coarsening,
+                       bool mat_lor)
 {
   // If the solver will use a LOR preconditioner, we need to construct with a specific basis
   // type.
@@ -57,7 +57,7 @@ ConstructFECollections(int p, int dim, int mg_max_levels,
     {
       break;
     }
-    switch (mg_coarsen_type)
+    switch (mg_coarsening)
     {
       case MultigridCoarsening::LINEAR:
         p--;

--- a/palace/linalg/ksp.cpp
+++ b/palace/linalg/ksp.cpp
@@ -123,7 +123,7 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
   const int print = iodata.problem.verbose - 1;
   switch (type)
   {
-    case LinearSolverType::AMS:
+    case LinearSolver::AMS:
       // Can either be the coarse solve for geometric multigrid or the solver at the finest
       // space (in which case fespaces.GetNumLevels() == 1).
       MFEM_VERIFY(aux_fespaces, "AMS solver relies on both primary space "
@@ -132,11 +132,11 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
           iodata, fespaces.GetNumLevels() > 1, fespaces.GetFESpaceAtLevel(0),
           aux_fespaces->GetFESpaceAtLevel(0), print);
       break;
-    case LinearSolverType::BOOMER_AMG:
+    case LinearSolver::BOOMER_AMG:
       pc = MakeWrapperSolver<OperType, BoomerAmgSolver>(iodata, fespaces.GetNumLevels() > 1,
                                                         print);
       break;
-    case LinearSolverType::SUPERLU:
+    case LinearSolver::SUPERLU:
 #if defined(MFEM_USE_SUPERLU)
       pc = MakeWrapperSolver<OperType, SuperLUSolver>(iodata, comm, print);
 #else
@@ -144,7 +144,7 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
                  "different solver!");
 #endif
       break;
-    case LinearSolverType::STRUMPACK:
+    case LinearSolver::STRUMPACK:
 #if defined(MFEM_USE_STRUMPACK)
       pc = MakeWrapperSolver<OperType, StrumpackSolver>(iodata, comm, print);
 #else
@@ -152,7 +152,7 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
                  "different solver!");
 #endif
       break;
-    case LinearSolverType::STRUMPACK_MP:
+    case LinearSolver::STRUMPACK_MP:
 #if defined(MFEM_USE_STRUMPACK)
       pc = MakeWrapperSolver<OperType, StrumpackMixedPrecisionSolver>(iodata, comm, print);
 #else
@@ -160,7 +160,7 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
                  "different solver!");
 #endif
       break;
-    case LinearSolverType::MUMPS:
+    case LinearSolver::MUMPS:
 #if defined(MFEM_USE_MUMPS)
       pc = MakeWrapperSolver<OperType, MumpsSolver>(iodata, comm, print);
 #else
@@ -168,10 +168,10 @@ ConfigurePreconditionerSolver(const IoData &iodata, MPI_Comm comm,
           "Solver was not built with MUMPS support, please choose a different solver!");
 #endif
       break;
-    case LinearSolverType::JACOBI:
+    case LinearSolver::JACOBI:
       pc = std::make_unique<JacobiSmoother<OperType>>(comm);
       break;
-    case LinearSolverType::DEFAULT:
+    case LinearSolver::DEFAULT:
       MFEM_ABORT("Unexpected solver type for preconditioner configuration!");
       break;
   }

--- a/palace/linalg/mumps.cpp
+++ b/palace/linalg/mumps.cpp
@@ -9,8 +9,7 @@ namespace palace
 {
 
 MumpsSolver::MumpsSolver(MPI_Comm comm, mfem::MUMPSSolver::MatType sym,
-                         config::LinearSolverData::SymFactType reorder, double blr_tol,
-                         int print)
+                         SymbolicFactorization reorder, double blr_tol, int print)
   : mfem::MUMPSSolver(comm)
 {
   // Configure the solver (must be called before SetOperator).
@@ -18,26 +17,26 @@ MumpsSolver::MumpsSolver(MPI_Comm comm, mfem::MUMPSSolver::MatType sym,
   SetMatrixSymType(sym);
   switch (reorder)
   {
-    case config::LinearSolverData::SymFactType::METIS:
+    case SymbolicFactorization::METIS:
       SetReorderingStrategy(mfem::MUMPSSolver::METIS);
       break;
-    case config::LinearSolverData::SymFactType::PARMETIS:
+    case SymbolicFactorization::PARMETIS:
       SetReorderingStrategy(mfem::MUMPSSolver::PARMETIS);
       break;
-    case config::LinearSolverData::SymFactType::SCOTCH:
+    case SymbolicFactorization::SCOTCH:
       SetReorderingStrategy(mfem::MUMPSSolver::SCOTCH);
       break;
-    case config::LinearSolverData::SymFactType::PTSCOTCH:
+    case SymbolicFactorization::PTSCOTCH:
       SetReorderingStrategy(mfem::MUMPSSolver::PTSCOTCH);
       break;
-    case config::LinearSolverData::SymFactType::PORD:
+    case SymbolicFactorization::PORD:
       SetReorderingStrategy(mfem::MUMPSSolver::PORD);
       break;
-    case config::LinearSolverData::SymFactType::AMD:
-    case config::LinearSolverData::SymFactType::RCM:
+    case SymbolicFactorization::AMD:
+    case SymbolicFactorization::RCM:
       SetReorderingStrategy(mfem::MUMPSSolver::AMD);
       break;
-    case config::LinearSolverData::SymFactType::DEFAULT:
+    case SymbolicFactorization::DEFAULT:
       SetReorderingStrategy(mfem::MUMPSSolver::AUTOMATIC);  // Should have good default
       break;
   }

--- a/palace/linalg/mumps.hpp
+++ b/palace/linalg/mumps.hpp
@@ -32,7 +32,7 @@ public:
           : iodata.solver.linear.complex_coarse_solve
               ? mfem::MUMPSSolver::UNSYMMETRIC
               : mfem::MUMPSSolver::SYMMETRIC_INDEFINITE,
-          iodata.solver.linear.sym_fact_type,
+          iodata.solver.linear.sym_factorization,
           (iodata.solver.linear.strumpack_compression_type == SparseCompression::BLR)
               ? iodata.solver.linear.strumpack_lr_tol
               : 0.0,

--- a/palace/linalg/mumps.hpp
+++ b/palace/linalg/mumps.hpp
@@ -19,24 +19,24 @@ namespace palace
 class MumpsSolver : public mfem::MUMPSSolver
 {
 public:
-  MumpsSolver(MPI_Comm comm, mfem::MUMPSSolver::MatType sym,
-              config::LinearSolverData::SymFactType reorder, double blr_tol, int print);
+  MumpsSolver(MPI_Comm comm, mfem::MUMPSSolver::MatType sym, SymbolicFactorization reorder,
+              double blr_tol, int print);
   MumpsSolver(const IoData &iodata, MPI_Comm comm, int print)
-    : MumpsSolver(comm,
-                  (iodata.solver.linear.pc_mat_shifted ||
-                   iodata.problem.type == config::ProblemData::Type::TRANSIENT ||
-                   iodata.problem.type == config::ProblemData::Type::ELECTROSTATIC ||
-                   iodata.problem.type == config::ProblemData::Type::MAGNETOSTATIC)
-                      ? mfem::MUMPSSolver::SYMMETRIC_POSITIVE_DEFINITE
-                  : iodata.solver.linear.complex_coarse_solve
-                      ? mfem::MUMPSSolver::UNSYMMETRIC
-                      : mfem::MUMPSSolver::SYMMETRIC_INDEFINITE,
-                  iodata.solver.linear.sym_fact_type,
-                  (iodata.solver.linear.strumpack_compression_type ==
-                   config::LinearSolverData::CompressionType::BLR)
-                      ? iodata.solver.linear.strumpack_lr_tol
-                      : 0.0,
-                  print)
+    : MumpsSolver(
+          comm,
+          (iodata.solver.linear.pc_mat_shifted ||
+           iodata.problem.type == ProblemType::TRANSIENT ||
+           iodata.problem.type == ProblemType::ELECTROSTATIC ||
+           iodata.problem.type == ProblemType::MAGNETOSTATIC)
+              ? mfem::MUMPSSolver::SYMMETRIC_POSITIVE_DEFINITE
+          : iodata.solver.linear.complex_coarse_solve
+              ? mfem::MUMPSSolver::UNSYMMETRIC
+              : mfem::MUMPSSolver::SYMMETRIC_INDEFINITE,
+          iodata.solver.linear.sym_fact_type,
+          (iodata.solver.linear.strumpack_compression_type == SparseCompression::BLR)
+              ? iodata.solver.linear.strumpack_lr_tol
+              : 0.0,
+          print)
   {
   }
 };

--- a/palace/linalg/strumpack.cpp
+++ b/palace/linalg/strumpack.cpp
@@ -11,26 +11,25 @@ namespace palace
 namespace
 {
 
-strumpack::CompressionType
-GetCompressionType(config::LinearSolverData::CompressionType type)
+strumpack::CompressionType GetCompressionType(SparseCompression type)
 {
   switch (type)
   {
-    case config::LinearSolverData::CompressionType::HSS:
+    case SparseCompression::HSS:
       return strumpack::CompressionType::HSS;
-    case config::LinearSolverData::CompressionType::BLR:
+    case SparseCompression::BLR:
       return strumpack::CompressionType::BLR;
-    case config::LinearSolverData::CompressionType::HODLR:
+    case SparseCompression::HODLR:
       return strumpack::CompressionType::HODLR;
-    case config::LinearSolverData::CompressionType::ZFP:
+    case SparseCompression::ZFP:
       return strumpack::CompressionType::LOSSY;
-    case config::LinearSolverData::CompressionType::BLR_HODLR:
+    case SparseCompression::BLR_HODLR:
       return strumpack::CompressionType::BLR_HODLR;
       break;
-    case config::LinearSolverData::CompressionType::ZFP_BLR_HODLR:
+    case SparseCompression::ZFP_BLR_HODLR:
       return strumpack::CompressionType::ZFP_BLR_HODLR;
       break;
-    case config::LinearSolverData::CompressionType::NONE:
+    case SparseCompression::NONE:
       return strumpack::CompressionType::NONE;
   }
   return strumpack::CompressionType::NONE;  // For compiler warning
@@ -40,9 +39,8 @@ GetCompressionType(config::LinearSolverData::CompressionType type)
 
 template <typename StrumpackSolverType>
 StrumpackSolverBase<StrumpackSolverType>::StrumpackSolverBase(
-    MPI_Comm comm, config::LinearSolverData::SymFactType reorder,
-    config::LinearSolverData::CompressionType compression, double lr_tol, int butterfly_l,
-    int lossy_prec, int print)
+    MPI_Comm comm, SymbolicFactorization reorder, SparseCompression compression,
+    double lr_tol, int butterfly_l, int lossy_prec, int print)
   : StrumpackSolverType(comm), comm(comm)
 {
   // Configure the solver.
@@ -53,27 +51,27 @@ StrumpackSolverBase<StrumpackSolverType>::StrumpackSolverBase(
   this->SetMatching(strumpack::MatchingJob::NONE);
   switch (reorder)
   {
-    case config::LinearSolverData::SymFactType::METIS:
+    case SymbolicFactorization::METIS:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::METIS);
       // this->SetReorderingStrategy(strumpack::ReorderingStrategy::AND);
       break;
-    case config::LinearSolverData::SymFactType::PARMETIS:
+    case SymbolicFactorization::PARMETIS:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::PARMETIS);
       break;
-    case config::LinearSolverData::SymFactType::SCOTCH:
+    case SymbolicFactorization::SCOTCH:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::SCOTCH);
       break;
-    case config::LinearSolverData::SymFactType::PTSCOTCH:
+    case SymbolicFactorization::PTSCOTCH:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::PTSCOTCH);
       break;
-    case config::LinearSolverData::SymFactType::AMD:
+    case SymbolicFactorization::AMD:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::AMD);
       // this->SetReorderingStrategy(strumpack::ReorderingStrategy::MMD);
       break;
-    case config::LinearSolverData::SymFactType::RCM:
+    case SymbolicFactorization::RCM:
       this->SetReorderingStrategy(strumpack::ReorderingStrategy::RCM);
-    case config::LinearSolverData::SymFactType::PORD:
-    case config::LinearSolverData::SymFactType::DEFAULT:
+    case SymbolicFactorization::PORD:
+    case SymbolicFactorization::DEFAULT:
       // Should have good default.
       break;
   }
@@ -83,7 +81,7 @@ StrumpackSolverBase<StrumpackSolverType>::StrumpackSolverBase(
   this->SetCompression(GetCompressionType(compression));
   switch (compression)
   {
-    case config::LinearSolverData::CompressionType::ZFP:
+    case SparseCompression::ZFP:
       if (lossy_prec <= 0)
       {
         this->SetCompression(strumpack::CompressionType::LOSSLESS);
@@ -93,16 +91,16 @@ StrumpackSolverBase<StrumpackSolverType>::StrumpackSolverBase(
         this->SetCompressionLossyPrecision(lossy_prec);
       }
       break;
-    case config::LinearSolverData::CompressionType::ZFP_BLR_HODLR:
+    case SparseCompression::ZFP_BLR_HODLR:
       this->SetCompressionLossyPrecision(lossy_prec);
-    case config::LinearSolverData::CompressionType::HODLR:
-    case config::LinearSolverData::CompressionType::BLR_HODLR:
+    case SparseCompression::HODLR:
+    case SparseCompression::BLR_HODLR:
       this->SetCompressionButterflyLevels(butterfly_l);
-    case config::LinearSolverData::CompressionType::HSS:
-    case config::LinearSolverData::CompressionType::BLR:
+    case SparseCompression::HSS:
+    case SparseCompression::BLR:
       this->SetCompressionRelTol(lr_tol);
       break;
-    case config::LinearSolverData::CompressionType::NONE:
+    case SparseCompression::NONE:
       break;
   }
   // if (mfem::Device::Allows(mfem::Backend::DEVICE_MASK))

--- a/palace/linalg/strumpack.hpp
+++ b/palace/linalg/strumpack.hpp
@@ -29,7 +29,7 @@ public:
                       int lossy_prec, int print);
 
   StrumpackSolverBase(const IoData &iodata, MPI_Comm comm, int print)
-    : StrumpackSolverBase(comm, iodata.solver.linear.sym_fact_type,
+    : StrumpackSolverBase(comm, iodata.solver.linear.sym_factorization,
                           iodata.solver.linear.strumpack_compression_type,
                           iodata.solver.linear.strumpack_lr_tol,
                           iodata.solver.linear.strumpack_butterfly_l,

--- a/palace/linalg/strumpack.hpp
+++ b/palace/linalg/strumpack.hpp
@@ -24,9 +24,9 @@ private:
   MPI_Comm comm;
 
 public:
-  StrumpackSolverBase(MPI_Comm comm, config::LinearSolverData::SymFactType reorder,
-                      config::LinearSolverData::CompressionType compression, double lr_tol,
-                      int butterfly_l, int lossy_prec, int print);
+  StrumpackSolverBase(MPI_Comm comm, SymbolicFactorization reorder,
+                      SparseCompression compression, double lr_tol, int butterfly_l,
+                      int lossy_prec, int print);
 
   StrumpackSolverBase(const IoData &iodata, MPI_Comm comm, int print)
     : StrumpackSolverBase(comm, iodata.solver.linear.sym_fact_type,

--- a/palace/linalg/superlu.cpp
+++ b/palace/linalg/superlu.cpp
@@ -34,8 +34,8 @@ int GetNpDep(int np, bool use_3d)
 
 }  // namespace
 
-SuperLUSolver::SuperLUSolver(MPI_Comm comm, config::LinearSolverData::SymFactType reorder,
-                             bool use_3d, int print)
+SuperLUSolver::SuperLUSolver(MPI_Comm comm, SymbolicFactorization reorder, bool use_3d,
+                             int print)
   : mfem::Solver(), comm(comm), A(nullptr), solver(comm, GetNpDep(Mpi::Size(comm), use_3d))
 {
   // Configure the solver.
@@ -57,20 +57,20 @@ SuperLUSolver::SuperLUSolver(MPI_Comm comm, config::LinearSolverData::SymFactTyp
   solver.SetReplaceTinyPivot(false);
   switch (reorder)
   {
-    case config::LinearSolverData::SymFactType::METIS:
+    case SymbolicFactorization::METIS:
       solver.SetColumnPermutation(mfem::superlu::METIS_AT_PLUS_A);
       break;
-    case config::LinearSolverData::SymFactType::PARMETIS:
+    case SymbolicFactorization::PARMETIS:
       solver.SetColumnPermutation(mfem::superlu::PARMETIS);
       break;
-    case config::LinearSolverData::SymFactType::AMD:
-    case config::LinearSolverData::SymFactType::RCM:
+    case SymbolicFactorization::AMD:
+    case SymbolicFactorization::RCM:
       solver.SetColumnPermutation(mfem::superlu::MMD_AT_PLUS_A);
       break;
-    case config::LinearSolverData::SymFactType::SCOTCH:
-    case config::LinearSolverData::SymFactType::PTSCOTCH:
-    case config::LinearSolverData::SymFactType::PORD:
-    case config::LinearSolverData::SymFactType::DEFAULT:
+    case SymbolicFactorization::SCOTCH:
+    case SymbolicFactorization::PTSCOTCH:
+    case SymbolicFactorization::PORD:
+    case SymbolicFactorization::DEFAULT:
       // Should have good default.
       break;
   }

--- a/palace/linalg/superlu.hpp
+++ b/palace/linalg/superlu.hpp
@@ -27,8 +27,7 @@ private:
   mfem::SuperLUSolver solver;
 
 public:
-  SuperLUSolver(MPI_Comm comm, config::LinearSolverData::SymFactType reorder, bool use_3d,
-                int print);
+  SuperLUSolver(MPI_Comm comm, SymbolicFactorization reorder, bool use_3d, int print);
   SuperLUSolver(const IoData &iodata, MPI_Comm comm, int print)
     : SuperLUSolver(comm, iodata.solver.linear.sym_fact_type,
                     iodata.solver.linear.superlu_3d, print)

--- a/palace/linalg/superlu.hpp
+++ b/palace/linalg/superlu.hpp
@@ -29,7 +29,7 @@ private:
 public:
   SuperLUSolver(MPI_Comm comm, SymbolicFactorization reorder, bool use_3d, int print);
   SuperLUSolver(const IoData &iodata, MPI_Comm comm, int print)
-    : SuperLUSolver(comm, iodata.solver.linear.sym_fact_type,
+    : SuperLUSolver(comm, iodata.solver.linear.sym_factorization,
                     iodata.solver.linear.superlu_3d, print)
   {
   }

--- a/palace/main.cpp
+++ b/palace/main.cpp
@@ -94,15 +94,15 @@ static int GetDeviceId(MPI_Comm comm, int ngpu)
 #endif
 }
 
-static std::string ConfigureDevice(config::SolverData::Device device)
+static std::string ConfigureDevice(Device device)
 {
   std::string device_str;
   switch (device)
   {
-    case config::SolverData::Device::CPU:
+    case Device::CPU:
       device_str = "cpu";
       break;
-    case config::SolverData::Device::GPU:
+    case Device::GPU:
 #if defined(MFEM_USE_CUDA)
       device_str = "cuda";
 #elif defined(MFEM_USE_HIP)
@@ -113,7 +113,7 @@ static std::string ConfigureDevice(config::SolverData::Device device)
       device_str = "cpu";
 #endif
       break;
-    case config::SolverData::Device::DEBUG:
+    case Device::DEBUG:
       device_str = "cpu,debug";
       break;
   }
@@ -287,19 +287,19 @@ int main(int argc, char *argv[])
   {
     switch (iodata.problem.type)
     {
-      case config::ProblemData::Type::DRIVEN:
+      case ProblemType::DRIVEN:
         return std::make_unique<DrivenSolver>(iodata, world_root, world_size, omp_threads,
                                               GetPalaceGitTag());
-      case config::ProblemData::Type::EIGENMODE:
+      case ProblemType::EIGENMODE:
         return std::make_unique<EigenSolver>(iodata, world_root, world_size, omp_threads,
                                              GetPalaceGitTag());
-      case config::ProblemData::Type::ELECTROSTATIC:
+      case ProblemType::ELECTROSTATIC:
         return std::make_unique<ElectrostaticSolver>(iodata, world_root, world_size,
                                                      omp_threads, GetPalaceGitTag());
-      case config::ProblemData::Type::MAGNETOSTATIC:
+      case ProblemType::MAGNETOSTATIC:
         return std::make_unique<MagnetostaticSolver>(iodata, world_root, world_size,
                                                      omp_threads, GetPalaceGitTag());
-      case config::ProblemData::Type::TRANSIENT:
+      case ProblemType::TRANSIENT:
         return std::make_unique<TransientSolver>(iodata, world_root, world_size,
                                                  omp_threads, GetPalaceGitTag());
     }

--- a/palace/models/curlcurloperator.cpp
+++ b/palace/models/curlcurloperator.cpp
@@ -24,10 +24,10 @@ CurlCurlOperator::CurlCurlOperator(const IoData &iodata,
   : print_hdr(true), dbc_attr(SetUpBoundaryProperties(iodata, *mesh.back())),
     nd_fecs(fem::ConstructFECollections<mfem::ND_FECollection>(
         iodata.solver.order, mesh.back()->Dimension(), iodata.solver.linear.mg_max_levels,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     h1_fecs(fem::ConstructFECollections<mfem::H1_FECollection>(
         iodata.solver.order, mesh.back()->Dimension(), iodata.solver.linear.mg_max_levels,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     rt_fec(std::make_unique<mfem::RT_FECollection>(iodata.solver.order - 1,
                                                    mesh.back()->Dimension())),
     nd_fespaces(fem::ConstructFiniteElementSpaceHierarchy<mfem::ND_FECollection>(

--- a/palace/models/farfieldboundaryoperator.cpp
+++ b/palace/models/farfieldboundaryoperator.cpp
@@ -81,7 +81,7 @@ FarfieldBoundaryOperator::SetUpBoundaryProperties(const IoData &iodata,
     farfield_bcs.Append(attr);
   }
   MFEM_VERIFY(farfield_bcs.Size() == 0 || order < 2 ||
-                  iodata.problem.type == config::ProblemData::Type::DRIVEN,
+                  iodata.problem.type == ProblemType::DRIVEN,
               "Second-order farfield boundaries are only available for frequency "
               "domain driven simulations!");
   return farfield_bcs;

--- a/palace/models/laplaceoperator.cpp
+++ b/palace/models/laplaceoperator.cpp
@@ -23,13 +23,13 @@ LaplaceOperator::LaplaceOperator(const IoData &iodata,
   : print_hdr(true), dbc_attr(SetUpBoundaryProperties(iodata, *mesh.back())),
     h1_fecs(fem::ConstructFECollections<mfem::H1_FECollection>(
         iodata.solver.order, mesh.back()->Dimension(), iodata.solver.linear.mg_max_levels,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     nd_fec(std::make_unique<mfem::ND_FECollection>(iodata.solver.order,
                                                    mesh.back()->Dimension())),
     rt_fecs(fem::ConstructFECollections<mfem::RT_FECollection>(
         iodata.solver.order - 1, mesh.back()->Dimension(),
         iodata.solver.linear.estimator_mg ? iodata.solver.linear.mg_max_levels : 1,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     h1_fespaces(fem::ConstructFiniteElementSpaceHierarchy<mfem::H1_FECollection>(
         iodata.solver.linear.mg_max_levels, mesh, h1_fecs, &dbc_attr, &dbc_tdof_lists)),
     nd_fespace(*mesh.back(), nd_fec.get()),

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -55,11 +55,11 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
     attr_list.Append(elem.attributes.data(), elem.attributes.size());
     switch (elem.coordinate_system)
     {
-      case config::internal::ElementData::CoordinateSystem::CYLINDRICAL:
+      case CoordinateSystem::CYLINDRICAL:
         elems.push_back(
             std::make_unique<CoaxialElementData>(elem.direction, attr_list, mesh));
         break;
-      case config::internal::ElementData::CoordinateSystem::CARTESIAN:
+      case CoordinateSystem::CARTESIAN:
         elems.push_back(
             std::make_unique<UniformElementData>(elem.direction, attr_list, mesh));
         break;

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -185,7 +185,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
       continue;
     }
     const auto &data = iodata.domains.materials[i];
-    if (iodata.problem.type == config::ProblemData::Type::ELECTROSTATIC)
+    if (iodata.problem.type == ProblemType::ELECTROSTATIC)
     {
       MFEM_VERIFY(IsValid(data.epsilon_r), "Material has no valid permittivity defined!");
       if (!IsIdentity(data.mu_r) || IsValid(data.sigma) || std::abs(data.lambda_L) > 0.0)
@@ -195,7 +195,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
             "electrical conductivity, or London depth!\n");
       }
     }
-    else if (iodata.problem.type == config::ProblemData::Type::MAGNETOSTATIC)
+    else if (iodata.problem.type == ProblemType::MAGNETOSTATIC)
     {
       MFEM_VERIFY(IsValid(data.mu_r), "Material has no valid permeability defined!");
       if (!IsIdentity(data.epsilon_r) || IsValid(data.tandelta) || IsValid(data.sigma) ||
@@ -210,7 +210,7 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
     {
       MFEM_VERIFY(IsValid(data.mu_r) && IsValid(data.epsilon_r),
                   "Material has no valid permeability or no valid permittivity defined!");
-      if (iodata.problem.type == config::ProblemData::Type::TRANSIENT)
+      if (iodata.problem.type == ProblemType::TRANSIENT)
       {
         MFEM_VERIFY(!IsValid(data.tandelta),
                     "Transient problem type does not support material loss tangent, use "
@@ -334,8 +334,8 @@ void MaterialOperator::SetUpFloquetWaveVector(const IoData &iodata,
   wave_vector += local_wave_vector;
   has_wave_attr = (wave_vector.Norml2() > tol);
 
-  MFEM_VERIFY(!has_wave_attr || iodata.problem.type == config::ProblemData::Type::DRIVEN ||
-                  iodata.problem.type == config::ProblemData::Type::EIGENMODE,
+  MFEM_VERIFY(!has_wave_attr || iodata.problem.type == ProblemType::DRIVEN ||
+                  iodata.problem.type == ProblemType::EIGENMODE,
               "Quasi-periodic Floquet boundary conditions are only available for "
               " frequency domain driven or eigenmode simulations!");
   MFEM_VERIFY(!has_wave_attr || sdim == 3,

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -195,13 +195,13 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
 
     // Electric Boundary Field & Surface Charge.
     E_sr = std::make_unique<BdrFieldVectorCoefficient>(E->Real());
-    Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
+    Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
         &E->Real(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector());
 
     if constexpr (HasComplexGridFunction<solver_t>())
     {
       E_si = std::make_unique<BdrFieldVectorCoefficient>(E->Imag());
-      Q_si = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>(
+      Q_si = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
           &E->Imag(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector());
     }
   }
@@ -835,17 +835,17 @@ void PostOperator<solver_t>::MeasureSurfaceFlux() const
   for (const auto &[idx, data] : surf_post_op.flux_surfs)
   {
     auto flux = surf_post_op.GetSurfaceFlux(idx, E.get(), B.get());
-    if (data.type == SurfaceFluxType::ELECTRIC)
+    if (data.type == SurfaceFlux::ELECTRIC)
     {
       flux *= units.GetScaleFactor<Units::ValueType::CAPACITANCE>();
       flux *= units.GetScaleFactor<Units::ValueType::VOLTAGE>();
     }
-    else if (data.type == SurfaceFluxType::MAGNETIC)
+    else if (data.type == SurfaceFlux::MAGNETIC)
     {
       flux *= units.GetScaleFactor<Units::ValueType::INDUCTANCE>();
       flux *= units.GetScaleFactor<Units::ValueType::CURRENT>();
     }
-    else if (data.type == SurfaceFluxType::POWER)
+    else if (data.type == SurfaceFlux::POWER)
     {
       flux *= units.GetScaleFactor<Units::ValueType::POWER>();
     }

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -24,19 +24,19 @@ namespace palace
 namespace
 {
 
-std::string ParaviewFoldername(const config::ProblemData::Type solver_t)
+std::string ParaviewFoldername(const ProblemType solver_t)
 {
   switch (solver_t)
   {
-    case config::ProblemData::Type::DRIVEN:
+    case ProblemType::DRIVEN:
       return "driven";
-    case config::ProblemData::Type::EIGENMODE:
+    case ProblemType::EIGENMODE:
       return "eigenmode";
-    case config::ProblemData::Type::ELECTROSTATIC:
+    case ProblemType::ELECTROSTATIC:
       return "electrostatic";
-    case config::ProblemData::Type::MAGNETOSTATIC:
+    case ProblemType::MAGNETOSTATIC:
       return "magnetostatic";
-    case config::ProblemData::Type::TRANSIENT:
+    case ProblemType::TRANSIENT:
       return "transient";
     default:
       return "unkown";
@@ -45,7 +45,7 @@ std::string ParaviewFoldername(const config::ProblemData::Type solver_t)
 
 }  // namespace
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 PostOperator<solver_t>::PostOperator(const IoData &iodata, fem_op_t<solver_t> &fem_op_)
   : fem_op(&fem_op_), units(iodata.units), post_dir(iodata.problem.output),
     post_op_csv(this),
@@ -53,12 +53,12 @@ PostOperator<solver_t>::PostOperator(const IoData &iodata, fem_op_t<solver_t> &f
     dom_post_op(std::move(
         [&iodata, &fem_op_]()
         {
-          if constexpr (solver_t == config::ProblemData::Type::ELECTROSTATIC)
+          if constexpr (solver_t == ProblemType::ELECTROSTATIC)
           {
             return DomainPostOperator(iodata, fem_op_.GetMaterialOp(),
                                       fem_op_.GetH1Space());
           }
-          else if constexpr (solver_t == config::ProblemData::Type::MAGNETOSTATIC)
+          else if constexpr (solver_t == ProblemType::MAGNETOSTATIC)
           {
             return DomainPostOperator(iodata, fem_op_.GetMaterialOp(),
                                       fem_op_.GetNDSpace());
@@ -106,23 +106,23 @@ PostOperator<solver_t>::PostOperator(const IoData &iodata, fem_op_t<solver_t> &f
   // If we write paraview fields, initialize paraview files and dependant measurements. We
   // currently don't use the dependant grid functions for non-paraview measurements, so only
   // initialize if needed.
-  if (solver_t == config::ProblemData::Type::DRIVEN)
+  if (solver_t == ProblemType::DRIVEN)
   {
     paraview_save_indices = iodata.solver.driven.save_indices;
   }
-  else if (solver_t == config::ProblemData::Type::EIGENMODE)
+  else if (solver_t == ProblemType::EIGENMODE)
   {
     paraview_n_post = iodata.solver.eigenmode.n_post;
   }
-  else if (solver_t == config::ProblemData::Type::ELECTROSTATIC)
+  else if (solver_t == ProblemType::ELECTROSTATIC)
   {
     paraview_n_post = iodata.solver.electrostatic.n_post;
   }
-  else if (solver_t == config::ProblemData::Type::MAGNETOSTATIC)
+  else if (solver_t == ProblemType::MAGNETOSTATIC)
   {
     paraview_n_post = iodata.solver.magnetostatic.n_post;
   }
-  else if (solver_t == config::ProblemData::Type::TRANSIENT)
+  else if (solver_t == ProblemType::TRANSIENT)
   {
     paraview_delta_post = iodata.solver.transient.delta_post;
   }
@@ -132,10 +132,10 @@ PostOperator<solver_t>::PostOperator(const IoData &iodata, fem_op_t<solver_t> &f
   post_op_csv.InitializeCSVDataCollection();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::InitializeParaviewDataCollection(int ex_idx)
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>
+    -> std::enable_if_t<U == ProblemType::DRIVEN, void>
 {
   fs::path sub_folder_name = "";
   auto nr_excitations = fem_op->GetPortExcitations().Size();
@@ -147,7 +147,7 @@ auto PostOperator<solver_t>::InitializeParaviewDataCollection(int ex_idx)
   InitializeParaviewDataCollection(sub_folder_name);
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 bool PostOperator<solver_t>::write_paraview_fields(std::size_t step)
 {
   return (paraview_delta_post > 0 && step % paraview_delta_post == 0) ||
@@ -156,7 +156,7 @@ bool PostOperator<solver_t>::write_paraview_fields(std::size_t step)
                             step);
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::InitializeParaviewDataCollection(
     const fs::path &sub_folder_name)
 {
@@ -403,7 +403,7 @@ void ScaleGridFunctions(double L, int dim, bool imag, T &E, T &B, T &V, T &A)
 
 }  // namespace
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteFields(double time, int step)
 {
   if (!write_paraview_fields())
@@ -432,7 +432,7 @@ void PostOperator<solver_t>::WriteFields(double time, int step)
   Mpi::Barrier(fem_op->GetComm());
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteFieldsFinal(const ErrorIndicator *indicator)
 {
   if (!write_paraview_fields())
@@ -519,7 +519,7 @@ void PostOperator<solver_t>::WriteFieldsFinal(const ErrorIndicator *indicator)
 
 // Measurements.
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureDomainFieldEnergy() const
 {
   measurement_cache.domain_E_field_energy_i.clear();
@@ -592,7 +592,7 @@ void PostOperator<solver_t>::MeasureDomainFieldEnergy() const
   {
     Mpi::Print(" Field energy H = {:.3e} J\n", measurement_cache.domain_H_field_energy_all);
   }
-  else if constexpr (solver_t != config::ProblemData::Type::EIGENMODE)
+  else if constexpr (solver_t != ProblemType::EIGENMODE)
   {
     Mpi::Print(" Field energy E ({:.3e} J) + H ({:.3e} J) = {:.3e} J\n",
                measurement_cache.domain_E_field_energy_all,
@@ -602,24 +602,22 @@ void PostOperator<solver_t>::MeasureDomainFieldEnergy() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureLumpedPorts() const
 {
   measurement_cache.lumped_port_vi.clear();
   measurement_cache.lumped_port_inductor_energy = 0.0;
   measurement_cache.lumped_port_capacitor_energy = 0.0;
 
-  if constexpr (solver_t == config::ProblemData::Type::EIGENMODE ||
-                solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN ||
+                solver_t == ProblemType::TRANSIENT)
   {
     for (const auto &[idx, data] : fem_op->GetLumpedPortOp())
     {
       auto &vi = measurement_cache.lumped_port_vi[idx];
       vi.P = data.GetPower(*E, *B);
       vi.V = data.GetVoltage(*E);
-      if constexpr (solver_t == config::ProblemData::Type::EIGENMODE ||
-                    solver_t == config::ProblemData::Type::DRIVEN)
+      if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN)
       {
         // Compute current from the port impedance, separate contributions for R, L, C
         // branches.
@@ -674,11 +672,11 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureLumpedPortsEig() const
 {
   // Depends on MeasureLumpedPorts.
-  if constexpr (solver_t == config::ProblemData::Type::EIGENMODE)
+  if constexpr (solver_t == ProblemType::EIGENMODE)
   {
     auto freq_re = measurement_cache.freq.real();
     auto energy_electric_all = measurement_cache.domain_E_field_energy_all +
@@ -727,12 +725,12 @@ void PostOperator<solver_t>::MeasureLumpedPortsEig() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureWavePorts() const
 {
   measurement_cache.wave_port_vi.clear();
 
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN)
+  if constexpr (solver_t == ProblemType::DRIVEN)
   {
     for (const auto &[idx, data] : fem_op->GetWavePortOp())
     {
@@ -749,11 +747,11 @@ void PostOperator<solver_t>::MeasureWavePorts() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureSParameter() const
 {
   // Depends on LumpedPorts, WavePorts.
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN)
+  if constexpr (solver_t == ProblemType::DRIVEN)
   {
     using fmt::format;
     using std::complex_literals::operator""i;
@@ -826,7 +824,7 @@ void PostOperator<solver_t>::MeasureSParameter() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureSurfaceFlux() const
 {
   // Compute the flux through a surface as Φ_j = ∫ F ⋅ n_j dS, with F = B, F = ε D, or F =
@@ -855,7 +853,7 @@ void PostOperator<solver_t>::MeasureSurfaceFlux() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureInterfaceEFieldEnergy() const
 {
   // Depends on Lumped Port Energy since this is used in normalization of participation
@@ -894,7 +892,7 @@ void PostOperator<solver_t>::MeasureInterfaceEFieldEnergy() const
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureProbes() const
 {
   measurement_cache.probe_E_field.clear();
@@ -922,13 +920,13 @@ void PostOperator<solver_t>::MeasureProbes() const
 
 using fmt::format;
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureAndPrintAll(int ex_idx, int step,
                                                 const ComplexVector &e,
                                                 const ComplexVector &b,
                                                 std::complex<double> omega)
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, double>
+    -> std::enable_if_t<U == ProblemType::DRIVEN, double>
 {
   BlockTimer bt0(Timer::POSTPRO);
   auto freq = units.Dimensionalize<Units::ValueType::FREQUENCY>(omega);
@@ -957,14 +955,14 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int ex_idx, int step,
   return total_energy;
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e,
                                                 const ComplexVector &b,
                                                 std::complex<double> omega,
                                                 double error_abs, double error_bkwd,
                                                 int num_conv)
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, double>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, double>
 {
   BlockTimer bt0(Timer::POSTPRO);
   auto freq = units.Dimensionalize<Units::ValueType::FREQUENCY>(omega);
@@ -1010,11 +1008,11 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
   return total_energy;
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &v, const Vector &e,
                                                 int idx)
-    -> std::enable_if_t<U == config::ProblemData::Type::ELECTROSTATIC, double>
+    -> std::enable_if_t<U == ProblemType::ELECTROSTATIC, double>
 {
   BlockTimer bt0(Timer::POSTPRO);
   SetVGridFunction(v);
@@ -1036,11 +1034,11 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &v, const
       measurement_cache.domain_H_field_energy_all);
   return total_energy;
 }
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &a, const Vector &b,
                                                 int idx)
-    -> std::enable_if_t<U == config::ProblemData::Type::MAGNETOSTATIC, double>
+    -> std::enable_if_t<U == ProblemType::MAGNETOSTATIC, double>
 {
   BlockTimer bt0(Timer::POSTPRO);
   SetAGridFunction(a);
@@ -1063,11 +1061,11 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &a, const
   return total_energy;
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &e, const Vector &b,
                                                 double t, double J_coef)
-    -> std::enable_if_t<U == config::ProblemData::Type::TRANSIENT, double>
+    -> std::enable_if_t<U == ProblemType::TRANSIENT, double>
 {
   BlockTimer bt0(Timer::POSTPRO);
   auto time = units.Dimensionalize<Units::ValueType::TIME>(t);
@@ -1091,7 +1089,7 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &e, const
   return total_energy;
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperator<solver_t>::MeasureFinalize(const ErrorIndicator &indicator)
 {
   BlockTimer bt0(Timer::POSTPRO);
@@ -1103,11 +1101,11 @@ void PostOperator<solver_t>::MeasureFinalize(const ErrorIndicator &indicator)
   }
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperator<solver_t>::MeasureDomainFieldEnergyOnly(const ComplexVector &e,
                                                           const ComplexVector &b)
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, double>
+    -> std::enable_if_t<U == ProblemType::DRIVEN, double>
 {
   SetEGridFunction(e);
   SetBGridFunction(b);
@@ -1123,44 +1121,41 @@ auto PostOperator<solver_t>::MeasureDomainFieldEnergyOnly(const ComplexVector &e
 
 // Explict template instantiation.
 
-template class PostOperator<config::ProblemData::Type::DRIVEN>;
-template class PostOperator<config::ProblemData::Type::EIGENMODE>;
-template class PostOperator<config::ProblemData::Type::ELECTROSTATIC>;
-template class PostOperator<config::ProblemData::Type::MAGNETOSTATIC>;
-template class PostOperator<config::ProblemData::Type::TRANSIENT>;
+template class PostOperator<ProblemType::DRIVEN>;
+template class PostOperator<ProblemType::EIGENMODE>;
+template class PostOperator<ProblemType::ELECTROSTATIC>;
+template class PostOperator<ProblemType::MAGNETOSTATIC>;
+template class PostOperator<ProblemType::TRANSIENT>;
 
 // Function explict instantiation.
 // TODO(C++20): with requires, we won't need a second template.
 
-template auto PostOperator<config::ProblemData::Type::DRIVEN>::MeasureAndPrintAll<
-    config::ProblemData::Type::DRIVEN>(int ex_idx, int step, const ComplexVector &e,
-                                       const ComplexVector &b, std::complex<double> omega)
-    -> double;
-
-template auto PostOperator<config::ProblemData::Type::EIGENMODE>::MeasureAndPrintAll<
-    config::ProblemData::Type::EIGENMODE>(int step, const ComplexVector &e,
-                                          const ComplexVector &b,
-                                          std::complex<double> omega, double error_abs,
-                                          double error_bkwd, int num_conv) -> double;
-
-template auto PostOperator<config::ProblemData::Type::ELECTROSTATIC>::MeasureAndPrintAll<
-    config::ProblemData::Type::ELECTROSTATIC>(int step, const Vector &v, const Vector &e,
-                                              int idx) -> double;
-
-template auto PostOperator<config::ProblemData::Type::MAGNETOSTATIC>::MeasureAndPrintAll<
-    config::ProblemData::Type::MAGNETOSTATIC>(int step, const Vector &a, const Vector &b,
-                                              int idx) -> double;
-
-template auto PostOperator<config::ProblemData::Type::TRANSIENT>::MeasureAndPrintAll<
-    config::ProblemData::Type::TRANSIENT>(int step, const Vector &e, const Vector &b,
-                                          double t, double J_coef) -> double;
-
-template auto PostOperator<config::ProblemData::Type::DRIVEN>::MeasureDomainFieldEnergyOnly<
-    config::ProblemData::Type::DRIVEN>(const ComplexVector &e, const ComplexVector &b)
-    -> double;
+template auto PostOperator<ProblemType::DRIVEN>::MeasureAndPrintAll<ProblemType::DRIVEN>(
+    int ex_idx, int step, const ComplexVector &e, const ComplexVector &b,
+    std::complex<double> omega) -> double;
 
 template auto
-PostOperator<config::ProblemData::Type::DRIVEN>::InitializeParaviewDataCollection(
-    int ex_idx) -> void;
+PostOperator<ProblemType::EIGENMODE>::MeasureAndPrintAll<ProblemType::EIGENMODE>(
+    int step, const ComplexVector &e, const ComplexVector &b, std::complex<double> omega,
+    double error_abs, double error_bkwd, int num_conv) -> double;
+
+template auto
+PostOperator<ProblemType::ELECTROSTATIC>::MeasureAndPrintAll<ProblemType::ELECTROSTATIC>(
+    int step, const Vector &v, const Vector &e, int idx) -> double;
+
+template auto
+PostOperator<ProblemType::MAGNETOSTATIC>::MeasureAndPrintAll<ProblemType::MAGNETOSTATIC>(
+    int step, const Vector &a, const Vector &b, int idx) -> double;
+
+template auto
+PostOperator<ProblemType::TRANSIENT>::MeasureAndPrintAll<ProblemType::TRANSIENT>(
+    int step, const Vector &e, const Vector &b, double t, double J_coef) -> double;
+
+template auto
+PostOperator<ProblemType::DRIVEN>::MeasureDomainFieldEnergyOnly<ProblemType::DRIVEN>(
+    const ComplexVector &e, const ComplexVector &b) -> double;
+
+template auto
+PostOperator<ProblemType::DRIVEN>::InitializeParaviewDataCollection(int ex_idx) -> void;
 
 }  // namespace palace

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -198,7 +198,7 @@ private:
   {
     int idx;                   // Surface index
     std::complex<double> Phi;  // Integrated flux
-    SurfaceFluxType type;
+    SurfaceFlux type;
   };
 
   struct InterfaceData

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -35,67 +35,66 @@ class SpaceOperator;
 class SurfaceCurrentOperator;
 class WavePortOperator;
 
-// Statically map solver (config::ProblemData::Type) to finite element operator.
+// Statically map solver (ProblemType) to finite element operator.
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 struct fem_op_map_type
 {
   using type = SpaceOperator;
 };
 template <>
-struct fem_op_map_type<config::ProblemData::Type::ELECTROSTATIC>
+struct fem_op_map_type<ProblemType::ELECTROSTATIC>
 {
   using type = LaplaceOperator;
 };
 template <>
-struct fem_op_map_type<config::ProblemData::Type::MAGNETOSTATIC>
+struct fem_op_map_type<ProblemType::MAGNETOSTATIC>
 {
   using type = CurlCurlOperator;
 };
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 using fem_op_t = typename fem_op_map_type<solver_t>::type;
 
 // Statically specify if solver uses real or complex fields.
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 constexpr bool HasComplexGridFunction()
 {
-  return solver_t == config::ProblemData::Type::DRIVEN ||
-         solver_t == config::ProblemData::Type::EIGENMODE;
+  return solver_t == ProblemType::DRIVEN || solver_t == ProblemType::EIGENMODE;
 }
 
 // Statically specify what fields a solver uses
 // TODO(C++20): Change these to inline consteval and use with requires.
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 constexpr bool HasVGridFunction()
 {
-  return solver_t == config::ProblemData::Type::ELECTROSTATIC;
+  return solver_t == ProblemType::ELECTROSTATIC;
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 constexpr bool HasAGridFunction()
 {
-  return solver_t == config::ProblemData::Type::MAGNETOSTATIC;
+  return solver_t == ProblemType::MAGNETOSTATIC;
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 constexpr bool HasEGridFunction()
 {
-  return solver_t != config::ProblemData::Type::MAGNETOSTATIC;
+  return solver_t != ProblemType::MAGNETOSTATIC;
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 constexpr bool HasBGridFunction()
 {
-  return solver_t != config::ProblemData::Type::ELECTROSTATIC;
+  return solver_t != ProblemType::ELECTROSTATIC;
 }
 
 //
 // A class to handle solution postprocessing for all solvers.
 //
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 class PostOperator
 {
 private:
@@ -157,9 +156,9 @@ private:
 public:
   // Public overload for the driven solver only, that takes in an excitation index and
   // sets the correct sub_folder_name path for the primary function above.
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto InitializeParaviewDataCollection(int ex_idx)
-      -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>;
+      -> std::enable_if_t<U == ProblemType::DRIVEN, void>;
 
 private:
   // Write to disk the E- and B-fields extracted from the solution vectors. Note that
@@ -325,7 +324,7 @@ private:
   //
   // TODO(C++20): Switch SFINAE to requires.
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetEGridFunction(const ComplexVector &e, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasEGridFunction<U>() && HasComplexGridFunction<U>(), void>
   {
@@ -338,7 +337,7 @@ private:
     }
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetEGridFunction(const Vector &e, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasEGridFunction<U>() && !HasComplexGridFunction<U>(), void>
   {
@@ -349,7 +348,7 @@ private:
     }
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetBGridFunction(const ComplexVector &b, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasBGridFunction<U>() && HasComplexGridFunction<U>(), void>
   {
@@ -362,7 +361,7 @@ private:
     }
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetBGridFunction(const Vector &b, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasBGridFunction<U>() && !HasComplexGridFunction<U>(), void>
   {
@@ -373,7 +372,7 @@ private:
     }
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetVGridFunction(const Vector &v, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasVGridFunction<U>() && !HasComplexGridFunction<U>(), void>
   {
@@ -384,7 +383,7 @@ private:
     }
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto SetAGridFunction(const Vector &a, bool exchange_face_nbr_data = true)
       -> std::enable_if_t<HasAGridFunction<U>() && !HasComplexGridFunction<U>(), void>
   {
@@ -420,29 +419,29 @@ public:
   // just write `MeasureAndPrintAll(...) requires (solver_t == Type::A)` without extra
   // template.
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureAndPrintAll(int ex_idx, int step, const ComplexVector &e,
                           const ComplexVector &b, std::complex<double> omega)
-      -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, double>;
+      -> std::enable_if_t<U == ProblemType::DRIVEN, double>;
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureAndPrintAll(int step, const ComplexVector &e, const ComplexVector &b,
                           std::complex<double> omega, double error_abs, double error_bkwd,
                           int num_conv)
-      -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, double>;
+      -> std::enable_if_t<U == ProblemType::EIGENMODE, double>;
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureAndPrintAll(int step, const Vector &v, const Vector &e, int idx)
-      -> std::enable_if_t<U == config::ProblemData::Type::ELECTROSTATIC, double>;
+      -> std::enable_if_t<U == ProblemType::ELECTROSTATIC, double>;
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureAndPrintAll(int step, const Vector &a, const Vector &b, int idx)
-      -> std::enable_if_t<U == config::ProblemData::Type::MAGNETOSTATIC, double>;
+      -> std::enable_if_t<U == ProblemType::MAGNETOSTATIC, double>;
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureAndPrintAll(int step, const Vector &e, const Vector &b, double t,
                           double J_coef)
-      -> std::enable_if_t<U == config::ProblemData::Type::TRANSIENT, double>;
+      -> std::enable_if_t<U == ProblemType::TRANSIENT, double>;
 
   // Write error indicator into ParaView file and print summary statistics to csv. Should be
   // called once at the end of the solver loop.
@@ -453,9 +452,9 @@ public:
   // the error indicator, but no other measurement / printing should be done.
   //
   // TODO(C++20): SFINAE to requires.
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto MeasureDomainFieldEnergyOnly(const ComplexVector &e, const ComplexVector &b)
-      -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, double>;
+      -> std::enable_if_t<U == ProblemType::DRIVEN, double>;
 
   // Access grid functions for field solutions. Note that these are NOT const functions. The
   // electrostatics / magnetostatics solver do measurements of the capacitance/ inductance
@@ -466,25 +465,25 @@ public:
   // Would need to store vector of V,A.
   //
   // TODO(C++20): Switch SFINAE to requires.
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto GetEGridFunction() -> std::enable_if_t<HasEGridFunction<U>(), decltype(*E) &>
   {
     return *E;
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto GetBGridFunction() -> std::enable_if_t<HasBGridFunction<U>(), decltype(*B) &>
   {
     return *B;
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto GetVGridFunction() -> std::enable_if_t<HasVGridFunction<U>(), decltype(*V) &>
   {
     return *V;
   }
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto GetAGridFunction() -> std::enable_if_t<HasAGridFunction<U>(), decltype(*A) &>
   {
     return *A;

--- a/palace/models/postoperatorcsv.cpp
+++ b/palace/models/postoperatorcsv.cpp
@@ -32,33 +32,33 @@ std::string DimLabel(int i)
 }
 
 // TODO(C++20): Do constexpr with string.
-std::string LabelIndexCol(const config::ProblemData::Type solver_t)
+std::string LabelIndexCol(const ProblemType solver_t)
 {
   switch (solver_t)
   {
-    case config::ProblemData::Type::DRIVEN:
+    case ProblemType::DRIVEN:
       return "f (GHz)";
-    case config::ProblemData::Type::EIGENMODE:
+    case ProblemType::EIGENMODE:
       return "m";
-    case config::ProblemData::Type::ELECTROSTATIC:
-    case config::ProblemData::Type::MAGNETOSTATIC:
+    case ProblemType::ELECTROSTATIC:
+    case ProblemType::MAGNETOSTATIC:
       return "i";
-    case config::ProblemData::Type::TRANSIENT:
+    case ProblemType::TRANSIENT:
       return "t (ns)";
     default:
       return "unkown";
   }
 }
-int PrecIndexCol(const config::ProblemData::Type solver_t)
+int PrecIndexCol(const ProblemType solver_t)
 {
   switch (solver_t)
   {
-    case config::ProblemData::Type::DRIVEN:
-    case config::ProblemData::Type::TRANSIENT:
+    case ProblemType::DRIVEN:
+    case ProblemType::TRANSIENT:
       return 8;
-    case config::ProblemData::Type::EIGENMODE:
-    case config::ProblemData::Type::ELECTROSTATIC:
-    case config::ProblemData::Type::MAGNETOSTATIC:
+    case ProblemType::EIGENMODE:
+    case ProblemType::ELECTROSTATIC:
+    case ProblemType::MAGNETOSTATIC:
       return 2;
     default:
       return 8;
@@ -86,7 +86,7 @@ void CheckAppendIndex(Column &idx_col, double idx_value, size_t m_idx_row)
 
 }  // namespace
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeDomainE()
 {
   using fmt::format;
@@ -121,7 +121,7 @@ void PostOperatorCSV<solver_t>::InitializeDomainE()
   domain_E->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintDomainE()
 {
   if (!domain_E)  // trivial check: always written and we are always on root
@@ -147,7 +147,7 @@ void PostOperatorCSV<solver_t>::PrintDomainE()
   domain_E->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeSurfaceF()
 {
   if (!(post_op->surf_post_op.flux_surfs.size() > 0))
@@ -207,7 +207,7 @@ void PostOperatorCSV<solver_t>::InitializeSurfaceF()
   surface_F->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintSurfaceF()
 {
   if (!surface_F)
@@ -228,7 +228,7 @@ void PostOperatorCSV<solver_t>::PrintSurfaceF()
   surface_F->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeSurfaceQ()
 {
   if (!(post_op->surf_post_op.eps_surfs.size() > 0))
@@ -256,7 +256,7 @@ void PostOperatorCSV<solver_t>::InitializeSurfaceQ()
   surface_Q->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintSurfaceQ()
 {
   if (!surface_Q)
@@ -274,7 +274,7 @@ void PostOperatorCSV<solver_t>::PrintSurfaceQ()
   surface_Q->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeProbeE()
 {
   if (!(post_op->interp_op.GetProbes().size() > 0) || !HasEGridFunction<solver_t>())
@@ -317,7 +317,7 @@ void PostOperatorCSV<solver_t>::InitializeProbeE()
   probe_E->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintProbeE()
 {
   if (!probe_E)
@@ -351,7 +351,7 @@ void PostOperatorCSV<solver_t>::PrintProbeE()
   probe_E->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeProbeB()
 {
   if (!(post_op->interp_op.GetProbes().size() > 0) || !HasBGridFunction<solver_t>())
@@ -395,7 +395,7 @@ void PostOperatorCSV<solver_t>::InitializeProbeB()
   probe_B->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintProbeB()
 {
   if (!probe_B)
@@ -430,12 +430,10 @@ void PostOperatorCSV<solver_t>::PrintProbeB()
   probe_B->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializeSurfaceI()
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN ||
-                            U == config::ProblemData::Type::TRANSIENT,
-                        void>
+    -> std::enable_if_t<U == ProblemType::DRIVEN || U == ProblemType::TRANSIENT, void>
 {
   if (!(post_op->fem_op->GetSurfaceCurrentOp().Size() > 0))
   {
@@ -460,12 +458,10 @@ auto PostOperatorCSV<solver_t>::InitializeSurfaceI()
   surface_I->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintSurfaceI()
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN ||
-                            U == config::ProblemData::Type::TRANSIENT,
-                        void>
+    -> std::enable_if_t<U == ProblemType::DRIVEN || U == ProblemType::TRANSIENT, void>
 {
   if (!surface_I)
   {
@@ -483,12 +479,11 @@ auto PostOperatorCSV<solver_t>::PrintSurfaceI()
   surface_I->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializePortVI()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE ||
-                            U == config::ProblemData::Type::DRIVEN ||
-                            U == config::ProblemData::Type::TRANSIENT,
+    -> std::enable_if_t<U == ProblemType::EIGENMODE || U == ProblemType::DRIVEN ||
+                            U == ProblemType::TRANSIENT,
                         void>
 {
   if (!(post_op->fem_op->GetLumpedPortOp().Size() > 0))
@@ -514,8 +509,7 @@ auto PostOperatorCSV<solver_t>::InitializePortVI()
     std::string ex_label = SingleColBlock() ? "" : format("[{}]", ex_idx);
 
     // Print incident signal, if solver supports excitation on ports.
-    if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                  solver_t == config::ProblemData::Type::TRANSIENT)
+    if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::TRANSIENT)
     {
       auto ex_spec = post_op->fem_op->GetPortExcitations().excitations.at(ex_idx);
       for (const auto &idx : ex_spec.lumped_port)
@@ -552,12 +546,11 @@ auto PostOperatorCSV<solver_t>::InitializePortVI()
   port_I->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintPortVI()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE ||
-                            U == config::ProblemData::Type::DRIVEN ||
-                            U == config::ProblemData::Type::TRANSIENT,
+    -> std::enable_if_t<U == ProblemType::EIGENMODE || U == ProblemType::DRIVEN ||
+                            U == ProblemType::TRANSIENT,
                         void>
 {
   if (!port_V)  // no need to recheck port_I
@@ -576,8 +569,7 @@ auto PostOperatorCSV<solver_t>::PrintPortVI()
   auto unit_V = post_op->units.template GetScaleFactor<Units::ValueType::VOLTAGE>();
   auto unit_A = post_op->units.template GetScaleFactor<Units::ValueType::CURRENT>();
 
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::TRANSIENT)
   {
     for (const auto &[idx, data] : lumped_port_op)
     {
@@ -610,10 +602,10 @@ auto PostOperatorCSV<solver_t>::PrintPortVI()
   port_I->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializePortS()
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>
+    -> std::enable_if_t<U == ProblemType::DRIVEN, void>
 {
   if (!post_op->fem_op->GetPortExcitations().IsMultipleSimple() ||
       !((post_op->fem_op->GetLumpedPortOp().Size() > 0) xor
@@ -651,10 +643,10 @@ auto PostOperatorCSV<solver_t>::InitializePortS()
   port_S->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintPortS()
-    -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>
+    -> std::enable_if_t<U == ProblemType::DRIVEN, void>
 {
   if (!port_S)
   {
@@ -675,10 +667,10 @@ auto PostOperatorCSV<solver_t>::PrintPortS()
   port_S->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializeEig()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   using fmt::format;
   eig = TableWithCSVFile(post_op->post_dir / "eig.csv");
@@ -692,10 +684,10 @@ auto PostOperatorCSV<solver_t>::InitializeEig()
   eig->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintEig()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   if (!eig)  // trivial check
   {
@@ -710,10 +702,10 @@ auto PostOperatorCSV<solver_t>::PrintEig()
   eig->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializeEigPortEPR()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   // TODO(C++20): Make this a filtered iterator in LumpedPortOp.
   for (const auto &[idx, data] : post_op->fem_op->GetLumpedPortOp())
@@ -738,10 +730,10 @@ auto PostOperatorCSV<solver_t>::InitializeEigPortEPR()
   port_EPR->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintEigPortEPR()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   if (!port_EPR)
   {
@@ -757,10 +749,10 @@ auto PostOperatorCSV<solver_t>::PrintEigPortEPR()
   port_EPR->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::InitializeEigPortQ()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   // TODO(C++20): Make this a filtered iterator in LumpedPortOp.
   for (const auto &[idx, data] : post_op->fem_op->GetLumpedPortOp())
@@ -786,10 +778,10 @@ auto PostOperatorCSV<solver_t>::InitializeEigPortQ()
   port_Q->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
-template <config::ProblemData::Type U>
+template <ProblemType solver_t>
+template <ProblemType U>
 auto PostOperatorCSV<solver_t>::PrintEigPortQ()
-    -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>
+    -> std::enable_if_t<U == ProblemType::EIGENMODE, void>
 {
   if (!port_Q)
   {
@@ -806,7 +798,7 @@ auto PostOperatorCSV<solver_t>::PrintEigPortQ()
   port_Q->WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintErrorIndicator(
     const ErrorIndicator::SummaryStatistics &indicator_stats)
 {
@@ -826,13 +818,12 @@ void PostOperatorCSV<solver_t>::PrintErrorIndicator(
   error_indicator.WriteFullTableTrunc();
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::InitializeCSVDataCollection()
 {
   // Initialize multi-excitation column block index. Only driven or transient support
   // excitations; for other solvers this is default to a single idx=0.
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::TRANSIENT)
   {
     auto excitation_helper = post_op->fem_op->GetPortExcitations();
     excitation_idx_all.clear();
@@ -855,22 +846,20 @@ void PostOperatorCSV<solver_t>::InitializeCSVDataCollection()
   InitializeProbeE();
   InitializeProbeB();
 #endif
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::TRANSIENT)
   {
     InitializeSurfaceI();
   }
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::EIGENMODE ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::EIGENMODE ||
+                solver_t == ProblemType::TRANSIENT)
   {
     InitializePortVI();
   }
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN)
+  if constexpr (solver_t == ProblemType::DRIVEN)
   {
     InitializePortS();
   }
-  if constexpr (solver_t == config::ProblemData::Type::EIGENMODE)
+  if constexpr (solver_t == ProblemType::EIGENMODE)
   {
     InitializeEig();
     InitializeEigPortEPR();
@@ -878,7 +867,7 @@ void PostOperatorCSV<solver_t>::InitializeCSVDataCollection()
   }
 }
 
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 void PostOperatorCSV<solver_t>::PrintAllCSVData(double idx_value_dimensionful, int step)
 {
   if (!Mpi::Root(post_op->fem_op->GetComm()))
@@ -895,23 +884,21 @@ void PostOperatorCSV<solver_t>::PrintAllCSVData(double idx_value_dimensionful, i
   PrintProbeE();
   PrintProbeB();
 #endif
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::TRANSIENT)
   {
     PrintSurfaceI();
   }
 
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN ||
-                solver_t == config::ProblemData::Type::EIGENMODE ||
-                solver_t == config::ProblemData::Type::TRANSIENT)
+  if constexpr (solver_t == ProblemType::DRIVEN || solver_t == ProblemType::EIGENMODE ||
+                solver_t == ProblemType::TRANSIENT)
   {
     PrintPortVI();
   }
-  if constexpr (solver_t == config::ProblemData::Type::DRIVEN)
+  if constexpr (solver_t == ProblemType::DRIVEN)
   {
     PrintPortS();
   }
-  if constexpr (solver_t == config::ProblemData::Type::EIGENMODE)
+  if constexpr (solver_t == ProblemType::EIGENMODE)
   {
     PrintEig();
     PrintEigPortEPR();
@@ -920,10 +907,10 @@ void PostOperatorCSV<solver_t>::PrintAllCSVData(double idx_value_dimensionful, i
 }
 
 // Explicit template instantiation.
-template class PostOperatorCSV<config::ProblemData::Type::DRIVEN>;
-template class PostOperatorCSV<config::ProblemData::Type::EIGENMODE>;
-template class PostOperatorCSV<config::ProblemData::Type::ELECTROSTATIC>;
-template class PostOperatorCSV<config::ProblemData::Type::MAGNETOSTATIC>;
-template class PostOperatorCSV<config::ProblemData::Type::TRANSIENT>;
+template class PostOperatorCSV<ProblemType::DRIVEN>;
+template class PostOperatorCSV<ProblemType::EIGENMODE>;
+template class PostOperatorCSV<ProblemType::ELECTROSTATIC>;
+template class PostOperatorCSV<ProblemType::MAGNETOSTATIC>;
+template class PostOperatorCSV<ProblemType::TRANSIENT>;
 
 }  // namespace palace

--- a/palace/models/postoperatorcsv.cpp
+++ b/palace/models/postoperatorcsv.cpp
@@ -169,7 +169,7 @@ void PostOperatorCSV<solver_t>::InitializeSurfaceF()
     {
       switch (data.type)
       {
-        case SurfaceFluxType::ELECTRIC:
+        case SurfaceFlux::ELECTRIC:
           if (HasComplexGridFunction<solver_t>())
           {
             surface_F->table.insert(format("F_{}_{}_re", idx, ex_idx),
@@ -183,7 +183,7 @@ void PostOperatorCSV<solver_t>::InitializeSurfaceF()
                                     format("Φ_elec[{}]{} (C)", idx, ex_label));
           }
           break;
-        case SurfaceFluxType::MAGNETIC:
+        case SurfaceFlux::MAGNETIC:
           if (HasComplexGridFunction<solver_t>())
           {
             surface_F->table.insert(format("F_{}_{}_re", idx, ex_idx),
@@ -197,7 +197,7 @@ void PostOperatorCSV<solver_t>::InitializeSurfaceF()
                                     format("Φ_mag[{}]{} (Wb)", idx, ex_label));
           }
           break;
-        case SurfaceFluxType::POWER:
+        case SurfaceFlux::POWER:
           surface_F->table.insert(format("F_{}_{}_re", idx, ex_idx),
                                   format("Φ_pow[{}]{} (W)", idx, ex_label));
           break;
@@ -220,7 +220,7 @@ void PostOperatorCSV<solver_t>::PrintSurfaceF()
   {
     surface_F->table[format("F_{}_{}_re", data.idx, m_ex_idx)] << data.Phi.real();
     if (HasComplexGridFunction<solver_t>() &&
-        (data.type == SurfaceFluxType::ELECTRIC || data.type == SurfaceFluxType::MAGNETIC))
+        (data.type == SurfaceFlux::ELECTRIC || data.type == SurfaceFlux::MAGNETIC))
     {
       surface_F->table[format("F_{}_{}_im", data.idx, m_ex_idx)] << data.Phi.imag();
     }

--- a/palace/models/postoperatorcsv.hpp
+++ b/palace/models/postoperatorcsv.hpp
@@ -10,14 +10,14 @@ namespace palace
 {
 
 // Advance declaration.
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 class PostOperator;
 
 // Helper class to PostOperator to collect csv tables and printers for measurement that will
 // be saved to file. This class contains a pointer to the corresponding PostOperator class
 // and is a friend to a PostOperator class; this is equivalent to having these members
 // and methods in PostOperator. It exists for code clarity.
-template <config::ProblemData::Type solver_t>
+template <ProblemType solver_t>
 class PostOperatorCSV
 {
   PostOperator<solver_t> *post_op = nullptr;
@@ -76,67 +76,61 @@ class PostOperatorCSV
   // prepare the tables for data insertion, whilst the print methods insert data
   // appropriately. Methods are only enabled when valid given the problem type.
 
-  template <config::ProblemData::Type U = solver_t>
-  auto InitializePortVI() -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE ||
-                                                  U == config::ProblemData::Type::DRIVEN ||
-                                                  U == config::ProblemData::Type::TRANSIENT,
-                                              void>;
+  template <ProblemType U = solver_t>
+  auto InitializePortVI()
+      -> std::enable_if_t<U == ProblemType::EIGENMODE || U == ProblemType::DRIVEN ||
+                              U == ProblemType::TRANSIENT,
+                          void>;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintPortVI() -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE ||
-                                             U == config::ProblemData::Type::DRIVEN ||
-                                             U == config::ProblemData::Type::TRANSIENT,
-                                         void>;
+  template <ProblemType U = solver_t>
+  auto PrintPortVI()
+      -> std::enable_if_t<U == ProblemType::EIGENMODE || U == ProblemType::DRIVEN ||
+                              U == ProblemType::TRANSIENT,
+                          void>;
 
   // Driven + Transient
   std::optional<TableWithCSVFile> surface_I;
 
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto InitializeSurfaceI()
-      -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN ||
-                              U == config::ProblemData::Type::TRANSIENT,
-                          void>;
+      -> std::enable_if_t<U == ProblemType::DRIVEN || U == ProblemType::TRANSIENT, void>;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintSurfaceI() -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN ||
-                                               U == config::ProblemData::Type::TRANSIENT,
-                                           void>;
+  template <ProblemType U = solver_t>
+  auto PrintSurfaceI()
+      -> std::enable_if_t<U == ProblemType::DRIVEN || U == ProblemType::TRANSIENT, void>;
 
   // Driven
   int driven_source_index = -1;
   std::optional<TableWithCSVFile> port_S;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto InitializePortS() -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>;
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintPortS() -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>;
+  template <ProblemType U = solver_t>
+  auto InitializePortS() -> std::enable_if_t<U == ProblemType::DRIVEN, void>;
+  template <ProblemType U = solver_t>
+  auto PrintPortS() -> std::enable_if_t<U == ProblemType::DRIVEN, void>;
 
   // Eigenmode
   std::optional<TableWithCSVFile> eig;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto InitializeEig() -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintEig() -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto InitializeEig() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto PrintEig() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
 
   std::vector<int> ports_with_L;
   std::vector<int> ports_with_R;
   std::optional<TableWithCSVFile> port_EPR;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto InitializeEigPortEPR()
-      -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintEigPortEPR()
-      -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto InitializeEigPortEPR() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto PrintEigPortEPR() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
 
   std::optional<TableWithCSVFile> port_Q;
 
-  template <config::ProblemData::Type U = solver_t>
-  auto InitializeEigPortQ()
-      -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
-  template <config::ProblemData::Type U = solver_t>
-  auto PrintEigPortQ() -> std::enable_if_t<U == config::ProblemData::Type::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto InitializeEigPortQ() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
+  template <ProblemType U = solver_t>
+  auto PrintEigPortQ() -> std::enable_if_t<U == ProblemType::EIGENMODE, void>;
 
 public:
   // Set-up all files to be called from post_op.
@@ -146,9 +140,9 @@ public:
   void PrintAllCSVData(double idx_value_dimensionful, int step);
 
   // Driven specific overload for specifying excitation index
-  template <config::ProblemData::Type U = solver_t>
+  template <ProblemType U = solver_t>
   auto PrintAllCSVData(double idx_value_dimensionful, int step, int ex_idx)
-      -> std::enable_if_t<U == config::ProblemData::Type::DRIVEN, void>
+      -> std::enable_if_t<U == ProblemType::DRIVEN, void>
   {
     m_ex_idx = ex_idx;
     PrintAllCSVData(idx_value_dimensionful, step);

--- a/palace/models/romoperator.hpp
+++ b/palace/models/romoperator.hpp
@@ -36,8 +36,7 @@ private:
 public:
   MinimalRationalInterpolation(int max_size);
   void AddSolutionSample(double omega, const ComplexVector &u,
-                         const SpaceOperator &space_op,
-                         GmresSolverBase::OrthogType orthog_type);
+                         const SpaceOperator &space_op, Orthogonalization orthog_type);
   std::vector<double> FindMaxError(int N) const;
 
   const auto &GetSamplePoints() const { return z; }
@@ -75,7 +74,7 @@ private:
   // PROM reduced-order basis (real-valued) and active dimension.
   std::vector<Vector> V;
   std::size_t dim_V = 0;
-  GmresSolverBase::OrthogType orthog_type;
+  Orthogonalization orthog_type;
 
   // MRIs: one for each excitation index.
   std::map<int, MinimalRationalInterpolation> mri;

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -52,17 +52,17 @@ SpaceOperator::SpaceOperator(const IoData &iodata,
     port_excitation_helper(lumped_port_op, wave_port_op, surf_j_op)
 {
   // Check Excitations.
-  if (iodata.problem.type == config::ProblemData::Type::DRIVEN)
+  if (iodata.problem.type == ProblemType::DRIVEN)
   {
     MFEM_VERIFY(!port_excitation_helper.Empty(),
                 "Driven problems must specify at least one excitation!");
   }
-  else if (iodata.problem.type == config::ProblemData::Type::EIGENMODE)
+  else if (iodata.problem.type == ProblemType::EIGENMODE)
   {
     MFEM_VERIFY(port_excitation_helper.Empty(),
                 "Eigenmode problems must not specify any excitation!");
   }
-  else if (iodata.problem.type == config::ProblemData::Type::TRANSIENT)
+  else if (iodata.problem.type == ProblemType::TRANSIENT)
   {
     MFEM_VERIFY(
         port_excitation_helper.Size() == 1,

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -29,14 +29,14 @@ SpaceOperator::SpaceOperator(const IoData &iodata,
     print_prec_hdr(true), dbc_attr(SetUpBoundaryProperties(iodata, *mesh.back())),
     nd_fecs(fem::ConstructFECollections<mfem::ND_FECollection>(
         iodata.solver.order, mesh.back()->Dimension(), iodata.solver.linear.mg_max_levels,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     h1_fecs(fem::ConstructFECollections<mfem::H1_FECollection>(
         iodata.solver.order, mesh.back()->Dimension(), iodata.solver.linear.mg_max_levels,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     rt_fecs(fem::ConstructFECollections<mfem::RT_FECollection>(
         iodata.solver.order - 1, mesh.back()->Dimension(),
         iodata.solver.linear.estimator_mg ? iodata.solver.linear.mg_max_levels : 1,
-        iodata.solver.linear.mg_coarsen_type, false)),
+        iodata.solver.linear.mg_coarsening, false)),
     nd_fespaces(fem::ConstructFiniteElementSpaceHierarchy<mfem::ND_FECollection>(
         iodata.solver.linear.mg_max_levels, mesh, nd_fecs, &dbc_attr, &nd_dbc_tdof_lists)),
     h1_fespaces(fem::ConstructFiniteElementSpaceHierarchy<mfem::H1_FECollection>(

--- a/palace/models/surfaceconductivityoperator.cpp
+++ b/palace/models/surfaceconductivityoperator.cpp
@@ -101,8 +101,7 @@ void SurfaceConductivityOperator::SetUpBoundaryProperties(const IoData &iodata,
       bdr.attr_list.Append(attr);
     }
   }
-  MFEM_VERIFY(boundaries.empty() ||
-                  iodata.problem.type == config::ProblemData::Type::DRIVEN,
+  MFEM_VERIFY(boundaries.empty() || iodata.problem.type == ProblemType::DRIVEN,
               "Finite conductivity boundaries are only available for frequency "
               "domain driven simulations!");
 }

--- a/palace/models/surfacecurrentoperator.cpp
+++ b/palace/models/surfacecurrentoperator.cpp
@@ -22,11 +22,11 @@ SurfaceCurrentData::SurfaceCurrentData(const config::SurfaceCurrentData &data,
     attr_list.Append(elem.attributes.data(), elem.attributes.size());
     switch (elem.coordinate_system)
     {
-      case config::internal::ElementData::CoordinateSystem::CYLINDRICAL:
+      case CoordinateSystem::CYLINDRICAL:
         elems.push_back(
             std::make_unique<CoaxialElementData>(elem.direction, attr_list, mesh));
         break;
-      case config::internal::ElementData::CoordinateSystem::CARTESIAN:
+      case CoordinateSystem::CARTESIAN:
         elems.push_back(
             std::make_unique<UniformElementData>(elem.direction, attr_list, mesh));
         break;

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -66,14 +66,14 @@ SurfacePostOperator::SurfaceFluxData::SurfaceFluxData(
   // Store the type of flux.
   switch (data.type)
   {
-    case SurfaceFluxType::ELECTRIC:
-      type = SurfaceFluxType::ELECTRIC;
+    case SurfaceFlux::ELECTRIC:
+      type = SurfaceFlux::ELECTRIC;
       break;
-    case SurfaceFluxType::MAGNETIC:
-      type = SurfaceFluxType::MAGNETIC;
+    case SurfaceFlux::MAGNETIC:
+      type = SurfaceFlux::MAGNETIC;
       break;
-    case SurfaceFluxType::POWER:
-      type = SurfaceFluxType::POWER;
+    case SurfaceFlux::POWER:
+      type = SurfaceFlux::POWER;
       break;
   }
 
@@ -109,17 +109,17 @@ SurfacePostOperator::SurfaceFluxData::GetCoefficient(const mfem::ParGridFunction
 {
   switch (type)
   {
-    case SurfaceFluxType::ELECTRIC:
+    case SurfaceFlux::ELECTRIC:
       return std::make_unique<
-          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFluxType::ELECTRIC>>>(
+          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>>(
           attr_list, E, nullptr, mat_op, two_sided, center);
-    case SurfaceFluxType::MAGNETIC:
+    case SurfaceFlux::MAGNETIC:
       return std::make_unique<
-          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFluxType::MAGNETIC>>>(
+          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFlux::MAGNETIC>>>(
           attr_list, nullptr, B, mat_op, two_sided, center);
-    case SurfaceFluxType::POWER:
+    case SurfaceFlux::POWER:
       return std::make_unique<
-          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFluxType::POWER>>>(
+          RestrictedCoefficient<BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>>>(
           attr_list, E, B, mat_op, two_sided, center);
   }
   return {};
@@ -208,11 +208,11 @@ SurfacePostOperator::SurfacePostOperator(const IoData &iodata,
   for (const auto &[idx, data] : iodata.boundaries.postpro.flux)
   {
     MFEM_VERIFY(iodata.problem.type != ProblemType::ELECTROSTATIC ||
-                    data.type == SurfaceFluxType::ELECTRIC,
+                    data.type == SurfaceFlux::ELECTRIC,
                 "Magnetic field or power surface flux postprocessing are not available "
                 "for electrostatic problems!");
     MFEM_VERIFY(iodata.problem.type != ProblemType::MAGNETOSTATIC ||
-                    data.type == SurfaceFluxType::MAGNETIC,
+                    data.type == SurfaceFlux::MAGNETIC,
                 "Electric field or power surface flux postprocessing are not available "
                 "for magnetostatic problems!");
     flux_surfs.try_emplace(idx, data, *h1_fespace.GetParMesh(), bdr_attr_marker);
@@ -250,7 +250,7 @@ std::complex<double> SurfacePostOperator::GetSurfaceFlux(int idx, const GridFunc
     f = it->second.GetCoefficient(E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr,
                                   mat_op);
     double doti = GetLocalSurfaceIntegral(*f, attr_marker);
-    if (it->second.type == SurfaceFluxType::POWER)
+    if (it->second.type == SurfaceFlux::POWER)
     {
       dot += doti;
     }

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -66,13 +66,13 @@ SurfacePostOperator::SurfaceFluxData::SurfaceFluxData(
   // Store the type of flux.
   switch (data.type)
   {
-    case config::SurfaceFluxData::Type::ELECTRIC:
+    case SurfaceFluxType::ELECTRIC:
       type = SurfaceFluxType::ELECTRIC;
       break;
-    case config::SurfaceFluxData::Type::MAGNETIC:
+    case SurfaceFluxType::MAGNETIC:
       type = SurfaceFluxType::MAGNETIC;
       break;
-    case config::SurfaceFluxData::Type::POWER:
+    case SurfaceFluxType::POWER:
       type = SurfaceFluxType::POWER;
       break;
   }
@@ -140,16 +140,16 @@ SurfacePostOperator::InterfaceDielectricData::InterfaceDielectricData(
   //                       p * E_elec = 1/2 t Re{∫ (ε E)ᴴ E_m dS} .
   switch (data.type)
   {
-    case config::InterfaceDielectricData::Type::DEFAULT:
+    case InterfaceDielectricType::DEFAULT:
       type = InterfaceDielectricType::DEFAULT;
       break;
-    case config::InterfaceDielectricData::Type::MA:
+    case InterfaceDielectricType::MA:
       type = InterfaceDielectricType::MA;
       break;
-    case config::InterfaceDielectricData::Type::MS:
+    case InterfaceDielectricType::MS:
       type = InterfaceDielectricType::MS;
       break;
-    case config::InterfaceDielectricData::Type::SA:
+    case InterfaceDielectricType::SA:
       type = InterfaceDielectricType::SA;
       break;
   }
@@ -207,12 +207,12 @@ SurfacePostOperator::SurfacePostOperator(const IoData &iodata,
   // Surface flux postprocessing.
   for (const auto &[idx, data] : iodata.boundaries.postpro.flux)
   {
-    MFEM_VERIFY(iodata.problem.type != config::ProblemData::Type::ELECTROSTATIC ||
-                    data.type == config::SurfaceFluxData::Type::ELECTRIC,
+    MFEM_VERIFY(iodata.problem.type != ProblemType::ELECTROSTATIC ||
+                    data.type == SurfaceFluxType::ELECTRIC,
                 "Magnetic field or power surface flux postprocessing are not available "
                 "for electrostatic problems!");
-    MFEM_VERIFY(iodata.problem.type != config::ProblemData::Type::MAGNETOSTATIC ||
-                    data.type == config::SurfaceFluxData::Type::MAGNETIC,
+    MFEM_VERIFY(iodata.problem.type != ProblemType::MAGNETOSTATIC ||
+                    data.type == SurfaceFluxType::MAGNETIC,
                 "Electric field or power surface flux postprocessing are not available "
                 "for magnetostatic problems!");
     flux_surfs.try_emplace(idx, data, *h1_fespace.GetParMesh(), bdr_attr_marker);
@@ -220,7 +220,7 @@ SurfacePostOperator::SurfacePostOperator(const IoData &iodata,
 
   // Interface dielectric postprocessing.
   MFEM_VERIFY(iodata.boundaries.postpro.dielectric.empty() ||
-                  iodata.problem.type != config::ProblemData::Type::MAGNETOSTATIC,
+                  iodata.problem.type != ProblemType::MAGNETOSTATIC,
               "Interface dielectric loss postprocessing is not available for "
               "magnetostatic problems!");
   for (const auto &[idx, data] : iodata.boundaries.postpro.dielectric)

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -140,17 +140,17 @@ SurfacePostOperator::InterfaceDielectricData::InterfaceDielectricData(
   //                       p * E_elec = 1/2 t Re{∫ (ε E)ᴴ E_m dS} .
   switch (data.type)
   {
-    case InterfaceDielectricType::DEFAULT:
-      type = InterfaceDielectricType::DEFAULT;
+    case InterfaceDielectric::DEFAULT:
+      type = InterfaceDielectric::DEFAULT;
       break;
-    case InterfaceDielectricType::MA:
-      type = InterfaceDielectricType::MA;
+    case InterfaceDielectric::MA:
+      type = InterfaceDielectric::MA;
       break;
-    case InterfaceDielectricType::MS:
-      type = InterfaceDielectricType::MS;
+    case InterfaceDielectric::MS:
+      type = InterfaceDielectric::MS;
       break;
-    case InterfaceDielectricType::SA:
-      type = InterfaceDielectricType::SA;
+    case InterfaceDielectric::SA:
+      type = InterfaceDielectric::SA;
       break;
   }
   t = data.t;
@@ -164,21 +164,21 @@ SurfacePostOperator::InterfaceDielectricData::GetCoefficient(
 {
   switch (type)
   {
-    case InterfaceDielectricType::DEFAULT:
+    case InterfaceDielectric::DEFAULT:
       return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectricType::DEFAULT>>>(
+          InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>>(
           attr_list, E, mat_op, t, epsilon);
-    case InterfaceDielectricType::MA:
+    case InterfaceDielectric::MA:
       return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectricType::MA>>>(attr_list, E,
+          InterfaceDielectricCoefficient<InterfaceDielectric::MA>>>(attr_list, E,
                                                                         mat_op, t, epsilon);
-    case InterfaceDielectricType::MS:
+    case InterfaceDielectric::MS:
       return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectricType::MS>>>(attr_list, E,
+          InterfaceDielectricCoefficient<InterfaceDielectric::MS>>>(attr_list, E,
                                                                         mat_op, t, epsilon);
-    case InterfaceDielectricType::SA:
+    case InterfaceDielectric::SA:
       return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectricType::SA>>>(attr_list, E,
+          InterfaceDielectricCoefficient<InterfaceDielectric::SA>>>(attr_list, E,
                                                                         mat_op, t, epsilon);
   }
   return {};  // For compiler warning

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -169,17 +169,17 @@ SurfacePostOperator::InterfaceDielectricData::GetCoefficient(
           InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>>(
           attr_list, E, mat_op, t, epsilon);
     case InterfaceDielectric::MA:
-      return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectric::MA>>>(attr_list, E,
-                                                                        mat_op, t, epsilon);
+      return std::make_unique<
+          RestrictedCoefficient<InterfaceDielectricCoefficient<InterfaceDielectric::MA>>>(
+          attr_list, E, mat_op, t, epsilon);
     case InterfaceDielectric::MS:
-      return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectric::MS>>>(attr_list, E,
-                                                                        mat_op, t, epsilon);
+      return std::make_unique<
+          RestrictedCoefficient<InterfaceDielectricCoefficient<InterfaceDielectric::MS>>>(
+          attr_list, E, mat_op, t, epsilon);
     case InterfaceDielectric::SA:
-      return std::make_unique<RestrictedCoefficient<
-          InterfaceDielectricCoefficient<InterfaceDielectric::SA>>>(attr_list, E,
-                                                                        mat_op, t, epsilon);
+      return std::make_unique<
+          RestrictedCoefficient<InterfaceDielectricCoefficient<InterfaceDielectric::SA>>>(
+          attr_list, E, mat_op, t, epsilon);
   }
   return {};  // For compiler warning
 }

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -41,7 +41,7 @@ private:
   };
   struct SurfaceFluxData : public SurfaceData
   {
-    SurfaceFluxType type;
+    SurfaceFlux type;
     bool two_sided;
     mfem::Vector center;
 

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -54,7 +54,7 @@ private:
   };
   struct InterfaceDielectricData : public SurfaceData
   {
-    InterfaceDielectricType type;
+    InterfaceDielectric type;
     double t, epsilon, tandelta;
 
     InterfaceDielectricData(const config::InterfaceDielectricData &data,

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -312,21 +312,21 @@ TimeOperator::TimeOperator(const IoData &iodata, SpaceOperator &space_op,
                                                          type);
   switch (iodata.solver.transient.type)
   {
-    case config::TransientSolverData::Type::GEN_ALPHA:
+    case TransientSolverType::GEN_ALPHA:
       {
         constexpr double rho_inf = 1.0;
         use_mfem_integrator = true;
         ode = std::make_unique<mfem::GeneralizedAlphaSolver>(rho_inf);
       }
       break;
-    case config::TransientSolverData::Type::RUNGE_KUTTA:
+    case TransientSolverType::RUNGE_KUTTA:
       {
         constexpr int gamma_opt = 2;
         use_mfem_integrator = true;
         ode = std::make_unique<mfem::SDIRK23Solver>(gamma_opt);
       }
       break;
-    case config::TransientSolverData::Type::ARKODE:
+    case TransientSolverType::ARKODE:
       {
 #if defined(MFEM_USE_SUNDIALS)
         // SUNDIALS ARKODE solver.
@@ -351,7 +351,7 @@ TimeOperator::TimeOperator(const IoData &iodata, SpaceOperator &space_op,
 #endif
       }
       break;
-    case config::TransientSolverData::Type::CVODE:
+    case TransientSolverType::CVODE:
       {
 #if defined(MFEM_USE_SUNDIALS)
         // SUNDIALS CVODE solver.

--- a/palace/models/timeoperator.cpp
+++ b/palace/models/timeoperator.cpp
@@ -312,21 +312,21 @@ TimeOperator::TimeOperator(const IoData &iodata, SpaceOperator &space_op,
                                                          type);
   switch (iodata.solver.transient.type)
   {
-    case TransientSolverType::GEN_ALPHA:
+    case TimeSteppingScheme::GEN_ALPHA:
       {
         constexpr double rho_inf = 1.0;
         use_mfem_integrator = true;
         ode = std::make_unique<mfem::GeneralizedAlphaSolver>(rho_inf);
       }
       break;
-    case TransientSolverType::RUNGE_KUTTA:
+    case TimeSteppingScheme::RUNGE_KUTTA:
       {
         constexpr int gamma_opt = 2;
         use_mfem_integrator = true;
         ode = std::make_unique<mfem::SDIRK23Solver>(gamma_opt);
       }
       break;
-    case TransientSolverType::ARKODE:
+    case TimeSteppingScheme::ARKODE:
       {
 #if defined(MFEM_USE_SUNDIALS)
         // SUNDIALS ARKODE solver.
@@ -351,7 +351,7 @@ TimeOperator::TimeOperator(const IoData &iodata, SpaceOperator &space_op,
 #endif
       }
       break;
-    case TransientSolverType::CVODE:
+    case TimeSteppingScheme::CVODE:
       {
 #if defined(MFEM_USE_SUNDIALS)
         // SUNDIALS CVODE solver.

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -651,23 +651,23 @@ WavePortData::WavePortData(const config::WavePortData &data,
     gmres->SetRestartDim(data.ksp_max_its);
     // gmres->SetPrecSide(PreconditionerSide::RIGHT);
 
-    LinearSolverType pc_type = solver.linear.type;
-    if (pc_type == LinearSolverType::SUPERLU)
+    LinearSolver pc_type = solver.linear.type;
+    if (pc_type == LinearSolver::SUPERLU)
     {
 #if !defined(MFEM_USE_SUPERLU)
       MFEM_ABORT("Solver was not built with SuperLU_DIST support, please choose a "
                  "different solver!");
 #endif
     }
-    else if (pc_type == LinearSolverType::STRUMPACK ||
-             pc_type == LinearSolverType::STRUMPACK_MP)
+    else if (pc_type == LinearSolver::STRUMPACK ||
+             pc_type == LinearSolver::STRUMPACK_MP)
     {
 #if !defined(MFEM_USE_STRUMPACK)
       MFEM_ABORT("Solver was not built with STRUMPACK support, please choose a "
                  "different solver!");
 #endif
     }
-    else if (pc_type == LinearSolverType::MUMPS)
+    else if (pc_type == LinearSolver::MUMPS)
     {
 #if !defined(MFEM_USE_MUMPS)
       MFEM_ABORT("Solver was not built with MUMPS support, please choose a "
@@ -677,11 +677,11 @@ WavePortData::WavePortData(const config::WavePortData &data,
     else  // Default choice
     {
 #if defined(MFEM_USE_SUPERLU)
-      pc_type = LinearSolverType::SUPERLU;
+      pc_type = LinearSolver::SUPERLU;
 #elif defined(MFEM_USE_STRUMPACK)
-      pc_type = LinearSolverType::STRUMPACK;
+      pc_type = LinearSolver::STRUMPACK;
 #elif defined(MFEM_USE_MUMPS)
-      pc_type = LinearSolverType::MUMPS;
+      pc_type = LinearSolver::MUMPS;
 #else
 #error "Wave port solver requires building with SuperLU_DIST, STRUMPACK, or MUMPS!"
 #endif
@@ -689,7 +689,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
     auto pc = std::make_unique<MfemWrapperSolver<ComplexOperator>>(
         [&]() -> std::unique_ptr<mfem::Solver>
         {
-          if (pc_type == LinearSolverType::SUPERLU)
+          if (pc_type == LinearSolver::SUPERLU)
           {
 #if defined(MFEM_USE_SUPERLU)
             auto slu = std::make_unique<SuperLUSolver>(
@@ -698,7 +698,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
             return slu;
 #endif
           }
-          else if (pc_type == LinearSolverType::STRUMPACK)
+          else if (pc_type == LinearSolver::STRUMPACK)
           {
 #if defined(MFEM_USE_STRUMPACK)
             auto strumpack = std::make_unique<StrumpackSolver>(
@@ -708,7 +708,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
             return strumpack;
 #endif
           }
-          else if (pc_type == LinearSolverType::MUMPS)
+          else if (pc_type == LinearSolver::MUMPS)
           {
 #if defined(MFEM_USE_MUMPS)
             auto mumps = std::make_unique<MumpsSolver>(

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -659,8 +659,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
                  "different solver!");
 #endif
     }
-    else if (pc_type == LinearSolver::STRUMPACK ||
-             pc_type == LinearSolver::STRUMPACK_MP)
+    else if (pc_type == LinearSolver::STRUMPACK || pc_type == LinearSolver::STRUMPACK_MP)
     {
 #if !defined(MFEM_USE_STRUMPACK)
       MFEM_ABORT("Solver was not built with STRUMPACK support, please choose a "
@@ -725,7 +724,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
 
     // Define the eigenvalue solver.
     constexpr int print = 0;
-    EigenSolverBackend type = data.eigen_type;
+    EigenSolverBackend type = data.eigen_solver;
     if (type == EigenSolverBackend::SLEPC)
     {
 #if !defined(PALACE_WITH_SLEPC)

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -725,15 +725,15 @@ WavePortData::WavePortData(const config::WavePortData &data,
 
     // Define the eigenvalue solver.
     constexpr int print = 0;
-    EigenSolverType type = data.eigen_type;
-    if (type == EigenSolverType::SLEPC)
+    EigenSolverBackend type = data.eigen_type;
+    if (type == EigenSolverBackend::SLEPC)
     {
 #if !defined(PALACE_WITH_SLEPC)
       MFEM_ABORT("Solver was not built with SLEPc support, please choose a "
                  "different solver!");
 #endif
     }
-    else if (type == EigenSolverType::ARPACK)
+    else if (type == EigenSolverBackend::ARPACK)
     {
 #if !defined(PALACE_WITH_ARPACK)
       MFEM_ABORT("Solver was not built with ARPACK support, please choose a "
@@ -743,20 +743,20 @@ WavePortData::WavePortData(const config::WavePortData &data,
     else  // Default choice
     {
 #if defined(PALACE_WITH_SLEPC)
-      type = EigenSolverType::SLEPC;
+      type = EigenSolverBackend::SLEPC;
 #elif defined(PALACE_WITH_ARPACK)
-      type = EigenSolverType::ARPACK;
+      type = EigenSolverBackend::ARPACK;
 #else
 #error "Wave port solver requires building with ARPACK or SLEPc!"
 #endif
     }
-    if (type == EigenSolverType::ARPACK)
+    if (type == EigenSolverBackend::ARPACK)
     {
 #if defined(PALACE_WITH_ARPACK)
       eigen = std::make_unique<arpack::ArpackEPSSolver>(port_comm, print);
 #endif
     }
-    else  // EigenSolverType::SLEPC
+    else  // EigenSolverBackend::SLEPC
     {
 #if defined(PALACE_WITH_SLEPC)
       auto slepc = std::make_unique<slepc::SlepcEPSSolver>(port_comm, print);

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -107,17 +107,17 @@ PALACE_JSON_SERIALIZE_ENUM(Excitation,
                             {Excitation::RAMP_STEP, "Ramp"},
                             {Excitation::SMOOTH_STEP, "SmoothStep"}})
 
-// Helper for converting string keys to enum for LinearSolverType, KrylovSolver, and
+// Helper for converting string keys to enum for LinearSolver, KrylovSolver, and
 // MultigridCoarsening
-PALACE_JSON_SERIALIZE_ENUM(LinearSolverType,
-                           {{LinearSolverType::DEFAULT, "Default"},
-                            {LinearSolverType::AMS, "AMS"},
-                            {LinearSolverType::BOOMER_AMG, "BoomerAMG"},
-                            {LinearSolverType::MUMPS, "MUMPS"},
-                            {LinearSolverType::SUPERLU, "SuperLU"},
-                            {LinearSolverType::STRUMPACK, "STRUMPACK"},
-                            {LinearSolverType::STRUMPACK_MP, "STRUMPACK-MP"},
-                            {LinearSolverType::JACOBI, "Jacobi"}})
+PALACE_JSON_SERIALIZE_ENUM(LinearSolver,
+                           {{LinearSolver::DEFAULT, "Default"},
+                            {LinearSolver::AMS, "AMS"},
+                            {LinearSolver::BOOMER_AMG, "BoomerAMG"},
+                            {LinearSolver::MUMPS, "MUMPS"},
+                            {LinearSolver::SUPERLU, "SuperLU"},
+                            {LinearSolver::STRUMPACK, "STRUMPACK"},
+                            {LinearSolver::STRUMPACK_MP, "STRUMPACK-MP"},
+                            {LinearSolver::JACOBI, "Jacobi"}})
 PALACE_JSON_SERIALIZE_ENUM(KrylovSolver, {{KrylovSolver::DEFAULT, "Default"},
                                           {KrylovSolver::CG, "CG"},
                                           {KrylovSolver::MINRES, "MINRES"},

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -79,12 +79,12 @@ PALACE_JSON_SERIALIZE_ENUM(SurfaceFlux, {{SurfaceFlux::ELECTRIC, "Electric"},
                                              {SurfaceFlux::MAGNETIC, "Magnetic"},
                                              {SurfaceFlux::POWER, "Power"}})
 
-// Helper for converting string keys to enum for InterfaceDielectricType.
-PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectricType,
-                           {{InterfaceDielectricType::DEFAULT, "Default"},
-                            {InterfaceDielectricType::MA, "MA"},
-                            {InterfaceDielectricType::MS, "MS"},
-                            {InterfaceDielectricType::SA, "SA"}})
+// Helper for converting string keys to enum for InterfaceDielectric.
+PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectric,
+                           {{InterfaceDielectric::DEFAULT, "Default"},
+                            {InterfaceDielectric::MA, "MA"},
+                            {InterfaceDielectric::MS, "MS"},
+                            {InterfaceDielectric::SA, "SA"}})
 
 // Helper for converting string keys to enum for FrequencySampleType.
 PALACE_JSON_SERIALIZE_ENUM(FrequencySampleType, {{FrequencySampleType::DEFAULT, "Default"},

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -86,11 +86,11 @@ PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectric,
                             {InterfaceDielectric::MS, "MS"},
                             {InterfaceDielectric::SA, "SA"}})
 
-// Helper for converting string keys to enum for FrequencySampleType.
-PALACE_JSON_SERIALIZE_ENUM(FrequencySampleType, {{FrequencySampleType::DEFAULT, "Default"},
-                                                 {FrequencySampleType::LINEAR, "Linear"},
-                                                 {FrequencySampleType::LOG, "Log"},
-                                                 {FrequencySampleType::POINT, "Point"}})
+// Helper for converting string keys to enum for FrequencySampling.
+PALACE_JSON_SERIALIZE_ENUM(FrequencySampling, {{FrequencySampling::DEFAULT, "Default"},
+                                                 {FrequencySampling::LINEAR, "Linear"},
+                                                 {FrequencySampling::LOG, "Log"},
+                                                 {FrequencySampling::POINT, "Point"}})
 
 // Helper for converting string keys to enum for TransientSolverType and ExcitationType.
 PALACE_JSON_SERIALIZE_ENUM(TransientSolverType,
@@ -1747,13 +1747,13 @@ void DrivenSolverData::SetUp(json &solver)
   {
     for (auto &r : *freq_samples)
     {
-      auto type = r.value("Type", r.find("Freq") != r.end() ? FrequencySampleType::POINT
-                                                            : FrequencySampleType::DEFAULT);
+      auto type = r.value("Type", r.find("Freq") != r.end() ? FrequencySampling::POINT
+                                                            : FrequencySampling::DEFAULT);
       auto f = [&]()
       {
         switch (type)
         {
-          case FrequencySampleType::LINEAR:
+          case FrequencySampling::LINEAR:
             {
               auto min_f = r.at("MinFreq");
               auto max_f = r.at("MaxFreq");
@@ -1771,14 +1771,14 @@ void DrivenSolverData::SetUp(json &solver)
                 return ConstructLinearRange(min_f, max_f, n_sample);
               }
             }
-          case FrequencySampleType::LOG:
+          case FrequencySampling::LOG:
             {
               auto min_f = r.at("MinFreq");
               auto max_f = r.at("MaxFreq");
               auto n_sample = r.at("NSample");
               return ConstructLogRange(min_f, max_f, n_sample);
             }
-          case FrequencySampleType::POINT:
+          case FrequencySampling::POINT:
             return r.at("Freq").get<std::vector<double>>();
         }
       }();

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -92,20 +92,20 @@ PALACE_JSON_SERIALIZE_ENUM(FrequencySampling, {{FrequencySampling::DEFAULT, "Def
                                                  {FrequencySampling::LOG, "Log"},
                                                  {FrequencySampling::POINT, "Point"}})
 
-// Helper for converting string keys to enum for TimeSteppingScheme and ExcitationType.
+// Helper for converting string keys to enum for TimeSteppingScheme and Excitation.
 PALACE_JSON_SERIALIZE_ENUM(TimeSteppingScheme,
                            {{TimeSteppingScheme::DEFAULT, "Default"},
                             {TimeSteppingScheme::GEN_ALPHA, "GeneralizedAlpha"},
                             {TimeSteppingScheme::RUNGE_KUTTA, "RungeKutta"},
                             {TimeSteppingScheme::CVODE, "CVODE"},
                             {TimeSteppingScheme::ARKODE, "ARKODE"}})
-PALACE_JSON_SERIALIZE_ENUM(ExcitationType,
-                           {{ExcitationType::SINUSOIDAL, "Sinusoidal"},
-                            {ExcitationType::GAUSSIAN, "Gaussian"},
-                            {ExcitationType::DIFF_GAUSSIAN, "DifferentiatedGaussian"},
-                            {ExcitationType::MOD_GAUSSIAN, "ModulatedGaussian"},
-                            {ExcitationType::RAMP_STEP, "Ramp"},
-                            {ExcitationType::SMOOTH_STEP, "SmoothStep"}})
+PALACE_JSON_SERIALIZE_ENUM(Excitation,
+                           {{Excitation::SINUSOIDAL, "Sinusoidal"},
+                            {Excitation::GAUSSIAN, "Gaussian"},
+                            {Excitation::DIFF_GAUSSIAN, "DifferentiatedGaussian"},
+                            {Excitation::MOD_GAUSSIAN, "ModulatedGaussian"},
+                            {Excitation::RAMP_STEP, "Ramp"},
+                            {Excitation::SMOOTH_STEP, "SmoothStep"}})
 
 // Helper for converting string keys to enum for LinearSolverType, KrylovSolver, and
 // MultigridCoarsening

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -51,20 +51,82 @@
     return os;                                                                      \
   }
 
+using json = nlohmann::json;
+namespace palace
+{
+// Helpers for converting enums specified in labels.hpp. Must be done in palace scope rather
+// than palace::config scope to ensure argument-dependent-lookup succeeds in json.
+
+// Helper for converting string keys to enum for CoordinateSystem.
+PALACE_JSON_SERIALIZE_ENUM(CoordinateSystem,
+                           {{CoordinateSystem::CARTESIAN, "Cartesian"},
+                            {CoordinateSystem::CYLINDRICAL, "Cylindrical"}})
+
+// Helper for converting string keys to enum for ProblemDataType.
+PALACE_JSON_SERIALIZE_ENUM(ProblemDataType,
+                           {{ProblemDataType::DRIVEN, "Driven"},
+                            {ProblemDataType::EIGENMODE, "Eigenmode"},
+                            {ProblemDataType::ELECTROSTATIC, "Electrostatic"},
+                            {ProblemDataType::MAGNETOSTATIC, "Magnetostatic"},
+                            {ProblemDataType::TRANSIENT, "Transient"}})
+
+// Helper for converting string keys to enum for EigenSolverType.
+PALACE_JSON_SERIALIZE_ENUM(EigenSolverType, {{EigenSolverType::DEFAULT, "Default"},
+                                             {EigenSolverType::SLEPC, "SLEPc"},
+                                             {EigenSolverType::ARPACK, "ARPACK"}})
+
+// Helper for converting string keys to enum for SurfaceFluxPostType.
+PALACE_JSON_SERIALIZE_ENUM(SurfaceFluxType, {{SurfaceFluxType::ELECTRIC, "Electric"},
+                                             {SurfaceFluxType::MAGNETIC, "Magnetic"},
+                                             {SurfaceFluxType::POWER, "Power"}})
+
+// Helper for converting string keys to enum for InterfaceDielectricType.
+PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectricType,
+                           {{InterfaceDielectricType::DEFAULT, "Default"},
+                            {InterfaceDielectricType::MA, "MA"},
+                            {InterfaceDielectricType::MS, "MS"},
+                            {InterfaceDielectricType::SA, "SA"}})
+
+// Helper for converting string keys to enum for FrequencySampleType.
+PALACE_JSON_SERIALIZE_ENUM(FrequencySampleType, {{FrequencySampleType::DEFAULT, "Default"},
+                                                 {FrequencySampleType::LINEAR, "Linear"},
+                                                 {FrequencySampleType::LOG, "Log"},
+                                                 {FrequencySampleType::POINT, "Point"}})
+
+// Helper for converting string keys to enum for TransientSolverType and ExcitationType.
+PALACE_JSON_SERIALIZE_ENUM(TransientSolverType,
+                           {{TransientSolverType::DEFAULT, "Default"},
+                            {TransientSolverType::GEN_ALPHA, "GeneralizedAlpha"},
+                            {TransientSolverType::RUNGE_KUTTA, "RungeKutta"},
+                            {TransientSolverType::CVODE, "CVODE"},
+                            {TransientSolverType::ARKODE, "ARKODE"}})
+PALACE_JSON_SERIALIZE_ENUM(ExcitationType,
+                           {{ExcitationType::SINUSOIDAL, "Sinusoidal"},
+                            {ExcitationType::GAUSSIAN, "Gaussian"},
+                            {ExcitationType::DIFF_GAUSSIAN, "DifferentiatedGaussian"},
+                            {ExcitationType::MOD_GAUSSIAN, "ModulatedGaussian"},
+                            {ExcitationType::RAMP_STEP, "Ramp"},
+                            {ExcitationType::SMOOTH_STEP, "SmoothStep"}})
+
+// Helper for converting string keys to enum for LinearSolverType.
+PALACE_JSON_SERIALIZE_ENUM(LinearSolverType,
+                           {{LinearSolverType::DEFAULT, "Default"},
+                            {LinearSolverType::AMS, "AMS"},
+                            {LinearSolverType::BOOMER_AMG, "BoomerAMG"},
+                            {LinearSolverType::MUMPS, "MUMPS"},
+                            {LinearSolverType::SUPERLU, "SuperLU"},
+                            {LinearSolverType::STRUMPACK, "STRUMPACK"},
+                            {LinearSolverType::STRUMPACK_MP, "STRUMPACK-MP"},
+                            {LinearSolverType::JACOBI, "Jacobi"}})
+
+// Helpers for converting string keys to enum for Device.
+PALACE_JSON_SERIALIZE_ENUM(Device, {{Device::CPU, "CPU"},
+                                    {Device::GPU, "GPU"},
+                                    {Device::DEBUG, "Debug"}})
+}  // namespace palace
+
 namespace palace::config
 {
-
-using json = nlohmann::json;
-
-namespace internal
-{
-
-// Helper for converting string keys to enum for ElementData::CoordinateSystem.
-PALACE_JSON_SERIALIZE_ENUM(ElementData::CoordinateSystem,
-                           {{ElementData::CoordinateSystem::CARTESIAN, "Cartesian"},
-                            {ElementData::CoordinateSystem::CYLINDRICAL, "Cylindrical"}})
-
-}  // namespace internal
 
 namespace
 {
@@ -230,14 +292,6 @@ std::ostream &operator<<(std::ostream &os, const SymmetricMatrixData<N> &data)
 constexpr bool JSON_DEBUG = false;
 
 }  // namespace
-
-// Helper for converting string keys to enum for ProblemData::Type.
-PALACE_JSON_SERIALIZE_ENUM(ProblemData::Type,
-                           {{ProblemData::Type::DRIVEN, "Driven"},
-                            {ProblemData::Type::EIGENMODE, "Eigenmode"},
-                            {ProblemData::Type::ELECTROSTATIC, "Electrostatic"},
-                            {ProblemData::Type::MAGNETOSTATIC, "Magnetostatic"},
-                            {ProblemData::Type::TRANSIENT, "Transient"}})
 
 void ProblemData::SetUp(json &config)
 {
@@ -1154,12 +1208,6 @@ void PeriodicBoundaryData::SetUp(json &boundaries)
   }
 }
 
-// Helper for converting string keys to enum for WavePortData::EigenSolverType.
-PALACE_JSON_SERIALIZE_ENUM(WavePortData::EigenSolverType,
-                           {{WavePortData::EigenSolverType::DEFAULT, "Default"},
-                            {WavePortData::EigenSolverType::SLEPC, "SLEPc"},
-                            {WavePortData::EigenSolverType::ARPACK, "ARPACK"}})
-
 void WavePortBoundaryData::SetUp(json &boundaries)
 {
   auto port = boundaries.find("WavePort");
@@ -1304,12 +1352,6 @@ void SurfaceCurrentBoundaryData::SetUp(json &boundaries)
   }
 }
 
-// Helper for converting string keys to enum for SurfaceFluxPostData::Type.
-PALACE_JSON_SERIALIZE_ENUM(SurfaceFluxData::Type,
-                           {{SurfaceFluxData::Type::ELECTRIC, "Electric"},
-                            {SurfaceFluxData::Type::MAGNETIC, "Magnetic"},
-                            {SurfaceFluxData::Type::POWER, "Power"}})
-
 void SurfaceFluxPostData::SetUp(json &postpro)
 {
   auto flux = postpro.find("SurfaceFlux");
@@ -1363,13 +1405,6 @@ void SurfaceFluxPostData::SetUp(json &postpro)
     }
   }
 }
-
-// Helper for converting string keys to enum for InterfaceDielectricData::Type.
-PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectricData::Type,
-                           {{InterfaceDielectricData::Type::DEFAULT, "Default"},
-                            {InterfaceDielectricData::Type::MA, "MA"},
-                            {InterfaceDielectricData::Type::MS, "MS"},
-                            {InterfaceDielectricData::Type::SA, "SA"}})
 
 void InterfaceDielectricPostData::SetUp(json &postpro)
 {
@@ -1644,12 +1679,6 @@ auto FindNearestValue(const std::vector<double> &vec, double x, double tol)
   return vec.end();
 }
 
-// Helper for converting string keys to enum for DrivenSolverData::FrequencySampleType.
-PALACE_JSON_SERIALIZE_ENUM(DrivenSolverData::FrequencySampleType,
-                           {{DrivenSolverData::FrequencySampleType::DEFAULT, "Default"},
-                            {DrivenSolverData::FrequencySampleType::LINEAR, "Linear"},
-                            {DrivenSolverData::FrequencySampleType::LOG, "Log"},
-                            {DrivenSolverData::FrequencySampleType::POINT, "Point"}})
 void DrivenSolverData::SetUp(json &solver)
 {
   auto driven = solver.find("Driven");
@@ -1961,23 +1990,6 @@ void MagnetostaticSolverData::SetUp(json &solver)
   }
 }
 
-// Helper for converting string keys to enum for TransientSolverData::Type and
-// TransientSolverData::ExcitationType.
-PALACE_JSON_SERIALIZE_ENUM(TransientSolverData::Type,
-                           {{TransientSolverData::Type::DEFAULT, "Default"},
-                            {TransientSolverData::Type::GEN_ALPHA, "GeneralizedAlpha"},
-                            {TransientSolverData::Type::RUNGE_KUTTA, "RungeKutta"},
-                            {TransientSolverData::Type::CVODE, "CVODE"},
-                            {TransientSolverData::Type::ARKODE, "ARKODE"}})
-PALACE_JSON_SERIALIZE_ENUM(
-    TransientSolverData::ExcitationType,
-    {{TransientSolverData::ExcitationType::SINUSOIDAL, "Sinusoidal"},
-     {TransientSolverData::ExcitationType::GAUSSIAN, "Gaussian"},
-     {TransientSolverData::ExcitationType::DIFF_GAUSSIAN, "DifferentiatedGaussian"},
-     {TransientSolverData::ExcitationType::MOD_GAUSSIAN, "ModulatedGaussian"},
-     {TransientSolverData::ExcitationType::RAMP_STEP, "Ramp"},
-     {TransientSolverData::ExcitationType::SMOOTH_STEP, "SmoothStep"}})
-
 void TransientSolverData::SetUp(json &solver)
 {
   auto transient = solver.find("Transient");
@@ -2059,19 +2071,10 @@ void TransientSolverData::SetUp(json &solver)
   }
 }
 
-// Helpers for converting string keys to enum for LinearSolverData::Type,
-// LinearSolverData::KspType, LinearSolverData::SideType,
-// LinearSolverData::MultigridCoarsenType, LinearSolverData::SymFactType,
-// LinearSolverData::CompressionType, and LinearSolverData::OrthogType.
-PALACE_JSON_SERIALIZE_ENUM(LinearSolverData::Type,
-                           {{LinearSolverData::Type::DEFAULT, "Default"},
-                            {LinearSolverData::Type::AMS, "AMS"},
-                            {LinearSolverData::Type::BOOMER_AMG, "BoomerAMG"},
-                            {LinearSolverData::Type::MUMPS, "MUMPS"},
-                            {LinearSolverData::Type::SUPERLU, "SuperLU"},
-                            {LinearSolverData::Type::STRUMPACK, "STRUMPACK"},
-                            {LinearSolverData::Type::STRUMPACK_MP, "STRUMPACK-MP"},
-                            {LinearSolverData::Type::JACOBI, "Jacobi"}})
+// Helpers for converting string keys to enum for LinearSolverData::KspType,
+// LinearSolverData::SideType, LinearSolverData::MultigridCoarsenType,
+// LinearSolverData::SymFactType, LinearSolverData::CompressionType, and
+// LinearSolverData::OrthogType.
 PALACE_JSON_SERIALIZE_ENUM(LinearSolverData::KspType,
                            {{LinearSolverData::KspType::DEFAULT, "Default"},
                             {LinearSolverData::KspType::CG, "CG"},
@@ -2247,11 +2250,6 @@ void LinearSolverData::SetUp(json &solver)
     std::cout << "GSOrthogonalization: " << gs_orthog_type << '\n';
   }
 }
-
-// Helpers for converting string keys to enum for SolverData::Device.
-PALACE_JSON_SERIALIZE_ENUM(SolverData::Device, {{SolverData::Device::CPU, "CPU"},
-                                                {SolverData::Device::GPU, "GPU"},
-                                                {SolverData::Device::DEBUG, "Debug"}})
 
 void SolverData::SetUp(json &config)
 {

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -75,9 +75,9 @@ PALACE_JSON_SERIALIZE_ENUM(EigenSolverType, {{EigenSolverType::DEFAULT, "Default
                                              {EigenSolverType::ARPACK, "ARPACK"}})
 
 // Helper for converting string keys to enum for SurfaceFluxPostType.
-PALACE_JSON_SERIALIZE_ENUM(SurfaceFluxType, {{SurfaceFluxType::ELECTRIC, "Electric"},
-                                             {SurfaceFluxType::MAGNETIC, "Magnetic"},
-                                             {SurfaceFluxType::POWER, "Power"}})
+PALACE_JSON_SERIALIZE_ENUM(SurfaceFlux, {{SurfaceFlux::ELECTRIC, "Electric"},
+                                             {SurfaceFlux::MAGNETIC, "Magnetic"},
+                                             {SurfaceFlux::POWER, "Power"}})
 
 // Helper for converting string keys to enum for InterfaceDielectricType.
 PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectricType,

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -92,13 +92,13 @@ PALACE_JSON_SERIALIZE_ENUM(FrequencySampling, {{FrequencySampling::DEFAULT, "Def
                                                  {FrequencySampling::LOG, "Log"},
                                                  {FrequencySampling::POINT, "Point"}})
 
-// Helper for converting string keys to enum for TransientSolverType and ExcitationType.
-PALACE_JSON_SERIALIZE_ENUM(TransientSolverType,
-                           {{TransientSolverType::DEFAULT, "Default"},
-                            {TransientSolverType::GEN_ALPHA, "GeneralizedAlpha"},
-                            {TransientSolverType::RUNGE_KUTTA, "RungeKutta"},
-                            {TransientSolverType::CVODE, "CVODE"},
-                            {TransientSolverType::ARKODE, "ARKODE"}})
+// Helper for converting string keys to enum for TimeSteppingScheme and ExcitationType.
+PALACE_JSON_SERIALIZE_ENUM(TimeSteppingScheme,
+                           {{TimeSteppingScheme::DEFAULT, "Default"},
+                            {TimeSteppingScheme::GEN_ALPHA, "GeneralizedAlpha"},
+                            {TimeSteppingScheme::RUNGE_KUTTA, "RungeKutta"},
+                            {TimeSteppingScheme::CVODE, "CVODE"},
+                            {TimeSteppingScheme::ARKODE, "ARKODE"}})
 PALACE_JSON_SERIALIZE_ENUM(ExcitationType,
                            {{ExcitationType::SINUSOIDAL, "Sinusoidal"},
                             {ExcitationType::GAUSSIAN, "Gaussian"},
@@ -2050,7 +2050,7 @@ void TransientSolverData::SetUp(json &solver)
   abs_tol = transient->value("AbsTol", abs_tol);
   MFEM_VERIFY(delta_t > 0, "\"TimeStep\" must be greater than 0.0!");
 
-  if (type == TransientSolverType::GEN_ALPHA || type == TransientSolverType::RUNGE_KUTTA)
+  if (type == TimeSteppingScheme::GEN_ALPHA || type == TimeSteppingScheme::RUNGE_KUTTA)
   {
     if (transient->contains("Order"))
     {

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -71,26 +71,25 @@ PALACE_JSON_SERIALIZE_ENUM(ProblemType, {{ProblemType::DRIVEN, "Driven"},
 
 // Helper for converting string keys to enum for EigenSolverBackend.
 PALACE_JSON_SERIALIZE_ENUM(EigenSolverBackend, {{EigenSolverBackend::DEFAULT, "Default"},
-                                             {EigenSolverBackend::SLEPC, "SLEPc"},
-                                             {EigenSolverBackend::ARPACK, "ARPACK"}})
+                                                {EigenSolverBackend::SLEPC, "SLEPc"},
+                                                {EigenSolverBackend::ARPACK, "ARPACK"}})
 
-// Helper for converting string keys to enum for SurfaceFluxPostType.
+// Helper for converting string keys to enum for SurfaceFlux.
 PALACE_JSON_SERIALIZE_ENUM(SurfaceFlux, {{SurfaceFlux::ELECTRIC, "Electric"},
-                                             {SurfaceFlux::MAGNETIC, "Magnetic"},
-                                             {SurfaceFlux::POWER, "Power"}})
+                                         {SurfaceFlux::MAGNETIC, "Magnetic"},
+                                         {SurfaceFlux::POWER, "Power"}})
 
 // Helper for converting string keys to enum for InterfaceDielectric.
-PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectric,
-                           {{InterfaceDielectric::DEFAULT, "Default"},
-                            {InterfaceDielectric::MA, "MA"},
-                            {InterfaceDielectric::MS, "MS"},
-                            {InterfaceDielectric::SA, "SA"}})
+PALACE_JSON_SERIALIZE_ENUM(InterfaceDielectric, {{InterfaceDielectric::DEFAULT, "Default"},
+                                                 {InterfaceDielectric::MA, "MA"},
+                                                 {InterfaceDielectric::MS, "MS"},
+                                                 {InterfaceDielectric::SA, "SA"}})
 
 // Helper for converting string keys to enum for FrequencySampling.
 PALACE_JSON_SERIALIZE_ENUM(FrequencySampling, {{FrequencySampling::DEFAULT, "Default"},
-                                                 {FrequencySampling::LINEAR, "Linear"},
-                                                 {FrequencySampling::LOG, "Log"},
-                                                 {FrequencySampling::POINT, "Point"}})
+                                               {FrequencySampling::LINEAR, "Linear"},
+                                               {FrequencySampling::LOG, "Log"},
+                                               {FrequencySampling::POINT, "Point"}})
 
 // Helper for converting string keys to enum for TimeSteppingScheme and Excitation.
 PALACE_JSON_SERIALIZE_ENUM(TimeSteppingScheme,
@@ -109,15 +108,14 @@ PALACE_JSON_SERIALIZE_ENUM(Excitation,
 
 // Helper for converting string keys to enum for LinearSolver, KrylovSolver, and
 // MultigridCoarsening
-PALACE_JSON_SERIALIZE_ENUM(LinearSolver,
-                           {{LinearSolver::DEFAULT, "Default"},
-                            {LinearSolver::AMS, "AMS"},
-                            {LinearSolver::BOOMER_AMG, "BoomerAMG"},
-                            {LinearSolver::MUMPS, "MUMPS"},
-                            {LinearSolver::SUPERLU, "SuperLU"},
-                            {LinearSolver::STRUMPACK, "STRUMPACK"},
-                            {LinearSolver::STRUMPACK_MP, "STRUMPACK-MP"},
-                            {LinearSolver::JACOBI, "Jacobi"}})
+PALACE_JSON_SERIALIZE_ENUM(LinearSolver, {{LinearSolver::DEFAULT, "Default"},
+                                          {LinearSolver::AMS, "AMS"},
+                                          {LinearSolver::BOOMER_AMG, "BoomerAMG"},
+                                          {LinearSolver::MUMPS, "MUMPS"},
+                                          {LinearSolver::SUPERLU, "SuperLU"},
+                                          {LinearSolver::STRUMPACK, "STRUMPACK"},
+                                          {LinearSolver::STRUMPACK_MP, "STRUMPACK-MP"},
+                                          {LinearSolver::JACOBI, "Jacobi"}})
 PALACE_JSON_SERIALIZE_ENUM(KrylovSolver, {{KrylovSolver::DEFAULT, "Default"},
                                           {KrylovSolver::CG, "CG"},
                                           {KrylovSolver::MINRES, "MINRES"},
@@ -1268,7 +1266,7 @@ void WavePortBoundaryData::SetUp(json &boundaries)
     MFEM_VERIFY(data.mode_idx > 0,
                 "\"WavePort\" boundary \"Mode\" must be positive (1-based)!");
     data.d_offset = it->value("Offset", data.d_offset);
-    data.eigen_type = it->value("SolverType", data.eigen_type);
+    data.eigen_solver = it->value("SolverType", data.eigen_solver);
 
     data.excitation = ParsePortExcitation(it, data.excitation);
     data.active = it->value("Active", data.active);
@@ -1300,7 +1298,7 @@ void WavePortBoundaryData::SetUp(json &boundaries)
       std::cout << "Attributes: " << data.attributes << '\n';
       std::cout << "Mode: " << data.mode_idx << '\n';
       std::cout << "Offset: " << data.d_offset << '\n';
-      std::cout << "SolverType: " << data.eigen_type << '\n';
+      std::cout << "SolverType: " << data.eigen_solver << '\n';
       std::cout << "Excitation: " << data.excitation << '\n';
       std::cout << "Active: " << data.active << '\n';
       std::cout << "MaxIts: " << data.ksp_max_its << '\n';
@@ -2113,7 +2111,7 @@ void LinearSolverData::SetUp(json &solver)
     return;
   }
   type = linear->value("Type", type);
-  ksp_type = linear->value("KSPType", ksp_type);
+  krylov_solver = linear->value("KSPType", krylov_solver);
   tol = linear->value("Tol", tol);
   max_it = linear->value("MaxIts", max_it);
   max_size = linear->value("MaxSize", max_size);
@@ -2121,7 +2119,7 @@ void LinearSolverData::SetUp(json &solver)
 
   // Options related to multigrid.
   mg_max_levels = linear->value("MGMaxLevels", mg_max_levels);
-  mg_coarsen_type = linear->value("MGCoarsenType", mg_coarsen_type);
+  mg_coarsening = linear->value("MGCoarsenType", mg_coarsening);
   mg_use_mesh = linear->value("MGUseMesh", mg_use_mesh);
   mg_cycle_it = linear->value("MGCycleIts", mg_cycle_it);
   mg_smooth_aux = linear->value("MGAuxiliarySmoother", mg_smooth_aux);
@@ -2135,8 +2133,8 @@ void LinearSolverData::SetUp(json &solver)
   pc_mat_real = linear->value("PCMatReal", pc_mat_real);
   pc_mat_shifted = linear->value("PCMatShifted", pc_mat_shifted);
   complex_coarse_solve = linear->value("ComplexCoarseSolve", complex_coarse_solve);
-  pc_side_type = linear->value("PCSide", pc_side_type);
-  sym_fact_type = linear->value("ColumnOrdering", sym_fact_type);
+  pc_side = linear->value("PCSide", pc_side);
+  sym_factorization = linear->value("ColumnOrdering", sym_factorization);
   strumpack_compression_type =
       linear->value("STRUMPACKCompressionType", strumpack_compression_type);
   strumpack_lr_tol = linear->value("STRUMPACKCompressionTol", strumpack_lr_tol);
@@ -2203,14 +2201,14 @@ void LinearSolverData::SetUp(json &solver)
   if constexpr (JSON_DEBUG)
   {
     std::cout << "Type: " << type << '\n';
-    std::cout << "KSPType: " << ksp_type << '\n';
+    std::cout << "KSPType: " << krylov_solver << '\n';
     std::cout << "Tol: " << tol << '\n';
     std::cout << "MaxIts: " << max_it << '\n';
     std::cout << "MaxSize: " << max_size << '\n';
     std::cout << "InitialGuess: " << initial_guess << '\n';
 
     std::cout << "MGMaxLevels: " << mg_max_levels << '\n';
-    std::cout << "MGCoarsenType: " << mg_coarsen_type << '\n';
+    std::cout << "MGCoarsenType: " << mg_coarsening << '\n';
     std::cout << "MGUseMesh: " << mg_use_mesh << '\n';
     std::cout << "MGCycleIts: " << mg_cycle_it << '\n';
     std::cout << "MGAuxiliarySmoother: " << mg_smooth_aux << '\n';
@@ -2223,8 +2221,8 @@ void LinearSolverData::SetUp(json &solver)
     std::cout << "PCMatReal: " << pc_mat_real << '\n';
     std::cout << "PCMatShifted: " << pc_mat_shifted << '\n';
     std::cout << "ComplexCoarseSolve: " << complex_coarse_solve << '\n';
-    std::cout << "PCSide: " << pc_side_type << '\n';
-    std::cout << "ColumnOrdering: " << sym_fact_type << '\n';
+    std::cout << "PCSide: " << pc_side << '\n';
+    std::cout << "ColumnOrdering: " << sym_factorization << '\n';
     std::cout << "STRUMPACKCompressionType: " << strumpack_compression_type << '\n';
     std::cout << "STRUMPACKCompressionTol: " << strumpack_lr_tol << '\n';
     std::cout << "STRUMPACKLossyPrecision: " << strumpack_lossy_precision << '\n';

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -69,10 +69,10 @@ PALACE_JSON_SERIALIZE_ENUM(ProblemType, {{ProblemType::DRIVEN, "Driven"},
                                          {ProblemType::MAGNETOSTATIC, "Magnetostatic"},
                                          {ProblemType::TRANSIENT, "Transient"}})
 
-// Helper for converting string keys to enum for EigenSolverType.
-PALACE_JSON_SERIALIZE_ENUM(EigenSolverType, {{EigenSolverType::DEFAULT, "Default"},
-                                             {EigenSolverType::SLEPC, "SLEPc"},
-                                             {EigenSolverType::ARPACK, "ARPACK"}})
+// Helper for converting string keys to enum for EigenSolverBackend.
+PALACE_JSON_SERIALIZE_ENUM(EigenSolverBackend, {{EigenSolverBackend::DEFAULT, "Default"},
+                                             {EigenSolverBackend::SLEPC, "SLEPc"},
+                                             {EigenSolverBackend::ARPACK, "ARPACK"}})
 
 // Helper for converting string keys to enum for SurfaceFluxPostType.
 PALACE_JSON_SERIALIZE_ENUM(SurfaceFlux, {{SurfaceFlux::ELECTRIC, "Electric"},

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -75,14 +75,6 @@ struct ElementData
   // map to (1,0,0), (0,1,0), and (0,0,1), respectively.
   std::array<double, 3> direction{{0.0, 0.0, 0.0}};
 
-  // Coordinate system that the normal vector is expressed in.
-  using CoordinateSystem = CoordinateSystem;
-
-  // enum class CoordinateSystem
-  // {
-  //   CARTESIAN,
-  //   CYLINDRICAL
-  // };
   CoordinateSystem coordinate_system = CoordinateSystem::CARTESIAN;
 
   // List of boundary attributes for this element.
@@ -97,8 +89,7 @@ struct ProblemData
 {
 public:
   // Simulation type.
-  using Type = ProblemDataType;
-  Type type = Type::DRIVEN;
+  ProblemType type = ProblemType::DRIVEN;
 
   // Level of printing.
   int verbose = 1;
@@ -515,7 +506,6 @@ public:
   double d_offset = 0.0;
 
   // Eigenvalue solver type for boundary mode calculation.
-  using EigenSolverType = EigenSolverType;
   EigenSolverType eigen_type = EigenSolverType::DEFAULT;
 
   // Input excitation for driven & transient solver:
@@ -566,8 +556,7 @@ struct SurfaceFluxData
 {
 public:
   // Surface flux type.
-  using Type = SurfaceFluxType;
-  Type type = Type::ELECTRIC;
+  SurfaceFluxType type = SurfaceFluxType::ELECTRIC;
 
   // Flag for whether or not to consider the boundary as an infinitely thin two-sided
   // boundary for postprocessing.
@@ -594,8 +583,7 @@ struct InterfaceDielectricData
 {
 public:
   // Type of interface dielectric for computing electric field energy participation ratios.
-  using Type = InterfaceDielectricType;
-  Type type = Type::DEFAULT;
+  InterfaceDielectricType type = InterfaceDielectricType::DEFAULT;
 
   // Dielectric interface thickness [m].
   double t = 0.0;
@@ -657,9 +645,6 @@ public:
 struct DrivenSolverData
 {
 public:
-  // Frequency sampling schemes.
-  using FrequencySampleType = FrequencySampleType;
-
   // Explicit frequency samples [GHz].
   std::vector<double> sample_f = {};
 
@@ -717,8 +702,7 @@ public:
   bool mass_orthog = false;
 
   // Eigenvalue solver type.
-  using Type = EigenSolverType;
-  Type type = Type::DEFAULT;
+  EigenSolverType type = EigenSolverType::DEFAULT;
 
   // For SLEPc eigenvalue solver, use linearized formulation for quadratic eigenvalue
   // problems.
@@ -749,11 +733,9 @@ struct TransientSolverData
 {
 public:
   // Time integration scheme type.
-  using Type = TransientSolverType;
-  Type type = Type::DEFAULT;
+  TransientSolverType type = TransientSolverType::DEFAULT;
 
   // Excitation type for port excitation.
-  using ExcitationType = ExcitationType;
   ExcitationType excitation = ExcitationType::SINUSOIDAL;
 
   // Excitation parameters: frequency [GHz] and pulse width [ns].
@@ -785,20 +767,10 @@ struct LinearSolverData
 {
 public:
   // Solver type.
-  using Type = LinearSolverType;
-  Type type = Type::DEFAULT;
+  LinearSolverType type = LinearSolverType::DEFAULT;
 
   // Krylov solver type.
-  enum class KspType
-  {
-    DEFAULT,
-    CG,
-    MINRES,
-    GMRES,
-    FGMRES,
-    BICGSTAB
-  };
-  KspType ksp_type = KspType::DEFAULT;
+  KrylovSolver ksp_type = KrylovSolver::DEFAULT;
 
   // Iterative solver relative tolerance.
   double tol = 1.0e-6;
@@ -816,12 +788,7 @@ public:
   int mg_max_levels = 100;
 
   // Type of coarsening for p-multigrid.
-  enum class MultigridCoarsenType
-  {
-    LINEAR,
-    LOGARITHMIC
-  };
-  MultigridCoarsenType mg_coarsen_type = MultigridCoarsenType::LOGARITHMIC;
+  MultigridCoarsening mg_coarsen_type = MultigridCoarsening::LOGARITHMIC;
 
   // Controls whether or not to include in the geometric multigrid hierarchy the mesh levels
   // from uniform refinement.
@@ -863,42 +830,16 @@ public:
   bool complex_coarse_solve = false;
 
   // Choose left or right preconditioning.
-  enum class SideType
-  {
-    DEFAULT,
-    RIGHT,
-    LEFT
-  };
-  SideType pc_side_type = SideType::DEFAULT;
+  PreconditionerSide pc_side_type = PreconditionerSide::DEFAULT;
 
   // Specify details for the column ordering method in the symbolic factorization for sparse
   // direct solvers.
-  enum class SymFactType
-  {
-    DEFAULT,
-    METIS,
-    PARMETIS,
-    SCOTCH,
-    PTSCOTCH,
-    PORD,
-    AMD,
-    RCM
-  };
-  SymFactType sym_fact_type = SymFactType::DEFAULT;
+  SymbolicFactorization sym_fact_type = SymbolicFactorization::DEFAULT;
 
   // Low-rank and butterfly compression parameters for sparse direct solvers which support
   // it (mainly STRUMPACK).
-  enum class CompressionType
-  {
-    NONE,
-    BLR,
-    HSS,
-    HODLR,
-    ZFP,
-    BLR_HODLR,
-    ZFP_BLR_HODLR
-  };
-  CompressionType strumpack_compression_type = CompressionType::NONE;
+  SparseCompression strumpack_compression_type = SparseCompression::NONE;
+
   double strumpack_lr_tol = 1.0e-3;
   int strumpack_lossy_precision = 16;
   int strumpack_butterfly_l = 1;
@@ -935,13 +876,7 @@ public:
 
   // Enable different variants of Gram-Schmidt orthogonalization for GMRES/FGMRES iterative
   // solvers and SLEPc eigenvalue solver.
-  enum class OrthogType
-  {
-    MGS,
-    CGS,
-    CGS2
-  };
-  OrthogType gs_orthog_type = OrthogType::MGS;
+  Orthogonalization gs_orthog = Orthogonalization::MGS;
 
   void SetUp(json &solver);
 };
@@ -963,7 +898,6 @@ public:
   int q_order_extra = 0;
 
   // Device used to configure MFEM.
-  using Device = Device;
   Device device = Device::CPU;
 
   // Backend for libCEED (https://libceed.org/en/latest/gettingstarted/#backends).

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -736,7 +736,7 @@ public:
   TimeSteppingScheme type = TimeSteppingScheme::DEFAULT;
 
   // Excitation type for port excitation.
-  ExcitationType excitation = ExcitationType::SINUSOIDAL;
+  Excitation excitation = Excitation::SINUSOIDAL;
 
   // Excitation parameters: frequency [GHz] and pulse width [ns].
   double pulse_f = 0.0;

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -556,7 +556,7 @@ struct SurfaceFluxData
 {
 public:
   // Surface flux type.
-  SurfaceFluxType type = SurfaceFluxType::ELECTRIC;
+  SurfaceFlux type = SurfaceFlux::ELECTRIC;
 
   // Flag for whether or not to consider the boundary as an infinitely thin two-sided
   // boundary for postprocessing.

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -506,7 +506,7 @@ public:
   double d_offset = 0.0;
 
   // Eigenvalue solver type for boundary mode calculation.
-  EigenSolverType eigen_type = EigenSolverType::DEFAULT;
+  EigenSolverBackend eigen_type = EigenSolverBackend::DEFAULT;
 
   // Input excitation for driven & transient solver:
   // - Wave/Lumped ports with same index are excited together.
@@ -702,7 +702,7 @@ public:
   bool mass_orthog = false;
 
   // Eigenvalue solver type.
-  EigenSolverType type = EigenSolverType::DEFAULT;
+  EigenSolverBackend type = EigenSolverBackend::DEFAULT;
 
   // For SLEPc eigenvalue solver, use linearized formulation for quadratic eigenvalue
   // problems.

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 #include <nlohmann/json_fwd.hpp>
+#include "labels.hpp"
 
 namespace palace::config
 {
@@ -75,11 +76,13 @@ struct ElementData
   std::array<double, 3> direction{{0.0, 0.0, 0.0}};
 
   // Coordinate system that the normal vector is expressed in.
-  enum class CoordinateSystem
-  {
-    CARTESIAN,
-    CYLINDRICAL
-  };
+  using CoordinateSystem = CoordinateSystem;
+
+  // enum class CoordinateSystem
+  // {
+  //   CARTESIAN,
+  //   CYLINDRICAL
+  // };
   CoordinateSystem coordinate_system = CoordinateSystem::CARTESIAN;
 
   // List of boundary attributes for this element.
@@ -94,14 +97,7 @@ struct ProblemData
 {
 public:
   // Simulation type.
-  enum class Type
-  {
-    DRIVEN,
-    EIGENMODE,
-    ELECTROSTATIC,
-    MAGNETOSTATIC,
-    TRANSIENT
-  };
+  using Type = ProblemDataType;
   Type type = Type::DRIVEN;
 
   // Level of printing.
@@ -519,12 +515,7 @@ public:
   double d_offset = 0.0;
 
   // Eigenvalue solver type for boundary mode calculation.
-  enum class EigenSolverType
-  {
-    DEFAULT,
-    SLEPC,
-    ARPACK
-  };
+  using EigenSolverType = EigenSolverType;
   EigenSolverType eigen_type = EigenSolverType::DEFAULT;
 
   // Input excitation for driven & transient solver:
@@ -575,12 +566,7 @@ struct SurfaceFluxData
 {
 public:
   // Surface flux type.
-  enum class Type
-  {
-    ELECTRIC,
-    MAGNETIC,
-    POWER
-  };
+  using Type = SurfaceFluxType;
   Type type = Type::ELECTRIC;
 
   // Flag for whether or not to consider the boundary as an infinitely thin two-sided
@@ -608,13 +594,7 @@ struct InterfaceDielectricData
 {
 public:
   // Type of interface dielectric for computing electric field energy participation ratios.
-  enum class Type
-  {
-    DEFAULT,
-    MA,
-    MS,
-    SA
-  };
+  using Type = InterfaceDielectricType;
   Type type = Type::DEFAULT;
 
   // Dielectric interface thickness [m].
@@ -678,13 +658,7 @@ struct DrivenSolverData
 {
 public:
   // Frequency sampling schemes.
-  enum class FrequencySampleType : u_int8_t
-  {
-    LINEAR,
-    LOG,
-    POINT,
-    DEFAULT = LINEAR
-  };
+  using FrequencySampleType = FrequencySampleType;
 
   // Explicit frequency samples [GHz].
   std::vector<double> sample_f = {};
@@ -743,7 +717,7 @@ public:
   bool mass_orthog = false;
 
   // Eigenvalue solver type.
-  using Type = WavePortData::EigenSolverType;
+  using Type = EigenSolverType;
   Type type = Type::DEFAULT;
 
   // For SLEPc eigenvalue solver, use linearized formulation for quadratic eigenvalue
@@ -775,26 +749,11 @@ struct TransientSolverData
 {
 public:
   // Time integration scheme type.
-  enum class Type
-  {
-    GEN_ALPHA,
-    RUNGE_KUTTA,
-    ARKODE,
-    CVODE,
-    DEFAULT = GEN_ALPHA
-  };
+  using Type = TransientSolverType;
   Type type = Type::DEFAULT;
 
   // Excitation type for port excitation.
-  enum class ExcitationType
-  {
-    SINUSOIDAL,
-    GAUSSIAN,
-    DIFF_GAUSSIAN,
-    MOD_GAUSSIAN,
-    RAMP_STEP,
-    SMOOTH_STEP
-  };
+  using ExcitationType = ExcitationType;
   ExcitationType excitation = ExcitationType::SINUSOIDAL;
 
   // Excitation parameters: frequency [GHz] and pulse width [ns].
@@ -826,17 +785,7 @@ struct LinearSolverData
 {
 public:
   // Solver type.
-  enum class Type
-  {
-    DEFAULT,
-    AMS,
-    BOOMER_AMG,
-    MUMPS,
-    SUPERLU,
-    STRUMPACK,
-    STRUMPACK_MP,
-    JACOBI
-  };
+  using Type = LinearSolverType;
   Type type = Type::DEFAULT;
 
   // Krylov solver type.
@@ -1014,12 +963,7 @@ public:
   int q_order_extra = 0;
 
   // Device used to configure MFEM.
-  enum class Device
-  {
-    CPU,
-    GPU,
-    DEBUG
-  };
+  using Device = Device;
   Device device = Device::CPU;
 
   // Backend for libCEED (https://libceed.org/en/latest/gettingstarted/#backends).
@@ -1042,4 +986,4 @@ int GetNumSteps(double start, double end, double delta);
 
 }  // namespace palace::config
 
-#endif  // PALACE_UTILS_CONFIGFILE_HPP
+#endif  // PALACE_UTILS_CONFIG_FILE_HPP

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -767,7 +767,7 @@ struct LinearSolverData
 {
 public:
   // Solver type.
-  LinearSolverType type = LinearSolverType::DEFAULT;
+  LinearSolver type = LinearSolver::DEFAULT;
 
   // Krylov solver type.
   KrylovSolver ksp_type = KrylovSolver::DEFAULT;

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -583,7 +583,7 @@ struct InterfaceDielectricData
 {
 public:
   // Type of interface dielectric for computing electric field energy participation ratios.
-  InterfaceDielectricType type = InterfaceDielectricType::DEFAULT;
+  InterfaceDielectric type = InterfaceDielectric::DEFAULT;
 
   // Dielectric interface thickness [m].
   double t = 0.0;

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -506,7 +506,7 @@ public:
   double d_offset = 0.0;
 
   // Eigenvalue solver type for boundary mode calculation.
-  EigenSolverBackend eigen_type = EigenSolverBackend::DEFAULT;
+  EigenSolverBackend eigen_solver = EigenSolverBackend::DEFAULT;
 
   // Input excitation for driven & transient solver:
   // - Wave/Lumped ports with same index are excited together.
@@ -770,7 +770,7 @@ public:
   LinearSolver type = LinearSolver::DEFAULT;
 
   // Krylov solver type.
-  KrylovSolver ksp_type = KrylovSolver::DEFAULT;
+  KrylovSolver krylov_solver = KrylovSolver::DEFAULT;
 
   // Iterative solver relative tolerance.
   double tol = 1.0e-6;
@@ -788,7 +788,7 @@ public:
   int mg_max_levels = 100;
 
   // Type of coarsening for p-multigrid.
-  MultigridCoarsening mg_coarsen_type = MultigridCoarsening::LOGARITHMIC;
+  MultigridCoarsening mg_coarsening = MultigridCoarsening::LOGARITHMIC;
 
   // Controls whether or not to include in the geometric multigrid hierarchy the mesh levels
   // from uniform refinement.
@@ -830,11 +830,11 @@ public:
   bool complex_coarse_solve = false;
 
   // Choose left or right preconditioning.
-  PreconditionerSide pc_side_type = PreconditionerSide::DEFAULT;
+  PreconditionerSide pc_side = PreconditionerSide::DEFAULT;
 
   // Specify details for the column ordering method in the symbolic factorization for sparse
   // direct solvers.
-  SymbolicFactorization sym_fact_type = SymbolicFactorization::DEFAULT;
+  SymbolicFactorization sym_factorization = SymbolicFactorization::DEFAULT;
 
   // Low-rank and butterfly compression parameters for sparse direct solvers which support
   // it (mainly STRUMPACK).

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -733,7 +733,7 @@ struct TransientSolverData
 {
 public:
   // Time integration scheme type.
-  TransientSolverType type = TransientSolverType::DEFAULT;
+  TimeSteppingScheme type = TimeSteppingScheme::DEFAULT;
 
   // Excitation type for port excitation.
   ExcitationType excitation = ExcitationType::SINUSOIDAL;

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -326,28 +326,28 @@ void IoData::CheckConfiguration()
   }
 
   // Resolve default values in configuration file.
-  if (solver.linear.type == LinearSolverType::DEFAULT)
+  if (solver.linear.type == LinearSolver::DEFAULT)
   {
     if (problem.type == ProblemType::ELECTROSTATIC)
     {
-      solver.linear.type = LinearSolverType::BOOMER_AMG;
+      solver.linear.type = LinearSolver::BOOMER_AMG;
     }
     else if (problem.type == ProblemType::MAGNETOSTATIC ||
              problem.type == ProblemType::TRANSIENT)
     {
-      solver.linear.type = LinearSolverType::AMS;
+      solver.linear.type = LinearSolver::AMS;
     }
     else
     {
       // Prefer sparse direct solver for frequency domain problems if available.
 #if defined(MFEM_USE_SUPERLU)
-      solver.linear.type = LinearSolverType::SUPERLU;
+      solver.linear.type = LinearSolver::SUPERLU;
 #elif defined(MFEM_USE_STRUMPACK)
-      solver.linear.type = LinearSolverType::STRUMPACK;
+      solver.linear.type = LinearSolver::STRUMPACK;
 #elif defined(MFEM_USE_MUMPS)
-      solver.linear.type = LinearSolverType::MUMPS;
+      solver.linear.type = LinearSolver::MUMPS;
 #else
-      solver.linear.type = LinearSolverType::AMS;
+      solver.linear.type = LinearSolver::AMS;
 #endif
     }
   }
@@ -387,7 +387,7 @@ void IoData::CheckConfiguration()
   }
   if (solver.linear.pc_mat_shifted < 0)
   {
-    if (problem.type == ProblemType::DRIVEN && solver.linear.type == LinearSolverType::AMS)
+    if (problem.type == ProblemType::DRIVEN && solver.linear.type == LinearSolver::AMS)
     {
       // Default true only driven simulations using AMS (false for most cases).
       solver.linear.pc_mat_shifted = 1;

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -351,18 +351,18 @@ void IoData::CheckConfiguration()
 #endif
     }
   }
-  if (solver.linear.ksp_type == KrylovSolver::DEFAULT)
+  if (solver.linear.krylov_solver == KrylovSolver::DEFAULT)
   {
     // Problems with SPD operators use CG by default, else GMRES.
     if (problem.type == ProblemType::ELECTROSTATIC ||
         problem.type == ProblemType::MAGNETOSTATIC ||
         problem.type == ProblemType::TRANSIENT)
     {
-      solver.linear.ksp_type = KrylovSolver::CG;
+      solver.linear.krylov_solver = KrylovSolver::CG;
     }
     else
     {
-      solver.linear.ksp_type = KrylovSolver::GMRES;
+      solver.linear.krylov_solver = KrylovSolver::GMRES;
     }
   }
   if (solver.linear.max_size < 0)

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -7,13 +7,15 @@
 namespace palace
 {
 
-enum class CoordinateSystem : uint8_t
+// Usable coordinate systems.
+enum class CoordinateSystem : char
 {
   CARTESIAN,
   CYLINDRICAL
 };
 
-enum class ProblemDataType : uint8_t
+// Problem types Palace is able to solve.
+enum class ProblemType : char
 {
   DRIVEN,
   EIGENMODE,
@@ -22,21 +24,24 @@ enum class ProblemDataType : uint8_t
   TRANSIENT
 };
 
-enum class EigenSolverType : uint8_t
+// Eigenvalue solver type.
+enum class EigenSolverType : char
 {
   DEFAULT,
   SLEPC,
   ARPACK
 };
 
-enum class SurfaceFluxType : uint8_t
+// Surface fluxes.
+enum class SurfaceFluxType : char
 {
   ELECTRIC,
   MAGNETIC,
   POWER
 };
 
-enum class InterfaceDielectricType : uint8_t
+// Interface dielectrics for computing electric field energy participation ratios.
+enum class InterfaceDielectricType : char
 {
   DEFAULT,
   MA,
@@ -44,7 +49,8 @@ enum class InterfaceDielectricType : uint8_t
   SA
 };
 
-enum class FrequencySampleType : u_int8_t
+// Frequency sampling schemes.
+enum class FrequencySampleType : char
 {
   LINEAR,
   LOG,
@@ -52,7 +58,8 @@ enum class FrequencySampleType : u_int8_t
   DEFAULT = LINEAR
 };
 
-enum class TransientSolverType : uint8_t
+// Time integration scheme type.
+enum class TransientSolverType : char
 {
   GEN_ALPHA,
   RUNGE_KUTTA,
@@ -61,7 +68,8 @@ enum class TransientSolverType : uint8_t
   DEFAULT = GEN_ALPHA
 };
 
-enum class ExcitationType : uint8_t
+// Excitation type for port excitation.
+enum class ExcitationType : char
 {
   SINUSOIDAL,
   GAUSSIAN,
@@ -71,7 +79,8 @@ enum class ExcitationType : uint8_t
   SMOOTH_STEP
 };
 
-enum class LinearSolverType : uint8_t
+// Type of linear solver.
+enum class LinearSolverType : char
 {
   DEFAULT,
   AMS,
@@ -83,7 +92,69 @@ enum class LinearSolverType : uint8_t
   JACOBI
 };
 
-enum class Device : uint8_t
+// Krylov solver type in linear solver.
+enum class KrylovSolver : char
+{
+  DEFAULT,
+  CG,
+  MINRES,
+  GMRES,
+  FGMRES,
+  BICGSTAB
+};
+
+// Type of coarsening for p-multigrid.
+enum class MultigridCoarsening : char
+{
+  LINEAR,
+  LOGARITHMIC
+};
+
+// Preconditioning side.
+enum class PreconditionerSide : char
+{
+  DEFAULT,
+  RIGHT,
+  LEFT
+};
+
+// Column ordering method in the symbolic factorization for sparse direct solvers.
+enum class SymbolicFactorization : char
+{
+  DEFAULT,
+  METIS,
+  PARMETIS,
+  SCOTCH,
+  PTSCOTCH,
+  PORD,
+  AMD,
+  RCM
+};
+
+// Low-rank and butterfly compression scheme for sparse direct solvers which support it
+// (mainly STRUMPACK).
+enum class SparseCompression : char
+{
+  NONE,
+  BLR,
+  HSS,
+  HODLR,
+  ZFP,
+  BLR_HODLR,
+  ZFP_BLR_HODLR
+};
+
+// Variations of Gram-Schmidt orthogonalization for GMRES/FGMRES iterative solvers and SLEPc
+// eigenvalue solver.
+enum class Orthogonalization : char
+{
+  MGS,
+  CGS,
+  CGS2
+};
+
+// Device used to configure MFEM.
+enum class Device : char
 {
   CPU,
   GPU,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -69,7 +69,7 @@ enum class TimeSteppingScheme : char
 };
 
 // Excitation type for port excitation.
-enum class ExcitationType : char
+enum class Excitation : char
 {
   SINUSOIDAL,
   GAUSSIAN,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_UTILS_LABELS_HPP
+#define PALACE_UTILS_LABELS_HPP
+
+namespace palace
+{
+
+enum class CoordinateSystem : uint8_t
+{
+  CARTESIAN,
+  CYLINDRICAL
+};
+
+enum class ProblemDataType : uint8_t
+{
+  DRIVEN,
+  EIGENMODE,
+  ELECTROSTATIC,
+  MAGNETOSTATIC,
+  TRANSIENT
+};
+
+enum class EigenSolverType : uint8_t
+{
+  DEFAULT,
+  SLEPC,
+  ARPACK
+};
+
+enum class SurfaceFluxType : uint8_t
+{
+  ELECTRIC,
+  MAGNETIC,
+  POWER
+};
+
+enum class InterfaceDielectricType : uint8_t
+{
+  DEFAULT,
+  MA,
+  MS,
+  SA
+};
+
+enum class FrequencySampleType : u_int8_t
+{
+  LINEAR,
+  LOG,
+  POINT,
+  DEFAULT = LINEAR
+};
+
+enum class TransientSolverType : uint8_t
+{
+  GEN_ALPHA,
+  RUNGE_KUTTA,
+  ARKODE,
+  CVODE,
+  DEFAULT = GEN_ALPHA
+};
+
+enum class ExcitationType : uint8_t
+{
+  SINUSOIDAL,
+  GAUSSIAN,
+  DIFF_GAUSSIAN,
+  MOD_GAUSSIAN,
+  RAMP_STEP,
+  SMOOTH_STEP
+};
+
+enum class LinearSolverType : uint8_t
+{
+  DEFAULT,
+  AMS,
+  BOOMER_AMG,
+  MUMPS,
+  SUPERLU,
+  STRUMPACK,
+  STRUMPACK_MP,
+  JACOBI
+};
+
+enum class Device : uint8_t
+{
+  CPU,
+  GPU,
+  DEBUG
+};
+
+}  // namespace palace
+
+#endif  // PALACE_UTILS_LABELS_HPP

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -33,7 +33,7 @@ enum class EigenSolverType : char
 };
 
 // Surface fluxes.
-enum class SurfaceFluxType : char
+enum class SurfaceFlux : char
 {
   ELECTRIC,
   MAGNETIC,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -41,7 +41,7 @@ enum class SurfaceFlux : char
 };
 
 // Interface dielectrics for computing electric field energy participation ratios.
-enum class InterfaceDielectricType : char
+enum class InterfaceDielectric : char
 {
   DEFAULT,
   MA,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -25,7 +25,7 @@ enum class ProblemType : char
 };
 
 // Eigenvalue solver type.
-enum class EigenSolverType : char
+enum class EigenSolverBackend : char
 {
   DEFAULT,
   SLEPC,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -59,7 +59,7 @@ enum class FrequencySampling : char
 };
 
 // Time integration scheme type.
-enum class TransientSolverType : char
+enum class TimeSteppingScheme : char
 {
   GEN_ALPHA,
   RUNGE_KUTTA,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -14,7 +14,7 @@ enum class CoordinateSystem : char
   CYLINDRICAL
 };
 
-// Problem types Palace is able to solve.
+// The types of problem Palace is able to solve.
 enum class ProblemType : char
 {
   DRIVEN,
@@ -79,7 +79,7 @@ enum class Excitation : char
   SMOOTH_STEP
 };
 
-// Type of linear solver.
+// Possible linear solvers
 enum class LinearSolver : char
 {
   DEFAULT,
@@ -92,7 +92,7 @@ enum class LinearSolver : char
   JACOBI
 };
 
-// Krylov solver type in linear solver.
+// Krylov solvers to use in the linear solver.
 enum class KrylovSolver : char
 {
   DEFAULT,
@@ -103,7 +103,7 @@ enum class KrylovSolver : char
   BICGSTAB
 };
 
-// Type of coarsening for p-multigrid.
+// Method of coarsening for p-multigrid.
 enum class MultigridCoarsening : char
 {
   LINEAR,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -50,7 +50,7 @@ enum class InterfaceDielectric : char
 };
 
 // Frequency sampling schemes.
-enum class FrequencySampleType : char
+enum class FrequencySampling : char
 {
   LINEAR,
   LOG,

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -80,7 +80,7 @@ enum class Excitation : char
 };
 
 // Type of linear solver.
-enum class LinearSolverType : char
+enum class LinearSolver : char
 {
   DEFAULT,
   AMS,


### PR DESCRIPTION
Various enums from config are used more widely in the code base, or are shadowed in applications. This PR hoists them out and does some renaming of them and instances of them. This was part of the PostOperator refactor PR, but doing it completely got too large, so is easier to move out as it should change no functionality.