### PR TITLE
Move files instead of copying them in AMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The format of this changelog is based on
 
 #### Bug Fixes
 
+  - Improved IO performance for simulations with Adaptive Mesh Refinement. Now,
+    files from previous iterations are moved instead of being copied. The latest
+    output is always available at the top level of the output directory (as
+    symlinks to the latest `iterationXX` folder). [PR
+    673](https://github.com/awslabs/palace/pull/673)
   - Fixed port excitation parsing to correctly handle signed integer values
     [PR 635](https://github.com/awslabs/palace/pull/635).
 

--- a/docs/src/examples/transmon.md
+++ b/docs/src/examples/transmon.md
@@ -290,8 +290,9 @@ println("config[\"Solver\"][\"Order\"] = $(json_amr["Solver"]["Order"])") #hide
 ```
 
 After running the simulation, the `postpro` folder contains an `iterationN`
-subfolder for each AMR cycle. The convergence history shows the error decreasing
-with each refinement:
+subfolder for each AMR cycle. The top level output (outside of the `iterationN`
+folders) always points to the latest iteration completed. The convergence
+history shows the error decreasing with each refinement:
 
 ```@example
 import JSON #hide

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -28,34 +28,54 @@ namespace palace
 
 using json = nlohmann::json;
 
-namespace
-{
-
 void SaveIteration(MPI_Comm comm, const fs::path &output_dir, int step, int width)
 {
   BlockTimer bt(Timer::IO);
   Mpi::Barrier(comm);  // Wait for all processes to write postprocessing files
   if (Mpi::Root(comm))
   {
-    // Create a subfolder for the results of this adaptation.
+    // Create a subfolder for the results of this adaptation by moving (renaming) files.
     auto step_output = output_dir / fmt::format("iteration{:0{}d}", step, width);
     if (!fs::exists(step_output))
     {
       fs::create_directories(step_output);
     }
-    constexpr auto options =
-        fs::copy_options::recursive | fs::copy_options::overwrite_existing;
+    auto rel_step = step_output.filename();
     for (const auto &f : fs::directory_iterator(output_dir))
     {
-      if (f.path().filename().string().rfind("iteration") == 0)
+      const auto &fname = f.path().filename().string();
+      if (fname.rfind("iteration") == 0)
       {
         continue;
       }
-      fs::copy(f, step_output / f.path().filename(), options);
+      auto dest = step_output / f.path().filename();
+      if (f.is_symlink())
+      {
+        // Skip symlinks left from a previous iteration's save. They still point
+        // to valid data and will be overwritten by the next solve.
+        continue;
+      }
+      else if (fname == "palace.json")
+      {
+        // Copy metadata file since it is needed by subsequent iterations.
+        fs::copy(f, dest, fs::copy_options::overwrite_existing);
+      }
+      else
+      {
+        // Move to the iteration subfolder and leave a relative symlink behind
+        // so that the output directory always has accessible results. Remove
+        // any existing destination first (e.g. from a previous run).
+        fs::remove_all(dest);
+        fs::rename(f, dest);
+        fs::create_symlink(rel_step / f.path().filename(), f.path());
+      }
     }
   }
   Mpi::Barrier(comm);
 }
+
+namespace
+{
 
 json LoadMetadata(const fs::path &post_dir)
 {

--- a/palace/drivers/basesolver.hpp
+++ b/palace/drivers/basesolver.hpp
@@ -57,6 +57,13 @@ public:
   void SaveMetadata(const PortExcitations &excitation_helper) const;
 };
 
+// Archive the current postprocessing output for an AMR iteration. Creates a subfolder
+// "iterationXX" inside output_dir and moves all files and directories into it, leaving
+// relative symlinks behind so that the output directory always has accessible results.
+// The palace.json metadata file is copied (not moved) since it is read and updated by
+// subsequent iterations.
+void SaveIteration(MPI_Comm comm, const fs::path &output_dir, int step, int width);
+
 }  // namespace palace
 
 #endif  // PALACE_DRIVERS_BASE_SOLVER_HPP

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -134,8 +134,22 @@ PostOperator<solver_t>::PostOperator(const config::ProblemData &problem,
     output_delta_post = solver.transient.delta_post;
   }
 
-  gridfunction_output_dir =
-      (post_dir / "gridfunction" / OutputFolderName(solver_t)).string();
+  // Remove previous symlink/directory before writing. Removing directory only
+  // happens when the output folder is dirty.
+  auto gridfunction_root = post_dir / "gridfunction";
+  if (Mpi::Root(fem_op->GetComm()))
+  {
+    if (fs::is_symlink(gridfunction_root))
+    {
+      fs::remove(gridfunction_root);
+    }
+    else
+    {
+      fs::remove_all(gridfunction_root);
+    }
+  }
+  Mpi::Barrier(fem_op->GetComm());
+  gridfunction_output_dir = (gridfunction_root / OutputFolderName(solver_t)).string();
 
   SetupFieldCoefficients();
   InitializeParaviewDataCollection();
@@ -270,9 +284,24 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
   {
     return;
   }
-  fs::path paraview_dir_v = post_dir / "paraview" / OutputFolderName(solver_t);
+  // Remove previous symlink/directory before writing. Removing directory only
+  // happens when the output folder is dirty.
+  auto paraview_root = post_dir / "paraview";
+  if (Mpi::Root(fem_op->GetComm()))
+  {
+    if (fs::is_symlink(paraview_root))
+    {
+      fs::remove(paraview_root);
+    }
+    else
+    {
+      fs::remove_all(paraview_root);
+    }
+  }
+  Mpi::Barrier(fem_op->GetComm());
+  fs::path paraview_dir_v = paraview_root / OutputFolderName(solver_t);
   fs::path paraview_dir_b =
-      post_dir / "paraview" / fmt::format("{}_boundary", OutputFolderName(solver_t));
+      paraview_root / fmt::format("{}_boundary", OutputFolderName(solver_t));
   if (!sub_folder_name.empty())
   {
     paraview_dir_v /= sub_folder_name;

--- a/palace/utils/tablecsv.cpp
+++ b/palace/utils/tablecsv.cpp
@@ -300,6 +300,8 @@ TableWithCSVFile::TableWithCSVFile(std::string csv_file_fullpath, bool load_exis
 
 void TableWithCSVFile::WriteFullTableTrunc()
 {
+  // Remove previous file/symlink before writing.
+  fs::remove(csv_file_fullpath_);
   auto file_buffer = fmt::output_file(
       csv_file_fullpath_, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC);
   file_buffer.print("{}", table.format_table());

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/fixtures.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-basesolver.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-coefficient.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-config.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-constants.cpp

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -1,0 +1,245 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fstream>
+#include <catch2/catch_test_macros.hpp>
+#include "drivers/basesolver.hpp"
+#include "fixtures.hpp"
+#include "utils/communication.hpp"
+#include "utils/filesystem.hpp"
+
+using namespace palace;
+
+namespace
+{
+
+// Helper to create a file with given content.
+void CreateFile(const fs::path &path, const std::string &content = "test")
+{
+  std::ofstream f(path);
+  f << content;
+}
+
+// Helper to read file content.
+std::string ReadFile(const fs::path &path)
+{
+  std::ifstream f(path);
+  return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveIteration moves files and leaves symlinks", "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // Create test files in the output directory.
+  CreateFile(temp_dir / "palace.json", R"({"key": "value"})");
+  CreateFile(temp_dir / "domain-E.csv", "f,E\n1.0,2.0\n");
+  CreateFile(temp_dir / "port-S.csv", "f,S11\n1.0,0.5\n");
+
+  SaveIteration(comm, temp_dir, 1, 2);
+
+  auto iter_dir = temp_dir / "iteration01";
+
+  SECTION("Iteration subfolder is created")
+  {
+    CHECK(fs::is_directory(iter_dir));
+  }
+
+  SECTION("Regular files are moved to iteration subfolder")
+  {
+    CHECK(fs::is_regular_file(iter_dir / "domain-E.csv"));
+    CHECK(ReadFile(iter_dir / "domain-E.csv") == "f,E\n1.0,2.0\n");
+    CHECK(fs::is_regular_file(iter_dir / "port-S.csv"));
+    CHECK(ReadFile(iter_dir / "port-S.csv") == "f,S11\n1.0,0.5\n");
+  }
+
+  SECTION("Symlinks are left behind for moved files")
+  {
+    CHECK(fs::is_symlink(temp_dir / "domain-E.csv"));
+    CHECK(fs::is_symlink(temp_dir / "port-S.csv"));
+    // Symlinks should resolve to the moved files.
+    CHECK(ReadFile(temp_dir / "domain-E.csv") == "f,E\n1.0,2.0\n");
+    CHECK(ReadFile(temp_dir / "port-S.csv") == "f,S11\n1.0,0.5\n");
+  }
+
+  SECTION("Symlinks are relative")
+  {
+    auto target = fs::read_symlink(temp_dir / "domain-E.csv");
+    CHECK(target.is_relative());
+    CHECK(target == fs::path("iteration01") / "domain-E.csv");
+  }
+
+  SECTION("palace.json is copied, not moved or symlinked")
+  {
+    CHECK(fs::is_regular_file(temp_dir / "palace.json"));
+    CHECK(!fs::is_symlink(temp_dir / "palace.json"));
+    CHECK(fs::is_regular_file(iter_dir / "palace.json"));
+    CHECK(ReadFile(temp_dir / "palace.json") == R"({"key": "value"})");
+    CHECK(ReadFile(iter_dir / "palace.json") == R"({"key": "value"})");
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir, "SaveIteration handles directories",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  CreateFile(temp_dir / "palace.json", "{}");
+  fs::create_directories(temp_dir / "paraview" / "driven");
+  CreateFile(temp_dir / "paraview" / "driven" / "fields.vtu", "<VTK/>");
+
+  SaveIteration(comm, temp_dir, 1, 1);
+
+  auto iter_dir = temp_dir / "iteration1";
+
+  SECTION("Directory is moved to iteration subfolder")
+  {
+    CHECK(fs::is_directory(iter_dir / "paraview" / "driven"));
+    CHECK(ReadFile(iter_dir / "paraview" / "driven" / "fields.vtu") == "<VTK/>");
+  }
+
+  SECTION("Symlink is left behind for directory")
+  {
+    CHECK(fs::is_symlink(temp_dir / "paraview"));
+    CHECK(fs::is_directory(temp_dir / "paraview" / "driven"));
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveIteration handles two consecutive iterations", "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // Simulate first iteration output.
+  CreateFile(temp_dir / "palace.json", "{}");
+  CreateFile(temp_dir / "domain-E.csv", "iter1");
+
+  SaveIteration(comm, temp_dir, 1, 1);
+
+  // After first save: domain-E.csv is a symlink to iteration1/domain-E.csv.
+  CHECK(fs::is_symlink(temp_dir / "domain-E.csv"));
+  CHECK(ReadFile(temp_dir / "domain-E.csv") == "iter1");
+
+  // Simulate second iteration: solver overwrites symlink with a real file.
+  fs::remove(temp_dir / "domain-E.csv");
+  CreateFile(temp_dir / "domain-E.csv", "iter2");
+  CHECK(!fs::is_symlink(temp_dir / "domain-E.csv"));
+
+  SaveIteration(comm, temp_dir, 2, 1);
+
+  SECTION("First iteration data is preserved")
+  {
+    CHECK(ReadFile(temp_dir / "iteration1" / "domain-E.csv") == "iter1");
+  }
+
+  SECTION("Second iteration has new data")
+  {
+    CHECK(ReadFile(temp_dir / "iteration2" / "domain-E.csv") == "iter2");
+  }
+
+  SECTION("Symlink now points to second iteration")
+  {
+    CHECK(fs::is_symlink(temp_dir / "domain-E.csv"));
+    CHECK(fs::read_symlink(temp_dir / "domain-E.csv") ==
+          fs::path("iteration2") / "domain-E.csv");
+    CHECK(ReadFile(temp_dir / "domain-E.csv") == "iter2");
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveIteration preserves old symlinks for files not reproduced by solver",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // First iteration produces two files.
+  CreateFile(temp_dir / "palace.json", "{}");
+  CreateFile(temp_dir / "domain-E.csv", "iter1");
+  CreateFile(temp_dir / "extra.csv", "extra_data");
+
+  SaveIteration(comm, temp_dir, 1, 1);
+
+  // Simulate second iteration that only produces domain-E.csv (not extra.csv).
+  fs::remove(temp_dir / "domain-E.csv");
+  CreateFile(temp_dir / "domain-E.csv", "iter2");
+
+  // extra.csv is still a symlink from iteration 1.
+  CHECK(fs::is_symlink(temp_dir / "extra.csv"));
+
+  SaveIteration(comm, temp_dir, 2, 1);
+
+  SECTION("Old symlink is preserved, still accessible")
+  {
+    CHECK(fs::is_symlink(temp_dir / "extra.csv"));
+    CHECK(ReadFile(temp_dir / "extra.csv") == "extra_data");
+  }
+
+  SECTION("New file is moved to iteration2")
+  {
+    CHECK(ReadFile(temp_dir / "iteration2" / "domain-E.csv") == "iter2");
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveIteration handles dirty output directory from previous run",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // Simulate a previous run that left files in the iteration folder.
+  CreateFile(temp_dir / "palace.json", "{}");
+  fs::create_directories(temp_dir / "iteration1" / "paraview" / "driven");
+  CreateFile(temp_dir / "iteration1" / "paraview" / "driven" / "old.vtu", "old");
+  CreateFile(temp_dir / "iteration1" / "domain-E.csv", "old_data");
+
+  // New run produces fresh output.
+  CreateFile(temp_dir / "domain-E.csv", "new_data");
+  fs::create_directories(temp_dir / "paraview" / "driven");
+  CreateFile(temp_dir / "paraview" / "driven" / "new.vtu", "new");
+
+  // Should not throw despite destination files existing.
+  SaveIteration(comm, temp_dir, 1, 1);
+
+  SECTION("New data replaces old in iteration folder")
+  {
+    CHECK(ReadFile(temp_dir / "iteration1" / "domain-E.csv") == "new_data");
+    CHECK(fs::exists(temp_dir / "iteration1" / "paraview" / "driven" / "new.vtu"));
+    CHECK(!fs::exists(temp_dir / "iteration1" / "paraview" / "driven" / "old.vtu"));
+  }
+
+  SECTION("Symlinks point to new data")
+  {
+    CHECK(fs::is_symlink(temp_dir / "domain-E.csv"));
+    CHECK(ReadFile(temp_dir / "domain-E.csv") == "new_data");
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir, "SaveIteration skips iteration subfolders",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  CreateFile(temp_dir / "palace.json", "{}");
+  CreateFile(temp_dir / "domain-E.csv", "data");
+
+  // Create a pre-existing iteration folder.
+  fs::create_directories(temp_dir / "iteration1");
+  CreateFile(temp_dir / "iteration1" / "old.csv", "old");
+
+  SaveIteration(comm, temp_dir, 2, 1);
+
+  SECTION("Pre-existing iteration folder is untouched")
+  {
+    CHECK(fs::is_directory(temp_dir / "iteration1"));
+    CHECK(ReadFile(temp_dir / "iteration1" / "old.csv") == "old");
+  }
+
+  SECTION("New iteration folder is created")
+  {
+    CHECK(fs::is_directory(temp_dir / "iteration2"));
+    CHECK(ReadFile(temp_dir / "iteration2" / "domain-E.csv") == "data");
+  }
+}


### PR DESCRIPTION
Palace currently copies files in the iteration folders. This can be very expensive on shared filesystems or for large Paraview files.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
