### PR TITLE
Default Problem.Output to "postpro" when omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ The format of this changelog is based on
 
 #### Bug Fixes
 
+  - Fixed a contradiction between the configuration schema and runtime behavior where omitting
+    `config["Problem"]["Output"]` (allowed by the schema) aborted at startup with "Invalid output
+    directory, got empty string". `Output` now defaults to `"postpro"` when omitted
+    [PR 753](https://github.com/awslabs/palace/pull/753).
   - Revert change of adaptive PROM from interpolation back to projection.
   - Fixed nondeterministic current-dipole assembly when the source lies on a
     shared mesh entity by distributing the underlying MFEM delta source over all

--- a/docs/src/config/problem.md
+++ b/docs/src/config/problem.md
@@ -36,7 +36,8 @@ with
 
 `"Verbose" [1]` :  Controls the level of log file printing.
 
-`"Output" [None]` :  Directory path for saving postprocessing outputs.
+`"Output" ["postpro"]` :  Directory path for saving postprocessing outputs. When omitted,
+results are written to a `postpro` directory relative to the working directory.
 
 `"OutputFormats"` :  Top-level object for configuring the field output formats.
 

--- a/palace/utils/configfile.hpp
+++ b/palace/utils/configfile.hpp
@@ -63,8 +63,9 @@ public:
   // Level of printing.
   int verbose = 1;
 
-  // Output path for storing results.
-  std::string output = "";
+  // Output path for storing results. Defaults to "postpro" (relative to the working
+  // directory) when omitted, matching the convention used by the in-tree examples.
+  std::string output = "postpro";
 
   // Output formats configuration.
   OutputFormatsData output_formats = {};

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -736,6 +736,24 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
     CHECK(j_linear["MGCycleIts"].get<int>() == 1);
   }
 
+  SECTION("Omitted Output resolves to default and concretizes (issue #745)")
+  {
+    // The schema marks Problem.Output optional, so a config without it must parse
+    // without aborting and fall back to the documented "postpro" default.
+    json config = {{"Problem", {{"Type", "Electrostatic"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver", json::object()}};
+
+    IoData iodata(config, false);
+    CHECK(iodata.problem.output == "postpro");
+
+    // ConcretizeDefaults must emit the resolved, non-empty value back to JSON.
+    config = IoData::ConcretizeDefaults(iodata, config);
+    CHECK(config["Problem"]["Output"].get<std::string>() == "postpro");
+  }
+
   SECTION("Magnetostatic resolves to AMS with singular operator")
   {
     json config = {{"Problem", {{"Type", "Magnetostatic"}, {"Output", "test_output"}}},

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -10,6 +10,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include "fem/integrator.hpp"
+#include "fixtures.hpp"
 #include "models/postoperator.hpp"
 #include "utils/iodata.hpp"
 #include "utils/units.hpp"
@@ -343,7 +344,8 @@ TEST_CASE("PostOperator", "[idempotent][Serial]")
   }
 }
 
-TEST_CASE("GridFunction export", "[gridfunction][Serial][Parallel]")
+TEST_CASE_METHOD(test::SharedTempDir, "GridFunction export",
+                 "[gridfunction][Serial][Parallel]")
 {
   // Create iodata.
   Units units(0.496, 1.453);
@@ -352,6 +354,10 @@ TEST_CASE("GridFunction export", "[gridfunction][Serial][Parallel]")
   iodata.domains.materials.emplace_back().attributes = {1};
   iodata.boundaries.pec.attributes = {1};
   iodata.problem.output_formats.gridfunction = true;
+  // Direct output into a shared temporary directory. The default Problem.Output
+  // ("postpro") is relative to the working directory, which is not guaranteed to be
+  // writable during the test run.
+  iodata.problem.output = temp_dir.string();
   iodata.CheckConfiguration();  // initializes quadrature
 
   // Setup lumped port boundary data for driven and transient.


### PR DESCRIPTION
Give `Problem.Output` a concrete `"postpro"` default.

Requires #719

Closes #745
