### PR TITLE
Use spack cache for palace in doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,9 +106,7 @@ jobs:
         # Explicitly not using cache to get latest develop
       - name: Build Palace
         run: |
-          spack -e . install --only-concrete --show-log-on-error --only package --keep-stage --no-cache
-        # If you want to use the branch-local source instead (should we always do this?)
-        # spack -e . develop --path=$(pwd) local.palace@git."${{ github.head_ref || github.ref_name }}"=develop
+          spack -e . install --only-concrete --show-log-on-error --only package --keep-stage
 
       - name: Build and deploy
         env:


### PR DESCRIPTION
We can allow usage of the spack cache for the palace install during doc generation, useful for cases where only markdown is changed, where the previous builds are probably fine.