### PR TITLE
Refactor BuildParSumOperator for wider usage

### DIFF
--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -146,12 +146,10 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &space_op) const
       // Assemble frequency dependent matrices and initialize operators in linear
       // solver.
       auto A2 = space_op.GetExtraSystemMatrix<ComplexOperator>(omega, Operator::DIAG_ZERO);
-      auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * omega,
-                                        std::complex<double>(-omega * omega, 0.0), K.get(),
+      auto A = space_op.GetSystemMatrix(1.0 + 0i, 1i * omega, -omega * omega + 0i, K.get(),
                                         C.get(), M.get(), A2.get());
       auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
-          std::complex<double>(1.0, 0.0), 1i * omega,
-          std::complex<double>(-omega * omega, 0.0), omega);
+          1.0 + 0i, 1i * omega, -omega * omega + 0i, omega);
       ksp.SetOperators(*A, *P);
 
       Mpi::Print(

--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -149,8 +149,9 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &space_op) const
       auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * omega,
                                         std::complex<double>(-omega * omega, 0.0), K.get(),
                                         C.get(), M.get(), A2.get());
-      auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(1.0, omega, -omega * omega,
-                                                                 omega);
+      auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
+          std::complex<double>(1.0, 0.0), 1i * omega,
+          std::complex<double>(-omega * omega, 0.0), omega);
       ksp.SetOperators(*A, *P);
 
       Mpi::Print(

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -253,12 +253,10 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   // (K - σ² M) or P(iσ) = (K + iσ C - σ² M) during the eigenvalue solve. The
   // preconditioner for complex linear systems is constructed from a real approximation
   // to the complex system matrix.
-  auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * target,
-                                    std::complex<double>(-target * target, 0.0), K.get(),
+  auto A = space_op.GetSystemMatrix(1.0 + 0i, 1i * target, -target * target + 0i, K.get(),
                                     C.get(), M.get());
-  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
-      std::complex<double>(1.0, 0.0), 1i * target,
-      std::complex<double>(-target * target, 0.0), target);
+  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(1.0 + 0i, 1i * target,
+                                                             -target * target + 0i, target);
   auto ksp = std::make_unique<ComplexKspSolver>(iodata, space_op.GetNDSpaces(),
                                                 &space_op.GetH1Spaces());
   ksp->SetOperators(*A, *P);

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -256,8 +256,9 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * target,
                                     std::complex<double>(-target * target, 0.0), K.get(),
                                     C.get(), M.get());
-  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(1.0, target, -target * target,
-                                                             target);
+  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
+      std::complex<double>(1.0, 0.0), 1i * target,
+      std::complex<double>(-target * target, 0.0), target);
   auto ksp = std::make_unique<ComplexKspSolver>(iodata, space_op.GetNDSpaces(),
                                                 &space_op.GetH1Spaces());
   ksp->SetOperators(*A, *P);

--- a/palace/linalg/errorestimator.cpp
+++ b/palace/linalg/errorestimator.cpp
@@ -200,9 +200,9 @@ Vector ComputeErrorEstimates(const VecType &F, VecType &F_gf, VecType &G, VecTyp
       CeedInt nsub_ops;
       CeedOperator *sub_ops;
       PalaceCeedCall(
-          ceed, CeedCompositeOperatorGetNumSub(integ_op[utils::GetThreadNum()], &nsub_ops));
+          ceed, CeedOperatorCompositeGetNumSub(integ_op[utils::GetThreadNum()], &nsub_ops));
       PalaceCeedCall(
-          ceed, CeedCompositeOperatorGetSubList(integ_op[utils::GetThreadNum()], &sub_ops));
+          ceed, CeedOperatorCompositeGetSubList(integ_op[utils::GetThreadNum()], &sub_ops));
       MFEM_ASSERT(nsub_ops > 0, "Unexpected empty libCEED composite operator!");
       CeedOperatorField field;
       PalaceCeedCall(ceed, CeedOperatorGetFieldByName(sub_ops[0], "u_1", &field));

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -959,9 +959,15 @@ BuildParSumOperator(ScalarType (&&coeff_in)[N], const OperType *(&&ops_in)[N],
 // Explicit instantiation.
 template std::unique_ptr<ParOperator> BuildParSumOperator(double (&&)[2],
                                                           const Operator *(&&)[2], bool);
+template std::unique_ptr<ParOperator> BuildParSumOperator(double (&&)[3],
+                                                          const Operator *(&&)[3], bool);
 template std::unique_ptr<ParOperator> BuildParSumOperator(double (&&)[4],
                                                           const Operator *(&&)[4], bool);
 
+template std::unique_ptr<ComplexParOperator>
+    BuildParSumOperator(std::complex<double> (&&)[2], const ComplexOperator *(&&)[2], bool);
+template std::unique_ptr<ComplexParOperator>
+    BuildParSumOperator(std::complex<double> (&&)[3], const ComplexOperator *(&&)[3], bool);
 template std::unique_ptr<ComplexParOperator>
     BuildParSumOperator(std::complex<double> (&&)[4], const ComplexOperator *(&&)[4], bool);
 

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -952,6 +952,7 @@ BuildParSumOperator(ScalarType (&&coeff_in)[N], const OperType *(&&ops_in)[N],
   std::array<const ParOperType *, N> par_ops;
   std::transform(ops_in, ops_in + N, par_ops.begin(),
                  [](const OperType *op) { return dynamic_cast<const ParOperType *>(op); });
+
   return BuildParSumOperator(to_array<ScalarType>(std::move(coeff_in)), std::move(par_ops),
                              set_essential);
 }

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -914,7 +914,7 @@ BuildParSumOperator(const std::array<std::complex<double>, N> &coeff,
 // TODO: replace with std::to_array in c++20.
 namespace detail
 {
-// Helper for conversion to std::array
+// Helper for conversion to std::array.
 template <class T, std::size_t N, std::size_t... I>
 constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&&a)[N],
                                                            std::index_sequence<I...>)

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -46,6 +46,13 @@ void ParOperator::SetEssentialTrueDofs(const mfem::Array<int> &tdof_list,
   diag_policy = policy;
 }
 
+Operator::DiagonalPolicy ParOperator::GetDiagonalPolicy() const
+{
+  MFEM_VERIFY(dbc_tdof_list.Size() > 0,
+              "There is no DiagonalPolicy if no essential dofs have been set!");
+  return diag_policy;
+}
+
 void ParOperator::EliminateRHS(const Vector &x, Vector &b) const
 {
   MFEM_VERIFY(A, "No local matrix available for ParOperator::EliminateRHS!");
@@ -448,6 +455,13 @@ void ComplexParOperator::SetEssentialTrueDofs(const mfem::Array<int> &tdof_list,
   {
     RAPi->SetEssentialTrueDofs(tdof_list, Operator::DiagonalPolicy::DIAG_ZERO);
   }
+}
+
+Operator::DiagonalPolicy ComplexParOperator::GetDiagonalPolicy() const
+{
+  MFEM_VERIFY(dbc_tdof_list.Size() > 0,
+              "There is no DiagonalPolicy if no essential dofs have been set!");
+  return diag_policy;
 }
 
 void ComplexParOperator::AssembleDiagonal(ComplexVector &diag) const

--- a/palace/linalg/rap.cpp
+++ b/palace/linalg/rap.cpp
@@ -748,4 +748,197 @@ ComplexVector &ComplexParOperator::GetTestLVector() const
                                            : test_fespace.GetLVector<ComplexVector>();
 }
 
+// Helper that checks if two containers (Vector or Array<T>) are actually references to the
+// same underlying data.
+template <typename C>
+bool ReferencesSameMemory(const C &c1, const C &c2)
+{
+  const auto &m1 = c1.GetMemory();
+  const auto &m2 = c2.GetMemory();
+  return (m1.HostIsValid() && m2.HostIsValid() && c1.HostRead() == c2.HostRead()) ||
+         (m1.DeviceIsValid() && m2.DeviceIsValid() && c1.Read() == c2.Read());
+}
+
+// Combine a collection of ParOperator into a weighted summation. If set_essential is true,
+// extract the essential dofs from the operator array, and apply to the summed operator.
+template <std::size_t N>
+std::unique_ptr<ParOperator>
+BuildParSumOperator(const std::array<double, N> &coeff,
+                    const std::array<const ParOperator *, N> &ops, bool set_essential)
+{
+  auto it = std::find_if(ops.begin(), ops.end(), [](auto p) { return p != nullptr; });
+  MFEM_VERIFY(it != ops.end(),
+              "BuildParSumOperator requires at least one valid ParOperator!");
+  const auto first_op = *it;
+  const auto &fespace = first_op->TrialFiniteElementSpace();
+  MFEM_VERIFY(
+      std::all_of(ops.begin(), ops.end(), [&fespace](auto p)
+                  { return p == nullptr || &p->TrialFiniteElementSpace() == &fespace; }),
+      "All ComplexParOperators must have the same FiniteElementSpace!");
+
+  auto sum = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                           first_op->LocalOperator().Width());
+  for (std::size_t i = 0; i < coeff.size(); i++)
+  {
+    if (ops[i] && coeff[i] != 0)
+    {
+      sum->AddOperator(ops[i]->LocalOperator(), coeff[i]);
+    }
+  }
+
+  auto O = std::make_unique<ParOperator>(std::move(sum), fespace);
+  if (set_essential)
+  {
+    // Extract essential dof pointer from first operator with one.
+    auto it_ess = std::find_if(ops.begin(), ops.end(), [](auto p)
+                               { return p != nullptr && p->GetEssentialTrueDofs(); });
+    if (it_ess == ops.end())
+    {
+      return O;
+    }
+    const auto *ess_dofs = (*it_ess)->GetEssentialTrueDofs();
+
+    // Check other existant essential dof arrays are references.
+    MFEM_VERIFY(std::all_of(ops.begin(), ops.end(),
+                            [&](auto p)
+                            {
+                              if (p == nullptr)
+                              {
+                                return true;
+                              }
+                              auto p_ess_dofs = p->GetEssentialTrueDofs();
+                              return p_ess_dofs == nullptr ||
+                                     ReferencesSameMemory(*ess_dofs, *p_ess_dofs);
+                            }),
+                "If essential dofs are set, all suboperators must agree on them!");
+
+    // Use implied ordering of enumeration.
+    Operator::DiagonalPolicy policy = Operator::DiagonalPolicy::DIAG_ZERO;
+    for (auto p : ops)
+    {
+      policy = (p && p->GetEssentialTrueDofs()) ? std::max(policy, p->GetDiagonalPolicy())
+                                                : policy;
+    }
+    O->SetEssentialTrueDofs(*ess_dofs, policy);
+  }
+
+  return O;
+}
+
+// Combine a collection of ComplexParOperator into a weighted summation. If set_essential is
+// true, extract the essential dofs from the operator array, and apply to the summed
+// operator.
+template <std::size_t N>
+std::unique_ptr<ComplexParOperator>
+BuildParSumOperator(const std::array<std::complex<double>, N> &coeff,
+                    const std::array<const ComplexParOperator *, N> &ops,
+                    bool set_essential)
+{
+  auto it = std::find_if(ops.begin(), ops.end(), [](auto p) { return p != nullptr; });
+  MFEM_VERIFY(it != ops.end(),
+              "BuildParSumOperator requires at least one valid ComplexParOperator!");
+  const auto first_op = *it;
+  const auto &fespace = first_op->TrialFiniteElementSpace();
+  MFEM_VERIFY(
+      std::all_of(ops.begin(), ops.end(), [&fespace](auto p)
+                  { return p == nullptr || &p->TrialFiniteElementSpace() == &fespace; }),
+      "All ComplexParOperators must have the same FiniteElementSpace!");
+
+  auto sumr = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                            first_op->LocalOperator().Width());
+  auto sumi = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                            first_op->LocalOperator().Width());
+  for (std::size_t i = 0; i < coeff.size(); i++)
+  {
+    if (ops[i] && coeff[i].real() != 0)
+    {
+      if (ops[i]->LocalOperator().Real())
+      {
+        sumr->AddOperator(*ops[i]->LocalOperator().Real(), coeff[i].real());
+      }
+      if (ops[i]->LocalOperator().Imag())
+      {
+        sumi->AddOperator(*ops[i]->LocalOperator().Imag(), coeff[i].real());
+      }
+    }
+    if (ops[i] && coeff[i].imag() != 0)
+    {
+      if (ops[i]->LocalOperator().Imag())
+      {
+        sumr->AddOperator(*ops[i]->LocalOperator().Imag(), -coeff[i].imag());
+      }
+      if (ops[i]->LocalOperator().Real())
+      {
+        sumi->AddOperator(*ops[i]->LocalOperator().Real(), coeff[i].imag());
+      }
+    }
+  }
+  auto O = std::make_unique<ComplexParOperator>(std::move(sumr), std::move(sumi), fespace);
+  if (set_essential)
+  {
+    // Extract essential dof pointer from first operator with one.
+    auto it_ess = std::find_if(ops.begin(), ops.end(), [](auto p)
+                               { return p != nullptr && p->GetEssentialTrueDofs(); });
+    if (it_ess == ops.end())
+    {
+      return O;
+    }
+    const auto *ess_dofs = (*it_ess)->GetEssentialTrueDofs();
+
+    // Check other existant essential dof arrays are references.
+    MFEM_VERIFY(std::all_of(ops.begin(), ops.end(),
+                            [&](auto p)
+                            {
+                              if (p == nullptr)
+                              {
+                                return true;
+                              }
+                              auto p_ess_dofs = p->GetEssentialTrueDofs();
+                              return p_ess_dofs == nullptr ||
+                                     ReferencesSameMemory(*ess_dofs, *p_ess_dofs);
+                            }),
+                "If essential dofs are set, all suboperators must agree on them!");
+
+    // Use implied ordering of enumeration.
+    Operator::DiagonalPolicy policy = Operator::DiagonalPolicy::DIAG_ZERO;
+    for (auto p : ops)
+    {
+      policy = (p && p->GetEssentialTrueDofs()) ? std::max(policy, p->GetDiagonalPolicy())
+                                                : policy;
+    }
+    O->SetEssentialTrueDofs(*ess_dofs, policy);
+  }
+  return O;
+}
+
+// Dispatch for ParOperators which have been type erased.
+template <typename OperType, std::size_t N>
+typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
+                          ComplexParOperator, ParOperator>::type
+BuildParSumOperator(
+    const std::array<
+        typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
+                                  std::complex<double>, double>::type,
+        N> &coeff,
+    const std::array<const OperType *, N> &ops, bool set_essential)
+{
+  using ParOperType =
+      typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
+                                ComplexParOperator, ParOperator>::type;
+
+  std::array<const ParOperType *, N> par_ops;
+  std::transform(ops.begin(), ops.end(), par_ops.begin(),
+                 [](const OperType *op) { return dynamic_cast<const ParOperType *>(op); });
+  return BuildParSumOperator(coeff, std::move(par_ops), set_essential);
+}
+
+// Explicit instantiation.
+template std::unique_ptr<ComplexParOperator>
+BuildParSumOperator(const std::array<std::complex<double>, 4> &,
+                    const std::array<const ComplexParOperator *, 4> &, bool set_essential);
+
+template std::unique_ptr<ParOperator>
+BuildParSumOperator(const std::array<double, 4> &,
+                    const std::array<const ParOperator *, 4> &, bool set_essential);
+
 }  // namespace palace

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -244,7 +244,8 @@ auto BuildParSumOperator(const std::array<double, N> &coeff,
                   { return p == nullptr || &p->TrialFiniteElementSpace() == &fespace; }),
       "All ComplexParOperators must have the same FiniteElementSpace!");
 
-  auto sum = std::make_unique<SumOperator>(first_op->Height(), first_op->Width());
+  auto sum = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                           first_op->LocalOperator().Width());
   for (std::size_t i = 0; i < coeff.size(); i++)
   {
     if (ops[i] && coeff[i] != 0)
@@ -270,8 +271,10 @@ auto BuildParSumOperator(const std::array<std::complex<double>, N> &coeff,
                   { return p == nullptr || &p->TrialFiniteElementSpace() == &fespace; }),
       "All ComplexParOperators must have the same FiniteElementSpace!");
 
-  auto sumr = std::make_unique<SumOperator>(first_op->Height(), first_op->Width());
-  auto sumi = std::make_unique<SumOperator>(first_op->Height(), first_op->Width());
+  auto sumr = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                            first_op->LocalOperator().Width());
+  auto sumi = std::make_unique<SumOperator>(first_op->LocalOperator().Height(),
+                                            first_op->LocalOperator().Width());
   for (std::size_t i = 0; i < coeff.size(); i++)
   {
     if (ops[i] && coeff[i].real() != 0)

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -242,15 +242,11 @@ BuildParSumOperator(const std::array<std::complex<double>, N> &coeff,
 
 // Dispatcher to convert initializer list or C arrays into std::array whilst deducing sizes
 // and types.
-template <std::size_t N>
-std::unique_ptr<ParOperator> BuildParSumOperator(double (&&coeff_in)[N],
-                                                 const ParOperator *(&&ops_in)[N],
-                                                 bool set_essential = true);
-
-template <std::size_t N>
-std::unique_ptr<ComplexParOperator>
-BuildParSumOperator(std::complex<double> (&&coeff_in)[N],
-                    const ComplexParOperator *(&&ops_in)[N], bool set_essential = true);
+template <std::size_t N, typename ScalarType, typename OperType>
+std::unique_ptr<std::conditional_t<std::is_base_of_v<ComplexOperator, OperType>,
+                                   ComplexParOperator, ParOperator>>
+BuildParSumOperator(ScalarType (&&coeff_in)[N], const OperType *(&&ops_in)[N],
+                    bool set_essential = true);
 
 }  // namespace palace
 

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -240,44 +240,17 @@ BuildParSumOperator(const std::array<std::complex<double>, N> &coeff,
                     const std::array<const ComplexParOperator *, N> &ops,
                     bool set_essential = true);
 
-// Dispatch for ParOperators which have been type erased. Requires explicit instantiation.
-template <typename OperType, std::size_t N>
-typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
-                          ComplexParOperator, ParOperator>::type
-BuildParSumOperator(
-    const std::array<
-        typename std::conditional<std::is_same<OperType, ComplexOperator>::value,
-                                  std::complex<double>, double>::type,
-        N> &coeff,
-    const std::array<const OperType *, N> &ops, bool set_essential = true);
-
-namespace detail
-{
-// Helper for conversion to std::array
-template <class T, std::size_t N, std::size_t... I>
-constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&&a)[N],
-                                                           std::index_sequence<I...>)
-{
-  return {{std::move(a[I])...}};
-}
-}  // namespace detail
-
-template <class T, std::size_t N>
-constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&&a)[N])
-{
-  return detail::to_array_impl(std::move(a), std::make_index_sequence<N>{});
-}
-
 // Dispatcher to convert initializer list or C arrays into std::array whilst deducing sizes
 // and types.
-template <std::size_t N, typename ScalarType, typename OperatorType>
-auto BuildParSumOperator(ScalarType (&&coeff_in)[N], const OperatorType *(&&ops_in)[N],
-                         bool set_essential = true)
-{
-  return BuildParSumOperator(to_array<ScalarType>(std::move(coeff_in)),
-                             to_array<const OperatorType *>(std::move(ops_in)),
-                             set_essential);
-}
+template <std::size_t N>
+std::unique_ptr<ParOperator> BuildParSumOperator(double (&&coeff_in)[N],
+                                                 const ParOperator *(&&ops_in)[N],
+                                                 bool set_essential = true);
+
+template <std::size_t N>
+std::unique_ptr<ComplexParOperator>
+BuildParSumOperator(std::complex<double> (&&coeff_in)[N],
+                    const ComplexParOperator *(&&ops_in)[N], bool set_essential = true);
 
 }  // namespace palace
 

--- a/palace/linalg/vector.hpp
+++ b/palace/linalg/vector.hpp
@@ -112,9 +112,15 @@ public:
   // In-place addition (*this) += alpha * x.
   void AXPY(std::complex<double> alpha, const ComplexVector &x);
   void Add(std::complex<double> alpha, const ComplexVector &x) { AXPY(alpha, x); }
+  void Subtract(std::complex<double> alpha, const ComplexVector &x) { AXPY(-alpha, x); }
   ComplexVector &operator+=(const ComplexVector &x)
   {
     AXPY(1.0, x);
+    return *this;
+  }
+  ComplexVector &operator-=(const ComplexVector &x)
+  {
+    AXPY(-1.0, x);
     return *this;
   }
 

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -386,8 +386,9 @@ void RomOperator::SolveHDM(int excitation_idx, double omega, ComplexVector &u)
   auto A = space_op.GetSystemMatrix(std::complex<double>(1.0, 0.0), 1i * omega,
                                     std::complex<double>(-omega * omega, 0.0), K.get(),
                                     C.get(), M.get(), A2.get());
-  auto P =
-      space_op.GetPreconditionerMatrix<ComplexOperator>(1.0, omega, -omega * omega, omega);
+  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
+      std::complex<double>(1.0, 0.0), 1i * omega, std::complex<double>(-omega * omega, 0.0),
+      omega);
   ksp->SetOperators(*A, *P);
 
   // The HDM excitation vector is computed as RHS = iω RHS1 + RHS2(ω).

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -528,8 +528,8 @@ SpaceOperator::GetSystemMatrix(ScalarType a0, ScalarType a1, ScalarType a2,
   MFEM_VERIFY(height >= 0 && width >= 0,
               "At least one argument to GetSystemMatrix must not be empty!");
 
-  auto A = BuildParSumOperator<4>({a0, a1, a2, ScalarType{1}},
-                                  {PtAP_K, PtAP_C, PtAP_M, PtAP_A2});
+  auto A =
+      BuildParSumOperator({a0, a1, a2, ScalarType{1}}, {PtAP_K, PtAP_C, PtAP_M, PtAP_A2});
   A->SetEssentialTrueDofs(nd_dbc_tdof_lists.back(), Operator::DiagonalPolicy::DIAG_ONE);
   return A;
 }

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -499,7 +499,10 @@ std::unique_ptr<Operator> SpaceOperator::GetInnerProductMatrix(double a0, double
                                                                const ComplexOperator *K,
                                                                const ComplexOperator *M)
 {
-  return BuildParSumOperator({a0, a2}, {K->Real(), M->Real()}, false);
+  const auto *PtAP_K = (K) ? dynamic_cast<const ComplexParOperator *>(K) : nullptr;
+  const auto *PtAP_M = (M) ? dynamic_cast<const ComplexParOperator *>(M) : nullptr;
+  return BuildParSumOperator(
+      {a0, a2}, {PtAP_K ? PtAP_K->Real() : nullptr, PtAP_M ? PtAP_M->Real() : nullptr});
 }
 
 namespace

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -336,7 +336,8 @@ SpaceOperator::GetStiffnessMatrix(Operator::DiagonalPolicy diag_policy)
       fb(mat_op.MaxCeedBdrAttribute()), fc(mat_op.MaxCeedAttribute());
   AddStiffnessCoefficients(1.0, df, f);
   AddStiffnessBdrCoefficients(1.0, fb);
-  AddPeriodicCoefficients(1.0, f, fc);
+  AddRealPeriodicCoefficients(1.0, f);
+  AddImagPeriodicCoefficients(1.0, fc);
   int empty[2] = {(df.empty() && f.empty() && fb.empty()), (fc.empty())};
   Mpi::GlobalMin(2, empty, GetComm());
   if (empty[0] && empty[1])
@@ -730,12 +731,120 @@ auto BuildLevelParOperator<ComplexOperator>(std::unique_ptr<Operator> &&br,
 
 }  // namespace
 
-template <typename OperType>
-std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(double a0, double a1,
-                                                                 double a2, double a3)
+void SpaceOperator::AssemblePreconditioner(
+    std::complex<double> a0, std::complex<double> a1, std::complex<double> a2, double a3,
+    std::vector<std::unique_ptr<Operator>> &br_vec,
+    std::vector<std::unique_ptr<Operator>> &br_aux_vec,
+    std::vector<std::unique_ptr<Operator>> &bi_vec,
+    std::vector<std::unique_ptr<Operator>> &bi_aux_vec)
 {
-  // XX TODO: Handle complex coeff a0/a1/a2/a3 (like GetSystemMatrix).
+  constexpr bool skip_zeros = false, assemble_q_data = false;
+  MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()),
+      dfi(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
+      fi(mat_op.MaxCeedAttribute()), dfbr(mat_op.MaxCeedBdrAttribute()),
+      dfbi(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
+      fbi(mat_op.MaxCeedBdrAttribute()), fpi(mat_op.MaxCeedAttribute()),
+      fpr(mat_op.MaxCeedAttribute());
+  AddStiffnessCoefficients(a0.real(), dfr, fr);
+  AddStiffnessCoefficients(a0.imag(), dfi, fi);
+  AddStiffnessBdrCoefficients(a0.real(), fbr);
+  AddStiffnessBdrCoefficients(a0.imag(), fbi);
+  AddDampingCoefficients(a1.real(), fr);
+  AddDampingCoefficients(a1.imag(), fi);
+  AddDampingBdrCoefficients(a1.real(), fbr);
+  AddDampingBdrCoefficients(a1.imag(), fbi);
+  AddRealMassCoefficients(pc_mat_shifted ? std::abs(a2.real()) : a2.real(), fr);
+  AddRealMassCoefficients(a2.imag(), fi);
+  AddRealMassBdrCoefficients(pc_mat_shifted ? std::abs(a2.real()) : a2.real(), fbr);
+  AddRealMassBdrCoefficients(a2.imag(), fbi);
+  AddImagMassCoefficients(a2.real(), fi);
+  AddImagMassCoefficients(-a2.imag(), fr);
+  AddExtraSystemBdrCoefficients(a3, dfbr, dfbi, fbr, fbi);
+  AddRealPeriodicCoefficients(a0.real(), fr);
+  AddRealPeriodicCoefficients(a0.imag(), fi);
+  AddImagPeriodicCoefficients(a0.real(), fpi);
+  AddImagPeriodicCoefficients(-a0.imag(), fpr);
+  int empty[2] = {
+      (dfr.empty() && fr.empty() && dfbr.empty() && fbr.empty() && fpr.empty()),
+      (dfi.empty() && fi.empty() && dfbi.empty() && fbi.empty() && fpi.empty())};
+  Mpi::GlobalMin(2, empty, GetComm());
+  if (!empty[0])
+  {
+    br_vec = AssembleOperators(GetNDSpaces(), &dfr, &fr, &dfbr, &fbr, &fpr, skip_zeros,
+                               assemble_q_data);
+    br_aux_vec =
+        AssembleAuxOperators(GetH1Spaces(), &fr, &fbr, skip_zeros, assemble_q_data);
+  }
+  if (!empty[1])
+  {
+    bi_vec = AssembleOperators(GetNDSpaces(), &dfi, &fi, &dfbi, &fbi, &fpi, skip_zeros,
+                               assemble_q_data);
+    bi_aux_vec =
+        AssembleAuxOperators(GetH1Spaces(), &fi, &fbi, skip_zeros, assemble_q_data);
+  }
+}
 
+void SpaceOperator::AssemblePreconditioner(
+    std::complex<double> a0, std::complex<double> a1, std::complex<double> a2, double a3,
+    std::vector<std::unique_ptr<Operator>> &br_vec,
+    std::vector<std::unique_ptr<Operator>> &br_aux_vec)
+{
+  constexpr bool skip_zeros = false, assemble_q_data = false;
+  MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
+      dfbr(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
+      fpr(mat_op.MaxCeedAttribute());
+  AddStiffnessCoefficients(a0.real(), dfr, fr);
+  AddStiffnessBdrCoefficients(a0.real(), fbr);
+  AddDampingCoefficients(a1.imag(), fr);
+  AddDampingBdrCoefficients(a1.imag(), fbr);
+  AddAbsMassCoefficients(pc_mat_shifted ? std::abs(a2.real()) : a2.real(), fr);
+  AddRealMassBdrCoefficients(pc_mat_shifted ? std::abs(a2.real()) : a2.real(), fbr);
+  AddExtraSystemBdrCoefficients(a3, dfbr, dfbr, fbr, fbr);
+  AddRealPeriodicCoefficients(a0.real(), fr);
+  int empty = (dfr.empty() && fr.empty() && dfbr.empty() && fbr.empty() && fpr.empty());
+  Mpi::GlobalMin(1, &empty, GetComm());
+  if (!empty)
+  {
+    br_vec = AssembleOperators(GetNDSpaces(), &dfr, &fr, &dfbr, &fbr, &fpr, skip_zeros,
+                               assemble_q_data);
+    br_aux_vec =
+        AssembleAuxOperators(GetH1Spaces(), &fr, &fbr, skip_zeros, assemble_q_data);
+  }
+}
+
+void SpaceOperator::AssemblePreconditioner(
+    double a0, double a1, double a2, double a3,
+    std::vector<std::unique_ptr<Operator>> &br_vec,
+    std::vector<std::unique_ptr<Operator>> &br_aux_vec)
+{
+  constexpr bool skip_zeros = false, assemble_q_data = false;
+  MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
+      dfbr(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
+      fpr(mat_op.MaxCeedAttribute());
+  AddStiffnessCoefficients(a0, dfr, fr);
+  AddStiffnessBdrCoefficients(a0, fbr);
+  AddDampingCoefficients(a1, fr);
+  AddDampingBdrCoefficients(a1, fbr);
+  AddAbsMassCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fr);
+  AddRealMassBdrCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fbr);
+  AddExtraSystemBdrCoefficients(a3, dfbr, dfbr, fbr, fbr);
+  AddRealPeriodicCoefficients(a0, fr);
+  int empty = (dfr.empty() && fr.empty() && dfbr.empty() && fbr.empty() && fpr.empty());
+  Mpi::GlobalMin(1, &empty, GetComm());
+  if (!empty)
+  {
+    br_vec = AssembleOperators(GetNDSpaces(), &dfr, &fr, &dfbr, &fbr, &fpr, skip_zeros,
+                               assemble_q_data);
+    br_aux_vec =
+        AssembleAuxOperators(GetH1Spaces(), &fr, &fbr, skip_zeros, assemble_q_data);
+  }
+}
+
+template <typename OperType, typename ScalarType>
+std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(ScalarType a0,
+                                                                 ScalarType a1,
+                                                                 ScalarType a2, double a3)
+{
   // When partially assembled, the coarse operators can reuse the fine operator quadrature
   // data if the spaces correspond to the same mesh. When appropriate, we build the
   // preconditioner on all levels based on the actual complex-valued system matrix. The
@@ -753,62 +862,11 @@ std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(double a0, doub
   constexpr bool skip_zeros = false, assemble_q_data = false;
   if (std::is_same<OperType, ComplexOperator>::value && !pc_mat_real)
   {
-    MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()),
-        dfi(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
-        fi(mat_op.MaxCeedAttribute()), dfbr(mat_op.MaxCeedBdrAttribute()),
-        dfbi(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
-        fbi(mat_op.MaxCeedBdrAttribute()), fpi(mat_op.MaxCeedAttribute()),
-        fpr(mat_op.MaxCeedAttribute());
-    AddStiffnessCoefficients(a0, dfr, fr);
-    AddStiffnessBdrCoefficients(a0, fbr);
-    AddDampingCoefficients(a1, fi);
-    AddDampingBdrCoefficients(a1, fbi);
-    AddRealMassCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fr);
-    AddRealMassBdrCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fbr);
-    AddImagMassCoefficients(a2, fi);
-    AddExtraSystemBdrCoefficients(a3, dfbr, dfbi, fbr, fbi);
-    AddPeriodicCoefficients(a0, fr, fpi);
-    int empty[2] = {
-        (dfr.empty() && fr.empty() && dfbr.empty() && fbr.empty() && fpr.empty()),
-        (dfi.empty() && fi.empty() && dfbi.empty() && fbi.empty() && fpi.empty())};
-    Mpi::GlobalMin(2, empty, GetComm());
-    if (!empty[0])
-    {
-      br_vec = AssembleOperators(GetNDSpaces(), &dfr, &fr, &dfbr, &fbr, &fpr, skip_zeros,
-                                 assemble_q_data);
-      br_aux_vec =
-          AssembleAuxOperators(GetH1Spaces(), &fr, &fbr, skip_zeros, assemble_q_data);
-    }
-    if (!empty[1])
-    {
-      bi_vec = AssembleOperators(GetNDSpaces(), &dfi, &fi, &dfbi, &fbi, &fpi, skip_zeros,
-                                 assemble_q_data);
-      bi_aux_vec =
-          AssembleAuxOperators(GetH1Spaces(), &fi, &fbi, skip_zeros, assemble_q_data);
-    }
+    AssemblePreconditioner(a0, a1, a2, a3, br_vec, br_aux_vec, bi_vec, bi_aux_vec);
   }
   else
   {
-    MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()),
-        fr(mat_op.MaxCeedAttribute()), dfbr(mat_op.MaxCeedBdrAttribute()),
-        fbr(mat_op.MaxCeedBdrAttribute()), fpr(mat_op.MaxCeedAttribute());
-    AddStiffnessCoefficients(a0, dfr, fr);
-    AddStiffnessBdrCoefficients(a0, fbr);
-    AddDampingCoefficients(a1, fr);
-    AddDampingBdrCoefficients(a1, fbr);
-    AddAbsMassCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fr);
-    AddRealMassBdrCoefficients(pc_mat_shifted ? std::abs(a2) : a2, fbr);
-    AddExtraSystemBdrCoefficients(a3, dfbr, dfbr, fbr, fbr);
-    AddPeriodicCoefficients(a0, fr, fpr);
-    int empty = (dfr.empty() && fr.empty() && dfbr.empty() && fbr.empty() && fpr.empty());
-    Mpi::GlobalMin(1, &empty, GetComm());
-    if (!empty)
-    {
-      br_vec = AssembleOperators(GetNDSpaces(), &dfr, &fr, &dfbr, &fbr, &fpr, skip_zeros,
-                                 assemble_q_data);
-      br_aux_vec =
-          AssembleAuxOperators(GetH1Spaces(), &fr, &fbr, skip_zeros, assemble_q_data);
-    }
+    AssemblePreconditioner(a0, a2, a2, a3, br_vec, br_aux_vec);
   }
 
   auto B = std::make_unique<BaseMultigridOperator<OperType>>(n_levels);
@@ -939,14 +997,23 @@ void SpaceOperator::AddExtraSystemBdrCoefficients(double omega,
   wave_port_op.AddExtraSystemBdrCoefficients(omega, fbr, fbi);
 }
 
-void SpaceOperator::AddPeriodicCoefficients(double coeff, MaterialPropertyCoefficient &fm,
-                                            MaterialPropertyCoefficient &fc)
+void SpaceOperator::AddRealPeriodicCoefficients(double coeff,
+                                                MaterialPropertyCoefficient &f)
 {
   // Floquet periodicity contributions.
   if (mat_op.HasWaveVector())
   {
-    fm.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetFloquetMass(), coeff);
-    fc.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetFloquetCurl(), -coeff);
+    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetFloquetMass(), coeff);
+  }
+}
+
+void SpaceOperator::AddImagPeriodicCoefficients(double coeff,
+                                                MaterialPropertyCoefficient &f)
+{
+  // Floquet periodicity contributions.
+  if (mat_op.HasWaveVector())
+  {
+    f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetFloquetCurl(), -coeff);
   }
 }
 
@@ -1106,8 +1173,9 @@ SpaceOperator::GetSystemMatrix<ComplexOperator, std::complex<double>>(
     const ComplexOperator *);
 
 template std::unique_ptr<Operator>
-SpaceOperator::GetPreconditionerMatrix<Operator>(double, double, double, double);
+SpaceOperator::GetPreconditionerMatrix<Operator, double>(double, double, double, double);
 template std::unique_ptr<ComplexOperator>
-SpaceOperator::GetPreconditionerMatrix<ComplexOperator>(double, double, double, double);
+SpaceOperator::GetPreconditionerMatrix<ComplexOperator, std::complex<double>>(
+    std::complex<double>, std::complex<double>, std::complex<double>, double);
 
 }  // namespace palace

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -859,14 +859,13 @@ std::unique_ptr<OperType> SpaceOperator::GetPreconditionerMatrix(ScalarType a0,
   const auto n_levels = GetNDSpaces().GetNumLevels();
   std::vector<std::unique_ptr<Operator>> br_vec(n_levels), bi_vec(n_levels),
       br_aux_vec(n_levels), bi_aux_vec(n_levels);
-  constexpr bool skip_zeros = false, assemble_q_data = false;
   if (std::is_same<OperType, ComplexOperator>::value && !pc_mat_real)
   {
     AssemblePreconditioner(a0, a1, a2, a3, br_vec, br_aux_vec, bi_vec, bi_aux_vec);
   }
   else
   {
-    AssemblePreconditioner(a0, a2, a2, a3, br_vec, br_aux_vec);
+    AssemblePreconditioner(a0, a1, a2, a3, br_vec, br_aux_vec);
   }
 
   auto B = std::make_unique<BaseMultigridOperator<OperType>>(n_levels);

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -528,9 +528,8 @@ SpaceOperator::GetSystemMatrix(ScalarType a0, ScalarType a1, ScalarType a2,
   MFEM_VERIFY(height >= 0 && width >= 0,
               "At least one argument to GetSystemMatrix must not be empty!");
 
-  auto A =
-      BuildParSumOperator({a0, a1, a2, ScalarType{1}}, {PtAP_K, PtAP_C, PtAP_M, PtAP_A2});
-  A->SetEssentialTrueDofs(nd_dbc_tdof_lists.back(), Operator::DiagonalPolicy::DIAG_ONE);
+  auto A = BuildParSumOperator({a0, a1, a2, ScalarType{1}},
+                               {PtAP_K, PtAP_C, PtAP_M, PtAP_A2}, true);
   return A;
 }
 

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -486,134 +486,6 @@ SpaceOperator::GetExtraSystemMatrix(double omega, Operator::DiagonalPolicy diag_
   }
 }
 
-namespace
-{
-
-auto BuildParSumOperator(int h, int w, double a0, double a1, double a2,
-                         const ParOperator *K, const ParOperator *C, const ParOperator *M,
-                         const ParOperator *A2, const FiniteElementSpace &fespace)
-{
-  auto sum = std::make_unique<SumOperator>(h, w);
-  if (K && a0 != 0.0)
-  {
-    sum->AddOperator(K->LocalOperator(), a0);
-  }
-  if (C && a1 != 0.0)
-  {
-    sum->AddOperator(C->LocalOperator(), a1);
-  }
-  if (M && a2 != 0.0)
-  {
-    sum->AddOperator(M->LocalOperator(), a2);
-  }
-  if (A2)
-  {
-    sum->AddOperator(A2->LocalOperator(), 1.0);
-  }
-  return std::make_unique<ParOperator>(std::move(sum), fespace);
-}
-
-auto BuildParSumOperator(int h, int w, std::complex<double> a0, std::complex<double> a1,
-                         std::complex<double> a2, const ComplexParOperator *K,
-                         const ComplexParOperator *C, const ComplexParOperator *M,
-                         const ComplexParOperator *A2, const FiniteElementSpace &fespace)
-{
-  // Block 2 x 2 equivalent-real formulation for each term in the sum:
-  //                    [ sumr ]  +=  [ ar  -ai ] [ Ar ]
-  //                    [ sumi ]      [ ai   ar ] [ Ai ] .
-  auto sumr = std::make_unique<SumOperator>(h, w);
-  auto sumi = std::make_unique<SumOperator>(h, w);
-  if (K)
-  {
-    if (a0.real() != 0.0)
-    {
-      if (K->LocalOperator().Real())
-      {
-        sumr->AddOperator(*K->LocalOperator().Real(), a0.real());
-      }
-      if (K->LocalOperator().Imag())
-      {
-        sumi->AddOperator(*K->LocalOperator().Imag(), a0.real());
-      }
-    }
-    if (a0.imag() != 0.0)
-    {
-      if (K->LocalOperator().Imag())
-      {
-        sumr->AddOperator(*K->LocalOperator().Imag(), -a0.imag());
-      }
-      if (K->LocalOperator().Real())
-      {
-        sumi->AddOperator(*K->LocalOperator().Real(), a0.imag());
-      }
-    }
-  }
-  if (C && a1 != 0.0)
-  {
-    if (a1.real() != 0.0)
-    {
-      if (C->LocalOperator().Real())
-      {
-        sumr->AddOperator(*C->LocalOperator().Real(), a1.real());
-      }
-      if (C->LocalOperator().Imag())
-      {
-        sumi->AddOperator(*C->LocalOperator().Imag(), a1.real());
-      }
-    }
-    if (a1.imag() != 0.0)
-    {
-      if (C->LocalOperator().Imag())
-      {
-        sumr->AddOperator(*C->LocalOperator().Imag(), -a1.imag());
-      }
-      if (C->LocalOperator().Real())
-      {
-        sumi->AddOperator(*C->LocalOperator().Real(), a1.imag());
-      }
-    }
-  }
-  if (M && a2 != 0.0)
-  {
-    if (a2.real() != 0.0)
-    {
-      if (M->LocalOperator().Real())
-      {
-        sumr->AddOperator(*M->LocalOperator().Real(), a2.real());
-      }
-      if (M->LocalOperator().Imag())
-      {
-        sumi->AddOperator(*M->LocalOperator().Imag(), a2.real());
-      }
-    }
-    if (a2.imag() != 0.0)
-    {
-      if (M->LocalOperator().Imag())
-      {
-        sumr->AddOperator(*M->LocalOperator().Imag(), -a2.imag());
-      }
-      if (M->LocalOperator().Real())
-      {
-        sumi->AddOperator(*M->LocalOperator().Real(), a2.imag());
-      }
-    }
-  }
-  if (A2)
-  {
-    if (A2->LocalOperator().Real())
-    {
-      sumr->AddOperator(*A2->LocalOperator().Real(), 1.0);
-    }
-    if (A2->LocalOperator().Imag())
-    {
-      sumi->AddOperator(*A2->LocalOperator().Imag(), 1.0);
-    }
-  }
-  return std::make_unique<ComplexParOperator>(std::move(sumr), std::move(sumi), fespace);
-}
-
-}  // namespace
-
 template <typename OperType, typename ScalarType>
 std::unique_ptr<OperType>
 SpaceOperator::GetSystemMatrix(ScalarType a0, ScalarType a1, ScalarType a2,
@@ -656,8 +528,8 @@ SpaceOperator::GetSystemMatrix(ScalarType a0, ScalarType a1, ScalarType a2,
   MFEM_VERIFY(height >= 0 && width >= 0,
               "At least one argument to GetSystemMatrix must not be empty!");
 
-  auto A = BuildParSumOperator(height, width, a0, a1, a2, PtAP_K, PtAP_C, PtAP_M, PtAP_A2,
-                               GetNDSpace());
+  auto A = BuildParSumOperator<4>({a0, a1, a2, ScalarType{1}},
+                                  {PtAP_K, PtAP_C, PtAP_M, PtAP_A2});
   A->SetEssentialTrueDofs(nd_dbc_tdof_lists.back(), Operator::DiagonalPolicy::DIAG_ONE);
   return A;
 }

--- a/palace/models/spaceoperator.hpp
+++ b/palace/models/spaceoperator.hpp
@@ -81,12 +81,27 @@ private:
                                      MaterialPropertyCoefficient &dfbi,
                                      MaterialPropertyCoefficient &fbr,
                                      MaterialPropertyCoefficient &fbi);
-  void AddPeriodicCoefficients(double coeff, MaterialPropertyCoefficient &fm,
-                               MaterialPropertyCoefficient &fc);
+  void AddRealPeriodicCoefficients(double coeff, MaterialPropertyCoefficient &f);
+  void AddImagPeriodicCoefficients(double coeff, MaterialPropertyCoefficient &f);
 
   // Helper functions for excitation vector assembly.
   bool AddExcitationVector1Internal(int excitation_idx, Vector &RHS);
   bool AddExcitationVector2Internal(int excitation_idx, double omega, ComplexVector &RHS);
+
+  // Helper functions to build the preconditioner matrix.
+  void AssemblePreconditioner(std::complex<double> a0, std::complex<double> a1,
+                              std::complex<double> a2, double a3,
+                              std::vector<std::unique_ptr<Operator>> &br_vec,
+                              std::vector<std::unique_ptr<Operator>> &br_aux_vec,
+                              std::vector<std::unique_ptr<Operator>> &bi_vec,
+                              std::vector<std::unique_ptr<Operator>> &bi_aux_vec);
+  void AssemblePreconditioner(std::complex<double> a0, std::complex<double> a1,
+                              std::complex<double> a2, double a3,
+                              std::vector<std::unique_ptr<Operator>> &br_vec,
+                              std::vector<std::unique_ptr<Operator>> &br_aux_vec);
+  void AssemblePreconditioner(double a0, double a1, double a2, double a3,
+                              std::vector<std::unique_ptr<Operator>> &br_vec,
+                              std::vector<std::unique_ptr<Operator>> &br_aux_vec);
 
 public:
   SpaceOperator(const IoData &iodata, const std::vector<std::unique_ptr<Mesh>> &mesh);
@@ -180,9 +195,9 @@ public:
   // is real-valued (Mr > 0, Mi < 0, |Mr + Mi| is done on the material property coefficient,
   // not the matrix entries themselves):
   //             B = a0 K + a1 C -/+ a2 |Mr + Mi| + A2r(a3) + A2i(a3).
-  template <typename OperType>
-  std::unique_ptr<OperType> GetPreconditionerMatrix(double a0, double a1, double a2,
-                                                    double a3);
+  template <typename OperType, typename ScalarType>
+  std::unique_ptr<OperType> GetPreconditionerMatrix(ScalarType a0, ScalarType a1,
+                                                    ScalarType a2, double a3);
 
   // Construct and return the discrete curl or gradient matrices.
   const Operator &GetGradMatrix() const

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -614,7 +614,7 @@ void DomainMaterialData::SetUp(json &domains)
     MFEM_VERIFY(
         it->find("Attributes") != it->end(),
         "Missing \"Attributes\" list for \"Materials\" domain in the configuration file!");
-    MaterialData &data = vecdata.emplace_back();
+    MaterialData &data = emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
     std::sort(data.attributes.begin(), data.attributes.end());
     ParseSymmetricMatrixData(*it, "Permeability", data.mu_r);
@@ -935,7 +935,7 @@ void ConductivityBoundaryData::SetUp(json &boundaries)
     MFEM_VERIFY(
         it->find("Conductivity") != it->end(),
         "Missing \"Conductivity\" boundary \"Conductivity\" in the configuration file!");
-    ConductivityData &data = vecdata.emplace_back();
+    ConductivityData &data = emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
     std::sort(data.attributes.begin(), data.attributes.end());
     data.sigma = it->at("Conductivity");  // Required
@@ -979,7 +979,7 @@ void ImpedanceBoundaryData::SetUp(json &boundaries)
     MFEM_VERIFY(it->find("Attributes") != it->end(),
                 "Missing \"Attributes\" list for \"Impedance\" boundary in the "
                 "configuration file!");
-    ImpedanceData &data = vecdata.emplace_back();
+    ImpedanceData &data = emplace_back();
     data.attributes = it->at("Attributes").get<std::vector<int>>();  // Required
     std::sort(data.attributes.begin(), data.attributes.end());
     data.Rs = it->value("Rs", data.Rs);
@@ -1181,7 +1181,8 @@ void PeriodicBoundaryData::SetUp(json &boundaries)
     MFEM_VERIFY(it->find("ReceiverAttributes") != it->end(),
                 "Missing \"ReceiverAttributes\" list for \"Periodic\" boundary in the "
                 "configuration file!");
-    PeriodicData data;
+
+    PeriodicData &data = boundary_pairs.emplace_back();
     data.donor_attributes = it->at("DonorAttributes").get<std::vector<int>>();  // Required
     data.receiver_attributes =
         it->at("ReceiverAttributes").get<std::vector<int>>();  // Required
@@ -1206,7 +1207,6 @@ void PeriodicBoundaryData::SetUp(json &boundaries)
           "\"AffineTransformation\" should specify an array in the configuration file!");
       data.affine_transform = transformation->get<std::array<double, 16>>();
     }
-    boundary_pairs.push_back(data);
 
     // Cleanup
     it->erase("DonorAttributes");

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -29,6 +29,11 @@ protected:
   std::vector<DataType> vecdata = {};
 
 public:
+  template <typename... Args>
+  decltype(auto) emplace_back(Args &&...args)
+  {
+    return vecdata.emplace_back(std::forward<Args>(args)...);
+  }
   [[nodiscard]] const auto &operator[](int i) const { return vecdata[i]; }
   [[nodiscard]] auto &operator[](int i) { return vecdata[i]; }
   [[nodiscard]] const auto &at(int i) const { return vecdata.at(i); }

--- a/palace/utils/iodata.hpp
+++ b/palace/utils/iodata.hpp
@@ -42,6 +42,8 @@ private:
   void CheckConfiguration();
 
 public:
+  IoData(const Units &units) : units(units) {}
+
   // Parse command line arguments and override options defaults.
   IoData(const char *filename, bool print);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-libceed.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-postoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-postoperatorcsv.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-rap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-vector.cpp
 )
@@ -68,7 +69,9 @@ set_property(
   APPEND PROPERTY COMPILE_DEFINITIONS "PALACE_TEST_MESH_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/mesh\""
 )
 set_property(
-  SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/test-geodata.cpp
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-geodata.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-rap.cpp
   APPEND PROPERTY COMPILE_DEFINITIONS "MFEM_DATA_PATH=\"${MFEM_DATA_PATH}\""
 )
 

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -336,4 +336,4 @@ TEST_CASE("Default IOData", "[iodata][Serial]")
   REQUIRE(mat_op.HasLossTangent() == false);
 }
 
-}  // namespace palaces construction of iodata)
+}  // namespace palace

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -11,8 +11,10 @@
 #include "utils/geodata_impl.hpp"
 
 #include "fem/interpolator.hpp"
+#include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
 #include "utils/filesystem.hpp"
+#include "utils/iodata.hpp"
 
 namespace palace
 {
@@ -316,4 +318,22 @@ TEST_CASE("PeriodicGmsh", "[geodata][Serial]")
   }
 }
 
-}  // namespace palace
+TEST_CASE("Default IOData", "[iodata][Serial]")
+{
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+
+  iodata.domains.materials.emplace_back();
+  iodata.domains.materials.back().attributes = {0};
+
+  // Pull from the mfem externals data folder.
+  auto ref_tet_path = fs::path(MFEM_DATA_PATH) / "ref-tetrahedron.mesh";
+  mfem::Mesh single_tet(ref_tet_path.string());
+  mfem::ParMesh pmesh(Mpi::World(), single_tet);
+
+  MaterialOperator mat_op(iodata, pmesh);
+
+  REQUIRE(mat_op.HasLossTangent() == false);
+}
+
+}  // namespace palaces construction of iodata)

--- a/test/unit/test-rap.cpp
+++ b/test/unit/test-rap.cpp
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include "fem/bilinearform.hpp"
+#include "linalg/rap.hpp"
+#include "models/spaceoperator.hpp"
+#include "utils/filesystem.hpp"
+#include "utils/geodata.hpp"
+#include "utils/iodata.hpp"
+
+namespace palace
+{
+using json = nlohmann::json;
+using namespace std::complex_literals;
+using namespace Catch;
+namespace fs = std::filesystem;
+
+TEST_CASE("BuildParSumOperator", "[rap]")
+{
+  // Verify that BuildParSumOperator can assemble collections of ParOperators.
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.domains.materials.emplace_back().attributes = {1};
+
+  // Pull from the mfem externals data folder.
+  auto ref_tet_path = fs::path(MFEM_DATA_PATH) / "ref-tetrahedron.mesh";
+  auto comm = Mpi::World();
+  mfem::Mesh mfem_mesh(ref_tet_path.string());
+  while (mfem_mesh.GetNE() < Mpi::Size(comm))
+  {
+    mfem_mesh.UniformRefinement();  // avoid empty partition
+  }
+  Mesh mesh(comm, mfem_mesh);
+
+  constexpr int order = 2, dim = 3;
+  mfem::ND_FECollection nd_fec(order, dim, mfem::BasisType::GaussLobatto,
+                               mfem::BasisType::GaussLegendre);
+  FiniteElementSpace nd_fes(mesh, &nd_fec);
+  MaterialOperator mat_op(iodata, mesh);
+  MaterialPropertyCoefficient df(mat_op.MaxCeedAttribute()), f(mat_op.MaxCeedAttribute());
+
+  df.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetInvPermeability(), 1.0);
+  f.AddCoefficient(mat_op.GetAttributeToMaterial(), mat_op.GetPermittivityReal(), 1.0);
+  SECTION("ParOperator")
+  {
+    int empty = {df.empty() && f.empty()};
+    Mpi::GlobalMin(2, &empty, comm);
+    REQUIRE(empty == 0);  // There must be a non-empty.
+
+    BilinearForm da(nd_fes), a(nd_fes);
+    da.AddDomainIntegrator<CurlCurlIntegrator>(df);
+    a.AddDomainIntegrator<VectorFEMassIntegrator>(df);
+
+    constexpr bool skip_zeros = false;
+    std::unique_ptr<Operator> DA =
+        std::make_unique<ParOperator>(da.Assemble(skip_zeros), nd_fes);
+    std::unique_ptr<Operator> A =
+        std::make_unique<ParOperator>(a.Assemble(skip_zeros), nd_fes);
+
+    REQUIRE(DA);
+    REQUIRE(A);
+
+    constexpr double c1 = 1.1, c2 = 2.3;
+    auto sum = BuildParSumOperator({c1, 2.3, c2},
+                                   {DA.get(), std::unique_ptr<Operator>().get(), A.get()});
+
+    // Check that the action of the sum operator is equivalent to the weighted sum of the
+    // actions of the components.
+    Vector v0(DA->Height()), x1(DA->Height()), x2(DA->Height());
+    v0 = 1.5;
+    x1 = 0.0;
+    x2 = 0.0;
+
+    sum->Mult(v0, x1);
+    DA->AddMult(v0, x2, c1);
+    A->AddMult(v0, x2, c2);
+
+    x1 -= x2;
+    x1.Abs();
+    double constexpr tol = 1e-12;
+    CHECK(x1.Max() < tol);
+    CHECK(x1.Max() < tol);
+  }
+
+  SECTION("ComplexParOperator")
+  {
+    int empty = {df.empty() && f.empty()};
+    Mpi::GlobalMin(2, &empty, comm);
+    REQUIRE(empty == 0);  // There must be a non-empty.
+
+    BilinearForm dar(nd_fes), dai(nd_fes), ar(nd_fes), ai(nd_fes);
+    dar.AddDomainIntegrator<CurlCurlIntegrator>(df);
+    dai.AddDomainIntegrator<VectorFEMassIntegrator>(f);
+    ar.AddDomainIntegrator<VectorFEMassIntegrator>(df);
+    ai.AddDomainIntegrator<CurlCurlIntegrator>(f);
+
+    constexpr bool skip_zeros = false;
+    std::unique_ptr<ComplexOperator> DA = std::make_unique<ComplexParOperator>(
+        dar.Assemble(skip_zeros), dai.Assemble(skip_zeros), nd_fes);
+    std::unique_ptr<ComplexOperator> A = std::make_unique<ComplexParOperator>(
+        ar.Assemble(skip_zeros), ai.Assemble(skip_zeros), nd_fes);
+
+    REQUIRE(DA);
+    REQUIRE(A);
+
+    const std::complex<double> c1 = 1.1 + 3.4i, c2 = 2.3 + 0.3i;
+    auto sum = BuildParSumOperator(
+        {c1, 3.1 + 0i, c2}, {DA.get(), std::unique_ptr<ComplexOperator>().get(), A.get()});
+
+    // Check that the action of the sum operator is equivalent to the weighted sum of the
+    // actions of the components.
+    ComplexVector v0(DA->Height()), x1(DA->Height()), x2(DA->Height());
+    v0.Real() = 1.5;
+    v0.Imag() = 0.6;
+    x1 = 0.0;
+    x2 = 0.0;
+
+    sum->Mult(v0, x1);
+    DA->AddMult(v0, x2, c1);
+    A->AddMult(v0, x2, c2);
+
+    x1 -= x2;
+    x1.Abs();
+    double constexpr tol = 1e-12;
+    CHECK(x1.Real().Max() < tol);
+    CHECK(x1.Imag().Max() < tol);
+  }
+}
+
+}  // namespace palace

--- a/test/unit/test-rap.cpp
+++ b/test/unit/test-rap.cpp
@@ -20,7 +20,7 @@ using namespace std::complex_literals;
 using namespace Catch;
 namespace fs = std::filesystem;
 
-TEST_CASE("BuildParSumOperator", "[rap]")
+TEST_CASE("BuildParSumOperator", "[rap][Serial][Parallel]")
 {
   // Verify that BuildParSumOperator can assemble collections of ParOperators.
   Units units(1.0, 1.0);


### PR DESCRIPTION
The nonlinear eigenvalue problem PR can be simplified if the `BuildParSumOperator` capability wasn't tied into `SpaceOperator`, this PR refactors to expose it. Plucks a commit from @simlapointe's branch to support complex coefficients and then fixes a typo.