### PR TITLE
Unpin CMake on macOS (#470)

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -202,6 +202,9 @@ jobs:
             export CC=$(brew --prefix llvm@21)/bin/clang
             export CXX=$(brew --prefix llvm@21)/bin/clang++
             export FC=gfortran-15
+            # Homebrew clang does not default to the macOS SDK sysroot, so
+            # system headers like pthread.h are not found. Point it at the SDK.
+            export SDKROOT=$(xcrun --show-sdk-path)
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
             export CC=gcc-15
             export CXX=g++-15

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -176,7 +176,8 @@ jobs:
         # FindMPI that prevents it from finding MPI when compiling with GNU
         # compilers. CMake was pinned to 3.31.8 (see #470) because CMake 4.x
         # could not find some std headers with llvm@18. Test whether the latest
-        # CMake has resolved this so we can drop the pin.
+        # CMake combined with llvm@19 (instead of llvm@18) resolves this so we
+        # can drop the pin.
       - name: Setup cmake
         if: needs.filter.outputs.test == 'true'
         uses: jwlawson/actions-setup-cmake@v2
@@ -191,8 +192,8 @@ jobs:
         run: |
           # Configure environment
           if [[ "${{ matrix.compiler }}" == 'clang' ]]; then
-            export CC=$(brew --prefix llvm@18)/bin/clang
-            export CXX=$(brew --prefix llvm@18)/bin/clang++
+            export CC=$(brew --prefix llvm@19)/bin/clang
+            export CXX=$(brew --prefix llvm@19)/bin/clang++
             export FC=gfortran-15
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
             export CC=gcc-15

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -172,6 +172,13 @@ jobs:
           echo "DYLD_LIBRARY_PATH=/opt/arm/armpl_24.10_flang-new_clang_19/lib:${DYLD_LIBRARY_PATH:+${DYLD_LIBRARY_PATH}:}" >> $GITHUB_ENV
           hdiutil detach "/Volumes/armpl_24.10_flang-new_clang_19_installer" -quiet
 
+        # The macOS image ships llvm@18 but not llvm@19, so install it
+        # explicitly for the clang configurations.
+      - name: Install LLVM
+        if: needs.filter.outputs.test == 'true' && matrix.compiler == 'clang'
+        run: |
+          brew install llvm@19
+
         # We have to upgrade CMake because the bundled one has a bug with
         # FindMPI that prevents it from finding MPI when compiling with GNU
         # compilers. CMake was pinned to 3.31.8 (see #470) because CMake 4.x

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -172,18 +172,18 @@ jobs:
           echo "DYLD_LIBRARY_PATH=/opt/arm/armpl_24.10_flang-new_clang_19/lib:${DYLD_LIBRARY_PATH:+${DYLD_LIBRARY_PATH}:}" >> $GITHUB_ENV
           hdiutil detach "/Volumes/armpl_24.10_flang-new_clang_19_installer" -quiet
 
-        # The macOS image ships llvm@18 but not llvm@19, so install it
+        # The macOS image ships llvm@18 but not llvm@21, so install it
         # explicitly for the clang configurations.
       - name: Install LLVM
         if: needs.filter.outputs.test == 'true' && matrix.compiler == 'clang'
         run: |
-          brew install llvm@19
+          brew install llvm@21
 
         # We have to upgrade CMake because the bundled one has a bug with
         # FindMPI that prevents it from finding MPI when compiling with GNU
         # compilers. CMake was pinned to 3.31.8 (see #470) because CMake 4.x
         # could not find some std headers with llvm@18. Test whether the latest
-        # CMake combined with llvm@19 (instead of llvm@18) resolves this so we
+        # CMake combined with llvm@21 (instead of llvm@18) resolves this so we
         # can drop the pin.
       - name: Setup cmake
         if: needs.filter.outputs.test == 'true'
@@ -199,8 +199,8 @@ jobs:
         run: |
           # Configure environment
           if [[ "${{ matrix.compiler }}" == 'clang' ]]; then
-            export CC=$(brew --prefix llvm@19)/bin/clang
-            export CXX=$(brew --prefix llvm@19)/bin/clang++
+            export CC=$(brew --prefix llvm@21)/bin/clang
+            export CXX=$(brew --prefix llvm@21)/bin/clang++
             export FC=gfortran-15
           elif [[ "${{ matrix.compiler }}" == 'gcc' ]]; then
             export CC=gcc-15

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -174,12 +174,14 @@ jobs:
 
         # We have to upgrade CMake because the bundled one has a bug with
         # FindMPI that prevents it from finding MPI when compiling with GNU
-        # compilers.
+        # compilers. CMake was pinned to 3.31.8 (see #470) because CMake 4.x
+        # could not find some std headers with llvm@18. Test whether the latest
+        # CMake has resolved this so we can drop the pin.
       - name: Setup cmake
         if: needs.filter.outputs.test == 'true'
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.8'
+          cmake-version: '4.3.3'
 
       - name: Build Palace
         if: needs.filter.outputs.test == 'true'

--- a/cmake/ExternalLIBXSMM.cmake
+++ b/cmake/ExternalLIBXSMM.cmake
@@ -39,6 +39,26 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   list(APPEND LIBXSMM_OPTIONS
     "LDFLAGS=-undefined dynamic_lookup"
   )
+  # LIBXSMM's Makefile compiles with an explicit "-target" flag, which disables
+  # Clang's automatic macOS SDK detection, so system headers like pthread.h are
+  # not found. Tell the build where the SDK is via SDKROOT, which Clang uses as
+  # its sysroot. Passing it as a make variable also overrides LIBXSMM's own
+  # hardcoded SDKROOT default. Prefer CMake's resolved sysroot, falling back to
+  # xcrun when it is empty.
+  set(LIBXSMM_SDKROOT "${CMAKE_OSX_SYSROOT}")
+  if(NOT LIBXSMM_SDKROOT)
+    execute_process(
+      COMMAND xcrun --show-sdk-path
+      OUTPUT_VARIABLE LIBXSMM_SDKROOT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+  endif()
+  if(LIBXSMM_SDKROOT)
+    list(APPEND LIBXSMM_OPTIONS
+      "SDKROOT=${LIBXSMM_SDKROOT}"
+    )
+  endif()
 endif()
 
 string(REPLACE ";" "; " LIBXSMM_OPTIONS_PRINT "${LIBXSMM_OPTIONS}")


### PR DESCRIPTION
Tests whether issue #470 is resolved. In #469, CMake on the macOS CI had to be pinned to 3.31.8 because CMake 4.x could not find some std library headers when building with \`llvm@18\`.


Closes #470