### PR TITLE
Add path filter to only run CI as necessary

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -14,6 +14,10 @@ concurrency:
 
 jobs:
   build-and-test-linux:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only != 'true'
+      && needs.path-filter.outputs.singularity_only != 'true'
+      && needs.path-filter.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -14,6 +14,10 @@ concurrency:
 
 jobs:
   build-and-test-macos:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only != 'true'
+      && needs.path-filter.outputs.singularity_only != 'true'
+      && needs.path-filter.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/path-filter.yml
+++ b/.github/workflows/path-filter.yml
@@ -1,0 +1,109 @@
+name: Path Filter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  path-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      spack_only: ${{ steps.filter.outputs.spack_only }}
+      singularity_only: ${{ steps.filter.outputs.singularity_only }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            spack_only:
+              - 'spack/local/**'
+              - '!**/*'
+            singularity_only:
+              - 'singularity/local/**'
+              - '!**/*'
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+              - '!**/*'
+
+  # Dummy jobs that succeed when only spack, singularity or docs files change
+  build-and-test-linux:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only == 'true'
+      || needs.path-filter.outputs.singularity_only == 'true'
+      || needs.path-filter.outputs.docs_only == 'true' }}
+    strategy:
+      matrix:
+        config:
+          # List of configuration that must be kept in sync with build-and-test-linux.yml
+          - "x86, intel, intelmpi, intelmkl, shared, int64, openmp, slepc, superlu"
+          - "x86, clang, openmpi, aocl, static, int64, serial, slepc, mumps"
+          - "x86, gcc, openmpi, openblas, shared, int64, openmp, slepc, strumpack"
+          - "x86, intel, intelmpi, intelmkl, static, int32, serial, arpack, superlu"
+          - "x86, intel, intelmpi, intelmkl, static, int32, openmp, slepc, strumpack"
+          - "x86, intel, intelmpi, intelmkl, shared, int64, serial, arpack, mumps"
+          - "x86, gcc, openmpi, aocl, shared, int32, serial, arpack, superlu"
+          - "arm, gcc, mpich, openblas, shared, int64, openmp, slepc, superlu"
+          - "arm, clang, openmpi, armpl, static, int32, serial, arpack, strumpack"
+          - "arm, clang, mpich, armpl, shared, int32, serial, arpack, mumps"
+          - "arm, gcc, openmpi, openblas, static, int64, serial, slepc, mumps"
+          - "arm, gcc, openmpi, armpl, shared, int64, serial, arpack, superlu"
+          - "arm, clang, mpich, openblas, static, int32, openmp, slepc, strumpack"
+          - "arm, clang, mpich, openblas, static, int64, serial, arpack, superlu"
+          - "arm, gcc, openmpi, armpl, shared, int32, openmp, slepc, strumpack"
+          - "arm, gcc, openmpi, armpl, shared, int32, openmp, slepc, superlu"
+          - "arm, gcc, openmpi, armpl, shared, int64, openmp, slepc, strumpack"
+    name: build-and-test-linux (${{ matrix.config }})
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping linux build (${{ matrix.config }}) as only Spack, Singularity or docs files changed"
+
+  build-and-test-macos:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only == 'true'
+      || needs.path-filter.outputs.singularity_only == 'true'
+      || needs.path-filter.outputs.docs_only == 'true' }}
+    strategy:
+      matrix:
+        config:
+          # List of configuration that must be kept in sync with build-and-test-macos.yml
+          - "clang, openmpi, armpl, static, int32, serial, arpack, strumpack"
+          - "gcc, openmpi, openblas, static, int64, serial, slepc, mumps"
+          - "gcc, openmpi, armpl, shared, int64, serial, arpack, superlu"
+          - "clang, mpich, openblas, static, int32, openmp, slepc, strumpack"
+          - "clang, mpich, openblas, static, int64, serial, arpack, superlu"
+    name: build-and-test-macos (${{ matrix.config }})
+    runs-on: macos-latest-xlarge
+    steps:
+      - run: echo "Skipping macos build (${{ matrix.config }}) as only Spack, Singularity or docs files changed"
+
+  build-and-test-spack:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.singularity_only == 'true' || needs.path-filter.outputs.docs_only == 'true' }}
+    strategy:
+      matrix:
+        config:
+          # List of configuration that must be kept in sync with spack.yml
+          - "gcc, none, openblas, develop, openmpi"
+    name: spack (${{ matrix.config }})
+    runs-on: palace_ubuntu-latest_16-core
+    steps:
+      - run: echo "Skipping spack build (${{ matrix.config }}) as only Singularity or docs files changed"
+
+  build-and-test-singularity:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only == 'true' || needs.path-filter.outputs.docs_only == 'true' }}
+    strategy:
+      matrix:
+        config:
+          # List of configuration that must be kept in sync with spack.yml
+          - "gcc, none, openblas, develop, openmpi"
+    name: spack (${{ matrix.config }})
+    runs-on: palace_ubuntu-latest_16-core
+    steps:
+      - run: echo "Skipping singularity build as only Spack or docs files changed"

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   build-and-test-singularity:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.spack_only != 'true'
+      && needs.path-filter.outputs.docs_only != 'true' }}
     runs-on: palace_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -22,6 +22,9 @@ env:
 
 jobs:
   build-and-test-spack:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.singularity_only != 'true'
+      && needs.path-filter.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false # don't have one build stop others from finishing
       matrix:


### PR DESCRIPTION
Adds skips for CI runs if only docs, spack or singularity are updated. Should speed up doc CRs and tweaks to spack and singularity.
