### PR TITLE
Update wave port documentation

### DIFF
--- a/docs/src/config/boundaries.md
+++ b/docs/src/config/boundaries.md
@@ -91,18 +91,18 @@ boundary using a user specified surface impedance.
 artificial scattering boundary conditions at farfield boundaries.
 
 `"Conductivity"` :  Array of objects for configuring finite conductivity surface impedance
-boundary conditions. Finite conductivity boundaries are only available for the frequency
-domain driven simulation type.
+boundary conditions. Finite conductivity boundaries are only available for frequency
+domain driven and eigenmode simulation types.
 
 `"LumpedPort"` :  Array of objects for configuring lumped port boundary conditions. Lumped
 ports can be specified on boundaries which are internal to the computational domain.
 
 `"WavePort"` :  Array of objects for configuring numeric wave port boundary conditions. Wave
 ports can only be specified on boundaries which are on the true boundary of the
-computational domain. Additionally, wave port boundaries are only available for the
-frequency domain driven simulation type.
+computational domain. Additionally, wave port boundaries are only available for
+frequency domain driven and eigenmode simulation types.
 
-`"WavePortPEC"` :  Top-level object for configuring PEC boundary conditions for boundary
+`"WavePortPEC"` :  Top-level object for configuring additional PEC boundary conditions for boundary
 mode analysis performed on the wave port boundaries. Thus, this object is only relevant
 when wave port boundaries are specified under
 [`config["Boundaries"]["WavePort"]`](#boundaries%5B%22WavePort%22%5D).
@@ -405,10 +405,10 @@ for the wave port problem.
 
 with
 
-`"Attributes" [None]` :  Integer array of mesh boundary attributes to consider along with
-those specified under
-[`config["Boundaries"]["PEC"]["Attributes"]`](#boundaries%5B%22PEC%22%5D) as PEC when
-performing wave port boundary mode analysis.
+`"Attributes" [None]` :  Integer array of mesh boundary attributes to consider as PEC when solving the
+2D eigenproblem for the wave port boundary mode analysis, along with those specified under
+[`config["Boundaries"]["PEC"]["Attributes"]`](#boundaries%5B%22PEC%22%5D) and
+[`config["Boundaries"]["Conductivity"]["Attributes"]`](#boundaries%5B%22Conductivity%22%5D).
 
 ## `boundaries["SurfaceCurrent"]`
 

--- a/docs/src/guide/boundaries.md
+++ b/docs/src/guide/boundaries.md
@@ -49,7 +49,7 @@ boundary conditions, can be applied using the `"Absorbing"` boundary keyword und
 first-order absorbing boundary condition is a special case of the above impedance boundary
 and is available for eigenmode or frequency or time domain driven simulation types. The
 second-order absorbing boundary condition is only available for frequency domain driven
-simulations.
+and eigenmode simulations.
 
 [Perfectly matched layer (PML)](https://en.wikipedia.org/wiki/Perfectly_matched_layer)
 boundaries for frequency and time domain electromagnetic formulations are not yet
@@ -63,7 +63,7 @@ A finite conductivity boundary condition can be specified using the
 [`"Conductivity"`](../config/boundaries.md#boundaries%5B%22Conductivity%22%5D) boundary
 keyword. This boundary condition models the effect of a boundary with non-infinite
 conductivity (an imperfect conductor) for conductors with thickness much larger than the
-skin depth. It is available only for frequency domain driven simulations. For more
+skin depth. It is available only for frequency domain driven and eigenmode simulations. For more
 information see the
 [Other boundary conditions](../reference.md#Other-boundary-conditions) section of the
 reference.
@@ -99,17 +99,23 @@ incorporating periodicity as part of the meshing process.
     [`"LumpedPort"`](../config/boundaries.md#boundaries%5B%22LumpedPort%22%5D).
 
   - [`config["Boundaries"]["WavePort"]`](../config/boundaries.md#boundaries%5B%22WavePort%22%5D) :
-    Numeric wave ports are available for frequency domain driven simulations. In this case,
+    Numeric wave ports are available for frequency domain driven and eigenmode simulations. In this case,
     a port boundary condition is applied with an optional excitation using a modal field
     shape which is computed by solving a 2D boundary mode eigenproblem on each wave port
     boundary. This allows for more accurate scattering parameter calculations when modeling
     waveguides or transmission lines with arbitrary cross sections.
     
-    The homogeneous Dirichlet boundary conditions for the wave port boundary mode analysis
-    are taken from the `"PEC"` boundaries of the full 3D model, as well as any optional
-    additional boundary attributes given under `"WavePortPEC"`. Any boundary of the wave
-    port not labeled with with a PEC condition has the natural boundary condition for zero
-    tangential magnetic field prescribed for the purpose of port mode calculation.
+    The 2D wave port eigenproblem only supports PEC and PMC boundary conditions. Boundaries
+    that are specified as `"PEC"` or `"Conductivity"` in the full 3D model and intersect the wave port
+    boundary will be considered as PEC in the 2D boundary mode analysis, as well as any additional
+    boundary attributes given under `"WavePortPEC"`. [`config["Boundaries"]["WavePortPEC"`](../config/boundaries.md#boundaries%5B%22WavePortPEC%22%5D)
+    allows to assign non-PEC attributes from the 3D model (e.g. impedance or absorbing boundary conditions)
+    as a PEC boundary condition for the 2D wave port solve. In addition, boundaries of wave ports other
+    than the wave port currently being considered, in the case wave ports are touching and share one or
+    more edges, are also considered as PEC for the wave port boundary mode analysis. Boundaries of the
+    wave port not labeled with a `"PEC"`, `"Conductivity"`, `"WavePortPEC"`, or `"WavePort"` condition
+    have the natural boundary condition of zero tangential magnetic field (PMC) prescribed for the purpose
+    of port mode calculation.
     
     Unlike lumped ports, wave port boundaries cannot be defined internal to the
     computational domain and instead must exist only on the outer boundary of the domain


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
Update the wave port documentation to clarify how boundary conditions from the full 3D model are mapped to PEC and PMC in the 2D wave port eigenproblem. Also update a few places in the docs stating that frequency-dependent boundary conditions are only available for driven simulations (they are now available for both driven and eigenmode).