### PR TITLE
Skip expensive CI actions when only modifying Markdowns

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags: '*'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR optimizes CI resource usage by adding paths-ignore filters to skip expensive build and test workflows when only Markdown files are modified.

This only applies to pull requests, and not to the push to main (so that we can ensure that every test is always green for every commit on main)