### PR TITLE
Tighten CI permission

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -1,5 +1,8 @@
 name: Build and Test (Linux)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -1,5 +1,8 @@
 name: Build and Test (macOS)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -1,5 +1,8 @@
 name: Documentation Preview Cleanup
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     tags: '*'
   pull_request:
 
+permissions:
+  packages: write
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,9 +24,6 @@ env:
 
 jobs:
   build-docs:
-    permissions:
-      packages: write
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -1,5 +1,8 @@
 name: Singularity
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -9,6 +9,10 @@ on:
       - '**.md'
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,5 +1,8 @@
 name: Style
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
From CodeQL:

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.
