### PR TITLE
Pin Spack to 1.2

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Setup environment
       uses: ./.github/actions/setup-runner
       with:
-        # Spack develop because we want to have access to the most recent
-        # version of spack-packages
-        spack-version: 'develop'
+        # Pin to the Spack 1.2 release series for reproducible CI (instead of
+        # the moving `develop` branch).
+        spack-version: 'releases/v1.2'
         llvm-version: 'dont-install'
         setup-intel: 'false'
 

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -23,6 +23,7 @@ spack:
     # $env is the current environment
     # $spack is the spack root
     template_dirs:
+      - "."
       - $env
       - $spack/share/spack/templates
   packages:

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -34,7 +34,9 @@ spack:
     template: PalaceDockerfile
     images:
       os: "ubuntu:24.04"
-      spack: develop
+      # Pinned to the Spack 1.2 release series (prebuilt spack/ubuntu-noble:1.2
+      # image on Docker Hub) instead of the moving `develop` tag.
+      spack: "1.2"
   # Find pre-compiled packages in binary caches. Requires GITHUB_USER and
   # GITHUB_TOKEN (or a personal access token).
   #

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -38,9 +38,9 @@ runs:
     - name: Setup environment
       uses: ./.github/actions/setup-runner
       with:
-        # Spack develop because we want to have access to the most recent
-        # version of spack-packages
-        spack-version: 'develop'
+        # Pin to the Spack 1.2 release series for reproducible CI (instead of
+        # the moving `develop` branch).
+        spack-version: 'releases/v1.2'
         # LLVM 19 because it is the latest supported by CUDA 12.9
         llvm-version: ${{ inputs.toolchain == 'llvm' && '19' || 'dont-install' }}
         setup-intel: ${{ inputs.toolchain == 'intel-oneapi' && 'true' || 'false' }}

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Use develop versions of key dependencies'
     required: false
     default: 'false'
+  spack-version:
+    description: 'Spack git ref to use (e.g. develop, releases/v1.2)'
+    required: false
+    default: 'releases/v1.2'
   test-cases:
     description: 'Test cases: "default", "long", or space-separated list'
     required: false
@@ -38,9 +42,9 @@ runs:
     - name: Setup environment
       uses: ./.github/actions/setup-runner
       with:
-        # Pin to the Spack 1.2 release series for reproducible CI (instead of
-        # the moving `develop` branch).
-        spack-version: 'releases/v1.2'
+        # Defaults to the pinned Spack 1.2 release series (see the action's
+        # input default); the lookahead workflow overrides this with `develop`.
+        spack-version: ${{ inputs.spack-version }}
         # LLVM 19 because it is the latest supported by CUDA 12.9
         llvm-version: ${{ inputs.toolchain == 'llvm' && '19' || 'dont-install' }}
         setup-intel: ${{ inputs.toolchain == 'intel-oneapi' && 'true' || 'false' }}

--- a/.github/actions/run-regression-tests/action.yml
+++ b/.github/actions/run-regression-tests/action.yml
@@ -41,7 +41,7 @@ runs:
       if: inputs.testing-on-build-runner != 'true'
       uses: ./.github/actions/setup-runner
       with:
-        spack-version: 'develop'
+        spack-version: 'releases/v1.2'
         llvm-version: ${{ inputs.toolchain == 'llvm' && '19' || 'dont-install' }}
         setup-intel: ${{ inputs.toolchain == 'intel-oneapi' && 'true' || 'false' }}
 

--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -5,9 +5,9 @@ name: 'Setup Runners'
 description: 'Common steps to prepare the environment to run Palace tests'
 inputs:
   spack-version:
-    description: 'Spack git tag to use'
+    description: 'Spack git ref to use (e.g. develop, releases/v1.2)'
     required: false
-    default: 'develop'
+    default: 'releases/v1.2'
   llvm-version:
     description: 'Version of LLVM to use (only major version supported, e.g. "19")'
     required: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,11 @@ jobs:
         if: needs.filter.outputs.should_build == 'true'
         uses: spack/setup-spack@v3
         with:
-          ref: develop
+          # Pin to the Spack 1.2 release series (matching the self-hosted
+          # runners) instead of the moving `develop` branch. spack@1.2 pairs
+          # with the spack-packages releases/v2026.06 repo (see repos.yaml).
+          spack_ref: releases/v1.2
+          packages_ref: releases/v2026.06
           buildcache: true
           color: true
 

--- a/.github/workflows/lookahead.yml
+++ b/.github/workflows/lookahead.yml
@@ -69,3 +69,18 @@ jobs:
           variant: +cuda
           run-regression-tests: 'true'
           use-develop-deps: 'true'
+
+  # Build against the tip of Spack (develop) rather than the pinned 1.2 release
+  # series, to catch upstream Spack/spack-packages changes that break Palace.
+  # Dependencies stay at their pinned versions so a failure points at Spack.
+  build-test-x64-gcc-spack-develop:
+    needs: filter
+    if: needs.filter.outputs.test == 'true'
+    runs-on: [self-hosted, x64]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/palace-ci
+        with:
+          toolchain: gcc
+          run-regression-tests: 'true'
+          spack-version: 'develop'


### PR DESCRIPTION
We were using `develop` because we needed some unreleased features, but now we can use 1.2 to reduce maintenance.

I also add spack develop to the lookahead jobs so that we can see problems coming up