### PR TITLE
Fix spack recipe for +superlu/+strumpack with cuda

### DIFF
--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -84,8 +84,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
 
     with when("+superlu-dist"):
         depends_on("superlu-dist+parmetis")
-        depends_on("superlu-dist~cuda", when="~cuda")
-        depends_on("superlu-dist~rocm", when="~rocm")
         depends_on("superlu-dist+shared", when="+shared")
         depends_on("superlu-dist~shared", when="~shared")
         depends_on("superlu-dist+int64", when="+int64")
@@ -96,8 +94,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
     with when("+strumpack"):
         depends_on("fortran", type="build")
         depends_on("strumpack+butterflypack+zfp+parmetis")
-        depends_on("strumpack~cuda", when="~cuda")
-        depends_on("strumpack~rocm", when="~rocm")
         depends_on("strumpack+shared", when="+shared")
         depends_on("strumpack~shared", when="~shared")
         depends_on("strumpack+openmp", when="+openmp")
@@ -107,8 +103,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
 
     with when("+slepc"):
         depends_on("slepc~arpack")
-        depends_on("slepc~cuda", when="~cuda")
-        depends_on("slepc~rocm", when="~rocm")
         depends_on("petsc+mpi+double+complex")
         depends_on("petsc+shared", when="+shared")
         depends_on("petsc~shared", when="~shared")
@@ -116,8 +110,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("petsc~int64", when="~int64")
         depends_on("petsc+openmp", when="+openmp")
         depends_on("petsc~openmp", when="~openmp")
-        depends_on("petsc~cuda", when="~cuda")
-        depends_on("petsc~rocm", when="~rocm")
 
     with when("+arpack"):
         depends_on("fortran", type="build")
@@ -145,8 +137,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hypre~mixedint", when="~int64")
     depends_on("hypre+openmp", when="+openmp")
     depends_on("hypre~openmp", when="~openmp")
-    depends_on("hypre~cuda", when="~cuda")
-    depends_on("hypre~rocm", when="~rocm")
 
     with when("+libxsmm"):
         # NOTE: @=main != @main since libxsmm has a version main-2023-22
@@ -165,8 +155,6 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("sundials~shared", when="~shared")
         depends_on("sundials+openmp", when="+openmp")
         depends_on("sundials~openmp", when="~openmp")
-        depends_on("sundials~cuda", when="~cuda")
-        depends_on("sundials~rocm", when="~rocm")
 
     conflicts("+cuda", when="@:0.13", msg="CUDA is only supported for Palace versions after 0.13")
     conflicts("+rocm", when="@:0.13", msg="ROCm is only supported for Palace versions after 0.13")
@@ -214,9 +202,8 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
             depends_on(f"superlu-dist{rocm_variant}", when=f"+superlu-dist{rocm_variant}")
             depends_on(f"strumpack{rocm_variant}", when=f"+strumpack{rocm_variant}")
 
-
     with when("+tests"):
-            depends_on("catch2@3:")
+        depends_on("catch2@3:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
The Palace spack recipe was forcing `strumpack` to be `~cuda` regardless of the palace variant, so that it was not possible to install `palace+strumpack+cuda` because of conflicting variants. Superlu was also not correctly handled.
