### PR TITLE
Use symmetric block matrix for complex coarse solve

### DIFF
--- a/palace/linalg/mumps.hpp
+++ b/palace/linalg/mumps.hpp
@@ -29,9 +29,9 @@ public:
            iodata.problem.type == ProblemType::ELECTROSTATIC ||
            iodata.problem.type == ProblemType::MAGNETOSTATIC)
               ? mfem::MUMPSSolver::SYMMETRIC_POSITIVE_DEFINITE
-          : iodata.solver.linear.complex_coarse_solve
-              ? mfem::MUMPSSolver::UNSYMMETRIC
-              : mfem::MUMPSSolver::SYMMETRIC_INDEFINITE,
+          : iodata.boundaries.periodic.wave_vector == std::array<double, 3>{0.0, 0.0, 0.0}
+              ? mfem::MUMPSSolver::SYMMETRIC_INDEFINITE
+              : mfem::MUMPSSolver::UNSYMMETRIC,
           iodata.solver.linear.sym_factorization,
           (iodata.solver.linear.strumpack_compression_type == SparseCompression::BLR)
               ? iodata.solver.linear.strumpack_lr_tol

--- a/palace/linalg/solver.cpp
+++ b/palace/linalg/solver.cpp
@@ -55,8 +55,9 @@ void MfemWrapperSolver<ComplexOperator>::SetOperator(const ComplexOperator &op)
   {
     if (complex_matrix)
     {
-      // A = [Ar, -Ai]
-      //     [Ai,  Ar]
+      // A = [Ar, Ai]
+      //     [Ai, -Ar]
+      // We solve A [xr; -xi] = [br; bi]
       mfem::Array2D<const mfem::HypreParMatrix *> blocks(2, 2);
       mfem::Array2D<double> block_coeffs(2, 2);
       blocks(0, 0) = hAr;
@@ -64,9 +65,9 @@ void MfemWrapperSolver<ComplexOperator>::SetOperator(const ComplexOperator &op)
       blocks(1, 0) = hAi;
       blocks(1, 1) = hAr;
       block_coeffs(0, 0) = 1.0;
-      block_coeffs(0, 1) = -1.0;
+      block_coeffs(0, 1) = 1.0;
       block_coeffs(1, 0) = 1.0;
-      block_coeffs(1, 1) = 1.0;
+      block_coeffs(1, 1) = -1.0;
       A.reset(mfem::HypreParMatrixFromBlocks(blocks, &block_coeffs));
     }
     else
@@ -168,6 +169,8 @@ void MfemWrapperSolver<ComplexOperator>::Mult(const ComplexVector &x,
     Y.ReadWrite();
     yr.MakeRef(Y, 0, Ny);
     yi.MakeRef(Y, Ny, Ny);
+    // [yr; yi] is the complex conjugate of the solution
+    yi *= -1.0;
     y.Real() = yr;
     y.Imag() = yi;
   }


### PR DESCRIPTION
Thanks for developing and maintaining this nice project.

For "complex coarse solve", instead of solving

```math
A_1\begin{pmatrix}x_r \\ x_i \end{pmatrix}:=\begin{pmatrix} A_r & -A_i \\ A_i & A_r \end{pmatrix} \begin{pmatrix}x_r \\ x_i \end{pmatrix}=\begin{pmatrix}y_r \\ y_i \end{pmatrix},
```

we can solve

```math
A_2\begin{pmatrix}x_r \\ -x_i \end{pmatrix}:=\begin{pmatrix} A_r & A_i \\ A_i & -A_r \end{pmatrix} \begin{pmatrix}x_r \\ -x_i \end{pmatrix}=\begin{pmatrix}y_r \\ y_i \end{pmatrix}.
```

The idea is similar to [`mfem::ComplexOperator::Convention::BLOCK_SYMMETRIC`](https://docs.mfem.org/html/complex__operator_8hpp_source.html).

When $A_r$ and $A_i$ are both symmetric, $A_2$ will also be symmetric, which can be utitlized by `MUMPS` solver for more efficient solve.

I realized that $A_r$ and $A_i$ are unsymmetric when there is periodic boundary (?), but am not sure if there are other exceptions. Please let me know your suggestions for the correct/better approach. Thanks.