### PR TITLE
Harden CI against script injection in GitHub Actions (docs.yml, ghcr-cleanup.yml)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,11 +53,15 @@ jobs:
               - '.github/workflows/docs.yml'
       - name: Decide whether to build
         id: decide
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_TEST: ${{ steps.filter.outputs.test }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]] || [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_build=${{ steps.filter.outputs.test }}" >> "$GITHUB_OUTPUT"
+            echo "should_build=${FILTER_TEST}" >> "$GITHUB_OUTPUT"
           fi
 
   build-docs:
@@ -199,14 +203,15 @@ jobs:
         if: needs.filter.outputs.should_build == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_TAG: ${{ inputs.deploy_tag }}
         run: |
           # For workflow_dispatch with deploy_tag, override the runner's immutable
           # GITHUB_* env vars so Documenter.jl sees a tag push.
-          if [[ -n "${{ inputs.deploy_tag }}" ]]; then
+          if [[ -n "${DEPLOY_TAG}" ]]; then
             export GITHUB_EVENT_NAME=push
-            export GITHUB_REF=refs/tags/${{ inputs.deploy_tag }}
+            export GITHUB_REF="refs/tags/${DEPLOY_TAG}"
             export GITHUB_REF_TYPE=tag
-            export GITHUB_REF_NAME=${{ inputs.deploy_tag }}
+            export GITHUB_REF_NAME="${DEPLOY_TAG}"
           fi
           eval $(spack -e . load --sh palace)
           julia --project=docs -e 'using Pkg; Pkg.instantiate()'
@@ -216,8 +221,10 @@ jobs:
         if: >-
           needs.filter.outputs.should_build == 'true' &&
           (startsWith(github.ref, 'refs/tags/') || inputs.deploy_tag != '')
+        env:
+          TAG_REF: ${{ inputs.deploy_tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.deploy_tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           git fetch origin gh-pages --depth=1
           STABLE=$(git show origin/gh-pages:stable)

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -63,9 +63,10 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
         run: |
-          gh api /orgs/${{ github.repository_owner }}/packages/container/palace-develop-testing \
+          gh api "/orgs/${REPO_OWNER}/packages/container/palace-develop-testing" \
             --jq '"palace-develop-testing versions before cleanup: \(.version_count)"'
 
       # Each Spack spec is a tagged version in the container package. We keep
@@ -92,7 +93,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
         run: |
-          gh api /orgs/${{ github.repository_owner }}/packages/container/palace-develop-testing \
+          gh api "/orgs/${REPO_OWNER}/packages/container/palace-develop-testing" \
             --jq '"palace-develop-testing versions after cleanup: \(.version_count)"'


### PR DESCRIPTION
In addition to #787 for GitHub-managed runners