### PR TITLE
fix: pass freq instead of omega to WriteParaviewFields in driven solver

### DIFF
--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -1435,7 +1435,7 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int ex_idx, int step,
     auto ind = 1 + std::distance(output_save_indices.begin(),
                                  std::lower_bound(output_save_indices.begin(),
                                                   output_save_indices.end(), step));
-    WriteParaviewFields(omega.real(), ind);
+    WriteParaviewFields(freq.real(), ind);
     Mpi::Print(" Wrote fields to disk (Paraview) at step {:d}\n", step + 1);
   }
   if (ShouldWriteGridFunctionFields(step))


### PR DESCRIPTION
Fixes #751

In the driven solver's MeasureAndPrintAll, WriteParaviewFields was being 
called with omega.real() (angular frequency) instead of freq.real() (frequency 
in GHz). This caused ParaView's time axis to display wrong values.

The fix is a one-word change: omega.real() → freq.real(). The freq variable 
was already computed on the line above, and WriteMFEMGridFunctions in the 
same block was already using it correctly.