### PR TITLE
Slim containers

### DIFF
--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -71,6 +71,12 @@ RUN find /opt/software -type d \( -name examples -o -name doc -o -name docs \) -
       fi; \
     done; \
     true
+
+# Remove header files not needed at runtime (keep libCEED headers for JIT compilation)
+RUN find /opt/software -type d -name include \
+      -not -path "*/libceed-*/include" \
+      -exec rm -rf {} + 2>/dev/null; \
+    true
 {% if strip %}
 
 # Strip all the binaries

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -74,6 +74,9 @@ spack:
         # Enable AWS EFA
         libfabric:
           require: fabrics=efa,lnx,mrail,rxm,shm,sockets,tcp,udp
+        # We do not want to include the full Python stack in the container
+        rdma-core:
+          require: ~pyverbs
       develop:
         palace:
           spec: palace@=develop


### PR DESCRIPTION
I looked at the container for what else we could remove to make it smaller (headers and Python). Reduces size by 30%. 

With this, I reduced the size by 4x compared to an unmodified spack Dockerfile.
