### PR TITLE
Update clang to 18 and gcc to 15 inlight of update macos runners

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           # Configure environment
           if [[ "${{ matrix.compiler }}" == 'clang' ]]; then
-            export CC=$(brew --prefix llvm@15)/bin/clang
-            export CXX=$(brew --prefix llvm@15)/bin/clang++
+            export CC=$(brew --prefix llvm@18)/bin/clang
+            export CXX=$(brew --prefix llvm@18)/bin/clang++
             export FC=gfortran-12
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
             export CC=gcc-12

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -149,15 +149,20 @@ jobs:
           CMAKE_BUILD_TYPE: Release
           NUM_PROC_BUILD_MAX: '32'
         run: |
+          # We to install a separate version of CMake because the bundled one
+          # has a bug with FindMPI that prevents it from finding MPI when
+          # compiling with GNU compilers.
+          brew install cmake
+
           # Configure environment
           if [[ "${{ matrix.compiler }}" == 'clang' ]]; then
             export CC=$(brew --prefix llvm@18)/bin/clang
             export CXX=$(brew --prefix llvm@18)/bin/clang++
             export FC=gfortran-12
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
-            export CC=gcc-12
-            export CXX=g++-12
-            export FC=gfortran-12
+            export CC=gcc-15
+            export CXX=g++-15
+            export FC=gfortran-15
           fi
           if [[ "${{ matrix.math-libs }}" == 'openblas' ]]; then
             export OPENBLAS_DIR=$(brew --prefix openblas)


### PR DESCRIPTION
The default macos image updated, breaking the runners. This updates to using llvm18 and gcc14 which are on the osx15 image, from the old 15 and 12.