### PR TITLE
Build build only dependencies in spack CI

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -30,6 +30,11 @@ runs:
 
         end_timer "Setup podman and apptainer"
 
+    - name: Sleep on failure
+      shell: bash
+      if: failure()
+      run: sleep 7200
+
     - name: Compute image name
       id: name
       shell: bash

--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -50,7 +50,7 @@ RUN cd {{ paths.environment }} && spack env activate . && \
     fi
 
 # Install the software
-RUN cd {{ paths.environment }} && spack env activate . && spack install -j$(nproc) --fail-fast
+RUN cd {{ paths.environment }} && spack env activate . && spack install --include-build-deps -j$(nproc) --fail-fast
 
 # Push installed packages to the binary cache
 RUN cd {{ paths.environment }} && spack env activate . && \

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -121,10 +121,13 @@ runs:
 
         # The Intel compiler has problems with C/C++/Fortran interop in MUMPS.
         # Fixes: for_main.c:(.text+0x19): undefined reference to `MAIN__'
+        # libffi 3.5.2's configure trips icx on a gcc-only option.
         if [[ "${{ inputs.toolchain }}" == "intel-oneapi" ]]; then
           cat << INTELEOF >> spack.yaml
             mumps:
               require: fflags=-nofor-main
+            libffi:
+              require: "@:3.4.8"
         INTELEOF
         fi
 

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -224,7 +224,7 @@ runs:
       run: |
         source /tmp/timing_functions.sh
         start_timer
-        spack -e . install --only-concrete --no-check-signature --fail-fast --show-log-on-error --only dependencies --test root -j $(nproc)
+        spack -e . install --only-concrete --no-check-signature --fail-fast --show-log-on-error --include-build-deps --only dependencies --test root -j $(nproc)
         end_timer "Build Dependencies"
 
     - name: Print @develop commit hashes


### PR DESCRIPTION
There are failures in CI that appear to be because a build only dependency is not built by the `--only dependencies` build stage, possibly due to a spack update. This PR adds a flag to also force build those stages.

https://github.com/awslabs/palace/actions/runs/25180874981/job/73825496404?pr=719
