### PR TITLE
Use map instead of find_if to check for duplicate column names in tablecsv

### DIFF
--- a/palace/utils/tablecsv.cpp
+++ b/palace/utils/tablecsv.cpp
@@ -100,12 +100,12 @@ void Table::reserve(size_t n_rows, size_t n_cols)
 // Insert columns: map like interface.
 bool Table::insert(Column &&column)
 {
-  if (col_names.find(column.name) != col_names.end())
+  if (name_to_index.find(column.name) != name_to_index.end())
   {
     return false;
   }
+  name_to_index[column.name] = cols.size();
   auto &col = cols.emplace_back(std::move(column));
-  col_names.insert(col.name);
   if (reserve_n_rows > 0)
   {
     col.data.reserve(reserve_n_rows);
@@ -115,13 +115,12 @@ bool Table::insert(Column &&column)
 
 Column &Table::operator[](std::string_view name)
 {
-  auto it =
-      std::find_if(cols.begin(), cols.end(), [&name](auto &c) { return c.name == name; });
-  if (it == cols.end())
+  auto it = name_to_index.find(std::string(name));
+  if (it == name_to_index.end())
   {
     throw std::out_of_range(fmt::format("Column {} not found in table", name).c_str());
   }
-  return *it;
+  return cols[it->second];
 }
 
 // TODO: Improve all the functions below with ranges in C++20.

--- a/palace/utils/tablecsv.hpp
+++ b/palace/utils/tablecsv.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 namespace palace
@@ -81,8 +81,9 @@ class Table
   // Future: allow int and other output, allow non-owning memory via span.
   std::vector<Column> cols;
 
-  // Set of column names to avoid duplicate column names.
-  std::unordered_set<std::string> col_names;
+  // Map of column name to column index to avoid duplicate column names and allow
+  // fast retrieval by name.
+  std::unordered_map<std::string, std::size_t> name_to_index;
 
   // Cache value to reserve vector space by default.
   std::size_t reserve_n_rows = 0;


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
Use map instead of find_if to check for duplicate column names and allow for retrieval by name in tablecsv. find_if can get quite slow when inserting a large number of columns in a table (for example, when using more than > 10,000 probes).