### PR TITLE
Fix static builds, do not force dependency on shared libxsmm

### DIFF
--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -182,7 +182,8 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libceed+libxsmm", when="@0.14:")
         # NOTE: libxsmm builds on MacOS have linker issues
         # https://github.com/libxsmm/libxsmm/issues/883
-        depends_on("libxsmm+shared")
+        depends_on("libxsmm+shared", when="+shared")
+        depends_on("libxsmm~shared", when="~shared")
 
     with when("@0.14:"):
         depends_on("libceed@0.13:")


### PR DESCRIPTION
`depends_on("libxsmm+shared")` meant that the shared variant is always requested.

```
==> Error: failed to concretize `palace@develop+arpack+int64+libxsmm+mumps+openmp~shared+slepc+strumpack+sundials+superlu-dist` for the following reasons:
     1. 'libxsmm' requires conflicting variant values '~shared' and '+shared'
     2. 'libxsmm' requires conflicting variant values '~shared' and '+shared'
        required because palace depends on libxsmm@=main+shared blas=0 when +libxsmm 
          required because palace@develop+arpack+int64+libxsmm+mumps+openmp~shared+slepc+strumpack+sundials+superlu-dist requested explicitly 
        required because libceed depends on libxsmm~shared when +libxsmm~shared 
          required because palace depends on libceed~shared when @0.14:~shared 
            required because palace@develop+arpack+int64+libxsmm+mumps+openmp~shared+slepc+strumpack+sundials+superlu-dist requested explicitly 
          required because palace depends on libceed+libxsmm when @0.14:+libxsmm 
          required because palace depends on libceed@0.13: when @0.14: 
          required because palace depends on libceed+openmp when @0.14:+openmp 
```
