### PR TITLE
Fixes from running unit tests with asan

### DIFF
--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -554,7 +554,7 @@ TEST_CASE("Dimensional field output", "[postoperator][Serial][Parallel]")
   // Create fields, initialize them to random values, and set the corresponding
   // gridfunctions.
   ComplexVector e(nd_fespace.GetTrueVSize()), b(rt_fespace.GetTrueVSize());
-  Vector a(rt_fespace.GetTrueVSize()), v(h1_fespace.GetTrueVSize());
+  Vector a(nd_fespace.GetTrueVSize()), v(h1_fespace.GetTrueVSize());
   linalg::SetRandom(comm, e);
   linalg::SetRandom(comm, b);
   linalg::SetRandom(comm, a);

--- a/test/unit/test-rap.cpp
+++ b/test/unit/test-rap.cpp
@@ -50,7 +50,7 @@ TEST_CASE("BuildParSumOperator", "[rap][Serial][Parallel]")
   SECTION("ParOperator")
   {
     int empty = {df.empty() && f.empty()};
-    Mpi::GlobalMin(2, &empty, comm);
+    Mpi::GlobalMin(1, &empty, comm);
     REQUIRE(empty == 0);  // There must be a non-empty.
 
     BilinearForm da(nd_fes), a(nd_fes);
@@ -91,7 +91,7 @@ TEST_CASE("BuildParSumOperator", "[rap][Serial][Parallel]")
   SECTION("ComplexParOperator")
   {
     int empty = {df.empty() && f.empty()};
-    Mpi::GlobalMin(2, &empty, comm);
+    Mpi::GlobalMin(1, &empty, comm);
     REQUIRE(empty == 0);  // There must be a non-empty.
 
     BilinearForm dar(nd_fes), dai(nd_fes), ar(nd_fes), ai(nd_fes);


### PR DESCRIPTION
I was running palace unit tests with ASAN and found two problems in already existing tests

1. "Dimensional field output": The vector potential `a` should be Nedelec like. (@simlapointe)
2. "BuildParSumOperator": Buffer size mismatch in MPI reduction (@hughcars)

The fixes make ASAN pass (with np 1 and np 2 ranks), but I would appreciate a quick check to confirm this is right.