### PR TITLE
Loosen test tolerance in OrthogonalizeColumn by 10x

### DIFF
--- a/test/unit/test-orthog.cpp
+++ b/test/unit/test-orthog.cpp
@@ -318,6 +318,15 @@ TEST_CASE("OrthogonalizeColumn Weighted - Real 1", "[orthog][Serial]")
   CHECK_THAT(dot1, WithinAbs(0.0, 1e-12));
 
   // Resulting vector is along (1, -1) direction
+  //
+  // Note: The default WithinRel uses 100 * epsilon. Here we increase it by an extra factor
+  // of 10. The reason is that this test fails intermittently and by a small amount on the
+  // build configuration: build-and-test-linux (x86, intel, intelmpi, intelmkl, static,
+  // int32, openmp, slepc, strumpack). This is slightly surprising since the problem here is
+  // so small and it is a serial test. This is not urgent, but might be worth investigating
+  // in the future.
+  //
+  // See also the Complex text note below.
   CHECK_THAT(w[0], WithinRel(-w[1], 1000 * std::numeric_limits<double>::epsilon()));
 }
 
@@ -372,6 +381,14 @@ TEST_CASE("OrthogonalizeColumn Weighted - Complex 1", "[orthog][Serial]")
   CHECK_THAT(dot1.imag(), WithinAbs(0.0, 1e-12));
 
   // Resulting vector is along (1, -1) direction
-  CHECK_THAT(w.Real()[0], WithinRel(-w.Real()[1]));
-  CHECK_THAT(w.Imag()[0], WithinRel(-w.Imag()[1]));
+  //
+  // Note: The default WithinRel uses 100 * epsilon. Here we increase it by an extra factor
+  // of 10 — see note above. Here the build CI configuration that fails by a small amount
+  // is: build-and-test-linux (arm, clang, mpich, openblas, static, int32, openmp, slepc,
+  // strumpack).
+  //
+  CHECK_THAT(w.Real()[0],
+             WithinRel(-w.Real()[1], 1000 * std::numeric_limits<double>::epsilon()));
+  CHECK_THAT(w.Imag()[0],
+             WithinRel(-w.Imag()[1], 1000 * std::numeric_limits<double>::epsilon()));
 }


### PR DESCRIPTION
- Intel optimizers (non-consistently) goes above original tolerance in tests

Closes #671 

Factor 10 should be enough. From #671: 
(0.00052872439846396 - 0.00052872439846385) / 0.00052872439846385 = 2.0805×10⁻¹³ 

While:

1000 * std::numeric_limits<double>::epsilon() =  2.220446049250313e-13

However, given how small this problem is (3x3 matrix on 1 rank), the loss of precision here is really not great and maybe something to study in more detail.