### PR TITLE
Per-attribute scaling of surface impedance boundary coefficients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format of this changelog is based on
   - Fixed nondeterministic current-dipole assembly when the source lies on a
     shared mesh entity by distributing the underlying MFEM delta source over all
     containing elements.
+    [PR 742](https://github.com/awslabs/palace/pull/742).
   - Fixed a bug where nonconformal AMR would lead to erroneous results when waveports are present.
     Part of [PR 657](https://github.com/awslabs/palace/pull/657).
   - For `BoundaryMode` simulations on a 3D mesh, the non-dimensionalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ The format of this changelog is based on
     `config["Problem"]["Output"]` (allowed by the schema) aborted at startup with "Invalid output
     directory, got empty string". `Output` now defaults to `"postpro"` when omitted
     [PR 753](https://github.com/awslabs/palace/pull/753).
+  - Fixed impedance boundary mesh-cracking scaling to apply per-attribute rather than per-block,
+    allowing mixed cracked and uncracked attributes within a single impedance boundary definition.
+    [PR 748](https://github.com/awslabs/palace/pull/748).
   - Revert change of adaptive PROM from interpolation back to projection.
     [PR 733](https://github.com/awslabs/palace/pull/733).
   - Fixed nondeterministic current-dipole assembly when the source lies on a

--- a/docs/src/developer/testing.md
+++ b/docs/src/developer/testing.md
@@ -85,10 +85,10 @@ ctest -j8 --output-on-failure
 
 CTest will schedule execution of tests trying to use all the 8 processes. In
 this, CTest handles MPI processes correctly, and ensures that only one GPU test
-is being run at the time. If you compiled *Palace*, the total number of
+is being run at a time. If you compiled *Palace*, the total number of
 processes that could end up used in this example is `8 * OMP_NUM_THREADS`.
 
-If you run specific tests categories, you can use regex matching, for example
+To run specific tests categories, you can use regex matching, for example
 
 ```bash
 ctest -R mpi-            # Run only MPI tests
@@ -379,7 +379,7 @@ The following environment variables are useful when running under sanitizers:
 ## Regression tests
 
 In addition to unit tests, *Palace* comes with a series of regression tests.
-Regression tests based on the provided example applications in the
+Regression tests are based on the provided example applications in the
 [`examples/`](https://github.com/awslabs/palace/blob/main/examples/) directory
 and verify that the code reproduces results in reference files stored in
 [`test/examples/`](https://github.com/awslabs/palace/blob/main/test/examples/ref).

--- a/docs/src/developer/tutorial_add_new_unit_test.md
+++ b/docs/src/developer/tutorial_add_new_unit_test.md
@@ -109,7 +109,7 @@ We added GPU compatibility by (see, [MFEM documentation](https://mfem.org/gpu-su
 
  1. Adding `v.UseDevice(true);`, which defines our intent to use `v` for computations on the device.
  2. Defining `auto d_v = v.Write();`, a pointer to area of memory on the device.
- 3. Using `forall` to execute the execute the function on the device.
+ 3. Using `forall` to execute the function on the device.
 
 When we add GPU code, we need to make sure that the file is compiled with the
 correct compiler. To do so, we add the file to `TARGET_SOURCES_DEVICE` in the
@@ -131,7 +131,7 @@ To add MPI compatibility, we changed the `expected` value to account for how
 many copies of the vector `v` there are.
 
 With these additions, this test case is a meaningful and interesting test in all
-the possible configurations, so we we added the `[Parallel]` and `[GPU]` tags.
+the possible configurations, so we added the `[Parallel]` and `[GPU]` tags.
 
 *Palace* uses three special tags for execution control:
 

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -199,8 +199,7 @@ void SurfaceImpedanceOperator::AddStiffnessBdrCoefficients(double coeff,
       for (auto attr : bdr.attr_list)
       {
         const double s = bdr.attr_scaling.at(attr);
-        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
-                               coeff / (bdr.Ls * s));
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr), coeff / (bdr.Ls * s));
       }
     }
   }
@@ -217,8 +216,7 @@ void SurfaceImpedanceOperator::AddDampingBdrCoefficients(double coeff,
       for (auto attr : bdr.attr_list)
       {
         const double s = bdr.attr_scaling.at(attr);
-        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
-                               coeff / (bdr.Rs * s));
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr), coeff / (bdr.Rs * s));
       }
     }
   }
@@ -235,8 +233,7 @@ void SurfaceImpedanceOperator::AddMassBdrCoefficients(double coeff,
       for (auto attr : bdr.attr_list)
       {
         const double s = bdr.attr_scaling.at(attr);
-        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
-                               coeff * bdr.Cs / s);
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr), coeff * bdr.Cs / s);
       }
     }
   }

--- a/palace/models/surfaceimpedanceoperator.cpp
+++ b/palace/models/surfaceimpedanceoperator.cpp
@@ -92,18 +92,10 @@ void SurfaceImpedanceOperator::SetUpBoundaryProperties(
         continue;  // Can just ignore if wrong
       }
       bdr.attr_list.Append(attr);
-      // Compute a scaling factor to account for increased area when using mesh cracking.
-      if (cracked_attributes.find(attr) != cracked_attributes.end())
-      {
-        bdr.scaling = 2.0;
-      }
-      MFEM_VERIFY((cracked_attributes.find(attr) != cracked_attributes.end()) ||
-                      (bdr.scaling == 1.0),
-                  "Impedance boundary has both cracked and uncracked attributes!");
+      // Per-attribute scaling to account for increased area when using mesh cracking.
+      bdr.attr_scaling[attr] =
+          (cracked_attributes.find(attr) != cracked_attributes.end()) ? 2.0 : 1.0;
     }
-    bdr.Ls *= bdr.scaling;
-    bdr.Rs *= bdr.scaling;
-    bdr.Cs /= bdr.scaling;
   }
 }
 
@@ -128,17 +120,17 @@ void SurfaceImpedanceOperator::PrintBoundaryInfo(const Units &units,
       if (std::abs(bdr.Rs) > 0.0)
       {
         fmt::format_to(out, " Rs = {:.3e} Ω/sq,",
-                       units.Dimensionalize<VT::IMPEDANCE>(bdr.Rs / bdr.scaling));
+                       units.Dimensionalize<VT::IMPEDANCE>(bdr.Rs));
       }
       if (std::abs(bdr.Ls) > 0.0)
       {
         fmt::format_to(out, " Ls = {:.3e} H/sq,",
-                       units.Dimensionalize<VT::INDUCTANCE>(bdr.Ls / bdr.scaling));
+                       units.Dimensionalize<VT::INDUCTANCE>(bdr.Ls));
       }
       if (std::abs(bdr.Cs) > 0.0)
       {
         fmt::format_to(out, " Cs = {:.3e} F/sq,",
-                       units.Dimensionalize<VT::CAPACITANCE>(bdr.Cs * bdr.scaling));
+                       units.Dimensionalize<VT::CAPACITANCE>(bdr.Cs));
       }
       fmt::format_to(out, " n = ({:+.1f})\n",
                      fmt::join(mesh::GetSurfaceNormal(mesh, attr), ","));
@@ -204,7 +196,12 @@ void SurfaceImpedanceOperator::AddStiffnessBdrCoefficients(double coeff,
   {
     if (std::abs(bdr.Ls) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff / bdr.Ls);
+      for (auto attr : bdr.attr_list)
+      {
+        const double s = bdr.attr_scaling.at(attr);
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
+                               coeff / (bdr.Ls * s));
+      }
     }
   }
 }
@@ -217,7 +214,12 @@ void SurfaceImpedanceOperator::AddDampingBdrCoefficients(double coeff,
   {
     if (std::abs(bdr.Rs) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff / bdr.Rs);
+      for (auto attr : bdr.attr_list)
+      {
+        const double s = bdr.attr_scaling.at(attr);
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
+                               coeff / (bdr.Rs * s));
+      }
     }
   }
 }
@@ -230,7 +232,12 @@ void SurfaceImpedanceOperator::AddMassBdrCoefficients(double coeff,
   {
     if (std::abs(bdr.Cs) > 0.0)
     {
-      fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(bdr.attr_list), coeff * bdr.Cs);
+      for (auto attr : bdr.attr_list)
+      {
+        const double s = bdr.attr_scaling.at(attr);
+        fb.AddMaterialProperty(mat_op.GetCeedBdrAttributes(attr),
+                               coeff * bdr.Cs / s);
+      }
     }
   }
 }

--- a/palace/models/surfaceimpedanceoperator.hpp
+++ b/palace/models/surfaceimpedanceoperator.hpp
@@ -4,6 +4,7 @@
 #ifndef PALACE_MODELS_SURFACE_IMPEDANCE_OPERATOR_HPP
 #define PALACE_MODELS_SURFACE_IMPEDANCE_OPERATOR_HPP
 
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <mfem.hpp>
@@ -32,7 +33,7 @@ private:
   {
     double Rs, Ls, Cs;
     mfem::Array<int> attr_list;
-    double scaling = 1.0;
+    std::unordered_map<int, double> attr_scaling;
   };
   std::vector<ImpedanceData> boundaries;
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-vector.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-waveportimpedance.cpp

--- a/test/unit/test-surfaceimpedanceoperator.cpp
+++ b/test/unit/test-surfaceimpedanceoperator.cpp
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <optional>
+#include <unordered_set>
+#include <vector>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "fem/mesh.hpp"
+#include "models/materialoperator.hpp"
+#include "models/surfaceimpedanceoperator.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+using namespace Catch::Matchers;
+
+namespace
+{
+
+// Returns the scalar coefficient value assigned to bdr_attr, or std::nullopt if the
+// attribute is not present on this rank.
+std::optional<double> GetBdrCoeffValue(const MaterialPropertyCoefficient &fb,
+                                       const Mesh &mesh, int bdr_attr)
+{
+  auto ceed_attrs = mesh.GetCeedBdrAttributes(bdr_attr);
+  if (ceed_attrs.Size() == 0)
+  {
+    return std::nullopt;
+  }
+  int ceed_attr = ceed_attrs[0];
+  const auto &attr_mat = fb.GetAttributeToMaterial();
+  int mat_idx = attr_mat[ceed_attr - 1];
+  if (mat_idx < 0)
+  {
+    return std::nullopt;
+  }
+  return fb.GetMaterialProperties()(0, 0, mat_idx);
+}
+
+}  // namespace
+
+TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
+          "[surfaceimpedanceoperator][Serial][Parallel]")
+{
+  auto serial_mesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::TETRAHEDRON));
+  auto par_mesh = std::make_unique<mfem::ParMesh>(Mpi::World(), *serial_mesh);
+  Mesh palace_mesh(std::move(par_mesh));
+
+  // Sanity check: ParMesh's METIS partitioning must give every rank at least one element,
+  // otherwise this rank contributes nothing and the [Parallel] run is misleading.
+  REQUIRE(palace_mesh.GetNE() > 0);
+
+  config::MaterialData material;
+  material.attributes = {1};
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({material}, periodic, ProblemType::DRIVEN, palace_mesh);
+
+  Units units(1.0, 1.0);
+  const double coeff = 1.0;
+  const double Rs = 50.0, Ls = 1e-9, Cs = 1e-12;
+
+  // Globally REQUIRE that boundary attributes 1 and 2 were each visible on at least one
+  // rank, so under [Parallel] no SECTION silently passes with zero CHECKs everywhere.
+  auto require_global_coverage = [](bool local_v1, bool local_v2)
+  {
+    bool flags[2] = {local_v1, local_v2};
+    Mpi::GlobalOr(2, flags, Mpi::World());
+    REQUIRE(flags[0]);
+    REQUIRE(flags[1]);
+  };
+
+  SECTION("All uncracked")
+  {
+    config::ImpedanceData imp;
+    imp.Rs = Rs;
+    imp.Ls = Ls;
+    imp.Cs = Cs;
+    imp.attributes = {1, 2};
+    std::unordered_set<int> cracked = {};
+
+    SurfaceImpedanceOperator op({imp}, cracked, units, mat_op, palace_mesh);
+
+    MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
+    op.AddStiffnessBdrCoefficients(coeff, fb);
+
+    auto v1 = GetBdrCoeffValue(fb, palace_mesh, 1);
+    auto v2 = GetBdrCoeffValue(fb, palace_mesh, 2);
+    if (v1)
+    {
+      CHECK_THAT(*v1, WithinRel(coeff / Ls, 1e-12));
+    }
+    if (v2)
+    {
+      CHECK_THAT(*v2, WithinRel(coeff / Ls, 1e-12));
+    }
+    require_global_coverage(v1.has_value(), v2.has_value());
+  }
+
+  SECTION("All cracked")
+  {
+    config::ImpedanceData imp;
+    imp.Rs = Rs;
+    imp.Ls = Ls;
+    imp.Cs = Cs;
+    imp.attributes = {1, 2};
+    std::unordered_set<int> cracked = {1, 2};
+
+    SurfaceImpedanceOperator op({imp}, cracked, units, mat_op, palace_mesh);
+
+    MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
+    op.AddStiffnessBdrCoefficients(coeff, fb);
+
+    auto v1 = GetBdrCoeffValue(fb, palace_mesh, 1);
+    auto v2 = GetBdrCoeffValue(fb, palace_mesh, 2);
+    if (v1)
+    {
+      CHECK_THAT(*v1, WithinRel(coeff / (Ls * 2.0), 1e-12));
+    }
+    if (v2)
+    {
+      CHECK_THAT(*v2, WithinRel(coeff / (Ls * 2.0), 1e-12));
+    }
+    require_global_coverage(v1.has_value(), v2.has_value());
+  }
+
+  SECTION("Mixed cracked/uncracked - stiffness")
+  {
+    config::ImpedanceData imp;
+    imp.Rs = Rs;
+    imp.Ls = Ls;
+    imp.Cs = Cs;
+    imp.attributes = {1, 2};
+    std::unordered_set<int> cracked = {2};
+
+    SurfaceImpedanceOperator op({imp}, cracked, units, mat_op, palace_mesh);
+
+    MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
+    op.AddStiffnessBdrCoefficients(coeff, fb);
+
+    auto v1 = GetBdrCoeffValue(fb, palace_mesh, 1);
+    auto v2 = GetBdrCoeffValue(fb, palace_mesh, 2);
+    if (v1)
+    {
+      CHECK_THAT(*v1, WithinRel(coeff / (Ls * 1.0), 1e-12));
+    }
+    if (v2)
+    {
+      CHECK_THAT(*v2, WithinRel(coeff / (Ls * 2.0), 1e-12));
+    }
+    require_global_coverage(v1.has_value(), v2.has_value());
+  }
+
+  SECTION("Mixed cracked/uncracked - damping")
+  {
+    config::ImpedanceData imp;
+    imp.Rs = Rs;
+    imp.Ls = Ls;
+    imp.Cs = Cs;
+    imp.attributes = {1, 2};
+    std::unordered_set<int> cracked = {2};
+
+    SurfaceImpedanceOperator op({imp}, cracked, units, mat_op, palace_mesh);
+
+    MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
+    op.AddDampingBdrCoefficients(coeff, fb);
+
+    auto v1 = GetBdrCoeffValue(fb, palace_mesh, 1);
+    auto v2 = GetBdrCoeffValue(fb, palace_mesh, 2);
+    if (v1)
+    {
+      CHECK_THAT(*v1, WithinRel(coeff / (Rs * 1.0), 1e-12));
+    }
+    if (v2)
+    {
+      CHECK_THAT(*v2, WithinRel(coeff / (Rs * 2.0), 1e-12));
+    }
+    require_global_coverage(v1.has_value(), v2.has_value());
+  }
+
+  SECTION("Mixed cracked/uncracked - mass")
+  {
+    config::ImpedanceData imp;
+    imp.Rs = Rs;
+    imp.Ls = Ls;
+    imp.Cs = Cs;
+    imp.attributes = {1, 2};
+    std::unordered_set<int> cracked = {2};
+
+    SurfaceImpedanceOperator op({imp}, cracked, units, mat_op, palace_mesh);
+
+    MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
+    op.AddMassBdrCoefficients(coeff, fb);
+
+    auto v1 = GetBdrCoeffValue(fb, palace_mesh, 1);
+    auto v2 = GetBdrCoeffValue(fb, palace_mesh, 2);
+    if (v1)
+    {
+      CHECK_THAT(*v1, WithinRel(coeff * Cs / 1.0, 1e-12));
+    }
+    if (v2)
+    {
+      CHECK_THAT(*v2, WithinRel(coeff * Cs / 2.0, 1e-12));
+    }
+    require_global_coverage(v1.has_value(), v2.has_value());
+  }
+}
+
+}  // namespace palace

--- a/test/unit/test-surfaceimpedanceoperator.cpp
+++ b/test/unit/test-surfaceimpedanceoperator.cpp
@@ -43,8 +43,7 @@ std::optional<double> GetBdrCoeffValue(const MaterialPropertyCoefficient &fb,
 
 }  // namespace
 
-TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
-          "[surfaceimpedanceoperator][Serial][Parallel]")
+TEST_CASE("SurfaceImpedanceOperator", "[surfaceimpedanceoperator][Serial][Parallel]")
 {
   auto serial_mesh = std::make_unique<mfem::Mesh>(
       mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::TETRAHEDRON));
@@ -74,7 +73,7 @@ TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
     REQUIRE(flags[1]);
   };
 
-  SECTION("All uncracked")
+  SECTION("Per-attribute scaling, all uncracked")
   {
     config::ImpedanceData imp;
     imp.Rs = Rs;
@@ -101,7 +100,7 @@ TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
     require_global_coverage(v1.has_value(), v2.has_value());
   }
 
-  SECTION("All cracked")
+  SECTION("Per-attribute scaling, all cracked")
   {
     config::ImpedanceData imp;
     imp.Rs = Rs;
@@ -128,7 +127,7 @@ TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
     require_global_coverage(v1.has_value(), v2.has_value());
   }
 
-  SECTION("Mixed cracked/uncracked - stiffness")
+  SECTION("Per-attribute scaling, mixed cracked/uncracked - stiffness")
   {
     config::ImpedanceData imp;
     imp.Rs = Rs;
@@ -155,7 +154,7 @@ TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
     require_global_coverage(v1.has_value(), v2.has_value());
   }
 
-  SECTION("Mixed cracked/uncracked - damping")
+  SECTION("Per-attribute scaling, mixed cracked/uncracked - damping")
   {
     config::ImpedanceData imp;
     imp.Rs = Rs;
@@ -182,7 +181,7 @@ TEST_CASE("SurfaceImpedanceOperator per-attribute scaling",
     require_global_coverage(v1.has_value(), v2.has_value());
   }
 
-  SECTION("Mixed cracked/uncracked - mass")
+  SECTION("Per-attribute scaling, mixed cracked/uncracked - mass")
   {
     config::ImpedanceData imp;
     imp.Rs = Rs;


### PR DESCRIPTION
Makes the scaling factor applied to sheet parameters (`Ls`, `Rs`, `Cs`) of impedance boundaries adjustable per-attribute rather than globally across the whole operator. This makes it possible to build models with impedance boundaries that have some attributes cracked (internal boundaries) and some attributes uncracked (external). I contributed a unit test for this as and checked the regression suite locally.
