### PR TITLE
Fix docs deployment for tag pushes and add workflow_dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
       - main
     tags: '*'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      deploy_tag:
+        description: 'Tag to deploy docs for (e.g., v0.16.0). Leave empty for a dev build.'
+        required: false
+        type: string
 
 permissions:
   packages: write
@@ -24,11 +30,13 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  # Filter to allow skipping the test if no relevant changes occurred.
+  # Filter to allow skipping the build if no relevant changes occurred. Tag pushes and
+  # manual triggers always build (tags must deploy versioned docs, and workflow_dispatch
+  # is intentional).
   filter:
     runs-on: ubuntu-latest
     outputs:
-      test: ${{ steps.filter.outputs.test }}
+      should_build: ${{ steps.decide.outputs.should_build }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -43,16 +51,26 @@ jobs:
               - 'examples/**'
               - 'spack_repo/**'
               - '.github/workflows/docs.yml'
+      - name: Decide whether to build
+        id: decide
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=${{ steps.filter.outputs.test }}" >> "$GITHUB_OUTPUT"
+          fi
 
   build-docs:
     needs: filter
     runs-on: palace_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v6
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
+        with:
+          ref: ${{ inputs.deploy_tag || github.ref }}
 
       - name: Setup Spack
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         uses: spack/setup-spack@v2
         with:
           ref: develop
@@ -61,7 +79,7 @@ jobs:
 
           
       - name: Patch Spack package.pys for known problems
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         shell: bash
         run: |
           PALACE_DIR=$PWD
@@ -82,7 +100,7 @@ jobs:
           ln -s "$(spack location --repo builtin)"/packages/mfem "$PALACE_DIR"/spack_repo/local/packages/
   
       - name: Setup Environment
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: |
           # Spack.yaml with most / all settings configured
           cat << EOF > spack.yaml
@@ -118,7 +136,7 @@ jobs:
           EOF
 
       - name: Configure External Packages
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: |
           # These cause build issues if built as externals
           #   - python : often distributed python isn't feature complete / not all dependencies get detected
@@ -134,19 +152,19 @@ jobs:
             --exclude curl
 
       - name: Configure Compilers for Spack
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: spack -e . compiler find && spack -e . compiler list
 
       - name: Configure Binary Mirror Keys for Spack
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: spack -e . buildcache keys --install --trust
 
       - name: Bootstrap Spack
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: spack  -e . bootstrap now
 
       - name: Concretize Spack
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         env:
           PALACE_REF: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -156,37 +174,42 @@ jobs:
 
         # Relies on cache-hit(s)
       - name: Build Dependencies
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: |
           spack -e . install --only-concrete --no-check-signature --fail-fast --show-log-on-error --only dependencies
 
         # Explicitly not using cache to get latest develop
       - name: Build Palace
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         run: |
           spack -e . install --only-concrete --show-log-on-error --only package --keep-stage --no-cache
         # If you want to use the branch-local source instead (should we always do this?)
         # spack -e . develop --path=$(pwd) palace@git."${{ github.head_ref || github.ref_name }}"=develop
 
       - uses: julia-actions/setup-julia@v2
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         with:
           version: '1'
 
       - uses: julia-actions/cache@v2
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
 
       - name: Build and deploy
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Override for Documenter.jl when manually deploying a tag's docs
+          GITHUB_EVENT_NAME: ${{ inputs.deploy_tag && 'push' || github.event_name }}
+          GITHUB_REF: ${{ inputs.deploy_tag && format('refs/tags/{0}', inputs.deploy_tag) || github.ref }}
+          GITHUB_REF_TYPE: ${{ inputs.deploy_tag && 'tag' || github.ref_type }}
+          GITHUB_REF_NAME: ${{ inputs.deploy_tag || github.ref_name }}
         run: |
           eval $(spack -e . load --sh palace)
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
           julia --project=docs --color=yes docs/make.jl
 
       - uses: actions/upload-artifact@v4
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.should_build == 'true'
         with:
           name: docs
           path: docs/build/
@@ -196,7 +219,7 @@ jobs:
       # NOTE: This might fail as external fork PRs can't push to GHCR.
       - name: Push to GHCR cache
         if: |
-          needs.filter.outputs.test == 'true' &&
+          needs.filter.outputs.should_build == 'true' &&
           !cancelled() &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: spack -e . buildcache push --force --with-build-dependencies --unsigned --update-index local-buildcache || true


### PR DESCRIPTION
`dorny/paths-filter` skips tag pushes when the tagged commit already exists on `main`, silently skipping `deploydocs()`. This is why `stable` still points to v0.15.0.

Adds a `decide` step that bypasses the filter for tag pushes and `workflow_dispatch`. Once merged, run the workflow manually with `deploy_tag: v0.16.0` to fix stable.

Fixes #662