### PR TITLE
Fix Paraview output for transient simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format of this changelog is based on
     [PR 525](https://github.com/awslabs/palace/pull/525).
   - Scaled Rs/Ls/Cs of impedance boundary conditions affected by mesh cracking, fixing bug where
     `"CrackInternalBoundaryElements"` would lead to incorrect results. [PR 544](https://github.com/awslabs/palace/pull/544).
+  - Fixed Paraview/MFEM output for transient simulations. [PR 561](https://github.com/awslabs/palace/pull/561).
 
 ## [0.14.0] - 2025-08-20
 

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -1333,13 +1333,13 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const Vector &e, const
   if (ShouldWriteParaviewFields(step))
   {
     Mpi::Print("\n");
-    WriteParaviewFields(double(step) / output_delta_post, time);
+    WriteParaviewFields(time, double(step) / output_delta_post);
     Mpi::Print(" Wrote fields to disk (Paraview) at step {:d}\n", step + 1);
   }
   if (ShouldWriteGridFunctionFields(step))
   {
     Mpi::Print("\n");
-    WriteMFEMGridFunctions(double(step) / output_delta_post, time);
+    WriteMFEMGridFunctions(time, double(step) / output_delta_post);
     Mpi::Print(" Wrote fields to disk (grid function) at step {:d}\n", step + 1);
   }
   return measurement_cache.domain_E_field_energy_all +


### PR DESCRIPTION
The arguments for `WriteParaviewFields` were inconsistent with the function signature.

![output](https://github.com/user-attachments/assets/b4815432-1c3e-4239-97d3-112f860c6a1b)
