### PR TITLE
Set DropSmallEntries default to false

### DIFF
--- a/docs/src/config/solver.md
+++ b/docs/src/config/solver.md
@@ -498,7 +498,7 @@ the sign for the mass matrix contribution, which can help performance at high fr
 `"ComplexCoarseSolve" [false]` : When set to `true`, the coarse-level solver uses the true
 complex-valued system matrix. When set to `false`, the real-valued approximation is used.
 
-`"DropSmallEntries" [true]` : When set to `true`, entries smaller than the double precision
+`"DropSmallEntries" [false]` : When set to `true`, entries smaller than the double precision
 machine epsilon are dropped from the system matrix used in the sparse direct solver.
 
 `"PCSide" ["Default"]` :  Side for preconditioning. Not all options are available for all

--- a/palace/linalg/divfree.cpp
+++ b/palace/linalg/divfree.cpp
@@ -119,6 +119,7 @@ DivFreeSolver<VecType>::DivFreeSolver(
   // The system matrix for the projection is real and SPD.
   auto amg = std::make_unique<MfemWrapperSolver<OperType>>(
       std::make_unique<BoomerAmgSolver>(1, 1, true, 0));
+  amg->SetDropSmallEntries(false);
   std::unique_ptr<Solver<OperType>> pc;
   if (h1_fespaces.GetNumLevels() > 1)
   {

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -888,7 +888,7 @@ public:
 
   // Drop small entries (< numerical ε) in the system matrix used in the sparse direct
   // solver.
-  bool drop_small_entries = true;
+  bool drop_small_entries = false;
 
   // Reuse the sparsity pattern (reordering) for repeated factorizations.
   bool reorder_reuse = true;


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->

Setting `"DropSmallEntries"` to false by default for now since we encountered a case where it was affecting the symmetry of the sparsity pattern, thus leading to factorization errors with STRUMPACK and MUMPS. Will investigate this further to see if this is a one-off (all other cases tested so far were fine) and/or if there is a way to prevent this.
