### PR TITLE
Add fortran dep when building with fortran based deps.

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -65,9 +65,9 @@ jobs:
 
           # Develop requires ^compiler, not %compiler
           if [[ "${{ matrix.spack_version }}" == 'v0.23.1' ]]; then
-            PALACE_SPEC="local.palace@develop %${{ matrix.compiler }} ${GPU_VARIANT} ^${{ matrix.mpi }} ^${{ matrix.blas }}"
+            PALACE_SPEC="local.palace@develop+strumpack+arpack+mumps %${{ matrix.compiler }} ${GPU_VARIANT} ^${{ matrix.mpi }} ^${{ matrix.blas }}"
           else
-            PALACE_SPEC="local.palace@develop${GPU_VARIANT} ^${{ matrix.mpi }} ^${{ matrix.blas }} ^${{ matrix.compiler }}"
+            PALACE_SPEC="local.palace@develop+strumpack+arpack+mumps${GPU_VARIANT} ^${{ matrix.mpi }} ^${{ matrix.blas }} ^${{ matrix.compiler }}"
           fi
 
           # Spack.yaml with most / all settings configured

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -73,6 +73,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("^mumps+int64", msg="Palace requires MUMPS without 64 bit integers")
     with when("+mumps"):
+        depends_on("fortran", type="build")
         depends_on("mumps+metis+parmetis")
         depends_on("mumps+shared", when="+shared")
         depends_on("mumps~shared", when="~shared")
@@ -89,6 +90,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("superlu-dist~openmp", when="~openmp")
 
     with when("+strumpack"):
+        depends_on("fortran", type="build")
         depends_on("strumpack+butterflypack+zfp+parmetis~cuda~rocm")
         depends_on("strumpack+shared", when="+shared")
         depends_on("strumpack~shared", when="~shared")
@@ -112,6 +114,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("petsc~rocm", when="~rocm")
 
     with when("+arpack"):
+        depends_on("fortran", type="build")
         depends_on("arpack-ng+mpi+icb")
         depends_on("arpack-ng+shared", when="+shared")
         depends_on("arpack-ng~shared", when="~shared")


### PR DESCRIPTION
I found that when building with all variants enabled for Palace, I get an error in Spack builds:

```
==> Installing palace-develop-fs4n7434ld4psa3gabzs3wc3ch26ikrh [39/39]

...

     20    -- Detecting Fortran compiler ABI info
     21    -- Detecting Fortran compiler ABI info - failed
     22    -- Check for working Fortran compiler: /data/home/lgh/projects/hpc-toolkit-examples/external-s
           pack-root/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-ntccuj2fi3y7asqifeq3i4iylrbxakw2/libe
           xec/spack/gcc/gfortran
     23    -- Check for working Fortran compiler: /data/home/lgh/projects/hpc-toolkit-examples/external-s
           pack-root/opt/spack/linux-x86_64_v3/compiler-wrapper-1.0-ntccuj2fi3y7asqifeq3i4iylrbxakw2/libe
           xec/spack/gcc/gfortran - broken
  >> 24    CMake Error at /data/home/lgh/projects/hpc-toolkit-examples/external-spack-root/opt/spack/linu
           x-x86_64_v3/cmake-3.31.8-nte37oks65h6l7obu3wjzon2xlyzszwo/share/cmake-3.31/Modules/CMakeTestFo
           rtranCompiler.cmake:59 (message):
     25      The Fortran compiler
     26
     27        "/data/home/lgh/projects/hpc-toolkit-examples/external-spack-root/opt/spack/linux-x86_64_v
           3/compiler-wrapper-1.0-ntccuj2fi3y7asqifeq3i4iylrbxakw2/libexec/spack/gcc/gfortran"
     28
     29      is not able to compile a simple test program.
     30

     ...

     34
     35        Run Build Command(s): /data/home/lgh/projects/hpc-toolkit-examples/external-spack-root/opt
           /spack/linux-x86_64_v3/cmake-3.31.8-nte37oks65h6l7obu3wjzon2xlyzszwo/bin/cmake -E env VERBOSE=
           1 /opt/gcc/bin/gmake -f Makefile cmTC_7d06f/fast
     36        /opt/gcc/bin/gmake  -f CMakeFiles/cmTC_7d06f.dir/build.make CMakeFiles/cmTC_7d06f.dir/buil
           d
     37        gmake[1]: Entering directory '/dev/shm/external-spack-tmp/lgh/spack-stage-palace-develop-f
           s4n7434ld4psa3gabzs3wc3ch26ikrh/spack-build-fs4n743/CMakeFiles/CMakeScratch/TryCompile-xtGvmp'
     38        Building Fortran object CMakeFiles/cmTC_7d06f.dir/testFortranCompiler.f.o
     39        /data/home/lgh/projects/hpc-toolkit-examples/external-spack-root/opt/spack/linux-x86_64_v3
           /compiler-wrapper-1.0-ntccuj2fi3y7asqifeq3i4iylrbxakw2/libexec/spack/gcc/gfortran    -c /dev/s
           hm/external-spack-tmp/lgh/spack-stage-palace-develop-fs4n7434ld4psa3gabzs3wc3ch26ikrh/spack-bu
           ild-fs4n743/CMakeFiles/CMakeScratch/TryCompile-xtGvmp/testFortranCompiler.f -o CMakeFiles/cmTC
           _7d06f.dir/testFortranCompiler.f.o
  >> 40    [spack cc]: Error: SPACK_FC_* variables not set: this usually means a missing `depends_on("for
           tran", type="build")` in package.py
  >> 41        gmake[1]: *** [CMakeFiles/cmTC_7d06f.dir/build.make:81: CMakeFiles/cmTC_7d06f.dir/testFort
           ranCompiler.f.o] Error 1
     42        gmake[1]: Leaving directory '/dev/shm/external-spack-tmp/lgh/spack-stage-palace-develop-fs
           4n7434ld4psa3gabzs3wc3ch26ikrh/spack-build-fs4n743/CMakeFiles/CMakeScratch/TryCompile-xtGvmp'
  >> 43        gmake: *** [Makefile:134: cmTC_7d06f/fast] Error 2
     44
```

So, this PR adds those variants to what we regularly build / test, and fixes our Spack package accordingly.