### PR TITLE
Fix palace license in Spack

### DIFF
--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -16,6 +16,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/awslabs/palace"
     git = "https://github.com/awslabs/palace.git"
+    license("Apache-2.0")
 
     maintainers("hughcars", "simlap", "cameronrutherford")
 


### PR DESCRIPTION
Before:
```
spack info palace

...
Licenses:
    None
```
Now:
```
spack info palace

Licenses:
    Apache-2.0
```

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
