### PR TITLE
Revert "Skip expensive CI actions when only modifying mds"

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags: '*'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Yesterday I opened a PR (#432) to skip CI workflows when only markdown files are modified. This is to avoid unnecessary >500 billable minutes. However, I didn't realize that we require those workflows to pass as required condition to merge a PR (through the GitHub UI).

We can fix this in four ways:
- Don't require those workflows to pass; this means that a developer could in theory click on "merge PR" even if some of those workflows are not green
- Add creating complementary workflow files to just post a green status (as officially recommended by [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks))
- Implement path filtering at the job level so that a status is always posted
- Revert to the previous behavior

Given that PR that only modify md files are not very frequent, I feel that the added complexity is not warranted, so I opted for just reverting the change.

Note, apparently this feature is being considered for implementation natively in GitHub (https://github.com/orgs/community/discussions/44490).

This reverts commit e40a3a3a73473dba370f4d5e44f5708007723ae6.

(Found in #434)