### PR TITLE
Print commit hash of @develop packages

### DIFF
--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -287,6 +287,15 @@ runs:
         spack -e . install --only-concrete --no-check-signature --fail-fast --show-log-on-error --only dependencies --test root -j $(nproc)
         end_timer "Build Dependencies"
 
+    - name: Print @develop commit hashes
+      if: inputs.use-develop-deps == 'true'
+      shell: bash
+      run: |
+        echo "=== @develop package commit hashes ==="
+        echo "hypre: $(git ls-remote https://github.com/hypre-space/hypre.git HEAD | cut -f1)"
+        echo "mfem: $(git ls-remote https://github.com/mfem/mfem.git HEAD | cut -f1)"
+        echo "=== end @develop hashes ==="
+
     - name: Build Palace
       shell: bash
       run: |


### PR DESCRIPTION
This helps with pin-pointing commits that break lookahead, as it happened in #700 

Prints:
```
=== @develop package commit hashes ===
hypre: 73f739a8e16820567333b5712997c7b950d3815a
mfem: aed9c8ef4ac78736814fbea2788e6bacbad66649
=== end @develop hashes ===
```