### PR TITLE
Fix container action using local spack recipe

### DIFF
--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -16,8 +16,13 @@ RUN test -f /opt/palace/CMakeLists.txt || \
 
 # Set up spack repo and apply patches to builtin spack packages
 RUN mkdir -p /opt/spack-environment && \
+    # Link our local spack repo to /opt/spack-environment
     ln -s /opt/palace/spack_repo /opt/spack-environment/spack_repo && \
+    # Add it to spack
+    spack repo add /opt/palace/spack_repo/local && \
+    # Workaround for https://github.com/spack/spack/issues/51505
     ln -sf $(spack location --repo builtin)/packages/mfem /opt/palace/spack_repo/local/packages/mfem && \
+    # Apply patches to builtin repo
     cd $(cd $(spack location --repo builtin) && git rev-parse --show-toplevel) && \
     for patch in /opt/palace/spack_repo/patches/*.diff; do \
       if [ -f "$patch" ]; then \

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -34,10 +34,6 @@ spack:
     images:
       os: "ubuntu:24.04"
       spack: develop
-  # Use Palace's local spack repo so our palace package (with its MFEM patches)
-  # overrides the builtin one.
-  repos:
-  - spack_repo/local
   # Find pre-compiled packages in binary caches. Requires GITHUB_USER and
   # GITHUB_TOKEN (or a personal access token).
   #


### PR DESCRIPTION
The PalaceDockerfile was symlinking the local copy of the palace recipe but never adding it to spack, so the container was being built with the published version

Should fix the problem in #706 
