### PR TITLE
Spack CI: Use OpenBlas 0.3.32

### DIFF
--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -272,6 +272,7 @@ runs:
       run: |
         source /tmp/timing_functions.sh
         start_timer
+        PALACE_REF="${PALACE_REF//\//-}"
         spack -e . develop --path=$(pwd) local.palace@git."${PALACE_REF}"=develop
         spack -e . concretize -f --test root
         end_timer "Concretize"

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -73,9 +73,7 @@ runs:
           C_CXX_COMPILER="intel-oneapi-compilers"
           FORTRAN_COMPILER="intel-oneapi-compilers"
         else
-          # OpenBlas 0.3.30 has issues on arm
-          # https://github.com/OpenMathLib/OpenBLAS/issues/5459
-          MATH_LIBS="${{ inputs.math-libs || 'openblas@0.3.29' }}"
+          MATH_LIBS="${{ inputs.math-libs || 'openblas' }}"
           MPI_IMPL="openmpi"
           C_CXX_COMPILER="${{ inputs.toolchain }}"
         fi

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -73,7 +73,7 @@ runs:
           C_CXX_COMPILER="intel-oneapi-compilers"
           FORTRAN_COMPILER="intel-oneapi-compilers"
         else
-          MATH_LIBS="${{ inputs.math-libs || 'openblas' }}"
+          MATH_LIBS="${{ inputs.math-libs || 'openblas@develop' }}"
           MPI_IMPL="openmpi"
           C_CXX_COMPILER="${{ inputs.toolchain }}"
         fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -169,6 +169,7 @@ jobs:
           PALACE_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           # Using `spack develop` in order to have an in-source build
+          PALACE_REF="${PALACE_REF//\//-}"
           spack -e . develop --path=$(pwd) local.palace@git."${PALACE_REF}"=develop
           spack -e . concretize -f
 


### PR DESCRIPTION
OpenBlas 0.3.30 has issues on ARM. These issues should have been fixed and now OpenBlas 0.3.32 was released.

Closes #598