### PR TITLE
Update some dependencies in the superbuild

### DIFF
--- a/cmake/ExternalGitTags.cmake
+++ b/cmake/ExternalGitTags.cmake
@@ -147,7 +147,7 @@ set(EXTERN_MUMPS_GIT_BRANCH
   "Git branch for external MUMPS build"
 )
 set(EXTERN_MUMPS_GIT_TAG
-  "v5.8.0.0" CACHE STRING
+  "1cfd19699702f9a64ff5d45827d6025ff5c3873a" CACHE STRING
   "Git tag for external MUMPS build"
 )
 

--- a/extern/patch/mumps/patch_build.diff
+++ b/extern/patch/mumps/patch_build.diff
@@ -766,10 +766,10 @@ index 3f0997e..6776359 100644
 -find_package(LAPACK REQUIRED COMPONENTS ${LAPACK_VENDOR})
 +find_package(LAPACK REQUIRED)
 diff --git a/cmake/scalapack.cmake b/cmake/scalapack.cmake
-index cd0f2e5..6813b71 100644
+index 8727508..3762473 100644
 --- a/cmake/scalapack.cmake
 +++ b/cmake/scalapack.cmake
-@@ -1,103 +1,1 @@
+@@ -1,103 +1 @@
 -include(ExternalProject)
 -include(GNUInstallDirs)
 -
@@ -798,7 +798,7 @@ index cd0f2e5..6813b71 100644
 -endif()
 -
 -if(MKL IN_LIST SCALAPACK_VENDOR AND NOT MKL64 IN_LIST SCALAPACK_VENDOR)
--  if(MUMPS_intsize64)
+-  if(intsize64)
 -    list(APPEND SCALAPACK_VENDOR MKL64)
 -  endif()
 -endif()
@@ -826,7 +826,7 @@ index cd0f2e5..6813b71 100644
 --DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
 --DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}
 --DCMAKE_Fortran_COMPILER:PATH=${CMAKE_Fortran_COMPILER}
---DSCALAPACK_BUILD_TESTING:BOOL=off
+--DBUILD_TESTING:BOOL=off
 --DCMAKE_BUILD_TYPE:STRING=Release
 -)
 -


### PR DESCRIPTION
This PR updates some of the dependencies in our superbuild. The dependencies that are updated here are the non-problematic ones. Hopefully, this will help upgrading the complex ones more easily.

I also took the opportunity to switch some of the git commits to git tags. This also helps with keeping things more in sync with the spack build, which uses released versions.

Takes care of some of the items in #585.