### PR TITLE
Clarify magnetostatic boundary terminology in comment and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@ The format of this changelog is based on
 
 #### Interface Changes
 
-  - `config["Boundaries"]["Terminal"]` must now be used for electrostatic and magnetostatic
-    simulations to compute capacitance and inductance matrices. Previously, terminals could
-    also be specified under `"LumpedPort"`.
+  - `config["Boundaries"]["Terminal"]` must now be used for electrostatic simulations to
+    compute capacitance matrices, and `config["Boundaries"]["SurfaceCurrent"]` for
+    magnetostatic simulations to compute inductance matrices. Previously, terminals and
+    surface current sources could also be specified under `"LumpedPort"`.
     [PR 624](https://github.com/awslabs/palace/pull/624).
   - `config["Solver"]["Eigenmode"]["Target"]` is now always required for eigenmode
     simulations. Previously, it could be omitted if a `"Driven"` section was also present.

--- a/palace/drivers/magnetostaticsolver.cpp
+++ b/palace/drivers/magnetostaticsolver.cpp
@@ -35,7 +35,8 @@ MagnetostaticSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   KspSolver ksp(iodata, curlcurl_op.GetNDSpaces(), &curlcurl_op.GetH1Spaces());
   ksp.SetOperators(*K, *K);
 
-  // Terminal indices are the set of boundaries over which to compute the inductance matrix.
+  // Surface current source indices define the boundaries over which to compute the
+  // inductance matrix.
   PostOperator<ProblemType::MAGNETOSTATIC> post_op(iodata, curlcurl_op);
   int n_step = static_cast<int>(curlcurl_op.GetSurfaceCurrentOp().Size());
   MFEM_VERIFY(n_step > 0,


### PR DESCRIPTION
The comment in magnetostaticsolver.cpp incorrectly referred to "Terminal indices" when the inductance matrix is actually computed over SurfaceCurrent boundaries. The CHANGELOG entry also conflated Terminal and SurfaceCurrent under the umbrella of "Terminal".

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
