### PR TITLE
Replace deprecated Catch2::Approx with Catch2::Matchers

### DIFF
--- a/docs/src/developer/tutorial_add_new_unit_test.md
+++ b/docs/src/developer/tutorial_add_new_unit_test.md
@@ -40,7 +40,7 @@ TEST_CASE("Vector Sum - Basic", "[myvector][Serial]")
   Vector v(2);
   v(0) = 1.0;
   v(1) = 2.0;
-  
+
   double sum = linalg::Sum(Mpi::World(), v);
   REQUIRE_THAT(sum, Catch::Matchers::WithinRel(3.0));
 }
@@ -66,11 +66,11 @@ add_executable(unit-tests
 Then, build and run:
 
 ```bash
-# Build tests
+# Build tests in the build directory
 make palace-tests
 
 # Run this specific test
-test/unit/unit-tests [myvector]
+palace-build/test/unit/unit-tests "[myvector]"
 ```
 
 We should see that `All tests passed`.

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -133,6 +133,8 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
   auto jsonstream = PreprocessFile(filename.c_str());  // Apply custom palace json
   auto config = json::parse(jsonstream);
 
+  using namespace Catch::Matchers;
+
   constexpr double delta_eps = 1.0e-9;  // Precision in frequency comparisons (Hz)
   {
     auto sample_f = std::vector{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1};
@@ -144,8 +146,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
       for (size_t i = 0; i < sample_f.size(); ++i)
       {
-        CHECK_THAT(driven_solver.sample_f[i],
-                   Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+        CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
       }
       CHECK(driven_solver.save_indices == save_indices);
       CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
@@ -157,8 +158,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
       for (size_t i = 0; i < sample_f.size(); ++i)
       {
-        CHECK_THAT(driven_solver.sample_f[i],
-                   Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+        CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
       }
       CHECK(driven_solver.save_indices == save_indices);
       CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
@@ -174,8 +174,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
     for (size_t i = 0; i < sample_f.size(); ++i)
     {
-      CHECK_THAT(driven_solver.sample_f[i],
-                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
     }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
@@ -191,8 +190,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
     for (size_t i = 0; i < sample_f.size(); ++i)
     {
-      CHECK_THAT(driven_solver.sample_f[i],
-                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
     }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
@@ -209,8 +207,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
     for (size_t i = 0; i < sample_f.size(); ++i)
     {
-      CHECK_THAT(driven_solver.sample_f[i],
-                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
     }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == prom_indices);
@@ -227,8 +224,7 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
 
     for (size_t i = 0; i < sample_f.size(); ++i)
     {
-      CHECK_THAT(driven_solver.sample_f[i],
-                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      CHECK_THAT(driven_solver.sample_f[i], WithinAbs(sample_f[i], delta_eps));
     }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == prom_indices);

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -6,11 +6,11 @@
 #include <sstream>
 #include <string>
 #include <fmt/format.h>
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include "utils/configfile.hpp"
 #include "utils/iodata.hpp"
@@ -133,8 +133,6 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
   auto jsonstream = PreprocessFile(filename.c_str());  // Apply custom palace json
   auto config = json::parse(jsonstream);
 
-  using namespace Catch::Matchers;
-
   constexpr double delta_eps = 1.0e-9;  // Precision in frequency comparisons (Hz)
   {
     auto sample_f = std::vector{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1};
@@ -144,7 +142,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
       config::DrivenSolverData driven_solver;
       REQUIRE_NOTHROW(driven_solver.SetUp(*config.find("driven_base_uniform_sample")));
 
-      CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+      for (size_t i = 0; i < sample_f.size(); ++i)
+      {
+        CHECK_THAT(driven_solver.sample_f[i],
+                   Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      }
       CHECK(driven_solver.save_indices == save_indices);
       CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
     }
@@ -153,7 +155,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
       config::DrivenSolverData driven_solver;
       REQUIRE_NOTHROW(driven_solver.SetUp(*config.find("driven_uniform_freq_step")));
 
-      CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+      for (size_t i = 0; i < sample_f.size(); ++i)
+      {
+        CHECK_THAT(driven_solver.sample_f[i],
+                   Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+      }
       CHECK(driven_solver.save_indices == save_indices);
       CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
     }
@@ -166,7 +172,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
     auto sample_f = std::vector{0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0};
     auto save_indices = std::vector<size_t>{0, 2, 4, 6, 8};
 
-    CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+    for (size_t i = 0; i < sample_f.size(); ++i)
+    {
+      CHECK_THAT(driven_solver.sample_f[i],
+                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+    }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
   }
@@ -179,7 +189,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
     auto save_indices =
         std::vector<size_t>{0, 2, 4, 5, 6, 7, 8};  // 0.0, 0.5, 1.0, 2.5, 5.0, 7.5, 10.0
 
-    CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+    for (size_t i = 0; i < sample_f.size(); ++i)
+    {
+      CHECK_THAT(driven_solver.sample_f[i],
+                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+    }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == std::vector{0, sample_f.size() - 1});
   }
@@ -193,7 +207,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
     auto save_indices = std::vector<size_t>{0, 2, 3, 4, 6, 7, 9, 11};
     auto prom_indices = std::vector<size_t>{0, sample_f.size() - 1, 2, 4, 7};
 
-    CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+    for (size_t i = 0; i < sample_f.size(); ++i)
+    {
+      CHECK_THAT(driven_solver.sample_f[i],
+                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+    }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == prom_indices);
   }
@@ -207,7 +225,11 @@ TEST_CASE("Config Driven Solver", "[config][Serial]")
     auto save_indices = std::vector<size_t>{0, 1, 3, 4, 5, 7};
     auto prom_indices = std::vector<size_t>{0, sample_f.size() - 1, 1, 4, 5};
 
-    CHECK_THAT(driven_solver.sample_f, Approx(sample_f).margin(delta_eps));
+    for (size_t i = 0; i < sample_f.size(); ++i)
+    {
+      CHECK_THAT(driven_solver.sample_f[i],
+                 Catch::Matchers::WithinAbs(sample_f[i], delta_eps));
+    }
     CHECK(driven_solver.save_indices == save_indices);
     CHECK(driven_solver.prom_indices == prom_indices);
   }

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -20,6 +20,7 @@ namespace palace
 {
 using json = nlohmann::json;
 namespace fs = std::filesystem;
+using namespace Catch::Matchers;
 
 TEST_CASE("TwoDimensionalDiagonalSquarePort", "[geodata][Serial]")
 {
@@ -126,21 +127,21 @@ TEST_CASE("TwoDimensionalDiagonalSquarePort", "[geodata][Serial]")
   auto length_x = (max_x - min_x) * invsqrt2;
   auto length_y = (max_y - min_y) * invsqrt2;
 
-  CHECK_THAT(length_x, Catch::Matchers::WithinAbs(length_y, 1e-6));
+  CHECK_THAT(length_x, WithinAbs(length_y, 1e-6));
 
   auto length = (length_x + length_y) / 2;
   auto lengths = box.Lengths();
-  CHECK_THAT(lengths[0], Catch::Matchers::WithinAbs(length, 1e-6));
-  CHECK_THAT(lengths[1], Catch::Matchers::WithinAbs(length, 1e-6));
-  CHECK_THAT(lengths[2], Catch::Matchers::WithinRel(0.0));
+  CHECK_THAT(lengths[0], WithinAbs(length, 1e-6));
+  CHECK_THAT(lengths[1], WithinAbs(length, 1e-6));
+  CHECK_THAT(lengths[2], WithinRel(0.0));
 
   auto normals = box.Normals();
-  CHECK_THAT(normals[0][0], Catch::Matchers::WithinAbs(ax0[0], 1e-4));
-  CHECK_THAT(normals[0][1], Catch::Matchers::WithinAbs(ax0[1], 1e-4));
-  CHECK_THAT(normals[0][2], Catch::Matchers::WithinAbs(ax0[2], 1e-4));
-  CHECK_THAT(normals[1][0], Catch::Matchers::WithinAbs(ax1[0], 1e-4));
-  CHECK_THAT(normals[1][1], Catch::Matchers::WithinAbs(ax1[1], 1e-4));
-  CHECK_THAT(normals[1][2], Catch::Matchers::WithinAbs(ax1[2], 1e-4));
+  CHECK_THAT(normals[0][0], WithinAbs(ax0[0], 1e-4));
+  CHECK_THAT(normals[0][1], WithinAbs(ax0[1], 1e-4));
+  CHECK_THAT(normals[0][2], WithinAbs(ax0[2], 1e-4));
+  CHECK_THAT(normals[1][0], WithinAbs(ax1[0], 1e-4));
+  CHECK_THAT(normals[1][1], WithinAbs(ax1[1], 1e-4));
+  CHECK_THAT(normals[1][2], WithinAbs(ax1[2], 1e-4));
   CHECK(box.planar);
 }
 
@@ -187,7 +188,7 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
       {
         // margin(1e-12) for comparing zeros.
         CHECK_THAT((*four_hex.GetNodes())(j + 3 * i),
-                   Catch::Matchers::WithinAbs(global_dof_vals[i][j], 1e-12));
+                   WithinAbs(global_dof_vals[i][j], 1e-12));
       }
 
     mfem::Vector vdof_vals, col;
@@ -206,8 +207,7 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
         {
           CAPTURE(i, j, global_dof_vals[verts[j]][i], col(j));
           // margin(1e-12) for comparing zeros.
-          CHECK_THAT(col(j),
-                     Catch::Matchers::WithinAbs(global_dof_vals[verts[j]][i], 1e-12));
+          CHECK_THAT(col(j), WithinAbs(global_dof_vals[verts[j]][i], 1e-12));
         }
       }
     };
@@ -295,7 +295,7 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
                              hex_FESpace->GetOrdering());
     for (int i = 0; i < tet_vals.Size(); i++)
     {
-      CHECK_THAT(tet_vals(i), Catch::Matchers::WithinAbs(hex_vals(i), 1e-9));
+      CHECK_THAT(tet_vals(i), WithinAbs(hex_vals(i), 1e-9));
     }
   }
 #endif

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <vector>
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "utils/geodata.hpp"
 #include "utils/geodata_impl.hpp"
@@ -19,7 +19,6 @@
 namespace palace
 {
 using json = nlohmann::json;
-using namespace Catch;
 namespace fs = std::filesystem;
 
 TEST_CASE("TwoDimensionalDiagonalSquarePort", "[geodata][Serial]")
@@ -127,21 +126,21 @@ TEST_CASE("TwoDimensionalDiagonalSquarePort", "[geodata][Serial]")
   auto length_x = (max_x - min_x) * invsqrt2;
   auto length_y = (max_y - min_y) * invsqrt2;
 
-  CHECK(length_x == Approx(length_y).margin(1e-6));
+  CHECK_THAT(length_x, Catch::Matchers::WithinAbs(length_y, 1e-6));
 
   auto length = (length_x + length_y) / 2;
   auto lengths = box.Lengths();
-  CHECK(lengths[0] == Approx(length).margin(1e-6));
-  CHECK(lengths[1] == Approx(length).margin(1e-6));
-  CHECK(lengths[2] == Approx(0.0));
+  CHECK_THAT(lengths[0], Catch::Matchers::WithinAbs(length, 1e-6));
+  CHECK_THAT(lengths[1], Catch::Matchers::WithinAbs(length, 1e-6));
+  CHECK_THAT(lengths[2], Catch::Matchers::WithinRel(0.0));
 
   auto normals = box.Normals();
-  CHECK(normals[0][0] == Approx(ax0[0]).margin(1e-4));
-  CHECK(normals[0][1] == Approx(ax0[1]).margin(1e-4));
-  CHECK(normals[0][2] == Approx(ax0[2]).margin(1e-4));
-  CHECK(normals[1][0] == Approx(ax1[0]).margin(1e-4));
-  CHECK(normals[1][1] == Approx(ax1[1]).margin(1e-4));
-  CHECK(normals[1][2] == Approx(ax1[2]).margin(1e-4));
+  CHECK_THAT(normals[0][0], Catch::Matchers::WithinAbs(ax0[0], 1e-4));
+  CHECK_THAT(normals[0][1], Catch::Matchers::WithinAbs(ax0[1], 1e-4));
+  CHECK_THAT(normals[0][2], Catch::Matchers::WithinAbs(ax0[2], 1e-4));
+  CHECK_THAT(normals[1][0], Catch::Matchers::WithinAbs(ax1[0], 1e-4));
+  CHECK_THAT(normals[1][1], Catch::Matchers::WithinAbs(ax1[1], 1e-4));
+  CHECK_THAT(normals[1][2], Catch::Matchers::WithinAbs(ax1[2], 1e-4));
   CHECK(box.planar);
 }
 
@@ -187,8 +186,8 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
       for (int j = 0; j < 3; j++)
       {
         // margin(1e-12) for comparing zeros.
-        CHECK((*four_hex.GetNodes())(j + 3 * i) ==
-              Approx(global_dof_vals[i][j]).margin(1e-12));
+        CHECK_THAT((*four_hex.GetNodes())(j + 3 * i),
+                   Catch::Matchers::WithinAbs(global_dof_vals[i][j], 1e-12));
       }
 
     mfem::Vector vdof_vals, col;
@@ -207,7 +206,8 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
         {
           CAPTURE(i, j, global_dof_vals[verts[j]][i], col(j));
           // margin(1e-12) for comparing zeros.
-          CHECK(col(j) == Approx(global_dof_vals[verts[j]][i]).margin(1e-12));
+          CHECK_THAT(col(j),
+                     Catch::Matchers::WithinAbs(global_dof_vals[verts[j]][i], 1e-12));
         }
       }
     };
@@ -295,7 +295,7 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
                              hex_FESpace->GetOrdering());
     for (int i = 0; i < tet_vals.Size(); i++)
     {
-      CHECK(tet_vals(i) == Approx(hex_vals(i)).margin(1e-9));
+      CHECK_THAT(tet_vals(i), Catch::Matchers::WithinAbs(hex_vals(i), 1e-9));
     }
   }
 #endif

--- a/test/unit/test-postoperatorcsv.cpp
+++ b/test/unit/test-postoperatorcsv.cpp
@@ -3,7 +3,6 @@
 
 #include <complex>
 #include <fmt/format.h>
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/generators/catch_generators_all.hpp>

--- a/test/unit/test-rap.cpp
+++ b/test/unit/test-rap.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <vector>
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 

--- a/test/unit/test-vector.cpp
+++ b/test/unit/test-vector.cpp
@@ -12,7 +12,6 @@
 
 namespace palace
 {
-using namespace Catch;
 
 TEST_CASE("Vector Sum - Real", "[vector][Serial][Parallel][GPU]")
 {

--- a/test/unit/test-vector.cpp
+++ b/test/unit/test-vector.cpp
@@ -12,6 +12,7 @@
 
 namespace palace
 {
+using namespace Catch::Matchers;
 
 TEST_CASE("Vector Sum - Real", "[vector][Serial][Parallel][GPU]")
 {
@@ -35,7 +36,7 @@ TEST_CASE("Vector Sum - Real", "[vector][Serial][Parallel][GPU]")
   // * size sum(rank) from 0 to size-1 = size * (size-1) / 2.
   double expected = 9.0 * size * (size - 1) / 2.0 + 6.0 * size;
 
-  REQUIRE_THAT(sum, Catch::Matchers::WithinRel(expected));
+  REQUIRE_THAT(sum, WithinRel(expected));
 }
 
 TEST_CASE("Vector Sum - Real - Asymmetric Sizes", "[vector][Parallel][GPU]")
@@ -69,7 +70,7 @@ TEST_CASE("Vector Sum - Real - Asymmetric Sizes", "[vector][Parallel][GPU]")
       expected += (r + 1) * 10 + i;
   }
 
-  REQUIRE_THAT(sum, Catch::Matchers::WithinRel(expected));
+  REQUIRE_THAT(sum, WithinRel(expected));
 }
 
 TEST_CASE("Vector Sum - Complex", "[vector][Serial][Parallel][GPU]")
@@ -104,8 +105,8 @@ TEST_CASE("Vector Sum - Complex", "[vector][Serial][Parallel][GPU]")
   double index_sum = cv.Size() * (cv.Size() - 1) / 2.0;
   double expected_imag = cv.Size() * rank_sum + size * index_sum;
 
-  REQUIRE_THAT(sum.real(), Catch::Matchers::WithinRel(expected_real));
-  REQUIRE_THAT(sum.imag(), Catch::Matchers::WithinRel(expected_imag));
+  REQUIRE_THAT(sum.real(), WithinRel(expected_real));
+  REQUIRE_THAT(sum.imag(), WithinRel(expected_imag));
 }
 
 TEST_CASE("ComplexVector Set", "[vector][Serial][Parallel][GPU]")
@@ -124,11 +125,11 @@ TEST_CASE("ComplexVector Set", "[vector][Serial][Parallel][GPU]")
 
   cv.Set(vals, 2, on_dev);
 
-  REQUIRE_THAT(cv.Real()[0], Catch::Matchers::WithinRel(1.0 * rank));
-  REQUIRE_THAT(cv.Real()[1], Catch::Matchers::WithinRel(2.0 * rank));
+  REQUIRE_THAT(cv.Real()[0], WithinRel(1.0 * rank));
+  REQUIRE_THAT(cv.Real()[1], WithinRel(2.0 * rank));
 
-  REQUIRE_THAT(cv.Imag()[0], Catch::Matchers::WithinRel(10.0 * rank));
-  REQUIRE_THAT(cv.Imag()[1], Catch::Matchers::WithinRel(20.0 * rank));
+  REQUIRE_THAT(cv.Imag()[0], WithinRel(10.0 * rank));
+  REQUIRE_THAT(cv.Imag()[1], WithinRel(20.0 * rank));
 }
 
 }  // namespace palace


### PR DESCRIPTION
This change removes usage of deprecated `Catch2::Approx` in favor of the more explicit `WithinAbs`/`WithinRel` matchers. 

Closes #486.