### PR TITLE
Fix issue with adaptively refined periodic meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     periodic problem could not be used as the input mesh for a subsequent solve. Loading now
     detects the already-periodic mesh and skips the periodicity construction.
     [PR 810](https://github.com/awslabs/palace/pull/810).
+  - Fixed an overflow in the mesh broadcast path used when loading nonconformal meshes. The
+    serialized mesh text can exceed 2 GiB for large meshes; the broadcast now uses a 64-bit
+    length and chunked `MPI_Bcast` calls to handle arbitrarily large payloads.
 
 ## [0.17.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     periodic problem could not be used as the input mesh for a subsequent solve. Loading now
     detects the already-periodic mesh and skips the periodicity construction.
     [PR 810](https://github.com/awslabs/palace/pull/810).
-  - Fixed an overflow in the mesh broadcast path used when loading nonconformal meshes. The
-    serialized mesh text can exceed 2 GiB for large meshes; the broadcast now uses a 64-bit
-    length and chunked `MPI_Bcast` calls to handle arbitrarily large payloads.
+  - Fixed an overflow in the mesh broadcast path used when loading nonconformal meshes by
+    introducing a chunked MPI broadcast call handle arbitrarily large meshes.
+    [PR 810](https://github.com/awslabs/palace/pull/810).
 
 ## [0.17.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,6 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 ## In progress
 
-#### Bug Fixes
-
-  - Fixed S-parameter post-processing for mixed Floquet + lumped/wave port configurations.
-    Previously, `MeasureSParameter()` skipped processing when Floquet ports coexisted with
-    lumped or wave ports, leaving `port-S.csv` with incorrect values. The fix applies a power
-    normalization factor, restoring S-matrix unitarity and reciprocity for the mixed
-    case [PR 804](https://github.com/awslabs/palace/pull/804).
-
 #### New Features
 
   - Added a `RationalImpedance` boundary condition: a surface (Robin) impedance boundary
@@ -33,6 +25,20 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     coefficients (its zeros and poles), generalizing the parallel-RLC `Impedance` boundary
     to any passive lumped-network response. SchemaVer 1-1-0
     [PR 770](https://github.com/awslabs/palace/pull/770).
+
+#### Bug Fixes
+
+  - Fixed S-parameter post-processing for mixed Floquet + lumped/wave port configurations.
+    Previously, `MeasureSParameter()` skipped processing when Floquet ports coexisted with
+    lumped or wave ports, leaving `port-S.csv` with incorrect values. The fix applies a power
+    normalization factor, restoring S-matrix unitarity and reciprocity for the mixed
+    case [PR 804](https://github.com/awslabs/palace/pull/804).
+  - Fixed a bug where a mesh saved with `"SaveAdaptMesh"` during nonconformal AMR on a
+    periodic problem could not be used as the input mesh for a subsequent solve. The saved
+    mesh is already periodic and retains only one of the two periodic boundary attributes,
+    so rebuilding the periodic vertex mapping from the configuration aborted with a
+    donor/receiver vertex count mismatch. Loading now detects the already-periodic mesh
+    and skips the periodicity construction.
 
 ## [0.17.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     normalization factor, restoring S-matrix unitarity and reciprocity for the mixed
     case [PR 804](https://github.com/awslabs/palace/pull/804).
   - Fixed a bug where a mesh saved with `"SaveAdaptMesh"` during nonconformal AMR on a
-    periodic problem could not be used as the input mesh for a subsequent solve. The saved
-    mesh is already periodic and retains only one of the two periodic boundary attributes,
-    so rebuilding the periodic vertex mapping from the configuration aborted with a
-    donor/receiver vertex count mismatch. Loading now detects the already-periodic mesh
-    and skips the periodicity construction.
+    periodic problem could not be used as the input mesh for a subsequent solve. Loading now
+    detects the already-periodic mesh and skips the periodicity construction.
+    [PR 810](https://github.com/awslabs/palace/pull/810).
 
 ## [0.17.0] - 2026-06-28
 

--- a/palace/utils/communication.hpp
+++ b/palace/utils/communication.hpp
@@ -4,7 +4,10 @@
 #ifndef PALACE_UTILS_COMMUNICATION_HPP
 #define PALACE_UTILS_COMMUNICATION_HPP
 
+#include <algorithm>
 #include <complex>
+#include <cstdint>
+#include <limits>
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/printf.h>
@@ -322,6 +325,22 @@ public:
   static void Broadcast(int len, T *buff, int root, MPI_Comm comm)
   {
     MPI_Bcast(buff, len, mpi::DataType<T>(), root, comm);
+  }
+
+  // Global broadcast from root for buffers whose length may exceed INT_MAX (e.g. a
+  // serialized multi-GB mesh). Chunks the transfer to respect the int count limit of the
+  // classic MPI interface. The chunk length is exposed for testing the chunking logic
+  // with small buffers.
+  template <typename T>
+  static void BroadcastLarge(std::int64_t len, T *buff, int root, MPI_Comm comm,
+                             std::int64_t max_chunk = std::numeric_limits<int>::max())
+  {
+    MFEM_ASSERT(len >= 0 && max_chunk > 0, "Invalid BroadcastLarge lengths!");
+    for (std::int64_t offset = 0; offset < len; offset += max_chunk)
+    {
+      const int n = static_cast<int>(std::min(max_chunk, len - offset));
+      MPI_Bcast(buff + offset, n, mpi::DataType<T>(), root, comm);
+    }
   }
 
   // Allgather a fixed count of items per rank; every rank ends up with the concatenated

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -324,13 +324,15 @@ std::unique_ptr<mfem::ParMesh> Partition(IoData &iodata, std::unique_ptr<mfem::M
   }
   else
   {
-    // Send the preprocessed serial mesh and partitioning as a byte string.
+    // Send the preprocessed serial mesh and partitioning as a byte string. The
+    // serialized mesh can exceed INT_MAX bytes for large meshes, so use a 64-bit
+    // length and a chunked broadcast.
     MPI_Comm node_comm;
     MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, Mpi::Rank(comm), MPI_INFO_NULL,
                         &node_comm);
     constexpr bool generate_edges = false, refine = true, fix_orientation = false;
     std::string so;
-    int slen = 0;
+    std::int64_t slen = 0;
     if (smesh)
     {
       std::ostringstream fo(std::stringstream::out);
@@ -340,15 +342,14 @@ std::unique_ptr<mfem::ParMesh> Partition(IoData &iodata, std::unique_ptr<mfem::M
       smesh.reset();  // Root process needs to rebuild the mesh to ensure consistency
                       // with the saved serial mesh (refinement marking, for example)
       so = fo.str();
-      slen = static_cast<int>(so.size());
-      MFEM_VERIFY(so.size() == (std::size_t)slen, "Overflow in stringbuffer size!");
+      slen = static_cast<std::int64_t>(so.size());
     }
     Mpi::Broadcast(1, &slen, 0, node_comm);
     if (so.empty())
     {
       so.resize(slen);
     }
-    Mpi::Broadcast(slen, so.data(), 0, node_comm);
+    Mpi::BroadcastLarge(slen, so.data(), 0, node_comm);
     {
       std::istringstream fi(so);
       smesh = std::make_unique<mfem::Mesh>(fi, generate_edges, refine, fix_orientation);

--- a/palace/utils/geodata_impl.cpp
+++ b/palace/utils/geodata_impl.cpp
@@ -977,13 +977,10 @@ DeterminePeriodicVertexMapping(std::unique_ptr<mfem::Mesh> &mesh,
     }
   }
 
-  // A mesh saved after nonconformal AMR on a periodic mesh has a single boundary
-  // element per periodic seam face carrying only one of the two attributes (NCMesh
-  // stores one attribute per face, so the donor/receiver pair sharing a face after
-  // MakePeriodic collapses to one). Exactly one of the two sets being empty is thus
-  // the signature of an already-periodic mesh: skip MakePeriodic by returning an
-  // empty mapping. Both sets empty means the config names attributes not present in
-  // the mesh at all.
+  // A periodic mesh saved after nonconformal AMR retains only one of the two periodic
+  // boundary ttributes. Exactly one of the two sets being empty is thus the signature of an
+  // already-periodic mesh: skip MakePeriodic by returning an  empty mapping. Both sets
+  // empty means the config names attributes not present in the mesh at all.
   MFEM_VERIFY(!bdr_v_donor.empty() || !bdr_v_receiver.empty(),
               "No boundary elements found for donor or receiver attributes of a periodic "
               "boundary pair!");

--- a/palace/utils/geodata_impl.cpp
+++ b/palace/utils/geodata_impl.cpp
@@ -978,8 +978,8 @@ DeterminePeriodicVertexMapping(std::unique_ptr<mfem::Mesh> &mesh,
   }
 
   // A periodic mesh saved after nonconformal AMR retains only one of the two periodic
-  // boundary ttributes. Exactly one of the two sets being empty is thus the signature of an
-  // already-periodic mesh: skip MakePeriodic by returning an  empty mapping. Both sets
+  // boundary attributes. Exactly one of the two sets being empty is thus the signature of
+  // an already-periodic mesh: skip MakePeriodic by returning an empty mapping. Both sets
   // empty means the config names attributes not present in the mesh at all.
   MFEM_VERIFY(!bdr_v_donor.empty() || !bdr_v_receiver.empty(),
               "No boundary elements found for donor or receiver attributes of a periodic "

--- a/palace/utils/geodata_impl.cpp
+++ b/palace/utils/geodata_impl.cpp
@@ -978,17 +978,21 @@ DeterminePeriodicVertexMapping(std::unique_ptr<mfem::Mesh> &mesh,
   }
 
   // A periodic mesh saved after nonconformal AMR retains only one of the two periodic
-  // boundary attributes. Exactly one of the two sets being empty is thus the signature of
-  // an already-periodic mesh: skip MakePeriodic by returning an empty mapping. Both sets
-  // empty means the config names attributes not present in the mesh at all.
+  // boundary attributes, so one of the two sets being empty is expected for an
+  // already-periodic mesh: skip MakePeriodic by returning an empty mapping. Warn since an
+  // accidentally empty donor or receiver attribute set (previously an error) takes the
+  // same path. Both sets empty means the config names attributes not present in the mesh
+  // at all.
   MFEM_VERIFY(!bdr_v_donor.empty() || !bdr_v_receiver.empty(),
               "No boundary elements found for donor or receiver attributes of a periodic "
               "boundary pair!");
   if (bdr_v_donor.empty() || bdr_v_receiver.empty())
   {
-    Mpi::Print("Mesh is already periodic for donor/receiver attributes [{}]/[{}], "
-               "skipping MakePeriodic\n",
-               fmt::join(da, ", "), fmt::join(ra, ", "));
+    Mpi::Warning("No boundary elements found for {} attributes [{}] of a periodic "
+                 "boundary pair: assuming the mesh is already periodic and skipping "
+                 "periodic vertex matching!",
+                 bdr_v_donor.empty() ? "donor" : "receiver",
+                 fmt::join(bdr_v_donor.empty() ? da : ra, ", "));
     return {};
   }
 

--- a/palace/utils/geodata_impl.cpp
+++ b/palace/utils/geodata_impl.cpp
@@ -977,6 +977,24 @@ DeterminePeriodicVertexMapping(std::unique_ptr<mfem::Mesh> &mesh,
     }
   }
 
+  // A mesh saved after nonconformal AMR on a periodic mesh has a single boundary
+  // element per periodic seam face carrying only one of the two attributes (NCMesh
+  // stores one attribute per face, so the donor/receiver pair sharing a face after
+  // MakePeriodic collapses to one). Exactly one of the two sets being empty is thus
+  // the signature of an already-periodic mesh: skip MakePeriodic by returning an
+  // empty mapping. Both sets empty means the config names attributes not present in
+  // the mesh at all.
+  MFEM_VERIFY(!bdr_v_donor.empty() || !bdr_v_receiver.empty(),
+              "No boundary elements found for donor or receiver attributes of a periodic "
+              "boundary pair!");
+  if (bdr_v_donor.empty() || bdr_v_receiver.empty())
+  {
+    Mpi::Print("Mesh is already periodic for donor/receiver attributes [{}]/[{}], "
+               "skipping MakePeriodic\n",
+               fmt::join(da, ", "), fmt::join(ra, ", "));
+    return {};
+  }
+
   MFEM_VERIFY(bdr_v_donor.size() == bdr_v_receiver.size(),
               "Different number of "
               "vertices on donor and receiver boundaries. Cannot create periodic mesh.");

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-basesolver.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-boundarymodeoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-coefficient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-communication.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-config.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-constants.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-domainpostoperator.cpp

--- a/test/unit/test-communication.cpp
+++ b/test/unit/test-communication.cpp
@@ -9,7 +9,7 @@
 
 using namespace palace;
 
-TEST_CASE("BroadcastLarge", "[communication][Serial][Parallel]")
+TEST_CASE("BroadcastLarge", "[communication][Parallel]")
 {
   MPI_Comm comm = Mpi::World();
   const int root = 0;

--- a/test/unit/test-communication.cpp
+++ b/test/unit/test-communication.cpp
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+#include <catch2/catch_test_macros.hpp>
+#include "utils/communication.hpp"
+
+using namespace palace;
+
+TEST_CASE("BroadcastLarge", "[communication][Serial][Parallel]")
+{
+  MPI_Comm comm = Mpi::World();
+  const int root = 0;
+
+  SECTION("Chunked matches unchunked")
+  {
+    // Length chosen to exercise full chunks plus a partial remainder chunk.
+    const std::int64_t len = 1000;
+    std::vector<char> ref(len), buf(len);
+    if (Mpi::Rank(comm) == root)
+    {
+      for (std::int64_t i = 0; i < len; i++)
+      {
+        ref[i] = static_cast<char>(i % 251);
+      }
+      buf = ref;
+    }
+    Mpi::Broadcast(static_cast<int>(len), ref.data(), root, comm);
+    for (const std::int64_t chunk : {std::int64_t(1), std::int64_t(7), std::int64_t(333),
+                                     std::int64_t(1000), std::int64_t(5000)})
+    {
+      std::vector<char> out = (Mpi::Rank(comm) == root) ? buf : std::vector<char>(len);
+      Mpi::BroadcastLarge(len, out.data(), root, comm, chunk);
+      REQUIRE(out == ref);
+    }
+  }
+
+  SECTION("Zero length")
+  {
+    std::vector<char> buf;
+    Mpi::BroadcastLarge(0, buf.data(), root, comm, 16);
+    REQUIRE(buf.empty());
+  }
+
+  SECTION("Non-char type")
+  {
+    const std::int64_t len = 137;
+    std::vector<double> buf(len, 0.0);
+    if (Mpi::Rank(comm) == root)
+    {
+      std::iota(buf.begin(), buf.end(), 0.5);
+    }
+    Mpi::BroadcastLarge(len, buf.data(), root, comm, 16);
+    std::vector<double> ref(len);
+    std::iota(ref.begin(), ref.end(), 0.5);
+    REQUIRE(buf == ref);
+  }
+}

--- a/test/unit/test-geodata.cpp
+++ b/test/unit/test-geodata.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <memory>
+#include <sstream>
 #include <utility>
 #include <vector>
 #include <catch2/catch_test_macros.hpp>
@@ -448,6 +449,20 @@ TEST_CASE("PeriodicGmsh", "[geodata][Serial]")
     auto periodic_mapping = mesh::DeterminePeriodicVertexMapping(mesh, data);
     REQUIRE(periodic_mapping.empty());
   }
+
+  // Round-trip the periodic mesh through the nonconformal (AMR) save format. The NCMesh
+  // conversion stores a single boundary attribute per face, so the donor/receiver pair
+  // sharing each seam face collapses to one attribute; the reloaded mesh must still be
+  // detected as already periodic.
+  mesh->EnsureNCMesh(true);
+  std::stringstream buffer;
+  mesh->Print(buffer);
+  buffer.seekg(0);
+  mesh = std::make_unique<mfem::Mesh>(buffer, false, true, false);
+  REQUIRE((mesh->bdr_attributes.Find(1) >= 0) != (mesh->bdr_attributes.Find(2) >= 0));
+  REQUIRE(mesh::DeterminePeriodicVertexMapping(
+              mesh, boundary_torus.periodic.boundary_pairs.front())
+              .empty());
 }
 
 TEST_CASE("Default IOData", "[iodata][Serial]")


### PR DESCRIPTION
Fixed a bug where a mesh saved with `"SaveAdaptMesh"` during nonconformal AMR on a periodic problem could not be used as the input mesh for a subsequent solve. Loading now detects the already-periodic mesh and skips the periodicity construction. Also added chunked MPI broadcasting to read large NC meshes. Closes #809.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
