### PR TITLE
Release eigenmode solve state before postprocessing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,11 @@ jobs:
               - '.github/workflows/docs.yml'
       - name: Decide whether to build
         id: decide
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]] || [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_build=${{ steps.filter.outputs.test }}" >> "$GITHUB_OUTPUT"
@@ -198,15 +201,16 @@ jobs:
       - name: Build and deploy
         if: needs.filter.outputs.should_build == 'true'
         env:
+          DEPLOY_TAG: ${{ inputs.deploy_tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # For workflow_dispatch with deploy_tag, override the runner's immutable
           # GITHUB_* env vars so Documenter.jl sees a tag push.
-          if [[ -n "${{ inputs.deploy_tag }}" ]]; then
+          if [[ -n "${DEPLOY_TAG}" ]]; then
             export GITHUB_EVENT_NAME=push
-            export GITHUB_REF=refs/tags/${{ inputs.deploy_tag }}
+            export GITHUB_REF=refs/tags/"${DEPLOY_TAG}"
             export GITHUB_REF_TYPE=tag
-            export GITHUB_REF_NAME=${{ inputs.deploy_tag }}
+            export GITHUB_REF_NAME="${DEPLOY_TAG}"
           fi
           eval $(spack -e . load --sh palace)
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
@@ -216,8 +220,10 @@ jobs:
         if: >-
           needs.filter.outputs.should_build == 'true' &&
           (startsWith(github.ref, 'refs/tags/') || inputs.deploy_tag != '')
+        env:
+          TAG_REF: ${{ inputs.deploy_tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.deploy_tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           git fetch origin gh-pages --depth=1
           STABLE=$(git show origin/gh-pages:stable)

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -62,10 +62,11 @@ jobs:
       - name: Print buildcache version count before cleanup
         continue-on-error: true
         env:
+          REPO_OWNER: ${{ github.repository_owner }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh api /orgs/${{ github.repository_owner }}/packages/container/palace-develop-testing \
+          gh api /orgs/"${REPO_OWNER}"/packages/container/palace-develop-testing \
             --jq '"palace-develop-testing versions before cleanup: \(.version_count)"'
 
       # Each Spack spec is a tagged version in the container package. We keep
@@ -91,8 +92,9 @@ jobs:
         if: always()
         continue-on-error: true
         env:
+          REPO_OWNER: ${{ github.repository_owner }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh api /orgs/${{ github.repository_owner }}/packages/container/palace-develop-testing \
+          gh api /orgs/"${REPO_OWNER}"/packages/container/palace-develop-testing \
             --jq '"palace-develop-testing versions after cleanup: \(.version_count)"'

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -4,6 +4,7 @@
 #include "eigensolver.hpp"
 
 #include <complex>
+#include <optional>
 #include <mfem.hpp>
 #include "fem/errorindicator.hpp"
 #include "fem/mesh.hpp"
@@ -32,190 +33,387 @@ using namespace std::complex_literals;
 std::pair<ErrorIndicator, long long int>
 EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 {
-  // Construct and extract the system matrices defining the eigenvalue problem. The diagonal
-  // values for the mass matrix PEC dof shift the Dirichlet eigenvalues out of the
-  // computational range. The damping matrix may be nullptr.
+  // Construct the space operator and keep it alive through postprocessing. The large
+  // eigensolver objects (system matrices, preconditioner, KSP, and eigensolver backend)
+  // are created in the nested scope below so they are destroyed before error estimation
+  // and field output allocate their own work buffers.
   BlockTimer bt0(Timer::CONSTRUCT);
   SpaceOperator space_op(iodata, mesh);
-  auto K = space_op.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
-  auto C = space_op.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
-  auto M = space_op.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
-
-  // Check if there are nonlinear terms and, if so, setup interpolation operator.
-  auto funcA2 = [&space_op](double omega) -> std::unique_ptr<ComplexOperator>
-  { return space_op.GetExtraSystemMatrix<ComplexOperator>(omega, Operator::DIAG_ZERO); };
-  auto funcP = [&space_op](std::complex<double> a0, std::complex<double> a1,
-                           std::complex<double> a2,
-                           double omega) -> std::unique_ptr<ComplexOperator>
-  { return space_op.GetPreconditionerMatrix<ComplexOperator>(a0, a1, a2, omega); };
-  const double target = iodata.solver.eigenmode.target;
-  auto A2 = funcA2(target);
-  bool has_A2 = (A2 != nullptr);
-
-  // Extend K, C, M operators with interpolated A2 operator.
-  // K' = K + A2_0, C' = C + A2_1, M' = M + A2_2
-  std::unique_ptr<ComplexOperator> Kp, Cp, Mp;
-  std::unique_ptr<Interpolation> interp_op;
-  std::unique_ptr<ComplexOperator> A2_0, A2_1, A2_2;
-  NonlinearEigenSolver nonlinear_type = iodata.solver.eigenmode.nonlinear_type;
-  if (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
-  {
-    const double target_max = iodata.solver.eigenmode.target_upper;
-    interp_op = std::make_unique<NewtonInterpolationOperator>(funcA2, A2->Width());
-    interp_op->Interpolate(1i * target, 1i * target_max);
-    A2_0 = interp_op->GetInterpolationOperator(0);
-    A2_1 = interp_op->GetInterpolationOperator(1);
-    A2_2 = interp_op->GetInterpolationOperator(2);
-    Kp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {K.get(), A2_0.get()});
-    Cp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {C.get(), A2_1.get()});
-    Mp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {M.get(), A2_2.get()});
-  }
-
   const auto &Curl = space_op.GetCurlMatrix();
   SaveMetadata(space_op.GetNDSpaces());
 
-  // Configure objects for postprocessing.
-  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
-  ComplexVector E(Curl.Width()), B(Curl.Height());
-  E.UseDevice(true);
-  B.UseDevice(true);
-
-  // Define and configure the eigensolver to solve the eigenvalue problem:
-  //         (K + λ C + λ² M) u = 0    or    K u = -λ² M u
-  // with λ = iω. In general, the system matrices are complex and symmetric.
+  const double target = iodata.solver.eigenmode.target;
+  bool has_C = false;
+  bool has_A2 = false;
+  int num_conv = 0;
+  std::vector<std::complex<double>> eigenvalues;
+  std::vector<double> errors_bkwd, errors_abs;
+  std::vector<ComplexVector> eigenvectors;
   std::unique_ptr<EigenvalueSolver> eigen;
-  const EigenSolverBackend type = iodata.solver.eigenmode.type;
+  std::optional<BlockTimer> post_timer;
+
+  {
+    // Construct and extract the system matrices defining the eigenvalue problem. The
+    // diagonal values for the mass matrix PEC dof shift the Dirichlet eigenvalues out of
+    // the computational range. The damping matrix may be nullptr.
+    auto K = space_op.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
+    auto C = space_op.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+    has_C = (C != nullptr);
+    auto M = space_op.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+
+    // Check if there are nonlinear terms and, if so, setup interpolation operator.
+    auto funcA2 = [&space_op](double omega) -> std::unique_ptr<ComplexOperator>
+    { return space_op.GetExtraSystemMatrix<ComplexOperator>(omega, Operator::DIAG_ZERO); };
+    auto funcP = [&space_op](std::complex<double> a0, std::complex<double> a1,
+                             std::complex<double> a2,
+                             double omega) -> std::unique_ptr<ComplexOperator>
+    { return space_op.GetPreconditionerMatrix<ComplexOperator>(a0, a1, a2, omega); };
+    auto A2 = funcA2(target);
+    has_A2 = (A2 != nullptr);
+
+    // Extend K, C, M operators with interpolated A2 operator.
+    // K' = K + A2_0, C' = C + A2_1, M' = M + A2_2
+    std::unique_ptr<ComplexOperator> Kp, Cp, Mp;
+    std::unique_ptr<Interpolation> interp_op;
+    std::unique_ptr<ComplexOperator> A2_0, A2_1, A2_2;
+    NonlinearEigenSolver nonlinear_type = iodata.solver.eigenmode.nonlinear_type;
+
+    // Declare solve-time owners in this scope so they are released before postprocessing.
+    // The outer eigensolver pointer remains alive just long enough to copy out converged
+    // eigenvectors after the solve-time matrices and preconditioner have gone out of scope.
+    std::unique_ptr<ComplexOperator> A, P;
+    std::unique_ptr<ComplexKspSolver> ksp;
+    std::unique_ptr<Operator> KM;
+    std::unique_ptr<DivFreeSolver<ComplexVector>> divfree;
+    if (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
+    {
+      const double target_max = iodata.solver.eigenmode.target_upper;
+      interp_op = std::make_unique<NewtonInterpolationOperator>(funcA2, A2->Width());
+      interp_op->Interpolate(1i * target, 1i * target_max);
+      A2_0 = interp_op->GetInterpolationOperator(0);
+      A2_1 = interp_op->GetInterpolationOperator(1);
+      A2_2 = interp_op->GetInterpolationOperator(2);
+      Kp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {K.get(), A2_0.get()});
+      Cp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {C.get(), A2_1.get()});
+      Mp = BuildParSumOperator({1.0 + 0i, 1.0 + 0i}, {M.get(), A2_2.get()});
+    }
+
+    // Define and configure the eigensolver to solve the eigenvalue problem:
+    //         (K + λ C + λ² M) u = 0    or    K u = -λ² M u
+    // with λ = iω. In general, the system matrices are complex and symmetric.
+    const EigenSolverBackend type = iodata.solver.eigenmode.type;
 #if !defined(PALACE_WITH_ARPACK) && !defined(PALACE_WITH_SLEPC)
 #error "Eigenmode solver requires building with ARPACK or SLEPc!"
 #endif
 #if !defined(PALACE_WITH_SLEPC)
-  if (nonlinear_type == NonlinearEigenSolver::SLP)
-  {
-    Mpi::Warning("SLP nonlinear eigensolver not available without SLEPc, using Hybrid!\n");
-  }
-  nonlinear_type = NonlinearEigenSolver::HYBRID;
-#endif
-  if (type == EigenSolverBackend::ARPACK)
-  {
-#if defined(PALACE_WITH_ARPACK)
-    Mpi::Print("\nConfiguring ARPACK eigenvalue solver:\n");
-    if (C || has_A2)
-    {
-      eigen = std::make_unique<arpack::ArpackPEPSolver>(space_op.GetComm(),
-                                                        iodata.problem.verbose);
-    }
-    else
-    {
-      eigen = std::make_unique<arpack::ArpackEPSSolver>(space_op.GetComm(),
-                                                        iodata.problem.verbose);
-    }
-#endif
-  }
-  else  // EigenSolverBackend::SLEPC
-  {
-#if defined(PALACE_WITH_SLEPC)
-    Mpi::Print("\nConfiguring SLEPc eigenvalue solver:\n");
-    std::unique_ptr<slepc::SlepcEigenvalueSolver> slepc;
     if (nonlinear_type == NonlinearEigenSolver::SLP)
     {
-      slepc = std::make_unique<slepc::SlepcNEPSolver>(space_op.GetComm(),
-                                                      iodata.problem.verbose);
-      slepc->SetType(slepc::SlepcEigenvalueSolver::Type::SLP);
-      slepc->SetProblemType(slepc::SlepcEigenvalueSolver::ProblemType::GENERAL);
+      Mpi::Warning(
+          "SLP nonlinear eigensolver not available without SLEPc, using Hybrid!\n");
     }
-    else
+    nonlinear_type = NonlinearEigenSolver::HYBRID;
+#endif
+    if (type == EigenSolverBackend::ARPACK)
     {
+#if defined(PALACE_WITH_ARPACK)
+      Mpi::Print("\nConfiguring ARPACK eigenvalue solver:\n");
       if (C || has_A2)
       {
-        if (!iodata.solver.eigenmode.pep_linear)
-        {
-          slepc = std::make_unique<slepc::SlepcPEPSolver>(space_op.GetComm(),
+        eigen = std::make_unique<arpack::ArpackPEPSolver>(space_op.GetComm(),
                                                           iodata.problem.verbose);
-          slepc->SetType(slepc::SlepcEigenvalueSolver::Type::TOAR);
-        }
-        else
-        {
-          slepc = std::make_unique<slepc::SlepcPEPLinearSolver>(space_op.GetComm(),
-                                                                iodata.problem.verbose);
-          slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
-        }
       }
       else
       {
-        slepc = std::make_unique<slepc::SlepcEPSSolver>(space_op.GetComm(),
-                                                        iodata.problem.verbose);
-        slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
+        eigen = std::make_unique<arpack::ArpackEPSSolver>(space_op.GetComm(),
+                                                          iodata.problem.verbose);
       }
-      slepc->SetProblemType(slepc::SlepcEigenvalueSolver::ProblemType::GEN_NON_HERMITIAN);
-    }
-    slepc->SetOrthogonalization(iodata.solver.linear.gs_orthog == Orthogonalization::MGS,
-                                iodata.solver.linear.gs_orthog == Orthogonalization::CGS2);
-    eigen = std::move(slepc);
 #endif
-  }
-  EigenvalueSolver::ScaleType scale = iodata.solver.eigenmode.scale
-                                          ? EigenvalueSolver::ScaleType::NORM_2
-                                          : EigenvalueSolver::ScaleType::NONE;
-  if (nonlinear_type == NonlinearEigenSolver::SLP)
-  {
-    eigen->SetOperators(*K, *C, *M, EigenvalueSolver::ScaleType::NONE);
-    eigen->SetExtraSystemMatrix(funcA2);
-    eigen->SetPreconditionerUpdate(funcP);
-  }
-  else
-  {
-    if (has_A2)
-    {
-      eigen->SetOperators(*Kp, *Cp, *Mp, scale);
     }
-    else if (C)
+    else  // EigenSolverBackend::SLEPC
     {
-      eigen->SetOperators(*K, *C, *M, scale);
+#if defined(PALACE_WITH_SLEPC)
+      Mpi::Print("\nConfiguring SLEPc eigenvalue solver:\n");
+      std::unique_ptr<slepc::SlepcEigenvalueSolver> slepc;
+      if (nonlinear_type == NonlinearEigenSolver::SLP)
+      {
+        slepc = std::make_unique<slepc::SlepcNEPSolver>(space_op.GetComm(),
+                                                        iodata.problem.verbose);
+        slepc->SetType(slepc::SlepcEigenvalueSolver::Type::SLP);
+        slepc->SetProblemType(slepc::SlepcEigenvalueSolver::ProblemType::GENERAL);
+      }
+      else
+      {
+        if (C || has_A2)
+        {
+          if (!iodata.solver.eigenmode.pep_linear)
+          {
+            slepc = std::make_unique<slepc::SlepcPEPSolver>(space_op.GetComm(),
+                                                            iodata.problem.verbose);
+            slepc->SetType(slepc::SlepcEigenvalueSolver::Type::TOAR);
+          }
+          else
+          {
+            slepc = std::make_unique<slepc::SlepcPEPLinearSolver>(space_op.GetComm(),
+                                                                  iodata.problem.verbose);
+            slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
+          }
+        }
+        else
+        {
+          slepc = std::make_unique<slepc::SlepcEPSSolver>(space_op.GetComm(),
+                                                          iodata.problem.verbose);
+          slepc->SetType(slepc::SlepcEigenvalueSolver::Type::KRYLOVSCHUR);
+        }
+        slepc->SetProblemType(slepc::SlepcEigenvalueSolver::ProblemType::GEN_NON_HERMITIAN);
+      }
+      slepc->SetOrthogonalization(iodata.solver.linear.gs_orthog == Orthogonalization::MGS,
+                                  iodata.solver.linear.gs_orthog ==
+                                      Orthogonalization::CGS2);
+      eigen = std::move(slepc);
+#endif
+    }
+    EigenvalueSolver::ScaleType scale = iodata.solver.eigenmode.scale
+                                            ? EigenvalueSolver::ScaleType::NORM_2
+                                            : EigenvalueSolver::ScaleType::NONE;
+    if (nonlinear_type == NonlinearEigenSolver::SLP)
+    {
+      eigen->SetOperators(*K, *C, *M, EigenvalueSolver::ScaleType::NONE);
+      eigen->SetExtraSystemMatrix(funcA2);
+      eigen->SetPreconditionerUpdate(funcP);
     }
     else
     {
-      eigen->SetOperators(*K, *M, scale);
+      if (has_A2)
+      {
+        eigen->SetOperators(*Kp, *Cp, *Mp, scale);
+      }
+      else if (C)
+      {
+        eigen->SetOperators(*K, *C, *M, scale);
+      }
+      else
+      {
+        eigen->SetOperators(*K, *M, scale);
+      }
+    }
+    eigen->SetNumModes(iodata.solver.eigenmode.n, iodata.solver.eigenmode.max_size);
+    const double tol = (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
+                           ? iodata.solver.eigenmode.linear_tol
+                           : iodata.solver.eigenmode.tol;
+    eigen->SetTol(tol);
+    eigen->SetMaxIter(iodata.solver.eigenmode.max_it);
+    Mpi::Print(" Scaling γ = {:.3e}, δ = {:.3e}\n", eigen->GetScalingGamma(),
+               eigen->GetScalingDelta());
+
+    // If desired, use an M-inner product for orthogonalizing the eigenvalue subspace. The
+    // constructed matrix just references the real SPD part of the mass matrix (no copy is
+    // performed). Boundary conditions don't need to be eliminated here.
+    if (iodata.solver.eigenmode.mass_orthog)
+    {
+      Mpi::Print(" Basis uses M-inner product\n");
+      KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
+      eigen->SetBMat(*KM);
+
+      // Mpi::Print(" Basis uses (K + M)-inner product\n");
+      // KM = space_op.GetInnerProductMatrix(1.0, 1.0, K.get(), M.get());
+      // eigen->SetBMat(*KM);
+    }
+
+    // Construct a divergence-free projector so the eigenvalue solve is performed in the
+    // space orthogonal to the zero eigenvalues of the stiffness matrix.
+    if (iodata.solver.linear.divfree_max_it > 0 &&
+        !space_op.GetMaterialOp().HasWaveVector() &&
+        !space_op.GetMaterialOp().HasLondonDepth())
+    {
+      Mpi::Print(" Configuring divergence-free projection\n");
+      constexpr int divfree_verbose = 0;
+      divfree = std::make_unique<DivFreeSolver<ComplexVector>>(
+          space_op.GetMaterialOp(), space_op.GetNDSpace(), space_op.GetH1Spaces(),
+          space_op.GetAuxBdrTDofLists(), iodata.solver.linear.divfree_tol,
+          iodata.solver.linear.divfree_max_it, divfree_verbose);
+      eigen->SetDivFreeProjector(*divfree);
+    }
+
+    // Set up the initial space for the eigenvalue solve. Satisfies boundary conditions and
+    // is projected appropriately.
+    if (iodata.solver.eigenmode.init_v0)
+    {
+      ComplexVector v0;
+      if (iodata.solver.eigenmode.init_v0_const)
+      {
+        Mpi::Print(" Using constant starting vector\n");
+        space_op.GetConstantInitialVector(v0);
+      }
+      else
+      {
+        Mpi::Print(" Using random starting vector\n");
+        space_op.GetRandomInitialVector(v0);
+      }
+      if (divfree)
+      {
+        divfree->Mult(v0);
+      }
+      eigen->SetInitialSpace(v0);  // Copies the vector
+
+      // Debug
+      // const auto &Grad = space_op.GetGradMatrix();
+      // ComplexVector r0(Grad->Width());
+      // r0.UseDevice(true);
+      // Grad.MultTranspose(v0.Real(), r0.Real());
+      // Grad.MultTranspose(v0.Imag(), r0.Imag());
+      // r0.Print();
+    }
+
+    // Configure the shift-and-invert strategy is employed to solve for the eigenvalues
+    // closest to the specified target, σ.
+    {
+      const double f_target =
+          iodata.units.Dimensionalize<Units::ValueType::FREQUENCY>(target) / (2 * M_PI);
+      Mpi::Print(" Shift-and-invert σ = {:.3e} GHz ({:.3e})\n", f_target, target);
+    }
+    if (C || has_A2 || nonlinear_type == NonlinearEigenSolver::SLP)
+    {
+      // Search for eigenvalues closest to λ = iσ.
+      eigen->SetShiftInvert(1i * target);
+      if (type == EigenSolverBackend::ARPACK)
+      {
+        // ARPACK searches based on eigenvalues of the transformed problem. The eigenvalue
+        // 1 / (λ - σ) will be a large-magnitude negative imaginary number for an eigenvalue
+        // λ with frequency close to but not below the target σ.
+        eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::SMALLEST_IMAGINARY);
+      }
+      else if (nonlinear_type == NonlinearEigenSolver::SLP)
+      {
+        eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_MAGNITUDE);
+      }
+      else
+      {
+        eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_IMAGINARY);
+      }
+    }
+    else
+    {
+      // Linear EVP has eigenvalues μ = -λ² = ω². Search for eigenvalues closest to μ = σ².
+      eigen->SetShiftInvert(target * target);
+      if (type == EigenSolverBackend::ARPACK)
+      {
+        // ARPACK searches based on eigenvalues of the transformed problem. 1 / (μ - σ²)
+        // will be a large-magnitude positive real number for an eigenvalue μ with frequency
+        // close to but below the target σ².
+        eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::LARGEST_REAL);
+      }
+      else
+      {
+        eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_REAL);
+      }
+    }
+
+    // Set up the linear solver required for solving systems involving the shifted operator
+    // (K - σ² M) or P(iσ) = (K + iσ C - σ² M) during the eigenvalue solve. The
+    // preconditioner for complex linear systems is constructed from a real approximation
+    // to the complex system matrix.
+    A = space_op.GetSystemMatrix(1.0 + 0.0i, 1i * target, -target * target + 0.0i, K.get(),
+                                 C.get(), M.get(), A2.get());
+    P = space_op.GetPreconditionerMatrix<ComplexOperator>(1.0 + 0.0i, 1i * target,
+                                                          -target * target + 0.0i, target);
+    ksp = std::make_unique<ComplexKspSolver>(iodata, space_op.GetNDSpaces(),
+                                             &space_op.GetH1Spaces());
+    ksp->SetOperators(*A, *P);
+    eigen->SetLinearSolver(*ksp);
+
+    // Eigenvalue problem solve.
+    {
+      BlockTimer bt1(Timer::EPS);
+      Mpi::Print("\n");
+      num_conv = eigen->Solve();
+      {
+        std::complex<double> lambda = (num_conv > 0) ? eigen->GetEigenvalue(0) : 0.0;
+        Mpi::Print(" Found {:d} converged eigenvalue{}{}\n", num_conv,
+                   (num_conv > 1) ? "s" : "",
+                   (num_conv > 0) ? fmt::format(" (first = {:.3e}{:+.3e}i)", lambda.real(),
+                                                lambda.imag())
+                                  : "");
+      }
+
+      if (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
+      {
+        Mpi::Print("\n Refining eigenvalues with Quasi-Newton solver\n");
+        auto qn = std::make_unique<QuasiNewtonSolver>(
+            space_op.GetComm(), std::move(eigen), num_conv, iodata.problem.verbose,
+            iodata.solver.eigenmode.refine_nonlinear);
+        qn->SetTol(iodata.solver.eigenmode.tol);
+        qn->SetMaxIter(iodata.solver.eigenmode.max_it);
+        if (C)
+        {
+          qn->SetOperators(*K, *C, *M, EigenvalueSolver::ScaleType::NONE);
+        }
+        else
+        {
+          qn->SetOperators(*K, *M, EigenvalueSolver::ScaleType::NONE);
+        }
+        qn->SetExtraSystemMatrix(funcA2);
+        qn->SetPreconditionerUpdate(funcP);
+        qn->SetNumModes(iodata.solver.eigenmode.n, iodata.solver.eigenmode.max_size);
+        qn->SetPreconditionerLag(iodata.solver.eigenmode.preconditioner_lag,
+                                 iodata.solver.eigenmode.preconditioner_lag_tol);
+        qn->SetMaxRestart(iodata.solver.eigenmode.max_restart);
+        qn->SetLinearSolver(*ksp);
+        qn->SetShiftInvert(1i * target);
+        eigen = std::move(qn);
+
+        // Suppress wave port output during nonlinear eigensolver iterations.
+        space_op.GetWavePortOp().SetSuppressOutput(true);
+        num_conv = eigen->Solve();
+        space_op.GetWavePortOp().SetSuppressOutput(false);
+      }
+    }
+
+    // The eigenvalue solve is complete. Attribute all following normalization,
+    // eigenpair/vector extraction, error estimation, and field output to postprocessing
+    // rather than operator construction.
+    post_timer.emplace(Timer::POSTPRO);
+
+    SaveMetadata(*ksp);
+
+    if (!KM)
+    {
+      // Normalize the finalized eigenvectors with respect to mass matrix (unit electric
+      // field energy) even if they are not computed to be orthogonal with respect to it.
+      KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
+      eigen->SetBMat(*KM);
+      eigen->RescaleEigenvectors(num_conv);
+    }
+
+    // Cache scalar eigenpair data while all operators referenced by the eigensolver are
+    // still alive for error scaling.
+    eigenvalues.resize(num_conv);
+    errors_bkwd.resize(num_conv);
+    errors_abs.resize(num_conv);
+    for (int i = 0; i < num_conv; i++)
+    {
+      eigenvalues[i] = eigen->GetEigenvalue(i);
+      errors_bkwd[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
+      errors_abs[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
     }
   }
-  eigen->SetNumModes(iodata.solver.eigenmode.n, iodata.solver.eigenmode.max_size);
-  const double tol = (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
-                         ? iodata.solver.eigenmode.linear_tol
-                         : iodata.solver.eigenmode.tol;
-  eigen->SetTol(tol);
-  eigen->SetMaxIter(iodata.solver.eigenmode.max_it);
-  Mpi::Print(" Scaling γ = {:.3e}, δ = {:.3e}\n", eigen->GetScalingGamma(),
-             eigen->GetScalingDelta());
 
-  // If desired, use an M-inner product for orthogonalizing the eigenvalue subspace. The
-  // constructed matrix just references the real SPD part of the mass matrix (no copy is
-  // performed). Boundary conditions don't need to be eliminated here.
-  std::unique_ptr<Operator> KM;
-  if (iodata.solver.eigenmode.mass_orthog)
+  // Copy the finalized eigenvectors only after solve-time matrices, preconditioners, and
+  // KSP state have gone out of scope. SLEPc/ARPACK still own their converged-vector
+  // storage here, but it no longer overlaps the larger Palace operator/preconditioner
+  // allocations.
+  eigenvectors.reserve(num_conv);
+  for (int i = 0; i < num_conv; i++)
   {
-    Mpi::Print(" Basis uses M-inner product\n");
-    KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
-    eigen->SetBMat(*KM);
-
-    // Mpi::Print(" Basis uses (K + M)-inner product\n");
-    // KM = space_op.GetInnerProductMatrix(1.0, 1.0, K.get(), M.get());
-    // eigen->SetBMat(*KM);
+    auto &E = eigenvectors.emplace_back(Curl.Width());
+    E.UseDevice(true);
+    eigen->GetEigenvector(i, E);
   }
+  eigen.reset();
 
-  // Construct a divergence-free projector so the eigenvalue solve is performed in the space
-  // orthogonal to the zero eigenvalues of the stiffness matrix.
-  std::unique_ptr<DivFreeSolver<ComplexVector>> divfree;
-  if (iodata.solver.linear.divfree_max_it > 0 &&
-      !space_op.GetMaterialOp().HasWaveVector() &&
-      !space_op.GetMaterialOp().HasLondonDepth())
-  {
-    Mpi::Print(" Configuring divergence-free projection\n");
-    constexpr int divfree_verbose = 0;
-    divfree = std::make_unique<DivFreeSolver<ComplexVector>>(
-        space_op.GetMaterialOp(), space_op.GetNDSpace(), space_op.GetH1Spaces(),
-        space_op.GetAuxBdrTDofLists(), iodata.solver.linear.divfree_tol,
-        iodata.solver.linear.divfree_max_it, divfree_verbose);
-    eigen->SetDivFreeProjector(*divfree);
-  }
+  // Configure postprocessing objects only after solve-only state has gone out of scope.
+  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
+  ComplexVector B(Curl.Height());
+  B.UseDevice(true);
 
   // If using Floquet BCs, a correction term (kp x E) needs to be added to the B field.
   std::unique_ptr<FloquetCorrSolver<ComplexVector>> floquet_corr;
@@ -225,93 +423,6 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
         space_op.GetMaterialOp(), space_op.GetNDSpace(), space_op.GetRTSpace(),
         iodata.solver.linear.tol, iodata.solver.linear.max_it, 0);
   }
-
-  // Set up the initial space for the eigenvalue solve. Satisfies boundary conditions and is
-  // projected appropriately.
-  if (iodata.solver.eigenmode.init_v0)
-  {
-    ComplexVector v0;
-    if (iodata.solver.eigenmode.init_v0_const)
-    {
-      Mpi::Print(" Using constant starting vector\n");
-      space_op.GetConstantInitialVector(v0);
-    }
-    else
-    {
-      Mpi::Print(" Using random starting vector\n");
-      space_op.GetRandomInitialVector(v0);
-    }
-    if (divfree)
-    {
-      divfree->Mult(v0);
-    }
-    eigen->SetInitialSpace(v0);  // Copies the vector
-
-    // Debug
-    // const auto &Grad = space_op.GetGradMatrix();
-    // ComplexVector r0(Grad->Width());
-    // r0.UseDevice(true);
-    // Grad.MultTranspose(v0.Real(), r0.Real());
-    // Grad.MultTranspose(v0.Imag(), r0.Imag());
-    // r0.Print();
-  }
-
-  // Configure the shift-and-invert strategy is employed to solve for the eigenvalues
-  // closest to the specified target, σ.
-  {
-    const double f_target =
-        iodata.units.Dimensionalize<Units::ValueType::FREQUENCY>(target) / (2 * M_PI);
-    Mpi::Print(" Shift-and-invert σ = {:.3e} GHz ({:.3e})\n", f_target, target);
-  }
-  if (C || has_A2 || nonlinear_type == NonlinearEigenSolver::SLP)
-  {
-    // Search for eigenvalues closest to λ = iσ.
-    eigen->SetShiftInvert(1i * target);
-    if (type == EigenSolverBackend::ARPACK)
-    {
-      // ARPACK searches based on eigenvalues of the transformed problem. The eigenvalue
-      // 1 / (λ - σ) will be a large-magnitude negative imaginary number for an eigenvalue
-      // λ with frequency close to but not below the target σ.
-      eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::SMALLEST_IMAGINARY);
-    }
-    else if (nonlinear_type == NonlinearEigenSolver::SLP)
-    {
-      eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_MAGNITUDE);
-    }
-    else
-    {
-      eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_IMAGINARY);
-    }
-  }
-  else
-  {
-    // Linear EVP has eigenvalues μ = -λ² = ω². Search for eigenvalues closest to μ = σ².
-    eigen->SetShiftInvert(target * target);
-    if (type == EigenSolverBackend::ARPACK)
-    {
-      // ARPACK searches based on eigenvalues of the transformed problem. 1 / (μ - σ²)
-      // will be a large-magnitude positive real number for an eigenvalue μ with frequency
-      // close to but below the target σ².
-      eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::LARGEST_REAL);
-    }
-    else
-    {
-      eigen->SetWhichEigenpairs(EigenvalueSolver::WhichType::TARGET_REAL);
-    }
-  }
-
-  // Set up the linear solver required for solving systems involving the shifted operator
-  // (K - σ² M) or P(iσ) = (K + iσ C - σ² M) during the eigenvalue solve. The
-  // preconditioner for complex linear systems is constructed from a real approximation
-  // to the complex system matrix.
-  auto A = space_op.GetSystemMatrix(1.0 + 0.0i, 1i * target, -target * target + 0.0i,
-                                    K.get(), C.get(), M.get(), A2.get());
-  auto P = space_op.GetPreconditionerMatrix<ComplexOperator>(
-      1.0 + 0.0i, 1i * target, -target * target + 0.0i, target);
-  auto ksp = std::make_unique<ComplexKspSolver>(iodata, space_op.GetNDSpaces(),
-                                                &space_op.GetH1Spaces());
-  ksp->SetOperators(*A, *P);
-  eigen->SetLinearSolver(*ksp);
 
   // Initialize structures for storing and reducing the results of error estimation.
   const bool is_2d = (space_op.GetNDSpace().Dimension() < 3);
@@ -345,73 +456,15 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   };
   ErrorIndicator indicator;
 
-  // Eigenvalue problem solve.
-  BlockTimer bt1(Timer::EPS);
-  Mpi::Print("\n");
-  int num_conv = eigen->Solve();
-  {
-    std::complex<double> lambda = (num_conv > 0) ? eigen->GetEigenvalue(0) : 0.0;
-    Mpi::Print(" Found {:d} converged eigenvalue{}{}\n", num_conv,
-               (num_conv > 1) ? "s" : "",
-               (num_conv > 0)
-                   ? fmt::format(" (first = {:.3e}{:+.3e}i)", lambda.real(), lambda.imag())
-                   : "");
-  }
-
-  if (has_A2 && nonlinear_type == NonlinearEigenSolver::HYBRID)
-  {
-    Mpi::Print("\n Refining eigenvalues with Quasi-Newton solver\n");
-    auto qn = std::make_unique<QuasiNewtonSolver>(space_op.GetComm(), std::move(eigen),
-                                                  num_conv, iodata.problem.verbose,
-                                                  iodata.solver.eigenmode.refine_nonlinear);
-    qn->SetTol(iodata.solver.eigenmode.tol);
-    qn->SetMaxIter(iodata.solver.eigenmode.max_it);
-    if (C)
-    {
-      qn->SetOperators(*K, *C, *M, EigenvalueSolver::ScaleType::NONE);
-    }
-    else
-    {
-      qn->SetOperators(*K, *M, EigenvalueSolver::ScaleType::NONE);
-    }
-    qn->SetExtraSystemMatrix(funcA2);
-    qn->SetPreconditionerUpdate(funcP);
-    qn->SetNumModes(iodata.solver.eigenmode.n, iodata.solver.eigenmode.max_size);
-    qn->SetPreconditionerLag(iodata.solver.eigenmode.preconditioner_lag,
-                             iodata.solver.eigenmode.preconditioner_lag_tol);
-    qn->SetMaxRestart(iodata.solver.eigenmode.max_restart);
-    qn->SetLinearSolver(*ksp);
-    qn->SetShiftInvert(1i * target);
-    eigen = std::move(qn);
-
-    // Suppress wave port output during nonlinear eigensolver iterations.
-    space_op.GetWavePortOp().SetSuppressOutput(true);
-    num_conv = eigen->Solve();
-    space_op.GetWavePortOp().SetSuppressOutput(false);
-  }
-
-  BlockTimer bt2(Timer::POSTPRO);
-  SaveMetadata(*ksp);
-
-  // Calculate and record the error indicators, and postprocess the results.
-  Mpi::Print("\nComputing solution error estimates and performing postprocessing\n");
-  if (!KM)
-  {
-    // Normalize the finalized eigenvectors with respect to mass matrix (unit electric field
-    // energy) even if they are not computed to be orthogonal with respect to it.
-    KM = space_op.GetInnerProductMatrix(0.0, 1.0, nullptr, M.get());
-    eigen->SetBMat(*KM);
-    eigen->RescaleEigenvectors(num_conv);
-  }
-  Mpi::Print("\n");
+  Mpi::Print("\nComputing solution error estimates and performing postprocessing\n\n");
 
   for (int i = 0; i < num_conv; i++)
   {
     // Get the eigenvalue and relative error.
-    std::complex<double> omega = eigen->GetEigenvalue(i);
-    double error_bkwd = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
-    double error_abs = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
-    if (!C && !has_A2)
+    std::complex<double> omega = eigenvalues[i];
+    double error_bkwd = errors_bkwd[i];
+    double error_abs = errors_abs[i];
+    if (!has_C && !has_A2)
     {
       // Linear EVP has eigenvalue μ = -λ² = ω².
       omega = std::sqrt(omega);
@@ -424,8 +477,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
     // Compute B = -1/(iω) ∇ x E on the true dofs, and set the internal GridFunctions in
     // PostOperator for all postprocessing operations.
-    eigen->GetEigenvector(i, E);
-
+    auto &E = eigenvectors[i];
     linalg::NormalizePhase(space_op.GetComm(), E);
 
     Curl.Mult(E.Real(), B.Real());
@@ -453,6 +505,8 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
       post_op.MeasureFinalize(indicator);
     }
   }
+  post_timer.reset();
+
   MFEM_VERIFY(num_conv >= iodata.solver.eigenmode.n, "Eigenmode solve only found "
                                                          << num_conv << " modes when "
                                                          << iodata.solver.eigenmode.n


### PR DESCRIPTION
## Summary

- Scope eigenmode solve-only objects so matrices, KSP/preconditioner state, nonlinear interpolation helpers, and the eigensolver backend are destroyed before postprocessing begins.
- Copy finalized eigenvalues, errors, and rescaled eigenvectors out of the eigensolver before leaving that scope.
- Construct eigenmode postprocessing objects only after solve state has been released, reducing peak memory pressure for output/error-estimation phases.

## Notes

This trades explicit storage of the converged eigenvectors for earlier release of substantially larger solve-time state. This is intended to reduce GPU peak memory for refined eigenmode cases where postprocessing/output allocates significant additional buffers.

## Testing

- `spack -e palace-eigensolver-peak-memory-env install -j4`
- Spack-built smoke run of `examples/cavity2d/cavity2d.json` with `N=1` and output redirected to `/tmp` completed successfully.
