### PR TITLE
Skip gh-pages coverage deploy for fork PRs

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -386,8 +386,12 @@ jobs:
             ctest -j "$(nproc 2> /dev/null || sysctl -n hw.ncpu)" --output-on-failure -LE "^(regression|long)$"
           fi
 
+      # NOTE: Fork PRs get a read-only GITHUB_TOKEN and cannot push to gh-pages;
+      # for those the coverage report is still available via the artifact below.
       - name: Deploy coverage to gh-pages
-        if: needs.filter.outputs.test == 'true' && matrix.with-coverage
+        if: |
+          needs.filter.outputs.test == 'true' && matrix.with-coverage &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -396,7 +400,9 @@ jobs:
           keep_files: true
 
       - name: Add coverage link to summary
-        if: needs.filter.outputs.test == 'true' && matrix.with-coverage
+        if: |
+          needs.filter.outputs.test == 'true' && matrix.with-coverage &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
For pull request events from forks, GITHUB_TOKEN is read-only regardless of the workflow's declared permissions, so the peaceiris/actions-gh-pages push to gh-pages fails with 403 and aborts the job before the regression test steps run (observed on PR #770, in the "Build and Test (Linux)" workflow).

Guard the deploy and the summary-link steps with the same same-repo condition already used by docs.yml for its GHCR cache push. The coverage report artifact upload is left unguarded since it works with a read-only token, so fork PRs still get a downloadable coverage report.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
