### PR TITLE
Harden CI against script injection in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -529,14 +529,18 @@ jobs:
 
       - name: Add coverage link to summary
         if: needs.filter.outputs.test == 'true' && matrix.with-coverage
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COVERAGE_URL="https://awslabs.github.io/palace/previews/PR${{ github.event.pull_request.number }}/coverage/"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            COVERAGE_URL="https://awslabs.github.io/palace/previews/PR${PR_NUMBER}/coverage/"
           else
-            COVERAGE_URL="https://awslabs.github.io/palace/coverage/${{ github.sha }}/"
+            COVERAGE_URL="https://awslabs.github.io/palace/coverage/${SHA}/"
           fi
-          echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "View the coverage report at: [Coverage Report](${COVERAGE_URL})" >> $GITHUB_STEP_SUMMARY
+          echo "### Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "View the coverage report at: [Coverage Report](${COVERAGE_URL})" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
         if: needs.filter.outputs.test == 'true' && matrix.with-coverage

--- a/.github/workflows/long-test-status-manager.yml
+++ b/.github/workflows/long-test-status-manager.yml
@@ -56,14 +56,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set bypass status for trivial changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests bypassed (trivial changes)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Require long tests when non-trivial changes are detected
   handle-non-trivial-changes:
@@ -74,14 +76,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set pending status for non-trivial changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=pending \
             --field context=long-tests \
             --field description="Waiting for long tests (add 'trigger-long-tests' label to run)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Handle adding/removing 'no-long-tests' label
   handle-no-long-tests:
@@ -91,23 +95,27 @@ jobs:
       # When label is added: bypass long test requirement
       - name: Set bypass status
         if: github.event.action == 'labeled'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests bypassed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # When label is removed: require long tests again
       - name: Remove bypass status
         if: github.event.action == 'unlabeled'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=pending \
             --field context=long-tests \
             --field description="Waiting for long tests (add 'trigger-long-tests' label to run)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -54,22 +54,26 @@ jobs:
 
       - name: Set success status
         if: github.event_name == 'pull_request' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=success \
             --field context=long-tests \
             --field description="Long tests passed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set failure status
         if: github.event_name == 'pull_request' && (failure() || cancelled())
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             --method POST \
             --field state=failure \
             --field context=long-tests \
             --field description="Long tests failed"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bind untrusted github.event.* context values to env variables and reference them as shell variables in run blocks instead of interpolating them directly into the script text. 
