### PR TITLE
Allow reusing NC AMR meshes in nonadaptive context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format of this changelog is based on
     `config["Solver"]["Eigenmode"]["NonlinearType"]` option to `"Hybrid"` (default) or `"SLP"`.
     The nonlinear eigensolver will automatically be used if frequency-dependent boundary
     conditions are used.
+  - Fixed bug where a mesh from a previous nonconformal adaptation could not be loaded to
+    use in a non-amr simulation.
 
 ## [0.14.0] - 2025-08-20
 

--- a/docs/src/config/model.md
+++ b/docs/src/config/model.md
@@ -20,7 +20,11 @@
 
 with
 
-`"Mesh" [None]` :  Input mesh file path, an absolute path is recommended.
+`"Mesh" [None]` :  Input mesh file path, an absolute path is recommended. If the provided
+mesh is nonconformal, it is assumed that it comes from a previous *Palace* solve using AMR,
+and all mesh preprocessing checks and modifications (for example
+[`model["Refinement"]["CrackInternalBoundaryElements"]`](#model%5B%22Refinement%22%5D)), are
+skipped .
 
 `"L0" [1.0e-6]` :  Unit, relative to m, for mesh vertex coordinates. For example, a value
 of `1.0e-6` implies the mesh coordinates are in μm.


### PR DESCRIPTION
A mesh output from a previous NC adaptation could not be used in a non-AMR context, as the mesh loader was assuming the NC status from the config file, whereas it should be extracted from the mesh reader.
