### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Note that each spack version needs it's own registry
+  # Note that each spack version needs its own registry
   SPACK_VERSION: develop
   REGISTRY: ghcr.io/awslabs/palace
   GITHUB_USER: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
           ref: develop
           buildcache: true
           color: true
-          # This seems unecessary, but otherwise we clone into ./spack
+          # This seems unnecessary, but otherwise we clone into ./spack
           # This then would override the spack local repo dir, and break CI
           path: spack-path
 

--- a/docs/src/config/domains.md
+++ b/docs/src/config/domains.md
@@ -126,4 +126,4 @@ with
 `"Index" [None]` :  Index of this probe, used in postprocessing output files.
 
 `"Center" [None]` :  Floating point array of length equal to the model spatial dimension
-specfiying the coordinates of this probe in mesh length units.
+specifying the coordinates of this probe in mesh length units.

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -32,7 +32,7 @@ The following conventions also apply:
 
 ## Static analysis
 
-During the `cmake` configuration step, definining the variables `ANALYZE_SOURCES_CLANG_TIDY`
+During the `cmake` configuration step, defining the variables `ANALYZE_SOURCES_CLANG_TIDY`
 and `ANALYZE_SOURCES_CPPCHECK` to `ON` will turn on static analysis using
 [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/) and
 [`cppcheck`](https://cppcheck.sourceforge.io/), respectively, during the build step. This
@@ -61,7 +61,7 @@ Timing facilities are provided by the `Timer` and `BlockTimer` classes.
 Creating a block as `BlockTimer b(idx)` where `idx` is a category like `CONSTRUCT`, `SOLVE`,
 etc. will record time so long as `b` is in scope; however, timing may be interrupted by
 creation of another `BlockTimer` object. It will resume whenever the new block is destroyed.
-Only one category is timed at once. This enables functions can declare how calls within them
+Only one category is timed at once. This enables functions to declare how calls within them
 are timed without needing to know how timing may be done by the calling function.
 
 The `BlockTimer` implementation relies upon a static member object of the `Timer` class,

--- a/docs/src/examples/spheres.md
+++ b/docs/src/examples/spheres.md
@@ -91,7 +91,7 @@ uses the computed field energies, the capacitance can also be calculated by dire
 integrating the charge on a boundary surface and dividing by the excitation voltage. The
 configuration file for this example contains this information under
 [`config["Boundaries"]["Postprocessing"]["SurfaceFlux"]`](../config/boundaries.md#boundaries%5B%22Postprocessing%22%5D%5B%22SurfaceFlux%22%5D).
-The resulting capacitances are written to `postpro/surface-C.csv`:
+The resulting capacitances are written to `postpro/terminal-C.csv`:
 
 ```
                i,                C[1] (F),                C[2] (F)

--- a/docs/src/guide/problem.md
+++ b/docs/src/guide/problem.md
@@ -29,7 +29,7 @@ In particular, lumped ports with nonzero resistance in the model will trigger co
 and quality factor calculations based on input-output (I-O) line coupling loss: By
 specifying resistive lumped ports in the model, the mode coupling quality factors will be
 computed as ``Q_{ml} = \omega_m/\kappa_{ml}``. The output file `port-Q.csv` will be created
-in the output directory containing these mode qualty factor contributions. For bulk and
+in the output directory containing these mode quality factor contributions. For bulk and
 interface dielectric loss calculations, which are not unique to the eigenmode simulation
 type, see the sections [Domain postprocessing](postprocessing.md#Domain-postprocessing) and
 [Boundary postprocessing](postprocessing.md#Boundary-postprocessing) of this guide.

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -24,8 +24,8 @@ and run:
 spack install palace
 ```
 
-More information about about the available configuration options and dependencies can be
-found using `spack info palace`.
+More information about the available configuration options and dependencies can
+be found using `spack info palace`.
 
 ## Build using Singularity/Apptainer
 
@@ -177,8 +177,8 @@ If the installation path of OpenBLAS is non-standard or is not found by default,
 set using the `OPENBLAS_DIR` or `OPENBLASROOT` environment variables, or added to
 `CMAKE_PREFIX_PATH` when calling CMake.
 
-It is recommended in most cases to use a serial BLAS and LAPACK builds (not multithreaded),
-as the standard parallelization in approach in *Palace* is to use pure MPI parallelism.
+It is recommended in most cases to use serial BLAS and LAPACK builds (not multithreaded),
+as the standard parallelization approach in *Palace* is to use pure MPI parallelism.
 
 ## Dependencies
 

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -267,7 +267,7 @@ BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>::GetLocalFlux(mfem::ElementTransfo
 // Uses the neighbor element on a user specified side to compute a single-sided value for
 // potentially discontinuous solutions for an interior boundary element. The four cases
 // correspond to a generic interface vs. specializations for metal-air, metal-substrate,
-// and subtrate-air interfaces following:
+// and substrate-air interfaces following:
 //   J. Wenner et al., Surface loss simulations of superconducting coplanar waveguide
 //     resonators, Appl. Phys. Lett. (2011).
 template <InterfaceDielectric Type>

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -173,7 +173,7 @@ protected:
   // measurements. Conceptually, its members could be a part of this class, like the
   // ParaView fields and functions above. It has been separated out for code readability. To
   // achieve this, it is has a pointer back to its "parent" PostOperator class and is a
-  // friend class so it can access the the private measurement_cache and references of the
+  // friend class so it can access the private measurement_cache and references of the
   // system from fem_op.
   friend PostOperatorCSV<solver_t>;
 

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Config Boundary Ports", "[config]")
     auto it_bool = boundary_ex_bool.lumpedport.begin();
     for (; it_int != boundary_ex_bool.lumpedport.end(); it_int++, it_bool++)
     {
-      CHECK(it_bool->first == it_int->first);  // Order is same as indicies are
+      CHECK(it_bool->first == it_int->first);  // Order is same as indices are
       CHECK(it_bool->second.excitation == it_int->second.excitation);
     }
   }

--- a/test/unit/test-libceed.cpp
+++ b/test/unit/test-libceed.cpp
@@ -62,7 +62,7 @@ auto Initialize(MPI_Comm comm, const std::string &input, int ref_levels, bool am
     pmesh->UniformRefinement();
   }
 
-  // Perform nonconforming AMR (two levels of refinement with no hanging node restritions).
+  // Perform nonconforming AMR (two levels of refinement with no hanging node restrictions).
   if (amr)
   {
     pmesh->RandomRefinement(0.5);


### PR DESCRIPTION
As I was going through palace, I found a few typos here and here. This PR fixes the ones I've seen so far.

The only noteworthy one is that the example was mentioning the `surface-C.csv` file. I don't know if this is an old file, but the capacitance matrix is now in the `terminal-C.csv`.