### PR TITLE
Pin Glib_jll < 2.74 for ARM CI compatibility

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Glib_jll = "7746bdde-850d-59dc-9ae8-88ece973131d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -17,3 +18,4 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 DeviceLayout = "=1.8.0"
+Glib_jll = "< 2.74"


### PR DESCRIPTION
## Summary
Pin `Glib_jll < 2.74` in `examples/Project.toml` to fix CairoMakie
precompilation failures on the ARM CI runners (Ubuntu 22.04).

## Root cause
Glib_jll's `__init__()` (in `wrappers/aarch64-linux-gnu.jl`) loads
`libgio` before `libglib`. When `libgio` is `dlopen`'d, it pulls in
`libgobject`, which depends on `libglib`. Because the bundled `libglib`
hasn't been loaded yet, the dynamic linker resolves against the system's
`libglib-2.0.so` instead of the co-bundled copy.

On the ARM runners (Ubuntu 22.04, system GLib 2.72), any Glib_jll built
against GLib >= 2.74 bundles a `libgobject` that references symbols not
present in GLib 2.72 (e.g. `g_bookmark_file_copy` from 2.76,
`g_dir_unref` from 2.80), causing:

```
could not load library libgio-2.0.so
libgobject-2.0.so.0: undefined symbol: g_bookmark_file_copy
```

This is a known JLL packaging issue (JuliaPackaging/Yggdrasil#8460 attempted
to fix the load order but was closed because product order is lost during
JSON serialization).

Pinning to `< 2.74` resolves `Glib_jll v2.68.3+2`, built against GLib 2.68
whose symbols are all present in the system GLib 2.72. CairoMakie v0.15.9
resolves fine with this constraint.

## Test plan
- CI passes on all configurations including ARM runners with CairoMakie postprocessing