### PR TITLE
Fix compilation warnings

### DIFF
--- a/palace/linalg/nleps.cpp
+++ b/palace/linalg/nleps.cpp
@@ -153,8 +153,9 @@ void NonLinearEigenvalueSolver::RescaleEigenvectors(int num_eig)
 QuasiNewtonSolver::QuasiNewtonSolver(MPI_Comm comm,
                                      std::unique_ptr<EigenvalueSolver> linear_eigensolver,
                                      int num_conv, int print, bool refine)
-  : linear_eigensolver_(std::move(linear_eigensolver)), nev_linear(num_conv),
-    refine_nonlinear(refine), NonLinearEigenvalueSolver(comm, print)
+  : NonLinearEigenvalueSolver(comm, print),
+    linear_eigensolver_(std::move(linear_eigensolver)), nev_linear(num_conv),
+    refine_nonlinear(refine)
 {
   opK = opC = opM = nullptr;
   normK = normC = normM = 0.0;

--- a/palace/linalg/rap.hpp
+++ b/palace/linalg/rap.hpp
@@ -137,7 +137,6 @@ private:
 
   // Diagonal policy for constrained true dofs.
   Operator::DiagonalPolicy diag_policy = Operator::DiagonalPolicy::DIAG_ZERO;
-  ;
 
   // Real and imaginary parts of the operator as non-owning ParOperator objects.
   std::unique_ptr<ParOperator> RAPr, RAPi;

--- a/palace/linalg/slepc.cpp
+++ b/palace/linalg/slepc.cpp
@@ -1582,7 +1582,7 @@ BV SlepcNEPSolverBase::GetBV() const
 
 ST SlepcNEPSolverBase::GetST() const
 {
-  ST st;
+  ST st = nullptr;
   // NEPGetST does not exist.
   return st;
 }


### PR DESCRIPTION
```
/Users/gbozzola/repos/palace/palace/linalg/slepc.cpp:1587:10: warning: variable 'st' is uninitialized when used here [-Wuninitialized]
 1587 |   return st;
      |          ^~
/Users/gbozzola/repos/palace/palace/linalg/slepc.cpp:1585:8: note: initialize the variable 'st' to silence this warning
 1585 |   ST st;
      |        ^
      |         = nullptr
1 warning generated.
In file included from /Users/gbozzola/repos/palace/palace/linalg/nleps.cpp:11:
/Users/gbozzola/repos/palace/palace/linalg/rap.hpp:140:3: warning: extra ';' inside a class [-Wextra-semi]
  140 |   ;
      |   ^
/Users/gbozzola/repos/palace/palace/linalg/nleps.cpp:157:5: warning: field 'refine_nonlinear' will be initialized after base 'NonLinearEigenvalueSolver' [-Wreorder-ctor]
  156 |   : linear_eigensolver_(std::move(linear_eigensolver)), nev_linear(num_conv),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~
      |     NonLinearEigenvalueSolver(comm, print)              linear_eigensolver_(std::move(linear_eigensolver))
  157 |     refine_nonlinear(refine), NonLinearEigenvalueSolver(comm, print)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     nev_linear(num_conv)      refine_nonlinear(refine)
```

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
