### PR TITLE
Force hypre to compile with C++17

### DIFF
--- a/cmake/ExternalHYPRE.cmake
+++ b/cmake/ExternalHYPRE.cmake
@@ -58,6 +58,7 @@ set(HYPRE_OPTIONS
   "--prefix=${CMAKE_INSTALL_PREFIX}"
   "--disable-fortran"
   "--with-MPI"
+  "--with-cxxstandard=17"
 )
 if(CMAKE_BUILD_TYPE MATCHES "Debug|debug|DEBUG")
   list(APPEND HYPRE_OPTIONS "--enable-debug")


### PR DESCRIPTION
PR #519 is almost ready, but it uncovered a couple of possible problems. For this reason, we might want to be cautious with it.

One of the key benefits of PR #519 is that it brings compatibility with CUDA 13 and with CUDA 12.9 + GCC 14. This PR does not fix compatibility with CUDA 13, but it does for CUDA 12.9 + GCC 14.
