### PR TITLE
Container CI: don't cache Palace itself

### DIFF
--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -49,12 +49,15 @@ RUN cd {{ paths.environment }} && spack env activate . && \
       echo "WARNING: Binary cache is not reachable, all packages will be built from source"; \
     fi
 
-# Install the software
-RUN cd {{ paths.environment }} && spack env activate . && spack install --include-build-deps -j$(nproc) --fail-fast
-
-# Push installed packages to the binary cache
+# palace@develop is pinned to branch="main", so every branch shares a spec
+# hash with different source. Build Palace --no-cache and push only deps.
 RUN cd {{ paths.environment }} && spack env activate . && \
-    spack buildcache push --unsigned local-buildcache
+    spack install --include-build-deps --only dependencies -j$(nproc) --fail-fast && \
+    spack install --only package --no-cache -j$(nproc) --fail-fast
+
+# Push deps only; Palace itself is branch-specific (see above).
+RUN cd {{ paths.environment }} && spack env activate . && \
+    spack buildcache push --only dependencies --unsigned local-buildcache
 
 # Remove unnecessary deps
 # TODO: Remove gcc and build-only dependencies to reduce image size.

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -319,7 +319,8 @@ runs:
       run: |
         source /tmp/timing_functions.sh
         start_timer
-        spack -e . buildcache push --force --with-build-dependencies --unsigned --update-index local-buildcache || true
+        # Push deps only; Palace itself is branch-specific (same reason as the container build).
+        spack -e . buildcache push --force --with-build-dependencies --only dependencies --unsigned --update-index local-buildcache || true
         end_timer "Push to GHCR cache"
 
     - name: Run Regression Tests

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -128,6 +128,9 @@ runs:
               require: fflags=-nofor-main
             libffi:
               require: "@:3.4.8"
+            # MKL 2026+ miscomputes CurrentDipole; pin to 2025.
+            intel-oneapi-mkl:
+              require: "@:2025"
         INTELEOF
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ The format of this changelog is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## In progress
+
+#### New Features
+
+  - Added `BoundaryMode` solver for mode analysis on 2D meshes, supporting both standalone 2D meshes
+    and 2D boundary submesh extracted from a 3D mesh [PR 657](https://github.com/awslabs/palace/pull/657).
+  - Added support for 2D meshes in all simulation types [PR 657](https://github.com/awslabs/palace/pull/657).
+  - Changed waveport formulation to enable support for impedance boundary conditions [PR 657](https://github.com/awslabs/palace/pull/657).
+  - Enabled voltage and impedance postprocessing for waveport and BoundaryMode by specifying a line
+    from ground to conductor, either through mesh coordinates or boundary attribute
+    in `config["Boundaries"]["Postprocessing"]["Impedance"]` [PR 657](https://github.com/awslabs/palace/pull/657).
+
+#### Bug Fixes
+
+  - Fixed a bug where nonconformal AMR would lead to erroneous results when waveports are present.
+    Part of [PR 657](https://github.com/awslabs/palace/pull/657).
+
 ## [0.16.1] - 2026-04-24
 
 #### New Features
@@ -85,13 +102,6 @@ The format of this changelog is based on
     basis orthogonalization matrix. Extended tests on aspects related to ROM and LumpedPortOp. [PR 326](https://github.com/awslabs/palace/pull/326).
   - Upgraded internal orthogonalization routines to optionally allow taking non-identity weights in
     inner product. Part of [PR 326](https://github.com/awslabs/palace/pull/326).
-  - Added `BoundaryMode` solver for mode analysis on 2D meshes, supporting both standalone 2D meshes
-    and 2D boundary submesh extracted from a 3D mesh [PR 657](https://github.com/awslabs/palace/pull/657).
-  - Added support for 2D meshes in all simulation types [PR 657](https://github.com/awslabs/palace/pull/657).
-  - Changed waveport formulation to enable support for impedance boundary conditions [PR 657](https://github.com/awslabs/palace/pull/657).
-  - Enabled voltage and impedance postprocessing for waveport and BoundaryMode by specifying a line
-    from ground to conductor, either through mesh coordinates or boundary attribute
-    in `config["Boundaries"]["Postprocessing"]["Impedance"]` [PR 657](https://github.com/awslabs/palace/pull/657).
 
 #### Bug Fixes
 
@@ -104,8 +114,6 @@ The format of this changelog is based on
   - Fixed a bug in complex diagonal operator multiplication where the imaginary part used an
     incorrect term in `AddMult` and `AddMultHermitianTranspose`.
     [PR 633](https://github.com/awslabs/palace/pull/633).
-  - Fixed a bug where nonconformal AMR would lead to erroneous results when waveports are present.
-    Part of [PR 657](https://github.com/awslabs/palace/pull/657).
 
 #### Interface Changes
 

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -94,6 +94,12 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         msg="GCC does not support AddressSanitizer on macOS (Apple Silicon). Use Clang instead.",
     )
 
+    # MKL 2026+ miscomputes CurrentDipole (~27% off on antenna_short_dipole).
+    conflicts(
+        "^intel-oneapi-mkl@2026:",
+        msg="MKL 2026+ miscomputes CurrentDipole; pin to @:2025",
+    )
+
     conflicts("^mumps+int64", msg="Palace requires MUMPS without 64 bit integers")
     with when("+mumps"):
         depends_on("fortran", type="build")


### PR DESCRIPTION
`palace@develop` is pinned to `branch="main"` in the Spack recipe, so every
branch's CI produces the same spec hash with a different binary. The container
build shares one OCI buildcache and force-pushes unsigned, so the last pusher
wins — poisoning every other branch's next container build. Dependencies are
content-keyed, so they're fine.

Split the Palace install into `--only dependencies` (from cache) + `--only
package --no-cache` (from local source), and restrict the cache push to
`--only dependencies`. Same pattern `palace-ci` already uses for the Spack job.

Fixes the current `testcase.jl:183` metafile-list failures on main and on
open PRs.

Drive-by: relocates PR #657's CHANGELOG bullets from the released 0.16.0
section into a new `In progress` block.
