### PR TITLE
Fix bug in mesh cracking refinement on periodic meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The format of this changelog is based on
     [PR 727](https://github.com/awslabs/palace/pull/727).
   - Fixed a bug causing incorrect S-parameters when lumped port pairs have different R values
     [PR 743](https://github.com/awslabs/palace/pull/743).
+  - Fixed a bug where mesh cracking would fail on periodic meshes [PR 777](https://github.com/awslabs/palace/pull/777).
 
 ## [0.16.1] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,8 @@ The format of this changelog is based on
     [PR 727](https://github.com/awslabs/palace/pull/727).
   - Fixed a bug causing incorrect S-parameters when lumped port pairs have different R values
     [PR 743](https://github.com/awslabs/palace/pull/743).
-  - Fixed a bug where mesh cracking would fail on periodic meshes [PR 777](https://github.com/awslabs/palace/pull/777).
+  - Fixed a bug where mesh cracking refinement (`RefineCrackElements`) would fail on periodic meshes
+    [PR 777](https://github.com/awslabs/palace/pull/777).
 
 ## [0.16.1] - 2026-04-24
 

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -2290,6 +2290,317 @@ void SplitMeshElements(std::unique_ptr<mfem::Mesh> &orig_mesh, bool make_simplex
   orig_mesh->FinalizeTopology();
 }
 
+// Conformally bisect a set of mesh edges by inserting a midpoint on each and splitting
+// every tetrahedron and boundary element incident on a split edge into two. Unlike
+// mfem::Mesh::GeneralRefinement, this performs a purely local edge-fan split with no
+// marked-edge/longest-edge selection and no global conformity-closure propagation. This is
+// essential for periodic meshes: MFEM's conforming bisection keys the new midpoint on the
+// collapsed vertex pair and cannot keep the two periodic copies of a seam edge consistent,
+// which corrupts the seam (aborting later in STable3D). A local edge-fan split touches only
+// the ring of elements around each edge, leaving the rest of the mesh (and the periodic
+// identification) untouched. The inserted midpoints are later duplicated by the regular
+// interior-boundary cracking pass, which decouples the two sides of the crack.
+//
+// To split many edges in a single mesh rebuild (rather than one expensive rebuild per
+// edge), a maximal independent subset of the candidate edges is selected such that no
+// tetrahedron contains more than one selected edge; this keeps the per-element split simple
+// (each affected tet/triangle bisects into exactly two children) while processing many edges
+// at once. The caller re-invokes (via the AddInterfaceBdrElements retry loop) to handle any
+// candidates not selected in this pass. Returns the number of edges split (0 if none).
+template <typename EdgeContainer>
+int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &edges)
+{
+  // Only pure tetrahedral meshes are supported (matching the previous refinement path,
+  // which marked and bisected only TETRAHEDRON elements). The caller invokes
+  // SplitMeshElements(make_simplex=true) immediately before reaching here, so any
+  // hexahedral/prism mesh has already been converted to tetrahedra; this guard makes that
+  // contract explicit rather than relying on the upstream conversion.
+  MFEM_VERIFY(orig_mesh->Dimension() == 3, "LocalEdgeSplit only supports 3D meshes!");
+  {
+    const auto element_types = mesh::CheckElements(*orig_mesh);
+    MFEM_VERIFY(element_types.has_simplices && !element_types.has_hexahedra &&
+                    !element_types.has_prisms && !element_types.has_pyramids,
+                "LocalEdgeSplit only supports pure tetrahedral meshes!");
+  }
+  if (edges.empty())
+  {
+    return 0;
+  }
+
+  std::unique_ptr<mfem::Table> vert_to_elem(orig_mesh->GetVertexToElementTable());
+  auto edge_ring = [&](int v0, int v1)
+  {
+    const int *e0 = vert_to_elem->GetRow(v0);
+    std::unordered_set<int> at_v0(e0, e0 + vert_to_elem->RowSize(v0));
+    std::vector<int> ring;
+    const int *e1 = vert_to_elem->GetRow(v1);
+    for (int i = 0; i < vert_to_elem->RowSize(v1); i++)
+    {
+      if (at_v0.find(e1[i]) != at_v0.end())
+      {
+        ring.push_back(e1[i]);
+      }
+    }
+    return ring;
+  };
+
+  // Select a maximal independent set of candidate edges: greedily accept an edge only if
+  // none of the tetrahedra in its ring already belong to an accepted edge. Each accepted
+  // edge is assigned a unique midpoint vertex id (appended after the original vertices).
+  // Map from a sorted vertex pair to the midpoint vertex id. The ids are assigned in a
+  // second pass over the (sorted) map so that they increase in the same order the midpoint
+  // vertices are subsequently added via AddVertex below; assigning during the (input-order)
+  // selection loop would mismatch the id with the AddVertex order whenever the input edge
+  // order differs from the sorted-key order, corrupting midpoint coordinates.
+  std::map<std::pair<int, int>, int> edge_midpoint;
+  std::unordered_set<int> claimed_elem;
+  for (const auto &e : edges)
+  {
+    int v0 = e.first, v1 = e.second;
+    auto ring = edge_ring(v0, v1);
+    MFEM_VERIFY(!ring.empty(), "Edge to split has no incident elements!");
+    bool conflict = false;
+    for (int el : ring)
+    {
+      if (claimed_elem.find(el) != claimed_elem.end())
+      {
+        conflict = true;
+        break;
+      }
+    }
+    if (conflict)
+    {
+      continue;  // Defer to a subsequent pass
+    }
+    for (int el : ring)
+    {
+      claimed_elem.insert(el);
+    }
+    edge_midpoint[{std::min(v0, v1), std::max(v0, v1)}] = -1;  // id assigned below
+  }
+  const int num_split = static_cast<int>(edge_midpoint.size());
+  MFEM_VERIFY(num_split > 0, "Failed to select any edge to split!");
+  {
+    int v_mid = orig_mesh->GetNV();
+    for (auto &[edge, mid] : edge_midpoint)
+    {
+      mid = v_mid++;
+    }
+  }
+
+  // For each element / boundary element, find the (at most one, by independence) split edge
+  // it contains, returning the matching midpoint id and the local endpoint vertices, or -1.
+  auto find_split_edge = [&edge_midpoint](const int *v, int nv, const int (*edge_vert)[2],
+                                          int nedge, int &lv0, int &lv1)
+  {
+    for (int le = 0; le < nedge; le++)
+    {
+      int a = v[edge_vert[le][0]], b = v[edge_vert[le][1]];
+      auto it = edge_midpoint.find({std::min(a, b), std::max(a, b)});
+      if (it != edge_midpoint.end())
+      {
+        lv0 = edge_vert[le][0];
+        lv1 = edge_vert[le][1];
+        return it->second;
+      }
+    }
+    return -1;
+  };
+  static const int tet_edge_vert[6][2] = {{0, 1}, {1, 2}, {2, 0}, {0, 3}, {1, 3}, {2, 3}};
+  static const int tri_edge_vert[3][2] = {{0, 1}, {1, 2}, {2, 0}};
+
+  // Count split elements / boundary elements to size the new mesh.
+  int n_split_elem = 0, n_split_bdr = 0;
+  for (int e = 0; e < orig_mesh->GetNE(); e++)
+  {
+    int lv0, lv1;
+    if (find_split_edge(orig_mesh->GetElement(e)->GetVertices(), 4, tet_edge_vert, 6, lv0,
+                        lv1) >= 0)
+    {
+      n_split_elem++;
+    }
+  }
+  for (int be = 0; be < orig_mesh->GetNBE(); be++)
+  {
+    int lv0, lv1;
+    if (find_split_edge(orig_mesh->GetBdrElement(be)->GetVertices(), 3, tri_edge_vert, 3,
+                        lv0, lv1) >= 0)
+    {
+      n_split_bdr++;
+    }
+  }
+
+  const int new_nv = orig_mesh->GetNV() + num_split;
+  const int new_ne = orig_mesh->GetNE() + n_split_elem;
+  const int new_nbe = orig_mesh->GetNBE() + n_split_bdr;
+  auto new_mesh = std::make_unique<mfem::Mesh>(orig_mesh->Dimension(), new_nv, new_ne,
+                                               new_nbe, orig_mesh->SpaceDimension());
+  for (int v = 0; v < orig_mesh->GetNV(); v++)
+  {
+    new_mesh->AddVertex(orig_mesh->GetVertex(v));
+  }
+  // Midpoint coordinates (geometric average; curved geometry is fixed up below for
+  // high-order meshes via per-parent node synthesis). The map iteration order (sorted keys)
+  // matches the id assignment above, so the vertex AddVertex returns equals the stored id.
+  for (const auto &[edge, mid] : edge_midpoint)
+  {
+    double coord[3] = {0.0, 0.0, 0.0};
+    const double *c0 = orig_mesh->GetVertex(edge.first);
+    const double *c1 = orig_mesh->GetVertex(edge.second);
+    for (int d = 0; d < orig_mesh->SpaceDimension(); d++)
+    {
+      coord[d] = 0.5 * (c0[d] + c1[d]);
+    }
+    int added = new_mesh->AddVertex(coord);
+    MFEM_VERIFY(added == mid,
+                "Midpoint vertex id mismatch: AddVertex returned "
+                    << added << " but edge midpoint id is " << mid
+                    << "; vertex add order must match id assignment order!");
+  }
+
+  // Add elements: a tet containing a split edge bisects into two children (one per endpoint
+  // replaced by the midpoint); all others are copied unchanged.
+  for (int e = 0; e < orig_mesh->GetNE(); e++)
+  {
+    const int *v = orig_mesh->GetElement(e)->GetVertices();
+    int lv0, lv1;
+    int mid = find_split_edge(v, 4, tet_edge_vert, 6, lv0, lv1);
+    if (mid < 0)
+    {
+      new_mesh->AddElement(orig_mesh->GetElement(e)->Duplicate(new_mesh.get()));
+      continue;
+    }
+    int attr = orig_mesh->GetAttribute(e);
+    for (int child = 0; child < 2; child++)
+    {
+      int cv[4];
+      for (int i = 0; i < 4; i++)
+      {
+        cv[i] = (i == ((child == 0) ? lv0 : lv1)) ? mid : v[i];
+      }
+      new_mesh->AddTet(cv, attr);
+    }
+  }
+  for (int be = 0; be < orig_mesh->GetNBE(); be++)
+  {
+    const mfem::Element *bel = orig_mesh->GetBdrElement(be);
+    const int *bv = bel->GetVertices();
+    int lv0, lv1;
+    int mid = find_split_edge(bv, 3, tri_edge_vert, 3, lv0, lv1);
+    if (mid < 0)
+    {
+      new_mesh->AddBdrElement(bel->Duplicate(new_mesh.get()));
+      continue;
+    }
+    int attr = bel->GetAttribute();
+    for (int child = 0; child < 2; child++)
+    {
+      int cv[3];
+      for (int i = 0; i < 3; i++)
+      {
+        cv[i] = (i == ((child == 0) ? lv0 : lv1)) ? mid : bv[i];
+      }
+      new_mesh->AddBdrTriangle(cv, attr);
+    }
+  }
+
+  constexpr bool generate_bdr = false;
+  new_mesh->FinalizeTopology(generate_bdr);
+
+  // Synthesize high-order node coordinates for the split (child) elements, accounting for
+  // the change in element count. Unsplit elements transfer their nodes 1:1; each child of a
+  // split tet evaluates the parent's nodal field at the child's nodes mapped into the parent
+  // reference frame (same idiom as MeshTetToHex). For linear meshes (no Nodes) the geometric
+  // midpoint above is exact and nothing more is needed.
+  if (orig_mesh->GetNodes())
+  {
+    new_mesh->EnsureNodes();
+    auto *orig_fespace = orig_mesh->GetNodes()->FESpace();
+    new_mesh->SetCurvature(orig_fespace->GetMaxElementOrder(), orig_fespace->IsDGSpace(),
+                           orig_mesh->SpaceDimension(), orig_fespace->GetOrdering());
+    const int sdim = orig_mesh->SpaceDimension();
+    const auto *orig_FE = orig_fespace->GetTypicalFE();
+    const auto *child_FE = new_mesh->GetNodes()->FESpace()->GetTypicalFE();
+
+    // Reference-space vertex locations of a tetrahedron.
+    static const double ref_vert[4][3] = {
+        {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
+
+    mfem::Array<int> orig_dofs, child_dofs;
+    mfem::Vector dof_vals(orig_FE->GetDof() * sdim);
+    mfem::DenseMatrix dof_vals_mat(dof_vals.GetData(), orig_FE->GetDof(), sdim);
+    mfem::DenseMatrix shape(orig_FE->GetDof(), child_FE->GetDof());
+    mfem::DenseMatrix point_matrix(child_FE->GetDof(), sdim);
+    mfem::Vector col;
+
+    int new_e = 0;
+    for (int e = 0; e < orig_mesh->GetNE(); e++)
+    {
+      const int *v = orig_mesh->GetElement(e)->GetVertices();
+      int lv0, lv1;
+      int mid = find_split_edge(v, 4, tet_edge_vert, 6, lv0, lv1);
+      if (mid < 0)
+      {
+        // Unsplit: copy nodes directly.
+        orig_fespace->GetElementVDofs(e, orig_dofs);
+        orig_mesh->GetNodes()->GetSubVector(orig_dofs, dof_vals);
+        new_mesh->GetNodes()->FESpace()->GetElementVDofs(new_e, child_dofs);
+        new_mesh->GetNodes()->SetSubVector(child_dofs, dof_vals);
+        new_e++;
+        continue;
+      }
+      // Split tet: the child replaces one endpoint of the split edge with the edge midpoint
+      // (reference midpoint of the two endpoint reference coordinates).
+      double ref_mid[3];
+      for (int d = 0; d < 3; d++)
+      {
+        ref_mid[d] = 0.5 * (ref_vert[lv0][d] + ref_vert[lv1][d]);
+      }
+      orig_mesh->GetNodes()->GetElementDofValues(e, dof_vals);
+      for (int child = 0; child < 2; child++)
+      {
+        double child_ref[4][3];
+        for (int i = 0; i < 4; i++)
+        {
+          for (int d = 0; d < 3; d++)
+          {
+            child_ref[i][d] = ref_vert[i][d];
+          }
+        }
+        int replace = (child == 0) ? lv0 : lv1;
+        for (int d = 0; d < 3; d++)
+        {
+          child_ref[replace][d] = ref_mid[d];
+        }
+        for (int j = 0; j < child_FE->GetNodes().Size(); j++)
+        {
+          const auto &cn = child_FE->GetNodes()[j];
+          mfem::IntegrationPoint ip;
+          double L0 = 1.0 - cn.x - cn.y - cn.z, L1 = cn.x, L2 = cn.y, L3 = cn.z;
+          double p[3];
+          for (int d = 0; d < 3; d++)
+          {
+            p[d] = L0 * child_ref[0][d] + L1 * child_ref[1][d] + L2 * child_ref[2][d] +
+                   L3 * child_ref[3][d];
+          }
+          ip.x = p[0];
+          ip.y = p[1];
+          ip.z = p[2];
+          shape.GetColumnReference(j, col);
+          orig_FE->CalcShape(ip, col);
+        }
+        MultAtB(shape, dof_vals_mat, point_matrix);
+        new_mesh->GetNodes()->FESpace()->GetElementVDofs(new_e, child_dofs);
+        new_mesh->GetNodes()->SetSubVector(child_dofs, point_matrix.GetData());
+        new_e++;
+      }
+    }
+  }
+
+  orig_mesh = std::move(new_mesh);
+  return num_split;
+}
+
 void ReorderMeshElements(mfem::Mesh &mesh, bool print)
 {
   mfem::Array<int> ordering;
@@ -2408,69 +2719,6 @@ std::unordered_map<int, int> CheckMesh(const mfem::Mesh &mesh,
   }
   return face_to_be;
 }
-
-template <typename T>
-class EdgeRefinementMesh : public mfem::Mesh
-{
-private:
-  // Container with keys being pairs of vertex indices (match row/column indices of v_to_v)
-  // of edges which we desire to be refined.
-  const T &refinement_edges;
-
-  void MarkTetMeshForRefinement(const mfem::DSTable &v_to_v) override
-  {
-    // The standard tetrahedral refinement in MFEM is to mark the longest edge of each tet
-    // for the first refinement. We hack this marking here in order to prioritize refinement
-    // of edges which are part of internal boundary faces being marked for refinement. This
-    // should hopefully limit the amount of extra refinement required to ensure conformity
-    // after the marked elements are refined. Marking will then discover only the longest
-    // edges, which are those within the boundary to be cracked.
-    mfem::Array<mfem::real_t> lengths;
-    GetEdgeLengths2(v_to_v, lengths);
-    const auto min_length = 0.01 * lengths.Min();
-    for (int i = 0; i < v_to_v.NumberOfRows(); i++)
-    {
-      for (mfem::DSTable::RowIterator it(v_to_v, i); !it; ++it)
-      {
-        int j = it.Column();
-        if (refinement_edges.find({i, j}) == refinement_edges.end())
-        {
-          // "Zero" the edge lengths which do not connect vertices on the interface. Avoid
-          // zero-length edges just in case.
-          lengths[it.Index()] = min_length;
-        }
-      }
-    }
-
-    // Finish marking (see mfem::Mesh::MarkTetMeshForRefinement).
-    mfem::Array<int> indices(NumOfEdges);
-    std::iota(indices.begin(), indices.end(), 0);
-    for (int i = 0; i < NumOfElements; i++)
-    {
-      if (elements[i]->GetType() == mfem::Element::TETRAHEDRON)
-      {
-        MFEM_ASSERT(dynamic_cast<mfem::Tetrahedron *>(elements[i]),
-                    "Unexpected non-Tetrahedron element type!");
-        static_cast<mfem::Tetrahedron *>(elements[i])->MarkEdge(v_to_v, lengths, indices);
-      }
-    }
-    for (int i = 0; i < NumOfBdrElements; i++)
-    {
-      if (boundary[i]->GetType() == mfem::Element::TRIANGLE)
-      {
-        MFEM_ASSERT(dynamic_cast<mfem::Triangle *>(boundary[i]),
-                    "Unexpected non-Triangle element type!");
-        static_cast<mfem::Triangle *>(boundary[i])->MarkEdge(v_to_v, lengths, indices);
-      }
-    }
-  }
-
-public:
-  EdgeRefinementMesh(mfem::Mesh &&mesh, const T &refinement_edges)
-    : mfem::Mesh(std::move(mesh)), refinement_edges(refinement_edges)
-  {
-  }
-};
 
 template <typename T>
 struct UnorderedPair
@@ -2731,14 +2979,17 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
       static int new_ref_its = 0;
       if (!coarse_crack_edge_to_be.empty())
       {
-        // Locally refine the mesh using conformal refinement. If necessary, convert the
-        // mesh to simplices first to enable conforming refinement (this will do nothing
-        // if the mesh is already a simplex mesh).
-        // Note: Eventually we can implement manual conforming face refinement of pairs of
-        // elements sharing a face for all element types (insert a vertex at the boundary
-        // element center and connect it to all other element vertices). For now, this adds
-        // complexity and making use of conformal simplex refinement seems good enough for
-        // most use cases.
+        // Locally refine the mesh to decouple the under-resolved seam edges. If necessary,
+        // convert the mesh to simplices first (this will do nothing if the mesh is already
+        // a simplex mesh). We use a manual, purely local edge-fan bisection
+        // (LocalEdgeSplit) rather than mfem::Mesh::GeneralRefinement: the latter uses
+        // marked-edge bisection with global conformity closure that keys new midpoints on
+        // collapsed vertex pairs, which corrupts the seam of a periodic mesh (the two
+        // periodic copies of an identified seam edge cannot be kept consistent, aborting
+        // later in STable3D). A local edge-fan split touches only the ring of elements
+        // around each edge, works identically for non-periodic and periodic (MakePeriodic
+        // or gmsh-$Periodic) meshes, and the inserted midpoints are decoupled by the
+        // regular cracking pass on the subsequent retry.
         int ne = orig_mesh->GetNE();
         SplitMeshElements(orig_mesh, true, false);
         if (ne != orig_mesh->GetNE())
@@ -2746,50 +2997,35 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           face_to_be.clear();
           return 0;  // Mesh was converted to simplices, start over
         }
-        std::unordered_map<int, int> elem_to_refine;
+        // Guard against non-convergence: each pass splits an independent subset of the
+        // flagged seam bridge edges, which removes them (and creates no new flagged edges)
+        // once the inserted midpoints are duplicated by cracking. If a crack runs *along* a
+        // periodic seam (rather than crossing it) the two sides cannot be decoupled by edge
+        // splitting, and bisecting a bridge edge would just create two new bridge edges,
+        // looping forever. Bound the number of refinement iterations and abort cleanly with
+        // an actionable message rather than splitting indefinitely (or silently producing a
+        // coupled mesh).
+        MFEM_VERIFY(
+            new_ref_its < 100,
+            "Unable to decouple interior boundary by local refinement after "
+                << new_ref_its
+                << " iterations. The cracked boundary likely runs along a periodic seam, "
+                   "which is not supported. Set \"RefineCrackElements\": false to crack "
+                   "without refinement (the seam edge will remain coupled).");
+        // Split a maximal independent subset of the flagged seam edges in one mesh rebuild;
+        // the outer retry loop re-detects and handles any edges deferred this pass. Vertex
+        // indices are stable across the split (only new vertices/elements are appended).
+        std::vector<std::pair<int, int>> split_edges;
+        split_edges.reserve(coarse_crack_edge_to_be.size());
         for (const auto &[edge, adjacent_be] : coarse_crack_edge_to_be)
         {
-          for (auto be : adjacent_be)
-          {
-            int f, o, e1, e2;
-            orig_mesh->GetBdrElementFace(be, &f, &o);
-            orig_mesh->GetFaceElements(f, &e1, &e2);
-            MFEM_ASSERT(e1 >= 0 && e2 >= 0,
-                        "Invalid internal boundary element connectivity!");
-            elem_to_refine[e1]++;  // Value-initialized to 0 at first access
-            elem_to_refine[e2]++;
-          }
+          split_edges.emplace_back(edge.first, edge.second);
         }
-        mfem::Array<mfem::Refinement> refinements;
-        refinements.Reserve(elem_to_refine.size());
-        for (const auto &[e, count] : elem_to_refine)
-        {
-          // Tetrahedral bisection (vs. default octasection) will result in fewer added
-          // elements at the cost of a potential minor mesh quality degradation.
-          refinements.Append(mfem::Refinement(e, mfem::Refinement::X));
-          // refinements.Append(mfem::Refinement(e, (count > 1) ? mfem::Refinement::XY
-          //                                                    : mfem::Refinement::X));
-        }
-        if (mesh::CheckElements(*orig_mesh).has_simplices)
-        {
-          // Mark tetrahedral mesh for refinement before doing local refinement. This is a
-          // bit of a strange pattern to override the standard conforming refinement of the
-          // mfem::Mesh class. We want to implement our own edge marking of the tetrahedra,
-          // so we move the mesh to a constructed derived class object, mark it, and then
-          // move assign it to the original base class object before refining. All of these
-          // moves should be cheap without any extra memory allocation. Also, we mark the
-          // mesh every time to ensure multiple rounds of refinement target the interior
-          // boundary (we don't care about preserving the refinement hierarchy).
-          constexpr bool refine = true, fix_orientation = false;
-          EdgeRefinementMesh ref_mesh(std::move(*orig_mesh), coarse_crack_edge_to_be);
-          ref_mesh.Finalize(refine, fix_orientation);
-          *orig_mesh = std::move(ref_mesh);
-        }
-        orig_mesh->GeneralRefinement(refinements, 0);
+        LocalEdgeSplit(orig_mesh, split_edges);
         new_ne_ref += orig_mesh->GetNE() - ne;
         new_ref_its++;
         face_to_be.clear();
-        return 0;  // Mesh was refined (conformally), start over
+        return 0;  // Mesh was refined (locally), start over
       }
       else if (new_ne_ref > 0)
       {

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -61,10 +61,17 @@ void ReorderMeshElements(mfem::Mesh &, bool = true);
 // Check that mesh boundary conditions are given for external boundaries.
 std::unordered_map<int, int> CheckMesh(const mfem::Mesh &, const config::BoundaryData &);
 
+struct CrackRefinementStats
+{
+  int new_ne = 0;
+  int iterations = 0;
+};
+
 // Adding boundary elements for material interfaces and exterior boundaries, and "crack"
 // desired internal boundary elements to disconnect the elements on either side.
 int AddInterfaceBdrElements(IoData &, std::unique_ptr<mfem::Mesh> &,
-                            std::unordered_map<int, int> &, MPI_Comm comm);
+                            std::unordered_map<int, int> &, CrackRefinementStats &,
+                            MPI_Comm comm);
 
 // Generate element-based mesh partitioning, using either a provided file or METIS.
 std::unique_ptr<int[]> GetMeshPartitioning(const mfem::Mesh &, int,
@@ -243,7 +250,9 @@ std::unique_ptr<mfem::Mesh> Load(IoData &iodata, MPI_Comm comm)
     auto face_to_be = CheckMesh(*smesh, iodata.boundaries);
     if (iodata.model.crack_bdr_elements || iodata.model.add_bdr_elements)
     {
-      while (AddInterfaceBdrElements(iodata, smesh, face_to_be, comm) != 1)
+      CrackRefinementStats crack_refinement_stats;
+      while (AddInterfaceBdrElements(iodata, smesh, face_to_be, crack_refinement_stats,
+                                     comm) != 1)
       {
         // May require multiple calls due to early exit/retry approach.
       }
@@ -2744,7 +2753,8 @@ struct UnorderedPairHasher
 };
 
 int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_mesh,
-                            std::unordered_map<int, int> &face_to_be, MPI_Comm comm)
+                            std::unordered_map<int, int> &face_to_be,
+                            CrackRefinementStats &crack_refinement_stats, MPI_Comm comm)
 {
   // Exclude some internal boundary conditions for which cracking would give invalid
   // results: lumpedports in particular.
@@ -2974,9 +2984,6 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           ++it;
         }
       }
-      // Static reporting variables so can persist across retries.
-      static int new_ne_ref = 0;
-      static int new_ref_its = 0;
       if (!coarse_crack_edge_to_be.empty())
       {
         // Locally refine the mesh to decouple the under-resolved seam edges. If necessary,
@@ -3006,9 +3013,9 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
         // an actionable message rather than splitting indefinitely (or silently producing a
         // coupled mesh).
         MFEM_VERIFY(
-            new_ref_its < 100,
+            crack_refinement_stats.iterations < 100,
             "Unable to decouple interior boundary by local refinement after "
-                << new_ref_its
+                << crack_refinement_stats.iterations
                 << " iterations. The cracked boundary likely runs along a periodic seam, "
                    "which is not supported. Set \"RefineCrackElements\": false to crack "
                    "without refinement (the seam edge will remain coupled).");
@@ -3022,17 +3029,17 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           split_edges.emplace_back(edge.first, edge.second);
         }
         LocalEdgeSplit(orig_mesh, split_edges);
-        new_ne_ref += orig_mesh->GetNE() - ne;
-        new_ref_its++;
+        crack_refinement_stats.new_ne += orig_mesh->GetNE() - ne;
+        crack_refinement_stats.iterations++;
         face_to_be.clear();
         return 0;  // Mesh was refined (locally), start over
       }
-      else if (new_ne_ref > 0)
+      else if (crack_refinement_stats.new_ne > 0)
       {
         Mpi::Print(
             "Added {:d} elements in {:d} iterations of local bisection for under-resolved "
             "interior boundaries\n",
-            new_ne_ref, new_ref_its);
+            crack_refinement_stats.new_ne, crack_refinement_stats.iterations);
       }
     }
 

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -182,6 +182,10 @@ std::unique_ptr<mfem::Mesh> Load(IoData &iodata, MPI_Comm comm)
               "If there are pyramid elements, AMR must be nonconformal!");
   MFEM_VERIFY(smesh->Conforming() || !use_amr || refinement.nonconformal,
               "The provided mesh is nonconformal, only nonconformal AMR can be performed!");
+  MFEM_VERIFY(iodata.boundaries.periodic.boundary_pairs.empty() || !use_amr ||
+                  refinement.nonconformal,
+              "Conformal mesh refinement is not supported on periodic meshes; set "
+              "\"Refinement\"/\"Nonconformal\": true to refine a periodic mesh!");
 
   // Clean up unused domain elements from the mesh.
   if (iodata.model.clean_unused_elements)
@@ -2290,6 +2294,11 @@ void SplitMeshElements(std::unique_ptr<mfem::Mesh> &orig_mesh, bool make_simplex
   orig_mesh->FinalizeTopology();
 }
 
+}  // namespace
+
+namespace mesh
+{
+
 // Conformally bisect a set of mesh edges by inserting a midpoint on each and splitting
 // every tetrahedron and boundary element incident on a split edge into two. Unlike
 // mfem::Mesh::GeneralRefinement, this performs a purely local edge-fan split with no
@@ -2308,8 +2317,8 @@ void SplitMeshElements(std::unique_ptr<mfem::Mesh> &orig_mesh, bool make_simplex
 // edges at once. The caller re-invokes (via the AddInterfaceBdrElements retry loop) to
 // handle any candidates not selected in this pass. Returns the number of edges split (0 if
 // none).
-template <typename EdgeContainer>
-int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &edges)
+int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh,
+                   const std::vector<std::pair<int, int>> &edges)
 {
   // Only pure tetrahedral meshes are supported (matching the previous refinement path,
   // which marked and bisected only TETRAHEDRON elements). The caller invokes
@@ -2600,6 +2609,11 @@ int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &
   orig_mesh = std::move(new_mesh);
   return num_split;
 }
+
+}  // namespace mesh
+
+namespace
+{
 
 void ReorderMeshElements(mfem::Mesh &mesh, bool print)
 {
@@ -3111,7 +3125,7 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           {
             split_edges.emplace_back(edge.first, edge.second);
           }
-          LocalEdgeSplit(orig_mesh, split_edges);
+          mesh::LocalEdgeSplit(orig_mesh, split_edges);
         }
         new_ne_ref += orig_mesh->GetNE() - ne;
         new_ref_its++;

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -2388,7 +2388,7 @@ int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh,
 
   // For each element / boundary element, find the (at most one, by independence) split edge
   // it contains, returning the matching midpoint id and the local endpoint vertices, or -1.
-  auto find_split_edge = [&edge_midpoint](const int *v, int nv, const int (*edge_vert)[2],
+  auto find_split_edge = [&edge_midpoint](const int *v, int nv, const int(*edge_vert)[2],
                                           int nedge, int &lv0, int &lv1)
   {
     for (int le = 0; le < nedge; le++)

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -61,17 +61,10 @@ void ReorderMeshElements(mfem::Mesh &, bool = true);
 // Check that mesh boundary conditions are given for external boundaries.
 std::unordered_map<int, int> CheckMesh(const mfem::Mesh &, const config::BoundaryData &);
 
-struct CrackRefinementStats
-{
-  int new_ne = 0;
-  int iterations = 0;
-};
-
 // Adding boundary elements for material interfaces and exterior boundaries, and "crack"
 // desired internal boundary elements to disconnect the elements on either side.
 int AddInterfaceBdrElements(IoData &, std::unique_ptr<mfem::Mesh> &,
-                            std::unordered_map<int, int> &, CrackRefinementStats &,
-                            MPI_Comm comm);
+                            std::unordered_map<int, int> &, MPI_Comm comm);
 
 // Generate element-based mesh partitioning, using either a provided file or METIS.
 std::unique_ptr<int[]> GetMeshPartitioning(const mfem::Mesh &, int,
@@ -250,9 +243,7 @@ std::unique_ptr<mfem::Mesh> Load(IoData &iodata, MPI_Comm comm)
     auto face_to_be = CheckMesh(*smesh, iodata.boundaries);
     if (iodata.model.crack_bdr_elements || iodata.model.add_bdr_elements)
     {
-      CrackRefinementStats crack_refinement_stats;
-      while (AddInterfaceBdrElements(iodata, smesh, face_to_be, crack_refinement_stats,
-                                     comm) != 1)
+      while (AddInterfaceBdrElements(iodata, smesh, face_to_be, comm) != 1)
       {
         // May require multiple calls due to early exit/retry approach.
       }
@@ -2313,9 +2304,10 @@ void SplitMeshElements(std::unique_ptr<mfem::Mesh> &orig_mesh, bool make_simplex
 // To split many edges in a single mesh rebuild (rather than one expensive rebuild per
 // edge), a maximal independent subset of the candidate edges is selected such that no
 // tetrahedron contains more than one selected edge; this keeps the per-element split simple
-// (each affected tet/triangle bisects into exactly two children) while processing many edges
-// at once. The caller re-invokes (via the AddInterfaceBdrElements retry loop) to handle any
-// candidates not selected in this pass. Returns the number of edges split (0 if none).
+// (each affected tet/triangle bisects into exactly two children) while processing many
+// edges at once. The caller re-invokes (via the AddInterfaceBdrElements retry loop) to
+// handle any candidates not selected in this pass. Returns the number of edges split (0 if
+// none).
 template <typename EdgeContainer>
 int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &edges)
 {
@@ -2461,10 +2453,9 @@ int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &
       coord[d] = 0.5 * (c0[d] + c1[d]);
     }
     int added = new_mesh->AddVertex(coord);
-    MFEM_VERIFY(added == mid,
-                "Midpoint vertex id mismatch: AddVertex returned "
-                    << added << " but edge midpoint id is " << mid
-                    << "; vertex add order must match id assignment order!");
+    MFEM_VERIFY(added == mid, "Midpoint vertex id mismatch: AddVertex returned "
+                                  << added << " but edge midpoint id is " << mid
+                                  << "; vertex add order must match id assignment order!");
   }
 
   // Add elements: a tet containing a split edge bisects into two children (one per endpoint
@@ -2518,9 +2509,9 @@ int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh, const EdgeContainer &
 
   // Synthesize high-order node coordinates for the split (child) elements, accounting for
   // the change in element count. Unsplit elements transfer their nodes 1:1; each child of a
-  // split tet evaluates the parent's nodal field at the child's nodes mapped into the parent
-  // reference frame (same idiom as MeshTetToHex). For linear meshes (no Nodes) the geometric
-  // midpoint above is exact and nothing more is needed.
+  // split tet evaluates the parent's nodal field at the child's nodes mapped into the
+  // parent reference frame (same idiom as MeshTetToHex). For linear meshes (no Nodes) the
+  // geometric midpoint above is exact and nothing more is needed.
   if (orig_mesh->GetNodes())
   {
     new_mesh->EnsureNodes();
@@ -2752,9 +2743,71 @@ struct UnorderedPairHasher
   }
 };
 
+template <typename T>
+class EdgeRefinementMesh : public mfem::Mesh
+{
+private:
+  // Container with keys being pairs of vertex indices (match row/column indices of v_to_v)
+  // of edges which we desire to be refined.
+  const T &refinement_edges;
+
+  void MarkTetMeshForRefinement(const mfem::DSTable &v_to_v) override
+  {
+    // The standard tetrahedral refinement in MFEM is to mark the longest edge of each tet
+    // for the first refinement. We hack this marking here in order to prioritize refinement
+    // of edges which are part of internal boundary faces being marked for refinement. This
+    // should hopefully limit the amount of extra refinement required to ensure conformity
+    // after the marked elements are refined. Marking will then discover only the longest
+    // edges, which are those within the boundary to be cracked.
+    mfem::Array<mfem::real_t> lengths;
+    GetEdgeLengths2(v_to_v, lengths);
+    const auto min_length = 0.01 * lengths.Min();
+    for (int i = 0; i < v_to_v.NumberOfRows(); i++)
+    {
+      for (mfem::DSTable::RowIterator it(v_to_v, i); !it; ++it)
+      {
+        int j = it.Column();
+        if (refinement_edges.find({i, j}) == refinement_edges.end())
+        {
+          // "Zero" the edge lengths which do not connect vertices on the interface. Avoid
+          // zero-length edges just in case.
+          lengths[it.Index()] = min_length;
+        }
+      }
+    }
+
+    // Finish marking (see mfem::Mesh::MarkTetMeshForRefinement).
+    mfem::Array<int> indices(NumOfEdges);
+    std::iota(indices.begin(), indices.end(), 0);
+    for (int i = 0; i < NumOfElements; i++)
+    {
+      if (elements[i]->GetType() == mfem::Element::TETRAHEDRON)
+      {
+        MFEM_ASSERT(dynamic_cast<mfem::Tetrahedron *>(elements[i]),
+                    "Unexpected non-Tetrahedron element type!");
+        static_cast<mfem::Tetrahedron *>(elements[i])->MarkEdge(v_to_v, lengths, indices);
+      }
+    }
+    for (int i = 0; i < NumOfBdrElements; i++)
+    {
+      if (boundary[i]->GetType() == mfem::Element::TRIANGLE)
+      {
+        MFEM_ASSERT(dynamic_cast<mfem::Triangle *>(boundary[i]),
+                    "Unexpected non-Triangle element type!");
+        static_cast<mfem::Triangle *>(boundary[i])->MarkEdge(v_to_v, lengths, indices);
+      }
+    }
+  }
+
+public:
+  EdgeRefinementMesh(mfem::Mesh &&mesh, const T &refinement_edges)
+    : mfem::Mesh(std::move(mesh)), refinement_edges(refinement_edges)
+  {
+  }
+};
+
 int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_mesh,
-                            std::unordered_map<int, int> &face_to_be,
-                            CrackRefinementStats &crack_refinement_stats, MPI_Comm comm)
+                            std::unordered_map<int, int> &face_to_be, MPI_Comm comm)
 {
   // Exclude some internal boundary conditions for which cracking would give invalid
   // results: lumpedports in particular.
@@ -2984,19 +3037,14 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           ++it;
         }
       }
+      // Static reporting variables so can persist across retries.
+      static int new_ne_ref = 0;
+      static int new_ref_its = 0;
       if (!coarse_crack_edge_to_be.empty())
       {
         // Locally refine the mesh to decouple the under-resolved seam edges. If necessary,
-        // convert the mesh to simplices first (this will do nothing if the mesh is already
-        // a simplex mesh). We use a manual, purely local edge-fan bisection
-        // (LocalEdgeSplit) rather than mfem::Mesh::GeneralRefinement: the latter uses
-        // marked-edge bisection with global conformity closure that keys new midpoints on
-        // collapsed vertex pairs, which corrupts the seam of a periodic mesh (the two
-        // periodic copies of an identified seam edge cannot be kept consistent, aborting
-        // later in STable3D). A local edge-fan split touches only the ring of elements
-        // around each edge, works identically for non-periodic and periodic (MakePeriodic
-        // or gmsh-$Periodic) meshes, and the inserted midpoints are decoupled by the
-        // regular cracking pass on the subsequent retry.
+        // convert the mesh to simplices first to enable conforming refinement (this will do
+        // nothing if the mesh is already a simplex mesh).
         int ne = orig_mesh->GetNE();
         SplitMeshElements(orig_mesh, true, false);
         if (ne != orig_mesh->GetNE())
@@ -3004,42 +3052,78 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
           face_to_be.clear();
           return 0;  // Mesh was converted to simplices, start over
         }
-        // Guard against non-convergence: each pass splits an independent subset of the
-        // flagged seam bridge edges, which removes them (and creates no new flagged edges)
-        // once the inserted midpoints are duplicated by cracking. If a crack runs *along* a
-        // periodic seam (rather than crossing it) the two sides cannot be decoupled by edge
-        // splitting, and bisecting a bridge edge would just create two new bridge edges,
-        // looping forever. Bound the number of refinement iterations and abort cleanly with
-        // an actionable message rather than splitting indefinitely (or silently producing a
-        // coupled mesh).
-        MFEM_VERIFY(
-            crack_refinement_stats.iterations < 100,
-            "Unable to decouple interior boundary by local refinement after "
-                << crack_refinement_stats.iterations
-                << " iterations. The cracked boundary likely runs along a periodic seam, "
-                   "which is not supported. Set \"RefineCrackElements\": false to crack "
-                   "without refinement (the seam edge will remain coupled).");
-        // Split a maximal independent subset of the flagged seam edges in one mesh rebuild;
-        // the outer retry loop re-detects and handles any edges deferred this pass. Vertex
-        // indices are stable across the split (only new vertices/elements are appended).
-        std::vector<std::pair<int, int>> split_edges;
-        split_edges.reserve(coarse_crack_edge_to_be.size());
-        for (const auto &[edge, adjacent_be] : coarse_crack_edge_to_be)
+        const bool periodic = !iodata.boundaries.periodic.boundary_pairs.empty();
+        if (!periodic)
         {
-          split_edges.emplace_back(edge.first, edge.second);
+          // Non-periodic mesh: use MFEM's marked-edge conforming refinement.
+          std::unordered_map<int, int> elem_to_refine;
+          for (const auto &[edge, adjacent_be] : coarse_crack_edge_to_be)
+          {
+            for (auto be : adjacent_be)
+            {
+              int f, o, e1, e2;
+              orig_mesh->GetBdrElementFace(be, &f, &o);
+              orig_mesh->GetFaceElements(f, &e1, &e2);
+              MFEM_ASSERT(e1 >= 0 && e2 >= 0,
+                          "Invalid internal boundary element connectivity!");
+              elem_to_refine[e1]++;  // Value-initialized to 0 at first access
+              elem_to_refine[e2]++;
+            }
+          }
+          mfem::Array<mfem::Refinement> refinements;
+          refinements.Reserve(elem_to_refine.size());
+          for (const auto &[e, count] : elem_to_refine)
+          {
+            // Tetrahedral bisection (vs. default octasection) will result in fewer added
+            // elements at the cost of a potential minor mesh quality degradation.
+            refinements.Append(mfem::Refinement(e, mfem::Refinement::X));
+          }
+          if (mesh::CheckElements(*orig_mesh).has_simplices)
+          {
+            // Mark tetrahedral mesh for refinement before doing local refinement. This is a
+            // bit of a strange pattern to override the standard conforming refinement of
+            // the mfem::Mesh class. We want to implement our own edge marking of the
+            // tetrahedra, so we move the mesh to a constructed derived class object, mark
+            // it, and then move assign it to the original base class object before
+            // refining. All of these moves should be cheap without any extra memory
+            // allocation. Also, we mark the mesh every time to ensure multiple rounds of
+            // refinement target the interior boundary (we don't care about preserving the
+            // refinement hierarchy).
+            constexpr bool refine = true, fix_orientation = false;
+            EdgeRefinementMesh ref_mesh(std::move(*orig_mesh), coarse_crack_edge_to_be);
+            ref_mesh.Finalize(refine, fix_orientation);
+            *orig_mesh = std::move(ref_mesh);
+          }
+          orig_mesh->GeneralRefinement(refinements, 0);
         }
-        LocalEdgeSplit(orig_mesh, split_edges);
-        crack_refinement_stats.new_ne += orig_mesh->GetNE() - ne;
-        crack_refinement_stats.iterations++;
+        else
+        {
+          // Periodic mesh: MFEM's GeneralRefinement keys new midpoints on the collapsed
+          // vertex pairs and cannot keep the two periodic copies of an identified seam edge
+          // consistent, corrupting the seam and aborting later in STable3D. Use a manual,
+          // purely local edge-fan bisection (LocalEdgeSplit) that touches only the ring of
+          // elements around each flagged edge with no global conformity closure, so the
+          // periodic seam is never disturbed. The inserted midpoints are decoupled by the
+          // regular cracking pass on the subsequent retry.
+          std::vector<std::pair<int, int>> split_edges;
+          split_edges.reserve(coarse_crack_edge_to_be.size());
+          for (const auto &[edge, adjacent_be] : coarse_crack_edge_to_be)
+          {
+            split_edges.emplace_back(edge.first, edge.second);
+          }
+          LocalEdgeSplit(orig_mesh, split_edges);
+        }
+        new_ne_ref += orig_mesh->GetNE() - ne;
+        new_ref_its++;
         face_to_be.clear();
-        return 0;  // Mesh was refined (locally), start over
+        return 0;  // Mesh was refined, start over
       }
-      else if (crack_refinement_stats.new_ne > 0)
+      else if (new_ne_ref > 0)
       {
         Mpi::Print(
             "Added {:d} elements in {:d} iterations of local bisection for under-resolved "
             "interior boundaries\n",
-            crack_refinement_stats.new_ne, crack_refinement_stats.iterations);
+            new_ne_ref, new_ref_its);
       }
     }
 

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -3044,9 +3044,9 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
       static int new_ref_its = 0;
       if (!coarse_crack_edge_to_be.empty())
       {
-        // Locally refine the mesh to decouple the under-resolved seam edges. If necessary,
-        // convert the mesh to simplices first to enable conforming refinement (this will do
-        // nothing if the mesh is already a simplex mesh).
+        // Locally refine the mesh using conformal refinement. If necessary, convert the
+        // mesh to simplices first to enable conforming refinement (this will do nothing
+        // if the mesh is already a simplex mesh).
         // Note: Eventually we can implement manual conforming face refinement of pairs of
         // elements sharing a face for all element types (insert a vertex at the boundary
         // element center and connect it to all other element vertices). For now, this adds

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -2437,7 +2437,7 @@ int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh,
   {
     new_mesh->AddVertex(orig_mesh->GetVertex(v));
   }
-  // Midpoint coordinates (geometric average; curved geometry is fixed up below for
+  // Midpoint coordinates (arithmetic average; curved geometry is fixed up below for
   // high-order meshes via per-parent node synthesis). The map iteration order (sorted keys)
   // matches the id assignment above, so the vertex AddVertex returns equals the stored id.
   for (const auto &[edge, mid] : edge_midpoint)

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -2309,22 +2309,10 @@ namespace mesh
 // the ring of elements around each edge, leaving the rest of the mesh (and the periodic
 // identification) untouched. The inserted midpoints are later duplicated by the regular
 // interior-boundary cracking pass, which decouples the two sides of the crack.
-//
-// To split many edges in a single mesh rebuild (rather than one expensive rebuild per
-// edge), a maximal independent subset of the candidate edges is selected such that no
-// tetrahedron contains more than one selected edge; this keeps the per-element split simple
-// (each affected tet/triangle bisects into exactly two children) while processing many
-// edges at once. The caller re-invokes (via the AddInterfaceBdrElements retry loop) to
-// handle any candidates not selected in this pass. Returns the number of edges split (0 if
-// none).
 int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &orig_mesh,
                    const std::vector<std::pair<int, int>> &edges)
 {
-  // Only pure tetrahedral meshes are supported (matching the previous refinement path,
-  // which marked and bisected only TETRAHEDRON elements). The caller invokes
-  // SplitMeshElements(make_simplex=true) immediately before reaching here, so any
-  // hexahedral/prism mesh has already been converted to tetrahedra; this guard makes that
-  // contract explicit rather than relying on the upstream conversion.
+  // Only pure tetrahedral meshes are supported.
   MFEM_VERIFY(orig_mesh->Dimension() == 3, "LocalEdgeSplit only supports 3D meshes!");
   {
     const auto element_types = mesh::CheckElements(*orig_mesh);
@@ -2735,29 +2723,6 @@ std::unordered_map<int, int> CheckMesh(const mfem::Mesh &mesh,
 }
 
 template <typename T>
-struct UnorderedPair
-{
-  T first, second;
-  UnorderedPair(T first, T second) : first(first), second(second) {}
-  bool operator==(const UnorderedPair &v) const
-  {
-    return ((v.first == first && v.second == second) ||
-            (v.first == second && v.second == first));
-  }
-};
-
-template <typename T>
-struct UnorderedPairHasher
-{
-  std::size_t operator()(const UnorderedPair<T> &v) const
-  {
-    // Simple hash function for a pair, see https://tinyurl.com/2k4phapb.
-    return std::hash<T>()(std::min(v.first, v.second)) ^
-           std::hash<T>()(std::max(v.first, v.second)) << 1;
-  }
-};
-
-template <typename T>
 class EdgeRefinementMesh : public mfem::Mesh
 {
 private:
@@ -2817,6 +2782,29 @@ public:
   EdgeRefinementMesh(mfem::Mesh &&mesh, const T &refinement_edges)
     : mfem::Mesh(std::move(mesh)), refinement_edges(refinement_edges)
   {
+  }
+};
+
+template <typename T>
+struct UnorderedPair
+{
+  T first, second;
+  UnorderedPair(T first, T second) : first(first), second(second) {}
+  bool operator==(const UnorderedPair &v) const
+  {
+    return ((v.first == first && v.second == second) ||
+            (v.first == second && v.second == first));
+  }
+};
+
+template <typename T>
+struct UnorderedPairHasher
+{
+  std::size_t operator()(const UnorderedPair<T> &v) const
+  {
+    // Simple hash function for a pair, see https://tinyurl.com/2k4phapb.
+    return std::hash<T>()(std::min(v.first, v.second)) ^
+           std::hash<T>()(std::max(v.first, v.second)) << 1;
   }
 };
 
@@ -3059,6 +3047,11 @@ int AddInterfaceBdrElements(IoData &iodata, std::unique_ptr<mfem::Mesh> &orig_me
         // Locally refine the mesh to decouple the under-resolved seam edges. If necessary,
         // convert the mesh to simplices first to enable conforming refinement (this will do
         // nothing if the mesh is already a simplex mesh).
+        // Note: Eventually we can implement manual conforming face refinement of pairs of
+        // elements sharing a face for all element types (insert a vertex at the boundary
+        // element center and connect it to all other element vertices). For now, this adds
+        // complexity and making use of conformal simplex refinement seems good enough for
+        // most use cases.
         int ne = orig_mesh->GetNE();
         SplitMeshElements(orig_mesh, true, false);
         if (ne != orig_mesh->GetNE())

--- a/palace/utils/geodata_impl.hpp
+++ b/palace/utils/geodata_impl.hpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <Eigen/Dense>
 #include <mfem.hpp>
@@ -82,6 +83,11 @@ std::vector<int>
 DeterminePeriodicVertexMapping(std::unique_ptr<mfem::Mesh> &mesh,
                                const struct palace::config::PeriodicData &data,
                                const double tol = 1e-8);
+
+// Conformally bisect the selected mesh edges by splitting each incident tetrahedron and
+// boundary triangle. Used by periodic crack refinement.
+int LocalEdgeSplit(std::unique_ptr<mfem::Mesh> &mesh,
+                   const std::vector<std::pair<int, int>> &edges);
 
 }  // namespace mesh
 

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <array>
+#include <memory>
+#include <utility>
 #include <vector>
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
@@ -23,6 +26,56 @@ namespace palace
 using json = nlohmann::json;
 namespace fs = std::filesystem;
 using namespace Catch::Matchers;
+
+namespace
+{
+
+std::unique_ptr<mfem::Mesh> TwoEdgeFanTetMesh()
+{
+  auto mesh = std::make_unique<mfem::Mesh>(3, 10, 4, 0, 3);
+
+  mesh->AddVertex(0.0, 0.0, 0.0);
+  mesh->AddVertex(1.0, 0.0, 0.0);
+  mesh->AddVertex(0.0, 1.0, 0.0);
+  mesh->AddVertex(0.0, 0.0, 1.0);
+  mesh->AddVertex(0.0, 0.0, -1.0);
+  mesh->AddVertex(10.0, 0.0, 0.0);
+  mesh->AddVertex(11.0, 0.0, 0.0);
+  mesh->AddVertex(10.0, 1.0, 0.0);
+  mesh->AddVertex(10.0, 0.0, 1.0);
+  mesh->AddVertex(10.0, 0.0, -1.0);
+
+  mesh->AddTet(0, 1, 2, 3, 1);
+  mesh->AddTet(0, 2, 1, 4, 1);
+  mesh->AddTet(5, 6, 7, 8, 1);
+  mesh->AddTet(5, 7, 6, 9, 1);
+  mesh->FinalizeTopology();
+  return mesh;
+}
+
+bool ElementContainsEdge(const mfem::Element &el, int v0, int v1)
+{
+  bool has_v0 = false, has_v1 = false;
+  const int *verts = el.GetVertices();
+  for (int i = 0; i < el.GetNVertices(); i++)
+  {
+    has_v0 = has_v0 || verts[i] == v0;
+    has_v1 = has_v1 || verts[i] == v1;
+  }
+  return has_v0 && has_v1;
+}
+
+void CheckVertex(const mfem::Mesh &mesh, int v, const std::array<double, 3> &coord)
+{
+  const double *actual = mesh.GetVertex(v);
+  for (int d = 0; d < 3; d++)
+  {
+    CAPTURE(v, d);
+    CHECK_THAT(actual[d], WithinAbs(coord[d], 1.0e-12));
+  }
+}
+
+}  // namespace
 
 // TODO: Add this test when we can access MFEM_DATA_PATH from Spack
 // This requires MFEM to move to a CMake-based build system for spack.
@@ -336,6 +389,47 @@ TEST_CASE("TetToHex", "[geodata][Serial]")
     }
   }
 #endif
+}
+
+TEST_CASE("LocalEdgeSplit", "[geodata][Serial]")
+{
+  auto mesh = TwoEdgeFanTetMesh();
+
+  REQUIRE(mesh->GetNV() == 10);
+  REQUIRE(mesh->GetNE() == 4);
+  REQUIRE(mesh->GetNBE() == 12);
+
+  const std::vector<std::pair<int, int>> split_edges{{5, 6}, {0, 1}};
+  REQUIRE(mesh::LocalEdgeSplit(mesh, split_edges) == 2);
+
+  CHECK(mesh->GetNV() == 12);
+  CHECK(mesh->GetNE() == 8);
+  CHECK(mesh->GetNBE() == 16);
+
+  CheckVertex(*mesh, 10, {0.5, 0.0, 0.0});
+  CheckVertex(*mesh, 11, {10.5, 0.0, 0.0});
+
+  for (int e = 0; e < mesh->GetNE(); e++)
+  {
+    CAPTURE(e);
+    CHECK(!ElementContainsEdge(*mesh->GetElement(e), 0, 1));
+    CHECK(!ElementContainsEdge(*mesh->GetElement(e), 5, 6));
+  }
+  for (int be = 0; be < mesh->GetNBE(); be++)
+  {
+    CAPTURE(be);
+    CHECK(!ElementContainsEdge(*mesh->GetBdrElement(be), 0, 1));
+    CHECK(!ElementContainsEdge(*mesh->GetBdrElement(be), 5, 6));
+
+    int f, o, e1, e2;
+    mesh->GetBdrElementFace(be, &f, &o);
+    mesh->GetFaceElements(f, &e1, &e2);
+    CAPTURE(f, e1, e2);
+    CHECK((e1 >= 0) != (e2 >= 0));
+  }
+
+  CHECK(mesh->CheckElementOrientation(false) == 0);
+  CHECK(mesh->CheckBdrElementOrientation(false) == 0);
 }
 
 TEST_CASE("PeriodicGmsh", "[geodata][Serial]")


### PR DESCRIPTION
Periodic meshes do not support conformal mesh refinement, but the cracking refinement (`RefineCrackElements`) uses MFEM's conformal refinement (`GeneralRefinement(refinements, 0)`), leading to errors such as:
```
MFEM abort: (r,c,f) = (...)
 ... in function: int mfem::STable3D::operator()(int, int, int) const
 ... in file: general/stable3d.cpp:112
```
when apply mesh cracking to some periodic meshes, as reported in #773. 

This PR implements a new `LocalEdgeSplit` function that bypasses MFEM's conformal refinement to perform a similar edge refinement/splitting strategy for periodic meshes with mesh cracking.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
