### PR TITLE
Fix bug in 2D magnetic energy density coefficient

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -547,7 +547,7 @@ jobs:
 
       - name: Run regression tests for examples/
         if: needs.filter.outputs.test == 'true' && !matrix.with-sanitizers
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           NUM_PROC_TEST_MAX: '8'
         run: |

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   # Filter to allow skipping the test if no relevant changes occurred.
   filter:
-    runs-on: macos-latest
+    runs-on: macos-15
     outputs:
       test: ${{ steps.filter.outputs.test }}
     steps:
@@ -123,7 +123,7 @@ jobs:
         #   with-eigensolver: slepc
         #   with-solver: strumpack
 
-    runs-on: macos-latest-xlarge
+    runs-on: macos-15-xlarge
     steps:
       - uses: actions/checkout@v6
         if: needs.filter.outputs.test == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ The format of this changelog is based on
     [PR 743](https://github.com/awslabs/palace/pull/743).
   - Fixed a bug where mesh cracking refinement (`RefineCrackElements`) would fail on periodic meshes
     [PR 777](https://github.com/awslabs/palace/pull/777).
+  - Fixed a bug where the magnetic energy field calculation in 2D simulations used the incorrect
+    permeability vector components [PR 782](https://github.com/awslabs/palace/pull/782).
 
 ## [0.16.1] - 2026-04-24
 

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -562,6 +562,22 @@ template <>
 inline double EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>::GetLocalEnergyDensity(
     mfem::ElementTransformation &T) const
 {
+  if (T.GetSpaceDim() == 2)
+  {
+    // In 2D, B is the scalar out-of-plane component Bz (L2). The magnetic energy density
+    // is 1/2 μ⁻¹_zz |Bz|², matching the integrated domain energy (which uses the scalar
+    // z-z permeability). Using GetVectorValue / the in-plane μ⁻¹ tensor here would read
+    // the wrong tensor component (and an uninitialized vector slot), so use the scalar
+    // field value and z-z permeability instead.
+    double Bz = U.Real().GetValue(T, T.GetIntPoint());
+    double dot = Bz * Bz;
+    if (U.HasImag())
+    {
+      Bz = U.Imag().GetValue(T, T.GetIntPoint());
+      dot += Bz * Bz;
+    }
+    return 0.5 * mat_op.GetInvPermeabilityZZ(T.Attribute) * dot * scaling;
+  }
   double V_data[3];
   mfem::Vector V(V_data, T.GetSpaceDim());
   U.Real().GetVectorValue(T, T.GetIntPoint(), V);

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -565,10 +565,7 @@ inline double EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>::GetLocalEne
   if (T.GetSpaceDim() == 2)
   {
     // In 2D, B is the scalar out-of-plane component Bz (L2). The magnetic energy density
-    // is 1/2 μ⁻¹_zz |Bz|², matching the integrated domain energy (which uses the scalar
-    // z-z permeability). Using GetVectorValue / the in-plane μ⁻¹ tensor here would read
-    // the wrong tensor component (and an uninitialized vector slot), so use the scalar
-    // field value and z-z permeability instead.
+    // is 1/2 μ⁻¹_zz |Bz|², matching the integrated domain energy.
     double Bz = U.Real().GetValue(T, T.GetIntPoint());
     double dot = Bz * Bz;
     if (U.HasImag())


### PR DESCRIPTION
Fixed a bug where the magnetic energy field calculation in 2D simulations used the incorrect permeability vector components.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
