### PR TITLE
Cache GSLIB point locator for wave-port voltage-path integrals

### DIFF
--- a/palace/fem/interpolator.cpp
+++ b/palace/fem/interpolator.cpp
@@ -283,7 +283,11 @@ void InterpolateFunction(const mfem::Vector &xyz, const mfem::GridFunction &U,
                          mfem::Vector &vals, mfem::Ordering::Type ordering)
 {
 #if defined(MFEM_USE_GSLIB)
-  // Set up the interpolator.
+  // Set up a single-use interpolator, then delegate to the reusable-op overload. Callers
+  // that interpolate repeatedly on a fixed mesh (e.g. wave-port voltage-path line
+  // integrals during a frequency sweep) should instead build the FindPointsGSLIB once via
+  // SetupInterpolator and call the overload below — the geometric Setup is the expensive
+  // step and depends only on the mesh, not the field values.
   auto &src_mesh = *U.FESpace()->GetMesh();
   MFEM_VERIFY(src_mesh.GetNodes(), "Source mesh has no nodal FE space!");
   const int dim = src_mesh.SpaceDimension();
@@ -292,9 +296,32 @@ void InterpolateFunction(const mfem::Vector &xyz, const mfem::GridFunction &U,
   MPI_Comm comm = (src_pmesh) ? src_pmesh->GetComm() : MPI_COMM_SELF;
   mfem::FindPointsGSLIB op(comm);
   op.Setup(src_mesh, GSLIB_BB_TOL, GSLIB_NEWTON_TOL, npts);
+  InterpolateFunction(op, xyz, U, vals, ordering);
+#else
+  MFEM_ABORT("InterpolateFunction requires MFEM_USE_GSLIB!");
+#endif
+}
 
-  // Perform the interpolation, with the ordering of the returned values matching the
-  // ordering of the source grid function.
+void SetupInterpolator(mfem::FindPointsGSLIB &op, mfem::Mesh &mesh)
+{
+#if defined(MFEM_USE_GSLIB)
+  op.Setup(mesh, GSLIB_BB_TOL, GSLIB_NEWTON_TOL);
+#else
+  MFEM_ABORT("SetupInterpolator requires MFEM_USE_GSLIB!");
+#endif
+}
+
+void InterpolateFunction(mfem::FindPointsGSLIB &op, const mfem::Vector &xyz,
+                         const mfem::GridFunction &U, mfem::Vector &vals,
+                         mfem::Ordering::Type ordering)
+{
+#if defined(MFEM_USE_GSLIB)
+  // Perform the interpolation using a pre-Setup point locator (op.Setup already called on
+  // the source mesh). Setup is geometric — it depends only on the mesh — so a fixed-mesh
+  // caller reuses op across field values without paying the O(num_elements) hash build
+  // each call. The ordering of the returned values matches the source grid function.
+  const int dim = U.FESpace()->GetMesh()->SpaceDimension();
+  const int npts = xyz.Size() / dim;
   const int vdim = U.VectorDim();
   MFEM_VERIFY(vals.Size() == npts * vdim, "Incorrect size for interpolated values vector!");
   op.SetDefaultInterpolationValue(0.0);
@@ -305,10 +332,18 @@ void InterpolateFunction(const mfem::Vector &xyz, const mfem::GridFunction &U,
 #endif
 }
 
-double ComputeLineIntegral(const mfem::Vector &p1, const mfem::Vector &p2,
-                           const mfem::ParGridFunction &field, int quad_order)
-{
 #if defined(MFEM_USE_GSLIB)
+namespace
+{
+
+// Shared quadrature + dot-product core for the line integral. `interp` fills `vals`
+// (byNODES ordering, length npts*vdim) with the field sampled at the quadrature points;
+// it is the only part that touches GSLIB, so callers can supply either a fresh single-use
+// locator or a cached pre-Setup one.
+template <typename InterpFn>
+double LineIntegralCore(const mfem::Vector &p1, const mfem::Vector &p2,
+                        const mfem::ParGridFunction &field, int quad_order, InterpFn interp)
+{
   const int dim = p1.Size();
   MFEM_VERIFY(p2.Size() == dim, "ComputeLineIntegral: p1 and p2 must have same dimension!");
 
@@ -340,7 +375,7 @@ double ComputeLineIntegral(const mfem::Vector &p1, const mfem::Vector &p2,
   // Interpolate the vector field at the quadrature points.
   const int vdim = field.VectorDim();
   mfem::Vector vals(npts * vdim);
-  InterpolateFunction(xyz, field, vals, mfem::Ordering::byNODES);
+  interp(xyz, vals);
 
   // Compute the dot product F · dl at each quadrature point and sum. Only the first
   // min(vdim, dim) components contribute; higher components (if vdim > dim) are ignored
@@ -359,6 +394,35 @@ double ComputeLineIntegral(const mfem::Vector &p1, const mfem::Vector &p2,
     result += ir.IntPoint(i).weight * dot;
   }
   return result;
+}
+
+}  // namespace
+#endif
+
+double ComputeLineIntegral(const mfem::Vector &p1, const mfem::Vector &p2,
+                           const mfem::ParGridFunction &field, int quad_order)
+{
+#if defined(MFEM_USE_GSLIB)
+  return LineIntegralCore(
+      p1, p2, field, quad_order, [&field](const mfem::Vector &xyz, mfem::Vector &vals)
+      { InterpolateFunction(xyz, field, vals, mfem::Ordering::byNODES); });
+#else
+  MFEM_ABORT("ComputeLineIntegral requires MFEM_USE_GSLIB!");
+  return 0.0;
+#endif
+}
+
+double ComputeLineIntegral(mfem::FindPointsGSLIB &op, const mfem::Vector &p1,
+                           const mfem::Vector &p2, const mfem::ParGridFunction &field,
+                           int quad_order)
+{
+#if defined(MFEM_USE_GSLIB)
+  // As ComputeLineIntegral, but reuses a pre-Setup point locator (op.Setup already called
+  // on the field's mesh). Avoids rebuilding the GSLIB spatial hash on every call — the
+  // dominant cost when integrating repeatedly on a fixed mesh.
+  return LineIntegralCore(
+      p1, p2, field, quad_order, [&op, &field](const mfem::Vector &xyz, mfem::Vector &vals)
+      { InterpolateFunction(op, xyz, field, vals, mfem::Ordering::byNODES); });
 #else
   MFEM_ABORT("ComputeLineIntegral requires MFEM_USE_GSLIB!");
   return 0.0;

--- a/palace/fem/interpolator.hpp
+++ b/palace/fem/interpolator.hpp
@@ -10,6 +10,17 @@
 #include <mfem.hpp>
 #include "utils/configfile.hpp"
 
+namespace mfem
+{
+
+// Forward declaration so the GSLIB point-locator interpolation helpers below can be
+// declared unconditionally (matching the other functions in this header, which gate only
+// their definitions on MFEM_USE_GSLIB). The type is fully defined by <mfem.hpp> when GSLIB
+// is enabled; without it, only this declaration exists and the functions abort at runtime.
+class FindPointsGSLIB;
+
+}  // namespace mfem
+
 namespace palace
 {
 
@@ -62,6 +73,23 @@ void InterpolateFunction(const mfem::Vector &xyz, const mfem::GridFunction &U,
 // quadrature of the specified order on [0,1]. Returns the scalar integral value.
 double ComputeLineIntegral(const mfem::Vector &p1, const mfem::Vector &p2,
                            const mfem::ParGridFunction &field, int quad_order);
+
+// Setup a reusable GSLIB point locator on a fixed mesh. The geometric Setup is the
+// expensive step (builds a spatial hash over all elements) and depends only on the mesh,
+// so callers that interpolate repeatedly on it (e.g. wave-port voltage-path line integrals
+// over a frequency sweep) should Setup once and reuse the operator via the overloads below.
+// Requires MFEM_USE_GSLIB.
+void SetupInterpolator(mfem::FindPointsGSLIB &op, mfem::Mesh &mesh);
+
+// As above, but using a pre-Setup point locator (op.Setup already called on U's mesh).
+void InterpolateFunction(mfem::FindPointsGSLIB &op, const mfem::Vector &xyz,
+                         const mfem::GridFunction &U, mfem::Vector &V,
+                         mfem::Ordering::Type ordering = mfem::Ordering::byNODES);
+
+// As ComputeLineIntegral, but reusing a pre-Setup point locator.
+double ComputeLineIntegral(mfem::FindPointsGSLIB &op, const mfem::Vector &p1,
+                           const mfem::Vector &p2, const mfem::ParGridFunction &field,
+                           int quad_order);
 
 }  // namespace fem
 

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -599,6 +599,17 @@ WavePortData::WavePortData(const config::WavePortData &data,
     parent_E0t = std::make_unique<GridFunction>(nd_fespace, true);
     port_nd_transfer_reverse = std::make_unique<mfem::ParTransferMap>(
         mfem::ParSubMesh::CreateTransferMap(port_E0t->Real(), parent_E0t->Real()));
+
+#if defined(MFEM_USE_GSLIB)
+    // Build the GSLIB point locator on the (fixed) parent mesh once here.
+    // GetExcitationVoltage reuses it for every line integral instead of rebuilding the
+    // spatial hash per call — the dominant cost when the mode is evaluated at many
+    // frequencies (e.g. synthesis fit).
+    auto &parent_mesh = *parent_E0t->Real().FESpace()->GetMesh();
+    voltage_gslib_op =
+        std::make_unique<mfem::FindPointsGSLIB>(parent_E0t->Real().ParFESpace()->GetComm());
+    fem::SetupInterpolator(*voltage_gslib_op, parent_mesh);
+#endif
   }
 
   // Store polarity attributes [high, low]. The config parser enforces that this is
@@ -940,13 +951,20 @@ std::complex<double> WavePortData::GetVoltage(GridFunction &E) const
   MFEM_VERIFY(E.HasImag(),
               "Wave ports expect complex-valued E field in port voltage calculation!");
   std::complex<double> V(0.0, 0.0);
+#if defined(MFEM_USE_GSLIB)
+  // Reuse the cached point locator: E lives on the same parent mesh the op was Setup on.
   for (std::size_t k = 0; k + 1 < voltage_path.size(); k++)
   {
-    V.real(V.real() + fem::ComputeLineIntegral(voltage_path[k], voltage_path[k + 1],
-                                               E.Real(), voltage_n_samples));
-    V.imag(V.imag() + fem::ComputeLineIntegral(voltage_path[k], voltage_path[k + 1],
-                                               E.Imag(), voltage_n_samples));
+    V.real(V.real() + fem::ComputeLineIntegral(*voltage_gslib_op, voltage_path[k],
+                                               voltage_path[k + 1], E.Real(),
+                                               voltage_n_samples));
+    V.imag(V.imag() + fem::ComputeLineIntegral(*voltage_gslib_op, voltage_path[k],
+                                               voltage_path[k + 1], E.Imag(),
+                                               voltage_n_samples));
   }
+#else
+  MFEM_ABORT("Wave port VoltagePath computation requires MFEM_USE_GSLIB!");
+#endif
   return V;
 }
 
@@ -964,13 +982,22 @@ std::complex<double> WavePortData::GetExcitationVoltage() const
   port_nd_transfer_reverse->Transfer(port_E0t->Real(), parent_E0t->Real());
   port_nd_transfer_reverse->Transfer(port_E0t->Imag(), parent_E0t->Imag());
   std::complex<double> V(0.0, 0.0);
+#if defined(MFEM_USE_GSLIB)
+  // Reuse the cached point locator (Setup once at construction) — the GSLIB spatial hash
+  // depends only on the parent mesh, not the transferred field values. (Line integrals
+  // require GSLIB regardless; the cached locator just avoids rebuilding the hash per call.)
   for (std::size_t k = 0; k + 1 < voltage_path.size(); k++)
   {
-    V.real(V.real() + fem::ComputeLineIntegral(voltage_path[k], voltage_path[k + 1],
-                                               parent_E0t->Real(), voltage_n_samples));
-    V.imag(V.imag() + fem::ComputeLineIntegral(voltage_path[k], voltage_path[k + 1],
-                                               parent_E0t->Imag(), voltage_n_samples));
+    V.real(V.real() + fem::ComputeLineIntegral(*voltage_gslib_op, voltage_path[k],
+                                               voltage_path[k + 1], parent_E0t->Real(),
+                                               voltage_n_samples));
+    V.imag(V.imag() + fem::ComputeLineIntegral(*voltage_gslib_op, voltage_path[k],
+                                               voltage_path[k + 1], parent_E0t->Imag(),
+                                               voltage_n_samples));
   }
+#else
+  MFEM_ABORT("Wave port VoltagePath computation requires MFEM_USE_GSLIB!");
+#endif
   return V;
 }
 

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -112,6 +112,15 @@ private:
   std::unique_ptr<mfem::ParTransferMap> port_nd_transfer_reverse;
   std::unique_ptr<GridFunction> parent_E0t;
 
+  // Cached GSLIB point locator for the voltage-path line integrals, Setup once on the
+  // (fixed) parent mesh. The geometric Setup is the dominant cost, so reusing it across
+  // every Initialize() avoids an O(num_elements) hash rebuild per frequency — critical for
+  // the circuit-synthesis dispersion fit, which evaluates the mode at many frequencies.
+  // Only allocated if the user configured a voltage path.
+#if defined(MFEM_USE_GSLIB)
+  std::unique_ptr<mfem::FindPointsGSLIB> voltage_gslib_op;
+#endif
+
   // Optional polarity attributes (parent-mesh boundary attrs [high, low], signal
   // first, ground second). When non-zero (i.e. set by the user) the mode is flipped
   // so that E points from high to low, matching the lumped-port `+R Direction`


### PR DESCRIPTION
`WavePortData::GetExcitationVoltage` / `GetVoltage` compute the mode voltage as a line integral along the configured `VoltagePath`, evaluated via GSLIB point interpolation on the 3D parent mesh. The underlying `fem::ComputeLineIntegral` -> `InterpolateFunction` built a fresh `mfem::FindPointsGSLIB` and called `Setup()` on every invocation. That `Setup` is the expensive step — it builds a spatial hash over all parent-mesh elements (O(num_elements)) — and it depends only on the mesh, not the field values, so rebuilding it per call is pure waste.

This PR creates the setup `FindPointsGSLIB` only once at the wave port construction and reuses it. This is a performance improvement for adaptive sweeps with wave ports, results and `VoltagePath` UI should be unchanged.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
