### PR TITLE
Give doc cleanup write permissions

### DIFF
--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -1,7 +1,7 @@
 name: Documentation Preview Cleanup
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Doc clean up was only given read permissions, causing CI errors, see https://github.com/awslabs/palace/actions/runs/18009771835/job/51238945685