### PR TITLE
Make IoData quadrature error loud

### DIFF
--- a/palace/fem/integrator.cpp
+++ b/palace/fem/integrator.cpp
@@ -13,6 +13,9 @@ namespace fem
 
 int DefaultIntegrationOrder::Get(const mfem::IsoparametricTransformation &T)
 {
+  MFEM_VERIFY(
+      p_trial >= 0,
+      "DefaultIntegrationOrder not initialized, call IoData::CheckConfiguration()!");
   return 2 * p_trial + (q_order_jac ? T.OrderW() : 0) +
          (T.GetFE()->Space() == mfem::FunctionSpace::Pk ? q_order_extra_pk
                                                         : q_order_extra_qk);

--- a/palace/fem/integrator.hpp
+++ b/palace/fem/integrator.hpp
@@ -24,7 +24,7 @@ namespace fem
 // order 2 * p_trial + order(|J|) + q_extra.
 struct DefaultIntegrationOrder
 {
-  inline static int p_trial = 1;
+  inline static int p_trial = -1;  // Must be initialized before use
   inline static bool q_order_jac = true;
   inline static int q_order_extra_pk = 0;
   inline static int q_order_extra_qk = 0;

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -149,6 +149,11 @@ std::stringstream PreprocessFile(const char *filename)
 
 using json = nlohmann::json;
 
+IoData::IoData(const Units &units) : units(units), init(false)
+{
+  fem::DefaultIntegrationOrder::p_trial = -1;
+}
+
 IoData::IoData(const char *filename, bool print) : units(1.0, 1.0), init(false)
 {
   // Open configuration file and preprocess: strip whitespace, comments, and expand integer

--- a/palace/utils/iodata.hpp
+++ b/palace/utils/iodata.hpp
@@ -38,11 +38,12 @@ public:
 private:
   bool init;
 
+public:
   // Check configuration file options and compatibility with requested problem type.
+  // Exposed for testing; not intended for general use.
   void CheckConfiguration();
 
-public:
-  IoData(const Units &units) : units(units), init(false) {}
+  IoData(const Units &units);
 
   // Parse command line arguments and override options defaults.
   IoData(const char *filename, bool print);

--- a/test/unit/test-domainpostoperator.cpp
+++ b/test/unit/test-domainpostoperator.cpp
@@ -48,6 +48,7 @@ TEST_CASE("DomainPostOperator - Electric Energy Units", "[domainpostoperator][Se
   auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
 
   iodata.NondimensionalizeInputs(*par_mesh);
+  iodata.CheckConfiguration();  // initializes quadrature
   Mesh palace_mesh(std::move(par_mesh));
 
   mfem::ND_FECollection nd_fec(1, dim);

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -9,6 +9,7 @@
 #include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
+#include "fem/integrator.hpp"
 #include "models/postoperator.hpp"
 #include "utils/iodata.hpp"
 #include "utils/units.hpp"
@@ -347,9 +348,11 @@ TEST_CASE("GridFunction export", "[gridfunction][Serial][Parallel]")
   // Create iodata.
   Units units(0.496, 1.453);
   IoData iodata = IoData(units);
+
   iodata.domains.materials.emplace_back().attributes = {1};
   iodata.boundaries.pec.attributes = {1};
   iodata.problem.output_formats.gridfunction = true;
+  iodata.CheckConfiguration();  // initializes quadrature
 
   // Setup lumped port boundary data for driven and transient.
   auto filename = fmt::format("{}/{}", PALACE_TEST_DIR, "config/boundary_configs.json");

--- a/test/unit/test-rap.cpp
+++ b/test/unit/test-rap.cpp
@@ -27,6 +27,7 @@ TEST_CASE("BuildParSumOperator", "[rap][Serial][Parallel]")
   Units units(1.0, 1.0);
   IoData iodata(units);
   iodata.domains.materials.emplace_back().attributes = {1};
+  iodata.CheckConfiguration();  // initializes quadrature
 
   auto comm = Mpi::World();
 

--- a/test/unit/test-strattonchu.cpp
+++ b/test/unit/test-strattonchu.cpp
@@ -29,6 +29,7 @@
 #include <mfem/linalg/vector.hpp>
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
 #include "models/materialoperator.hpp"
 #include "models/surfacepostoperator.hpp"
 #include "utils/communication.hpp"
@@ -156,7 +157,7 @@ void runFarFieldTest(double freq_Hz, std::unique_ptr<mfem::Mesh> serial_mesh,
 {
   // Test constants.
   constexpr double atol = 1e-4;
-  constexpr double rtol = 5e-6;
+  constexpr double rtol = 1e-5;
 
   constexpr double p0 = 1e-9;  // Dipole moment [C⋅m]
 
@@ -170,6 +171,9 @@ void runFarFieldTest(double freq_Hz, std::unique_ptr<mfem::Mesh> serial_mesh,
   iodata.boundaries.postpro.farfield.attributes = attributes;
   iodata.boundaries.postpro.farfield.thetaphis.emplace_back();
   iodata.problem.type = ProblemType::DRIVEN;
+  iodata.solver.order = 3;      // Match the FE order used below.
+  iodata.CheckConfiguration();  // initializes quadrature
+  REQUIRE(fem::DefaultIntegrationOrder::p_trial == 3);
 
   auto comm = Mpi::World();
 
@@ -341,6 +345,7 @@ TEST_CASE("FarField constructor fails with anisotropic materials", "[strattonchu
   iodata.boundaries.postpro.farfield.attributes = {1};
   iodata.boundaries.postpro.farfield.thetaphis.emplace_back();
   iodata.problem.type = ProblemType::DRIVEN;
+  iodata.CheckConfiguration();  // initializes quadrature
 
   MPI_Comm comm = Mpi::World();
   std::unique_ptr<mfem::Mesh> serial_mesh = std::make_unique<mfem::Mesh>(


### PR DESCRIPTION
Some of the stratton chu tests were occasionally missing by 8e-6 rather than 5e-6, when very close to 0.0, in some CI runs on unrelated changes. This PR bumps that tolerance to 1e-5 which should be tight enough. 

Update: setting the quadrature rule to `p_trial` to the value that would be used in the main code path, causes the deviation. The test was using p=1 quadrature, which comes out at second order, compared to 6th order if `p_trial=3` was set. Thus the test was previously effectively underintegrating.