### PR TITLE
Fix small bug in MaterialOperator (attr_is_isotropic)

### DIFF
--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -221,10 +221,10 @@ void MaterialOperator::SetUpMaterialProperties(const IoData &iodata,
       }
     }
 
-    attr_is_isotropic[i] = internal::mat::IsIsotropic(data.mu_r) &&
-                           internal::mat::IsIsotropic(data.epsilon_r) &&
-                           internal::mat::IsIsotropic(data.tandelta) &&
-                           internal::mat::IsIsotropic(data.sigma);
+    attr_is_isotropic[count] = internal::mat::IsIsotropic(data.mu_r) &&
+                               internal::mat::IsIsotropic(data.epsilon_r) &&
+                               internal::mat::IsIsotropic(data.tandelta) &&
+                               internal::mat::IsIsotropic(data.sigma);
 
     // Map all attributes to this material property index.
     for (auto attr : data.attributes)


### PR DESCRIPTION
<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
The `attr_is_isotropic` bool array has size `nmats` and should thus use `count` as its index instead of `i`, otherwise this could lead to accessing the array beyond its size. This can occur in parallel runs where there are multiple material domains but some partitions do not extend to all the material domains. 