### PR TITLE
Restrict CMake versions for Palace 0.13.0

### DIFF
--- a/spack/local/packages/palace/package.py
+++ b/spack/local/packages/palace/package.py
@@ -66,6 +66,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@3.21:", type="build")
+    depends_on("cmake@3.21:3.29", type="build, when="@0.13.0")
     depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("zlib-api")

--- a/spack/local/packages/palace/package.py
+++ b/spack/local/packages/palace/package.py
@@ -66,7 +66,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cmake@3.21:", type="build")
-    depends_on("cmake@3.21:3.29", type="build, when="@0.13.0")
+    depends_on("cmake@3.21:3.29", type="build", when="@0.13.0")
     depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("zlib-api")


### PR DESCRIPTION
These changes are necessary as building Palace 0.13.0 w/ CMake >3.30 triggers the following error in building Mumps:

```
-- Found MPI: TRUE (found version "3.1") found components: C Fortran
-- Looking for Fortran sgemm
-- Looking for Fortran sgemm - not found
-- Looking for Fortran sgemm
-- Looking for Fortran sgemm - found
-- Found BLAS: /apps/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/apps/intel/oneapi/mkl/2025.0/lib/libmkl_gnu_thread.so;/apps/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;/opt/gcc/lib64/libgomp.so;-lm;-ldl
-- Found LAPACK: /apps/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/apps/intel/oneapi/mkl/2025.0/lib/libmkl_sequential.so;/apps/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;-lm;-ldl
-- Performing Test SCALAPACK_d_FOUND
-- Performing Test SCALAPACK_d_FOUND - Success
-- Performing Test SCALAPACK_s_FOUND
-- Performing Test SCALAPACK_s_FOUND - Success
-- Found SCALAPACK: /apps/palace/0.13.0-x86_64/lib/libscalapack.a
-- Performing Test BLAS_HAVE_dGEMMT
-- Performing Test BLAS_HAVE_dGEMMT - Success
-- Found METIS: /apps/palace/0.13.0-x86_64/lib/libparmetis.a;/apps/palace/0.13.0-x86_64/lib/libmetis.a  found components: ParMETIS
-- MUMPS ORDERING_DEFS: pord;parmetis;metis
-- MUMPS ORDERING_LIBS: METIS::METIS;pord
CMake Error at /opt/cmake/share/cmake-3.31/Modules/FetchContent.cmake:1951 (message):
  Calling FetchContent_Populate(MUMPS) is deprecated, call
  FetchContent_MakeAvailable(MUMPS) instead.  Policy CMP0169 can be set to
  OLD to allow FetchContent_Populate(MUMPS) to be called directly for now,
  but the ability to call it with declared details will be removed completely
  in a future version.
Call Stack (most recent call first):
  CMakeLists.txt:112 (FetchContent_Populate)


-- Configuring incomplete, errors occurred!
gmake[2]: *** [extern/CMakeFiles/mumps.dir/build.make:95: extern/mumps-cmake/src/mumps-stamp/mumps-configure] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:564: extern/CMakeFiles/mumps.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```