### PR TITLE
Link versioned documentation to corresponding examples links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,57 @@
 
 using Documenter
 
+# For tagged releases, rewrite GitHub links in the documentation source files to point to
+# the tagged version instead of the main branch. This ensures that users consulting the
+# documentation for a specific release are directed to the correct version of example files,
+# configuration files, and other source code.
+const PALACE_REPO_URL = "https://github.com/awslabs/palace"
+
+function get_git_ref()
+    # In GitHub Actions, GITHUB_REF_TYPE is "tag" for tag pushes and GITHUB_REF_NAME is the
+    # tag name (e.g., "v0.13.0"). For branch pushes, GITHUB_REF_TYPE is "branch".
+    ref_type = get(ENV, "GITHUB_REF_TYPE", "branch")
+    ref_name = get(ENV, "GITHUB_REF_NAME", "main")
+    if ref_type == "tag"
+        return ref_name
+    end
+    return "main"
+end
+
+"""
+    rewrite_github_links(src_dir, git_ref)
+
+Replace GitHub links pointing to the `main` branch with links to `git_ref` in all Markdown
+files under `src_dir`. Handles both file links (`blob/main`) and directory links
+(`tree/main`). Does nothing when `git_ref` is `"main"`.
+"""
+function rewrite_github_links(src_dir, git_ref)
+    git_ref == "main" && return  # Nothing to do for dev builds
+    patterns = [
+        "$PALACE_REPO_URL/blob/main" => "$PALACE_REPO_URL/blob/$git_ref",
+        "$PALACE_REPO_URL/tree/main" => "$PALACE_REPO_URL/tree/$git_ref"
+    ]
+    for (root, dirs, files) in walkdir(src_dir)
+        for file in files
+            endswith(file, ".md") || continue
+            filepath = joinpath(root, file)
+            content = read(filepath, String)
+            new_content = content
+            for (old, new) in patterns
+                new_content = replace(new_content, old => new)
+            end
+            if new_content != content
+                write(filepath, new_content)
+                @info "Rewrote GitHub links in $filepath to point to $git_ref"
+            end
+        end
+    end
+end
+
+git_ref = get_git_ref()
+@info "Building documentation with GitHub links pointing to: $git_ref"
+rewrite_github_links(joinpath(@__DIR__, "src"), git_ref)
+
 makedocs(
     format=Documenter.HTML(
         # Always use clean URLs so that raw HTML works, view local builds using a local


### PR DESCRIPTION
Closes #583 

>The [Palace documentation](https://awslabs.github.io/palace/stable) is versioned. This is important so that users can consult the documentation for the version of Palace they are using. However, the examples link to mesh and config files on the main GitHub branch (eg [here](https://awslabs.github.io/palace/stable/examples/spheres/)). This is a problem: if users follow those links, they will download files that might not work with the version of Palace that they are using and that they are consulting the documentation for. This happens frequently because we add new features that are not backwards compatible.
We should ensure that the stable documentation points to the tagged version of the examples.