### PR TITLE
Fix macOS CI (again)

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -144,21 +144,24 @@ jobs:
           echo "DYLD_LIBRARY_PATH=/opt/arm/armpl_24.10_flang-new_clang_19/lib:${DYLD_LIBRARY_PATH:+${DYLD_LIBRARY_PATH}:}" >> $GITHUB_ENV
           hdiutil detach "/Volumes/armpl_24.10_flang-new_clang_19_installer" -quiet
 
+        # We have to upgrade CMake because the bundled one has a bug with
+        # FindMPI that prevents it from finding MPI when compiling with GNU
+        # compilers.
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.8'
+
       - name: Build Palace
         env:
           CMAKE_BUILD_TYPE: Release
           NUM_PROC_BUILD_MAX: '32'
         run: |
-          # We to install a separate version of CMake because the bundled one
-          # has a bug with FindMPI that prevents it from finding MPI when
-          # compiling with GNU compilers.
-          brew install cmake
-
           # Configure environment
           if [[ "${{ matrix.compiler }}" == 'clang' ]]; then
             export CC=$(brew --prefix llvm@18)/bin/clang
             export CXX=$(brew --prefix llvm@18)/bin/clang++
-            export FC=gfortran-12
+            export FC=gfortran-15
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
             export CC=gcc-15
             export CXX=g++-15


### PR DESCRIPTION
The macos image changed and CI fails with

```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.

To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake
```
If I naively upgrade `cmake`, the build fails.

I found that:
- Default CMake has problems finding MPI
- CMake 4.1 has problems finding some std headers with llvm 18
- CMake 4.1 + llvm > 18 has problems with pthreads

So, I ended up pinning CMake to 3.31.8 (the latest in the 3.x series).

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
