### PR TITLE
Install gcc@15 with apt for container

### DIFF
--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -5,6 +5,19 @@
 ARG GITHUB_USER=""
 ARG GITHUB_TOKEN=""
 
+# FIXME(awslabs/palace#731): workaround for a Spack spec-groups bug that
+# prevents the gcc compiler from being installed. Build-stage only, so the
+# runtime image is unaffected. Remove with the spack.yaml `compilers` group
+# fix.
+#
+# noble's default archive does not carry gcc-15 yet; pull it from the
+# ubuntu-toolchain-r/test PPA.
+RUN apt-get -yqq update && \
+    apt-get -yqq install --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get -yqq install --no-install-recommends gcc-15 g++-15 gfortran-15 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy the Palace source tree
 COPY . /opt/palace
 
@@ -40,6 +53,10 @@ RUN mkdir -p /opt/spack-environment && \
 RUN mkdir -p {{ paths.environment }} && \
 set -o noclobber \
 {{ manifest }} > {{ paths.environment }}/spack.yaml
+
+# FIXME(awslabs/palace#731): remove with the apt step above.
+RUN cd {{ paths.environment }} && spack env activate . && \
+    spack compiler find
 
 # Check if the binary cache is reachable
 RUN cd {{ paths.environment }} && spack env activate . && \
@@ -94,4 +111,16 @@ RUN find -L {{ paths.view }}/* -type f -exec readlink -f '{}' \; | \
 RUN cd {{ paths.environment }} && \
     spack env activate --sh -d . > activate.sh
 
+{% endblock %}
+
+{% block final_stage %}
+# FIXME(awslabs/palace#731): mirror the build-stage PPA install in the final
+# image so libstdc++6 there is gcc-15's, matching what palace was built
+# against. Remove with the spack.yaml `compilers` group fix.
+RUN apt-get -yqq update && \
+    apt-get -yqq install --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get -yqq install --no-install-recommends libstdc++6 && \
+    apt-get -yqq purge --auto-remove -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
 {% endblock %}

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -50,23 +50,27 @@ spack:
         id_variable: GITHUB_USER
         secret_variable: GITHUB_TOKEN
   specs:
-    # Compile gcc@15, then use it to compile everything else
-  - group: compilers
-    # explicit false means that we do not want to include this in the container,
-    # unless something depends on it
-    explicit: false
-    specs:
-      # If you change this, you might need to change PalaceDockerfile so that we
-      # remove the compiler from the container
-      - gcc@15
-    override:
-      concretizer:
-        # Do not force the target to be specific, let it generic, so that we can
-        # reuse compilers across different machines.
-        targets:
-          granularity: generic
+    # FIXME(awslabs/palace#731): re-enable the `compilers` spec group when the
+    # underlying Spack spec-groups bug is fixed; gcc-15 is currently apt-
+    # installed in PalaceDockerfile.
+    #
+    # - group: compilers
+    #   # explicit false means that we do not want to include this in the
+    #   # container, unless something depends on it
+    #   explicit: false
+    #   specs:
+    #     # If you change this, you might need to change PalaceDockerfile so
+    #     # that we remove the compiler from the container
+    #     - gcc@15
+    #   override:
+    #     concretizer:
+    #       # Do not force the target to be specific, let it generic, so that
+    #       # we can reuse compilers across different machines.
+    #       targets:
+    #         granularity: generic
   - group: palace
-    needs: [compilers]
+    # FIXME(awslabs/palace#731): re-enable with `compilers` group above.
+    # needs: [compilers]
     specs:
     - palace@develop+libxsmm+superlu-dist+mumps+sundials+strumpack+slepc+arpack+int64 %gcc@15 ^openblas@0.3.29 ^openmpi schedulers=none fabrics=ofi
     override:


### PR DESCRIPTION
gcc@15 sits in a separate spec group with `explicit: false` (so `spack gc -y` can reap it after the build), and palace's compiler-wrapper holds gcc's install path as a string rather than a graph dep — so neither `--only dependencies` nor `--only package` materialises it, and the build fails when the wrapper tries to exec a binary that was never installed.

Fix: `spack install gcc@15` ahead of the existing two passes.