### PR TITLE
Fix docs inconsistency for second-order absorbing boundary conditions

### DIFF
--- a/docs/src/config/boundaries.md
+++ b/docs/src/config/boundaries.md
@@ -215,7 +215,7 @@ farfield absorbing boundary conditions.
 
 `"Order" [1]` :  Specify a first- or second-order approximation for the farfield absorbing
 boundary condition. Second-order absorbing boundary conditions are only available for the
-frequency domain driven simulation type.
+frequency domain driven and eigenmode simulation types.
 
 ## `boundaries["Conductivity"]`
 


### PR DESCRIPTION
## Summary

- The config reference (`docs/src/config/boundaries.md`) incorrectly stated that second-order absorbing boundary conditions are only available for the frequency domain driven simulation type.
- The guide (`docs/src/guide/boundaries.md`) and the code (`palace/models/farfieldboundaryoperator.cpp:85-89`) both confirm they are also available for eigenmode simulations.
- Updated the config reference to match.

Fixes #736.