### PR TITLE
[WIP] Wire Problem config through schema bridge

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -529,11 +529,15 @@ jobs:
 
       - name: Add coverage link to summary
         if: needs.filter.outputs.test == 'true' && matrix.with-coverage
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COVERAGE_URL="https://awslabs.github.io/palace/previews/PR${{ github.event.pull_request.number }}/coverage/"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            COVERAGE_URL="https://awslabs.github.io/palace/previews/PR${PR_NUMBER}/coverage/"
           else
-            COVERAGE_URL="https://awslabs.github.io/palace/coverage/${{ github.sha }}/"
+            COVERAGE_URL="https://awslabs.github.io/palace/coverage/${SHA}/"
           fi
           echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
           echo "View the coverage report at: [Coverage Report](${COVERAGE_URL})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,11 @@ jobs:
               - '.github/workflows/docs.yml'
       - name: Decide whether to build
         id: decide
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]] || [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_build=${{ steps.filter.outputs.test }}" >> "$GITHUB_OUTPUT"
@@ -198,15 +201,16 @@ jobs:
       - name: Build and deploy
         if: needs.filter.outputs.should_build == 'true'
         env:
+          DEPLOY_TAG: ${{ inputs.deploy_tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # For workflow_dispatch with deploy_tag, override the runner's immutable
           # GITHUB_* env vars so Documenter.jl sees a tag push.
-          if [[ -n "${{ inputs.deploy_tag }}" ]]; then
+          if [[ -n "${DEPLOY_TAG}" ]]; then
             export GITHUB_EVENT_NAME=push
-            export GITHUB_REF=refs/tags/${{ inputs.deploy_tag }}
+            export GITHUB_REF=refs/tags/"${DEPLOY_TAG}"
             export GITHUB_REF_TYPE=tag
-            export GITHUB_REF_NAME=${{ inputs.deploy_tag }}
+            export GITHUB_REF_NAME="${DEPLOY_TAG}"
           fi
           eval $(spack -e . load --sh palace)
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
@@ -216,8 +220,10 @@ jobs:
         if: >-
           needs.filter.outputs.should_build == 'true' &&
           (startsWith(github.ref, 'refs/tags/') || inputs.deploy_tag != '')
+        env:
+          TAG_REF: ${{ inputs.deploy_tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.deploy_tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           git fetch origin gh-pages --depth=1
           STABLE=$(git show origin/gh-pages:stable)

--- a/.github/workflows/long-test-status-manager.yml
+++ b/.github/workflows/long-test-status-manager.yml
@@ -57,12 +57,14 @@ jobs:
     steps:
       - name: Set bypass status for trivial changes
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests bypassed (trivial changes)"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Require long tests when non-trivial changes are detected
@@ -75,12 +77,14 @@ jobs:
     steps:
       - name: Set pending status for non-trivial changes
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=pending \
             --field context=long-tests \
             --field description="Waiting for long tests (add 'trigger-long-tests' label to run)"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Handle adding/removing 'no-long-tests' label
@@ -92,22 +96,26 @@ jobs:
       - name: Set bypass status
         if: github.event.action == 'labeled'
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests bypassed"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # When label is removed: require long tests again
       - name: Remove bypass status
         if: github.event.action == 'unlabeled'
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=pending \
             --field context=long-tests \
             --field description="Waiting for long tests (add 'trigger-long-tests' label to run)"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -55,21 +55,25 @@ jobs:
       - name: Set success status
         if: github.event_name == 'pull_request' && success()
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests passed"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set failure status
         if: github.event_name == 'pull_request' && (failure() || cancelled())
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api repos/"${REPO}"/statuses/"${HEAD_SHA}" \
             --method POST \
             --field state=failure \
             --field context=long-tests \
             --field description="Long tests failed"
         env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/palace/CMakeLists.txt
+++ b/palace/CMakeLists.txt
@@ -192,10 +192,10 @@ message(STATUS "Found nlohmann/json: ${nlohmann_json_VERSION} in ${nlohmann_json
 find_package(nlohmann_json_schema_validator REQUIRED CONFIG)
 message(STATUS "Found nlohmann_json_schema_validator: ${nlohmann_json_schema_validator_VERSION} in ${nlohmann_json_schema_validator_DIR}")
 
-# reflect-cpp: pulled in at build time only, consumed by the vendored
-# schema-emission helpers under palace/schema/cjs/ (used by the
-# palace_emit_schema helper target). Not linked into the runtime libpalace
-# in Phase 1.
+# reflect-cpp: consumed by the schema-emission helpers under palace/schema/
+# (palace_emit_schema) and, as of the Problem-section bridge, linked into the
+# runtime libpalace so utils/iodata.cpp can parse configuration into the schema
+# types via rfl::json::read.
 include(FetchContent)
 set(REFLECTCPP_JSON         ON  CACHE BOOL "" FORCE)
 set(REFLECTCPP_YAML         OFF CACHE BOOL "" FORCE)
@@ -448,7 +448,7 @@ endif()
 target_link_libraries(${LIB_TARGET_NAME}
   PUBLIC ${MFEM_LIBRARY} ${LIBCEED_TARGET} nlohmann_json::nlohmann_json
          nlohmann_json_schema_validator::validator fmt::fmt scn::scn
-         Eigen3::Eigen LAPACK::LAPACK MPI::MPI_CXX
+         Eigen3::Eigen LAPACK::LAPACK MPI::MPI_CXX reflectcpp
 )
 
 # Add MFEM include directory for Spack builds

--- a/palace/main.cpp
+++ b/palace/main.cpp
@@ -20,6 +20,7 @@
 #include "fem/mesh.hpp"
 #include "linalg/hypre.hpp"
 #include "linalg/slepc.hpp"
+#include "schema/types/config.hpp"
 #include "utils/communication.hpp"
 #include "utils/device.hpp"
 #include "utils/geodata.hpp"
@@ -217,7 +218,8 @@ int main(int argc, char *argv[])
     if (Mpi::Root(world_comm))
     {
       auto config = IoData::ParseAndValidate(argv[argc - 1]);
-      IoData iodata(config, false);
+      auto pconfig = IoData::ParsePalaceConfiguration(argv[argc - 1]);
+      IoData iodata(config, pconfig, false);
       if (!std::filesystem::exists(iodata.model.mesh))
       {
         MFEM_ABORT("Unable to open mesh file \"" << iodata.model.mesh << "\"!");
@@ -235,7 +237,8 @@ int main(int argc, char *argv[])
   // Parse configuration file.
   PrintPalaceBanner(world_comm);
   auto config = IoData::ParseAndValidate(argv[1]);
-  IoData iodata(config, false);
+  auto pconfig = IoData::ParsePalaceConfiguration(argv[1]);
+  IoData iodata(config, pconfig, false);
   MakeOutputFolder(iodata, world_comm);
 
   // Write the resolved configuration to the output directory so users have a complete

--- a/palace/schema/CMakeLists.txt
+++ b/palace/schema/CMakeLists.txt
@@ -13,8 +13,10 @@
 #      for `palace::schema::PalaceConfig` to stdout. Invoked at build time
 #      by cmake/EmbedSchema.cmake.
 #
-# Neither target is linked into libpalace in Phase 1; reflect-cpp stays out
-# of the runtime binary.
+# Neither of these targets is linked into libpalace. reflect-cpp itself is
+# linked into libpalace separately (see palace/CMakeLists.txt) so the runtime
+# can parse configuration into the schema types; these targets are only the
+# build-time schema-emission tooling.
 
 add_library(palace_schema_utils STATIC utils/schema.cpp)
 # PUBLIC includes the palace/ source root so consumers can write

--- a/palace/schema/types/problem.hpp
+++ b/palace/schema/types/problem.hpp
@@ -40,7 +40,7 @@ struct Problem
                      palace::schema::utils::Min<int, 0>) = 1;
 
   PALACE_SCHEMA_DESC(Output, "Directory path for saving postprocessing outputs.",
-                     std::string) = "";
+                     std::string) = "postpro";
 
   PALACE_SCHEMA_DESC(OutputFormats, "Configures the field output formats.",
                      ::palace::schema::OutputFormats) = {};

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -12,16 +12,51 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <fmt/format.h>
 #include <mfem.hpp>
 #include <nlohmann/json.hpp>
+#include <rfl/json.hpp>
 #include "fem/bilinearform.hpp"
 #include "fem/integrator.hpp"
+#include "schema/types/config.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
 #include "utils/jsonschema.hpp"
 
 namespace palace
 {
+
+namespace
+{
+
+// schema::ProblemType and palace::ProblemType share the same wire strings but declare
+// their enumerators in different orders, so a numeric cast would be wrong. Map by name
+// with an explicit switch; the compiler then flags any future enumerator that is added to
+// one enum but not handled here.
+ProblemType ToPalace(schema::ProblemType type)
+{
+  using S = schema::ProblemType;
+  switch (type)
+  {
+    case S::Driven:
+      return ProblemType::DRIVEN;
+    case S::Eigenmode:
+      return ProblemType::EIGENMODE;
+    case S::Electrostatic:
+      return ProblemType::ELECTROSTATIC;
+    case S::Magnetostatic:
+      return ProblemType::MAGNETOSTATIC;
+    case S::Transient:
+      return ProblemType::TRANSIENT;
+    case S::BoundaryMode:
+      return ProblemType::BOUNDARYMODE;
+  }
+  MFEM_ABORT("Unexpected schema::ProblemType value!");
+  return ProblemType::DRIVEN;  // Unreachable; silences a missing-return warning.
+}
+
+}  // namespace
 
 std::stringstream PreprocessFile(const char *filename)
 {
@@ -216,18 +251,70 @@ json IoData::ParseAndValidate(const char *filename)
   return config;
 }
 
-IoData::IoData(const nlohmann::json &config, bool print) : units(1.0, 1.0), init(false)
+namespace
+{
+
+// Parse a JSON string into the schema configuration object. rfl::DefaultIfMissing
+// default-constructs schema::PalaceConfiguration (running the in-class initializers) and
+// overlays only the present fields, so omitted optional fields fall back to their schema
+// defaults.
+schema::PalaceConfiguration ReadPalaceConfiguration(const std::string &str,
+                                                    std::string_view source)
+{
+  auto result = rfl::json::read<schema::PalaceConfiguration, rfl::DefaultIfMissing>(str);
+  MFEM_VERIFY(result, "Failed to parse the configuration " << source << "!\n  "
+                                                           << result.error().what());
+  return std::move(*result);
+}
+
+}  // namespace
+
+schema::PalaceConfiguration IoData::ParsePalaceConfiguration(const char *filename)
+{
+  // Preprocess (strip comments, expand integer ranges) independently of nlohmann::json,
+  // then parse the whole configuration into the schema type.
+  return ReadPalaceConfiguration(PreprocessFile(filename).str(),
+                                 fmt::format("file \"{}\"", filename));
+}
+
+schema::PalaceConfiguration IoData::ParsePalaceConfiguration(const nlohmann::json &config)
+{
+  // Parse an already-loaded JSON config object into the schema type by re-serializing it.
+  return ReadPalaceConfiguration(config.dump(), "object");
+}
+
+// Each field is unwrapped from its rfl::Description (and, for Verbose, the inner
+// rfl::Validator) via .value().
+config::ProblemData IoData::FromSchema(const schema::Problem &problem)
+{
+  config::ProblemData data;
+  data.type = ToPalace(problem.Type.value());
+  data.verbose = problem.Verbose.value().value();
+  data.output = problem.Output.value();
+  data.output_formats.paraview = problem.OutputFormats.value().Paraview.value();
+  data.output_formats.gridfunction = problem.OutputFormats.value().GridFunction.value();
+  return data;
+}
+
+IoData::IoData(const nlohmann::json &config, const schema::PalaceConfiguration &pconfig,
+               bool print)
+  : units(1.0, 1.0), init(false)
+{
+  // Initialize the Problem section from the schema configuration object. The remaining
+  // sections are still read from `config` in SetUpFromJson (to be migrated to `pconfig`).
+  problem = FromSchema(pconfig.Problem.value());
+  SetUpFromJson(config, print);
+}
+
+void IoData::SetUpFromJson(const nlohmann::json &config, bool print)
 {
   if (print)
   {
     Mpi::Print("\n{}\n", config.dump(2));
   }
 
-  // Set up configuration option data structures.
-  auto problem_it = config.find("Problem");
-  MFEM_VERIFY(problem_it != config.end(),
-              "\"Problem\" must be specified in the configuration file!");
-  problem = config::ProblemData(*problem_it);
+  // Set up the remaining configuration option data structures. `problem` is populated by
+  // the caller.
   auto model_it = config.find("Model");
   MFEM_VERIFY(model_it != config.end(),
               "\"Model\" must be specified in the configuration file!");
@@ -265,7 +352,8 @@ IoData::IoData(const nlohmann::json &config, bool print) : units(1.0, 1.0), init
   CheckConfiguration();
 }
 
-IoData::IoData(const char *filename, bool print) : IoData(ParseAndValidate(filename), print)
+IoData::IoData(const char *filename, bool print)
+  : IoData(ParseAndValidate(filename), ParsePalaceConfiguration(filename), print)
 {
 }
 

--- a/palace/utils/iodata.hpp
+++ b/palace/utils/iodata.hpp
@@ -19,6 +19,17 @@ class ParMesh;
 namespace palace
 {
 
+// Reflect-cpp schema types, parsed from the configuration and converted to the runtime
+// config:: structs. Forward-declared (used only as parameter/return types here) so
+// reflect-cpp stays out of this widely-included header; definitions live in schema/types.
+namespace schema
+{
+
+struct Problem;
+struct PalaceConfiguration;
+
+}  // namespace schema
+
 std::stringstream PreprocessFile(const char *filename);
 
 //
@@ -40,6 +51,11 @@ public:
 private:
   bool init;
 
+  // Shared body of the JSON constructors: reads Model/Domains/Boundaries/Solver from
+  // `config`, rejects unknown sections, and runs CheckConfiguration(). `problem` must
+  // already be populated by the caller.
+  void SetUpFromJson(const nlohmann::json &config, bool print);
+
 public:
   // Check configuration file options and compatibility with requested problem type.
   // Exposed for testing; not intended for general use.
@@ -47,14 +63,29 @@ public:
 
   explicit IoData(const Units &units);
 
-  // Construct from a pre-parsed and validated JSON config object.
-  IoData(const nlohmann::json &config, bool print);
+  // Construct from a pre-parsed and validated JSON config object together with the schema
+  // configuration object parsed from the same source. The Problem section is initialized
+  // from `pconfig`; the remaining sections are still read from `config` (to be migrated to
+  // `pconfig` in follow-ups). This is the seam for retiring the nlohmann::json path.
+  IoData(const nlohmann::json &config, const schema::PalaceConfiguration &pconfig,
+         bool print);
 
   // Parse configuration file, validate, and construct IoData.
   IoData(const char *filename, bool print);
 
   // Parse and validate a configuration file, returning the JSON object.
   static nlohmann::json ParseAndValidate(const char *filename);
+
+  // Parse a configuration directly into the reflect-cpp schema configuration object. The
+  // file overload preprocesses (strips comments, expands integer ranges) independently of
+  // nlohmann::json so the JSON path can eventually be removed; the json overload parses an
+  // already-loaded config object (used where the JSON has already been read/validated).
+  static schema::PalaceConfiguration ParsePalaceConfiguration(const char *filename);
+  static schema::PalaceConfiguration ParsePalaceConfiguration(const nlohmann::json &config);
+
+  // Derive the runtime ProblemData from a parsed "Problem" schema object. Exposed for
+  // testing the schema bridge; not intended for general use.
+  static config::ProblemData FromSchema(const schema::Problem &problem);
 
   // Return the user's config with any entries that were absent filled in from the
   // resolved IoData. User-provided values pass through untouched; only missing keys

--- a/scripts/schema/config-schema.json
+++ b/scripts/schema/config-schema.json
@@ -1828,7 +1828,7 @@
                 "Output": {
                     "type": "string",
                     "description": "Directory path for saving postprocessing outputs.",
-                    "default": ""
+                    "default": "postpro"
                 },
                 "OutputFormats": {
                     "$ref": "#/$defs/OutputFormats",

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -13,6 +13,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "embedded_schema.hpp"
 #include "linalg/ksp.hpp"
+#include "schema/types/config.hpp"
 #include "utils/configfile.hpp"
 #include "utils/iodata.hpp"
 #include "utils/jsonschema.hpp"
@@ -851,7 +852,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", json::object()}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
 
     // CheckConfiguration should have resolved the sentinels.
     CHECK(iodata.solver.linear.type == LinearSolver::BOOMER_AMG);
@@ -890,7 +891,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", json::object()}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata.problem.output == "postpro");
 
     // ConcretizeDefaults must emit the resolved, non-empty value back to JSON.
@@ -906,7 +907,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", json::object()}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata.solver.linear.type == LinearSolver::AMS);
     CHECK(iodata.solver.linear.krylov_solver == KrylovSolver::CG);
     CHECK(iodata.solver.linear.ams_singular_op == 1);
@@ -930,7 +931,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
         {"Boundaries", json::object()},
         {"Solver", {{"Order", 3}, {"Linear", {{"Type", "BoomerAMG"}, {"KSPType", "CG"}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata, config);
 
     // User-specified values should be preserved.
@@ -947,7 +948,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Eigenmode", {{"Target", 1.0}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
 
 #if defined(PALACE_WITH_SLEPC)
     CHECK(iodata.solver.eigenmode.type == EigenSolverBackend::SLEPC);
@@ -976,9 +977,13 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
          {{"WavePort", {{{"Index", 1}, {"Attributes", {2}}, {"Excitation", true}}}}}},
         {"Solver",
          {{"Driven",
-           {{"Samples", {{{"MinFreq", 1.0}, {"MaxFreq", 2.0}, {"FreqStep", 0.5}}}}}}}}};
+           {{"Samples",
+             {{{"Type", "Linear"},
+               {"MinFreq", 1.0},
+               {"MaxFreq", 2.0},
+               {"FreqStep", 0.5}}}}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata, config);
 
     auto type_str = config["Boundaries"]["WavePort"][0]["SolverType"].get<std::string>();
@@ -997,7 +1002,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Order", 5}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     // max(2 * 5, 4) = 10
     CHECK(iodata.solver.linear.mg_smooth_order == 10);
     // ams_max_it defaults to solver.order = 5
@@ -1016,7 +1021,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Linear", {{"MaxIts", 200}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata.solver.linear.max_size == 200);
 
     config = IoData::ConcretizeDefaults(iodata, config);
@@ -1031,7 +1036,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", json::object()}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata.solver.order == 1);
 
     config = IoData::ConcretizeDefaults(iodata, config);
@@ -1046,7 +1051,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", json::object()}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata, config);
     auto &j_linear = config["Solver"]["Linear"];
 
@@ -1071,7 +1076,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
          {{"Transient",
            {{"Excitation", "Sinusoidal"}, {"MaxTime", 1.0}, {"TimeStep", 0.01}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata.solver.transient.type == TimeSteppingScheme::GEN_ALPHA);
 
     config = IoData::ConcretizeDefaults(iodata, config);
@@ -1094,7 +1099,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Eigenmode", {{"Target", 1.0}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata, config);
     auto &j_eigen = config["Solver"]["Eigenmode"];
 
@@ -1118,7 +1123,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Order", 3}, {"Linear", {{"MaxIts", 250}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     // The resolved config must pass schema validation; otherwise a user cannot
@@ -1127,7 +1132,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
 
     CHECK(iodata2.solver.order == iodata1.solver.order);
     const auto &l1 = iodata1.solver.linear;
@@ -1195,14 +1200,14 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                {"LossTan", 0.002}}}}}}}},
         {"Solver", {{"Driven", {{"MinFreq", 1.0}, {"MaxFreq", 2.0}, {"FreqStep", 0.1}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
 
     const auto &m1 = iodata1.model;
     const auto &m2 = iodata2.model;
@@ -1339,7 +1344,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                     {{"Eigenmode", {{"Target", 1.0}, {"Type", "Default"}}},
                      {"Linear", {{"Type", "Default"}, {"KSPType", "Default"}}}}}};
 
-    IoData iodata(config, false);
+    IoData iodata(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata, config);
 
     auto &j_eigen = config["Solver"]["Eigenmode"];
@@ -1357,14 +1362,14 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"Eigenmode", {{"Target", 1.0}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata2.solver.eigenmode.type == iodata1.solver.eigenmode.type);
     // The emitted Type must be the concrete backend name, not the alias "Default".
     CHECK(config["Solver"]["Eigenmode"]["Type"].get<std::string>() != "Default");
@@ -1393,14 +1398,14 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
          {{"Transient",
            {{"Excitation", "Sinusoidal"}, {"MaxTime", 1.0}, {"TimeStep", 0.01}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
     CHECK(iodata2.solver.transient.type == iodata1.solver.transient.type);
     CHECK(config["Solver"]["Transient"]["Type"].get<std::string>() != "Default");
     CHECK(iodata2.solver.transient.excitation == iodata1.solver.transient.excitation);
@@ -1426,14 +1431,14 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                    {"Boundaries", json::object()},
                    {"Solver", {{"BoundaryMode", {{"Freq", 10.0}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
     const auto &b1 = iodata1.solver.boundary_mode;
     const auto &b2 = iodata2.solver.boundary_mode;
     CHECK(b2.n == b1.n);
@@ -1463,14 +1468,14 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
         {"Boundaries", {{"WavePort", {{{"Index", 1}, {"Attributes", {2}}}}}}},
         {"Solver", {{"Driven", {{"MinFreq", 1.0}, {"MaxFreq", 2.0}, {"FreqStep", 0.1}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
     INFO("schema validation error: " << err);
     CHECK(err.empty());
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
     REQUIRE(iodata2.boundaries.waveport.count(1) == 1);
     const auto &w1 = iodata1.boundaries.waveport.at(1);
     const auto &w2 = iodata2.boundaries.waveport.at(1);
@@ -1512,7 +1517,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
         {"Boundaries", json::object()},
         {"Solver", {{"Driven", {{"MinFreq", 1.0}, {"MaxFreq", 2.0}, {"FreqStep", 0.1}}}}}};
 
-    IoData iodata1(config, false);
+    IoData iodata1(config, IoData::ParsePalaceConfiguration(config), false);
     config = IoData::ConcretizeDefaults(iodata1, config);
 
     std::string err = ValidateConfig(config);
@@ -1527,7 +1532,7 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
     CHECK(j_mat.contains("Conductivity"));
     CHECK(j_mat.contains("LondonDepth"));
 
-    IoData iodata2(config, false);
+    IoData iodata2(config, IoData::ParsePalaceConfiguration(config), false);
     REQUIRE(iodata1.domains.materials.size() == 1);
     REQUIRE(iodata2.domains.materials.size() == 1);
     const auto &m1 = iodata1.domains.materials[0];
@@ -1548,5 +1553,63 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
                                        /*skip=*/{"MaterialAxes"});
     INFO("Domains.Materials[] missing keys: " << json(mat_gaps).dump());
     CHECK(mat_gaps.empty());
+  }
+}
+
+TEST_CASE("Problem schema bridge parity", "[config][Serial]")
+{
+  // The "Problem" section is parsed into the reflect-cpp schema type and the runtime
+  // config::ProblemData is derived from it. Pin that derivation against the legacy
+  // hand-rolled config::ProblemData(json) parser, which is kept as the oracle: for any
+  // input, parsing the config into the schema and deriving via FromSchema must agree with
+  // the old constructor.
+  auto check_parity = [](const json &problem)
+  {
+    const config::ProblemData expected(problem);
+    const auto pconfig = IoData::ParsePalaceConfiguration(json{{"Problem", problem}});
+    const config::ProblemData actual = IoData::FromSchema(pconfig.Problem.value());
+    CHECK(actual.type == expected.type);
+    CHECK(actual.verbose == expected.verbose);
+    CHECK(actual.output == expected.output);
+    CHECK(actual.output_formats.paraview == expected.output_formats.paraview);
+    CHECK(actual.output_formats.gridfunction == expected.output_formats.gridfunction);
+  };
+
+  SECTION("Minimal config falls back to schema defaults")
+  {
+    // Omitted Output → "postpro", Verbose → 1, OutputFormats → defaults.
+    check_parity({{"Type", "Driven"}});
+  }
+
+  SECTION("Every ProblemType enumerator maps correctly")
+  {
+    // Guards the ToPalace switch: schema and runtime enums share wire strings but differ
+    // in enumerator order, so each name must round-trip to the right runtime value.
+    for (const char *type : {"Eigenmode", "Driven", "Transient", "Electrostatic",
+                             "Magnetostatic", "BoundaryMode"})
+    {
+      check_parity({{"Type", type}});
+    }
+  }
+
+  SECTION("All fields populated")
+  {
+    check_parity({{"Type", "Transient"},
+                  {"Verbose", 3},
+                  {"Output", "results"},
+                  {"OutputFormats", {{"Paraview", false}, {"GridFunction", true}}}});
+  }
+
+  SECTION("Explicit empty Output passes through")
+  {
+    // An explicitly empty Output must survive as "" (both paths), so the downstream
+    // non-empty check fires identically to today.
+    check_parity({{"Type", "Driven"}, {"Output", ""}});
+  }
+
+  SECTION("Partial OutputFormats falls back per field")
+  {
+    // GridFunction omitted → its schema default (false).
+    check_parity({{"Type", "Driven"}, {"OutputFormats", {{"Paraview", false}}}});
   }
 }

--- a/test/unit/test-romoperator.cpp
+++ b/test/unit/test-romoperator.cpp
@@ -16,6 +16,7 @@
 #include "models/postoperatorcsv.hpp"
 #include "models/romoperator.hpp"
 #include "models/spaceoperator.hpp"
+#include "schema/types/config.hpp"
 #include "utils/communication.hpp"
 #include "utils/filesystem.hpp"
 #include "utils/geodata.hpp"
@@ -192,7 +193,7 @@ TEST_CASE_METHOD(palace::test::PerRankTempDir, "RomOperator-Synthesis-Port-Cube1
   setup_json["Solver"]["Linear"] = {
       {"Type", "Default"}, {"KSPType", "GMRES"}, {"MaxIts", 200}, {"Tol", 1.0e-8}};
 
-  IoData iodata(setup_json, false);
+  IoData iodata(setup_json, IoData::ParsePalaceConfiguration(setup_json), false);
 
   auto mesh_io = LoadScaleParMesh2(iodata, world_comm);
   SpaceOperator space_op(iodata, mesh_io);
@@ -427,7 +428,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir, "RomOperator-Synthesis-Port-Cube32
   setup_json["Solver"]["Linear"] = {
       {"Type", "Default"}, {"KSPType", "GMRES"}, {"MaxIts", 200}, {"Tol", 1.0e-8}};
 
-  IoData iodata(setup_json, false);
+  IoData iodata(setup_json, IoData::ParsePalaceConfiguration(setup_json), false);
 
   auto mesh_io = LoadScaleParMesh2(iodata, world_comm);
   SpaceOperator space_op(iodata, mesh_io);
@@ -658,7 +659,7 @@ TEST_CASE_METHOD(palace::test::PerRankTempDir, "RomOperator-Synthesis-PortOrthog
   setup_json["Solver"]["Linear"] = {
       {"Type", "Default"}, {"KSPType", "GMRES"}, {"MaxIts", 200}, {"Tol", 1.0e-8}};
 
-  IoData iodata(setup_json, false);
+  IoData iodata(setup_json, IoData::ParsePalaceConfiguration(setup_json), false);
   auto mesh_io = LoadScaleParMesh2(iodata, world_comm);
   SpaceOperator space_op(iodata, mesh_io);
   std::size_t max_size_per_excitation = 100;
@@ -712,7 +713,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir, "RomOperator-UpdatePROM-LinearDepe
   setup_json["Solver"]["Linear"] = {
       {"Type", "Default"}, {"KSPType", "GMRES"}, {"MaxIts", 200}, {"Tol", 1.0e-8}};
 
-  IoData iodata(setup_json, false);
+  IoData iodata(setup_json, IoData::ParsePalaceConfiguration(setup_json), false);
   auto mesh_io = LoadScaleParMesh2(iodata, world_comm);
   SpaceOperator space_op(iodata, mesh_io);
   std::size_t max_size_per_excitation = 100;
@@ -807,7 +808,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   setup_json["Solver"]["Linear"] = {
       {"Type", "Default"}, {"KSPType", "GMRES"}, {"MaxIts", 200}, {"Tol", 1.0e-8}};
 
-  IoData iodata(setup_json, false);
+  IoData iodata(setup_json, IoData::ParsePalaceConfiguration(setup_json), false);
 
   // The flag is parsed onto the config struct.
   const auto &cfg_ports = iodata.boundaries.lumpedport;
@@ -863,6 +864,7 @@ TEST_CASE("RomOperator-Synthesis-ExcludedExcitedRejected", "[romoperator][Serial
                             {"MaxFreq", 32.0},
                             {"FreqStep", 1.0}}}};
 
-  CHECK_THROWS_WITH((IoData{setup_json, false}),
-                    Catch::Matchers::ContainsSubstring("IncludeInSynthesis"));
+  CHECK_THROWS_WITH(
+      (IoData{setup_json, IoData::ParsePalaceConfiguration(setup_json), false}),
+      Catch::Matchers::ContainsSubstring("IncludeInSynthesis"));
 }


### PR DESCRIPTION
Summary: parse Problem config through the reflect-cpp schema bridge, add IoData schema parsing helpers, and update parity coverage/call sites for schema-backed Problem data. Tests: git diff --cached --check.