### PR TITLE
Print parallel mesh stats helper

### DIFF
--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -7,10 +7,11 @@
 # 3. Long tests run and the long-tests status is updated
 #
 # If the PR is updated while the label is present, the tests re-run
-# automatically.
+# automatically. It can also be run manually from the GitHub Actions UI.
 name: Long Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled, synchronize]
 
@@ -32,12 +33,14 @@ jobs:
   long-tests:
     runs-on: [self-hosted, x64]
     # Run if:
+    # - manually triggered from the Actions UI, OR
     # - the 'trigger-long-tests' label was just added, OR
     # - the PR was updated and already has the 'trigger-long-tests' label
     # Do not run from forks.
     if: |
       github.repository == 'awslabs/palace' &&
       (
+        github.event_name == 'workflow_dispatch' ||
         (github.event.action == 'labeled' && github.event.label.name == 'trigger-long-tests') ||
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'trigger-long-tests'))
       )
@@ -50,7 +53,7 @@ jobs:
           test-cases: long
 
       - name: Set success status
-        if: success()
+        if: github.event_name == 'pull_request' && success()
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             --method POST \
@@ -61,7 +64,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set failure status
-        if: failure() || cancelled()
+        if: github.event_name == 'pull_request' && (failure() || cancelled())
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             --method POST \

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -269,6 +269,10 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
       mesh.back()->Update();
     }
 
+    // Print statistics (element counts, size h, and shape regularity kappa) for the
+    // newly-refined mesh so the evolution of mesh quality under AMR is visible.
+    mesh::PrintMeshInfo(*mesh.back(), iodata, /*full=*/false);
+
     // Solve + estimate.
     Mpi::Print("\nProceeding with solve/estimate iteration {}...\n", it + 1);
     std::tie(indicators, ntdof) = Solve(mesh);

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -481,35 +481,43 @@ void RefineMesh(const IoData &iodata, std::vector<std::unique_ptr<mfem::ParMesh>
   }
 
   // Print some mesh information.
-  mfem::Vector bbmin, bbmax;
-  GetAxisAlignedBoundingBox(*mesh[0], bbmin, bbmax);
-  const double Lc = iodata.units.Dimensionalize<Units::ValueType::LENGTH>(1.0);
-  Mpi::Print(mesh[0]->GetComm(), "\nMesh curvature order: {}\nMesh bounding box:\n",
-             mesh[0]->GetNodes()
-                 ? std::to_string(mesh[0]->GetNodes()->FESpace()->GetMaxElementOrder())
-                 : "None");
-  if (mesh[0]->SpaceDimension() == 3)
-  {
-    Mpi::Print(mesh[0]->GetComm(),
-               " (Xmin, Ymin, Zmin) = ({:+.3e}, {:+.3e}, {:+.3e}) m\n"
-               " (Xmax, Ymax, Zmax) = ({:+.3e}, {:+.3e}, {:+.3e}) m\n",
-               bbmin[0] * Lc, bbmin[1] * Lc, bbmin[2] * Lc, bbmax[0] * Lc, bbmax[1] * Lc,
-               bbmax[2] * Lc);
-  }
-  else
-  {
-    Mpi::Print(mesh[0]->GetComm(),
-               " (Xmin, Ymin) = ({:+.3e}, {:+.3e}) m\n"
-               " (Xmax, Ymax) = ({:+.3e}, {:+.3e}) m\n",
-               bbmin[0] * Lc, bbmin[1] * Lc, bbmax[0] * Lc, bbmax[1] * Lc);
-  }
-  Mpi::Print(mesh[0]->GetComm(), "\n{}", (mesh.size() > 1) ? "Coarse " : "");
-  mesh[0]->PrintInfo();
+  PrintMeshInfo(*mesh[0], iodata, /*full=*/true, (mesh.size() > 1) ? "Coarse " : "");
   if (mesh.size() > 1)
   {
-    Mpi::Print(mesh[0]->GetComm(), "\nRefined ");
-    mesh.back()->PrintInfo();
+    PrintMeshInfo(*mesh.back(), iodata, /*full=*/false, "Refined ");
   }
+}
+
+void PrintMeshInfo(mfem::ParMesh &mesh, const IoData &iodata, bool full,
+                   const std::string &prefix)
+{
+  if (full)
+  {
+    mfem::Vector bbmin, bbmax;
+    GetAxisAlignedBoundingBox(mesh, bbmin, bbmax);
+    const double Lc = iodata.units.Dimensionalize<Units::ValueType::LENGTH>(1.0);
+    Mpi::Print(mesh.GetComm(), "\nMesh curvature order: {}\nMesh bounding box:\n",
+               mesh.GetNodes()
+                   ? std::to_string(mesh.GetNodes()->FESpace()->GetMaxElementOrder())
+                   : "None");
+    if (mesh.SpaceDimension() == 3)
+    {
+      Mpi::Print(mesh.GetComm(),
+                 " (Xmin, Ymin, Zmin) = ({:+.3e}, {:+.3e}, {:+.3e}) m\n"
+                 " (Xmax, Ymax, Zmax) = ({:+.3e}, {:+.3e}, {:+.3e}) m\n",
+                 bbmin[0] * Lc, bbmin[1] * Lc, bbmin[2] * Lc, bbmax[0] * Lc, bbmax[1] * Lc,
+                 bbmax[2] * Lc);
+    }
+    else
+    {
+      Mpi::Print(mesh.GetComm(),
+                 " (Xmin, Ymin) = ({:+.3e}, {:+.3e}) m\n"
+                 " (Xmax, Ymax) = ({:+.3e}, {:+.3e}) m\n",
+                 bbmin[0] * Lc, bbmin[1] * Lc, bbmax[0] * Lc, bbmax[1] * Lc);
+    }
+  }
+  Mpi::Print(mesh.GetComm(), "\n{}", prefix);
+  mesh.PrintInfo();
 }
 
 mfem::Mesh MeshTetToHex(const mfem::Mesh &orig_mesh)

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -49,6 +49,14 @@ double ComputeReferenceLength(const std::unique_ptr<mfem::Mesh> &mesh, MPI_Comm 
 // meshes and it should not be deleted. The fine mesh hierarchy is owned by the user.
 void RefineMesh(const IoData &iodata, std::vector<std::unique_ptr<mfem::ParMesh>> &mesh);
 
+// Print parallel mesh statistics (element/vertex/edge/face counts, element size h, and
+// shape regularity kappa). When `full` is true, also prints the (refinement-invariant)
+// mesh curvature order and bounding box; pass false to print only the statistics that
+// change under refinement (used after each adaptive mesh refinement iteration). `prefix`
+// is prepended to the stats block (e.g. "Coarse "/"Refined ").
+void PrintMeshInfo(mfem::ParMesh &mesh, const IoData &iodata, bool full = true,
+                   const std::string &prefix = "");
+
 // Dimensionalize a mesh for use in exporting a mesh. Scales vertices and nodes by L.
 void DimensionalizeMesh(mfem::Mesh &mesh, double L);
 


### PR DESCRIPTION
During a conformal adapt, after refining we did not print the mesh stats, which makes it difficult to keep track of whether or not the mesh quality is degrading (i.e. kappa is growing). This breaks it out into a helper function with optional `full` which will also print the bounding box and curvature information (things that are not changed by the progress of AMR).

Tested by looking at logs for no amr, conformal amr and non-conformal amr, and saw the printing in the correct location.