### PR TITLE
Add libCEED output functionals for GPU postprocessing

### DIFF
--- a/cmake/ExternalGitTags.cmake
+++ b/cmake/ExternalGitTags.cmake
@@ -76,7 +76,7 @@ set(EXTERN_LIBCEED_GIT_BRANCH
   "Git branch for external libCEED build"
 )
 set(EXTERN_LIBCEED_GIT_TAG
-  "95bd1e908b16e04a70015e3a9a7fddec5e9c3fc8" CACHE STRING
+  "240fe22d691579cf9c87e0271b53c25afdc3091d" CACHE STRING
   "Git tag for external libCEED build"
 )
 
@@ -89,9 +89,9 @@ set(EXTERN_LIBXSMM_GIT_BRANCH
   "main" CACHE STRING
   "Git branch for external LIBXSMM build"
 )
-# libxsmm does not tag versions very often (last was Dec 2021)
+# libCEED requires LIBXSMM 2.0 or newer.
 set(EXTERN_LIBXSMM_GIT_TAG
-  "ea0b20499a41377bab148257240adbbfe1b4a333" CACHE STRING
+  "5ce29626ddad947f0d5c433ce78c58ff64dfbbdb" CACHE STRING
   "Git tag for external LIBXSMM build"
 )
 

--- a/cmake/ExternalLibCEED.cmake
+++ b/cmake/ExternalLibCEED.cmake
@@ -107,6 +107,11 @@ endif()
 string(REPLACE ";" "; " LIBCEED_OPTIONS_PRINT "${LIBCEED_OPTIONS}")
 message(STATUS "LIBCEED_OPTIONS: ${LIBCEED_OPTIONS_PRINT}")
 
+# Patches to libCEED for Palace GPU postprocessing support.
+set(LIBCEED_PATCH_FILES
+  "${CMAKE_SOURCE_DIR}/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff"
+)
+
 include(ExternalProject)
 ExternalProject_Add(libCEED
   DEPENDS           ${LIBCEED_DEPENDENCIES}
@@ -117,6 +122,10 @@ ExternalProject_Add(libCEED
   PREFIX            ${CMAKE_BINARY_DIR}/extern/libCEED-cmake
   BUILD_IN_SOURCE   TRUE
   UPDATE_COMMAND    ""
+  PATCH_COMMAND
+    git reset --hard &&
+    git clean -fd &&
+    git apply "${LIBCEED_PATCH_FILES}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ${CMAKE_MAKE_PROGRAM} ${LIBCEED_OPTIONS} install

--- a/cmake/ExternalPalace.cmake
+++ b/cmake/ExternalPalace.cmake
@@ -101,6 +101,14 @@ if(PALACE_WITH_CUDA)
     "-DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}"
     "-DCMAKE_CUDA_FLAGS=${CMAKE_CUDA_FLAGS}"
   )
+  if(NOT "${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "")
+    # Forward the CUDA host compiler: BLT (via the umpire/camp CMake configs from
+    # MAGMA's dependencies) errors out if CMAKE_CUDA_HOST_COMPILER is not set before
+    # CUDA language enablement in the inner Palace configure.
+    list(APPEND PALACE_OPTIONS
+      "-DCMAKE_CUDA_HOST_COMPILER=${CMAKE_CUDA_HOST_COMPILER}"
+    )
+  endif()
   if(NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
     list(APPEND PALACE_OPTIONS
       "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"

--- a/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff
+++ b/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff
@@ -1,0 +1,2751 @@
+diff --git a/backends/cuda-ref/ceed-cuda-ref-basis.c b/backends/cuda-ref/ceed-cuda-ref-basis.c
+index 684f329e..704259fb 100644
+--- a/backends/cuda-ref/ceed-cuda-ref-basis.c
++++ b/backends/cuda-ref/ceed-cuda-ref-basis.c
+@@ -10,6 +10,7 @@
+ #include <ceed/jit-tools.h>
+ #include <cuda.h>
+ #include <cuda_runtime.h>
++#include <math.h>
+ #include <string.h>
+
+ #include "../cuda/ceed-cuda-common.h"
+@@ -255,6 +256,423 @@ static int CeedBasisApplyAddAtPoints_Cuda(CeedBasis basis, const CeedInt num_ele
+   return CEED_ERROR_SUCCESS;
+ }
+
++//------------------------------------------------------------------------------
++// Basis apply - non-tensor AtPoints
++//------------------------------------------------------------------------------
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++static int CeedBasisNonTensorModalTopologyAtPoints_Cuda(CeedElemTopology topo, CeedInt *modal_topology) {
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_LINE;
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TRIANGLE;
++      break;
++    case CEED_TOPOLOGY_TET:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TET;
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PRISM;
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PYRAMID;
++      break;
++    default:
++      *modal_topology = 0;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static CeedInt CeedBasisNonTensorNumModesAtPoints_Cuda(CeedElemTopology topo, CeedInt degree) {
++  const CeedInt tri_modes = (degree + 1) * (degree + 2) / 2;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      return degree + 1;
++    case CEED_TOPOLOGY_TRIANGLE:
++      return tri_modes;
++    case CEED_TOPOLOGY_TET:
++      return tri_modes * (degree + 3) / 3;
++    case CEED_TOPOLOGY_PRISM:
++      return tri_modes * (degree + 1);
++    case CEED_TOPOLOGY_PYRAMID:
++      return (degree + 1) * (degree + 2) * (2 * degree + 3) / 6;
++    default:
++      return 0;
++  }
++}
++
++static bool CeedBasisNonTensorDegreeAtPoints_Cuda(CeedElemTopology topo, CeedInt num_modes, CeedInt *degree) {
++  for (CeedInt p = 0; p <= 16; p++) {
++    if (CeedBasisNonTensorNumModesAtPoints_Cuda(topo, p) == num_modes) {
++      *degree = p;
++      return true;
++    }
++  }
++  return false;
++}
++
++static CeedScalar CeedBasisPowIntAtPoints_Cuda(CeedScalar x, CeedInt p) {
++  CeedScalar y = 1.0;
++
++  for (CeedInt i = 0; i < p; i++) y *= x;
++  return y;
++}
++
++static int CeedBasisNonTensorModesAtPoint_Cuda(CeedElemTopology topo, CeedInt degree, CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *phi) {
++  CeedInt mode = 0;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      for (CeedInt i = 0; i <= degree; i++) phi[mode++] = CeedBasisPowIntAtPoints_Cuda(x, i);
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          const CeedInt j = total - i;
++
++          phi[mode++] = CeedBasisPowIntAtPoints_Cuda(x, i) * CeedBasisPowIntAtPoints_Cuda(y, j);
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_TET:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          for (CeedInt j = 0; j <= total - i; j++) {
++            const CeedInt k = total - i - j;
++
++            phi[mode++] = CeedBasisPowIntAtPoints_Cuda(x, i) * CeedBasisPowIntAtPoints_Cuda(y, j) * CeedBasisPowIntAtPoints_Cuda(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      for (CeedInt k = 0; k <= degree; k++) {
++        for (CeedInt total = 0; total <= degree; total++) {
++          for (CeedInt i = 0; i <= total; i++) {
++            const CeedInt j = total - i;
++
++            phi[mode++] = CeedBasisPowIntAtPoints_Cuda(x, i) * CeedBasisPowIntAtPoints_Cuda(y, j) * CeedBasisPowIntAtPoints_Cuda(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      for (CeedInt k = 0; k <= degree; k++) {
++        const CeedInt xy_degree = degree - k;
++
++        for (CeedInt i = 0; i <= xy_degree; i++) {
++          for (CeedInt j = 0; j <= xy_degree; j++) {
++            phi[mode++] = CeedBasisPowIntAtPoints_Cuda(x, i) * CeedBasisPowIntAtPoints_Cuda(y, j) * CeedBasisPowIntAtPoints_Cuda(z, k);
++          }
++        }
++      }
++      break;
++    default:
++      break;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildModalAtPoints_Cuda(Ceed ceed, CeedElemTopology topo, CeedInt dim, CeedInt num_qpts, const CeedScalar *q_ref, CeedInt q_comp,
++                                            CeedInt num_nodes, const CeedScalar *tabulation, CeedInt requested_degree, bool require_overdetermined,
++                                            const char *label, CeedInt *degree, CeedInt *num_modes, CeedScalar **modal_at_points) {
++  const CeedScalar tolerance    = 10000. * CEED_EPSILON;
++  const CeedInt    first_degree = requested_degree >= 0 ? requested_degree : 0;
++  const CeedInt    last_degree  = requested_degree >= 0 ? requested_degree : 16;
++
++  for (CeedInt p = first_degree; p <= last_degree; p++) {
++    const CeedInt modes       = CeedBasisNonTensorNumModesAtPoints_Cuda(topo, p);
++    CeedScalar   *vandermonde = NULL, *vandermonde_pinv = NULL, *candidate = NULL;
++    CeedScalar    max_error = 0.0;
++
++    if (!modes || modes > num_qpts) break;
++    if (require_overdetermined && num_qpts <= modes) continue;
++
++    CeedCallBackend(CeedCalloc(num_qpts * modes, &vandermonde));
++    CeedCallBackend(CeedCalloc(modes * num_qpts, &vandermonde_pinv));
++    CeedCallBackend(CeedCalloc(q_comp * modes * num_nodes, &candidate));
++
++    for (CeedInt q = 0; q < num_qpts; q++) {
++      const CeedScalar x = q_ref[0 * num_qpts + q];
++      const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++      const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++      CeedCallBackend(CeedBasisNonTensorModesAtPoint_Cuda(topo, p, x, y, z, &vandermonde[q * modes]));
++    }
++    CeedCallBackend(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, modes, vandermonde_pinv));
++    for (CeedInt d = 0; d < q_comp; d++) {
++      CeedCallBackend(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &tabulation[d * num_qpts * num_nodes], &candidate[d * modes * num_nodes],
++                                               modes, num_nodes, num_qpts));
++    }
++
++    for (CeedInt d = 0; d < q_comp; d++) {
++      for (CeedInt q = 0; q < num_qpts; q++) {
++        for (CeedInt node = 0; node < num_nodes; node++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt mode = 0; mode < modes; mode++)
++            value += vandermonde[q * modes + mode] * candidate[d * modes * num_nodes + mode * num_nodes + node];
++          const CeedScalar error = fabs(value - tabulation[d * num_qpts * num_nodes + q * num_nodes + node]);
++
++          max_error = max_error > error ? max_error : error;
++        }
++      }
++    }
++
++    CeedCallBackend(CeedFree(&vandermonde));
++    CeedCallBackend(CeedFree(&vandermonde_pinv));
++    if (max_error <= tolerance) {
++      *degree          = p;
++      *num_modes       = modes;
++      *modal_at_points = candidate;
++      return CEED_ERROR_SUCCESS;
++    }
++    CeedCallBackend(CeedFree(&candidate));
++  }
++
++  return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
++                   "%s AtPoints requires tabulation points that overdetermine a complete polynomial reconstruction for non-standard spaces", label);
++}
++
++static int CeedBasisBuildNonTensorInterpAtPoints_Cuda(CeedBasis basis, CeedBasisNonTensor_Cuda *data) {
++  Ceed              ceed;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree = -1, num_modes, modal_topology, q_comp_interp;
++  const CeedScalar *interp, *q_ref;
++  CeedScalar       *interp_at_points = NULL;
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++  CeedCallBackend(CeedBasisGetInterp(basis, &interp));
++  CeedCallBackend(CeedBasisGetQRef(basis, &q_ref));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Cuda(topo, &modal_topology));
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints interpolation is not supported for this element topology");
++  CeedCheck(interp && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor interpolation AtPoints requires interp and q_ref tables");
++  if (!(fe_space == CEED_FE_SPACE_H1 && CeedBasisNonTensorDegreeAtPoints_Cuda(topo, num_nodes, &degree))) degree = -1;
++  CeedCallBackend(CeedBasisBuildModalAtPoints_Cuda(ceed, topo, dim, num_qpts, q_ref, q_comp_interp, num_nodes, interp, degree, degree < 0,
++                                                   "Non-tensor interpolation", &degree, &num_modes, &interp_at_points));
++
++  CeedCallCuda(ceed, cudaMalloc((void **)&data->d_interp_at_points, q_comp_interp * num_modes * num_nodes * sizeof(CeedScalar)));
++  CeedCallCuda(ceed, cudaMemcpy(data->d_interp_at_points, interp_at_points, q_comp_interp * num_modes * num_nodes * sizeof(CeedScalar),
++                                cudaMemcpyHostToDevice));
++  data->interp_num_modes_at_points = num_modes;
++  data->interp_degree_at_points    = degree;
++
++  CeedCallBackend(CeedFree(&interp_at_points));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildNonTensorGradAtPoints_Cuda(CeedBasis basis, CeedBasisNonTensor_Cuda *data) {
++  Ceed              ceed;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree, grad_degree, num_modes, modal_topology;
++  const CeedScalar *grad, *q_ref;
++  CeedScalar       *vandermonde = NULL, *vandermonde_pinv = NULL, *grad_at_points = NULL;
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCallBackend(CeedBasisGetGrad(basis, &grad));
++  CeedCallBackend(CeedBasisGetQRef(basis, &q_ref));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Cuda(topo, &modal_topology));
++  CeedCheck(fe_space == CEED_FE_SPACE_H1 && modal_topology, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints gradients are only supported for H^1 bases with supported topologies");
++  CeedCheck(grad && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "H^1 non-tensor gradient AtPoints requires grad and q_ref tables");
++  CeedCheck(CeedBasisNonTensorDegreeAtPoints_Cuda(topo, num_nodes, &degree), ceed, CEED_ERROR_UNSUPPORTED,
++            "Cannot infer non-tensor H^1 polynomial degree from %" CeedInt_FMT " nodes", num_nodes);
++
++  grad_degree = degree;
++  num_modes   = CeedBasisNonTensorNumModesAtPoints_Cuda(topo, grad_degree);
++  if (num_qpts < num_modes) {
++    CeedInt reduced_degree = CeedIntMax(0, degree - 1), reduced_num_modes = CeedBasisNonTensorNumModesAtPoints_Cuda(topo, reduced_degree);
++
++    CeedCheck(topo == CEED_TOPOLOGY_LINE || topo == CEED_TOPOLOGY_TRIANGLE || topo == CEED_TOPOLOGY_TET, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, num_modes, num_qpts);
++    CeedCheck(num_qpts >= reduced_num_modes, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, reduced_num_modes, num_qpts);
++    grad_degree = reduced_degree;
++    num_modes   = reduced_num_modes;
++  }
++
++  CeedCallBackend(CeedCalloc(num_qpts * num_modes, &vandermonde));
++  CeedCallBackend(CeedCalloc(num_modes * num_qpts, &vandermonde_pinv));
++  CeedCallBackend(CeedCalloc(dim * num_modes * num_nodes, &grad_at_points));
++
++  for (CeedInt q = 0; q < num_qpts; q++) {
++    const CeedScalar x = q_ref[0 * num_qpts + q];
++    const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++    const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++    CeedCallBackend(CeedBasisNonTensorModesAtPoint_Cuda(topo, grad_degree, x, y, z, &vandermonde[q * num_modes]));
++  }
++  CeedCallBackend(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, num_modes, vandermonde_pinv));
++  for (CeedInt d = 0; d < dim; d++) {
++    CeedCallBackend(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &grad[d * num_qpts * num_nodes], &grad_at_points[d * num_modes * num_nodes],
++                                             num_modes, num_nodes, num_qpts));
++  }
++
++  CeedCallCuda(ceed, cudaMalloc((void **)&data->d_grad_at_points, dim * num_modes * num_nodes * sizeof(CeedScalar)));
++  CeedCallCuda(ceed, cudaMemcpy(data->d_grad_at_points, grad_at_points, dim * num_modes * num_nodes * sizeof(CeedScalar), cudaMemcpyHostToDevice));
++  data->grad_num_modes_at_points = num_modes;
++  data->grad_degree_at_points    = grad_degree;
++
++  CeedCallBackend(CeedFree(&vandermonde));
++  CeedCallBackend(CeedFree(&vandermonde_pinv));
++  CeedCallBackend(CeedFree(&grad_at_points));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensorCore_Cuda(CeedBasis basis, bool apply_add, const CeedInt num_elem, const CeedInt *num_points,
++                                                    CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed                     ceed;
++  CeedElemTopology         topo;
++  CeedInt                  dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, max_num_points = 0;
++  CeedSize                 x_len, u_len, v_len, len_required;
++  const CeedScalar        *d_x, *d_u;
++  CeedScalar              *d_v;
++  CeedBasisNonTensor_Cuda *data;
++
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCallBackend(CeedVectorSetValue(v, 1.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedBasisGetData(basis, &data));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Cuda(topo, &modal_topology));
++
++  CeedCheck(!apply_add, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints does not support ApplyAdd");
++  CeedCheck(t_mode == CEED_NOTRANSPOSE, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints only supports CEED_NOTRANSPOSE");
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints is not supported for this element topology");
++
++  for (CeedInt i = 0; i < num_elem; i++) max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  if (max_num_points == 0) {
++    CeedCallBackend(CeedDestroy(&ceed));
++    return CEED_ERROR_SUCCESS;
++  }
++  CeedCallBackend(CeedVectorGetLength(x_ref, &x_len));
++  len_required = (CeedSize)dim * (CeedSize)num_elem * (CeedSize)max_num_points;
++  CeedCheck(
++      x_len >= len_required, ceed, CEED_ERROR_BACKEND,
++      "Reference coordinate vector at points must be padded to the same number of points in each element for BasisApplyAtPoints on GPU backends."
++      " Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++      x_len, len_required);
++  CeedCallBackend(CeedVectorGetLength(u, &u_len));
++  len_required = (CeedSize)num_comp * (CeedSize)num_elem * (CeedSize)num_nodes;
++  CeedCheck(u_len >= len_required, ceed, CEED_ERROR_BACKEND,
++            "Input vector incompatible with non-tensor BasisApplyAtPoints. Found %" CeedSize_FMT ", Required %" CeedSize_FMT, u_len, len_required);
++  CeedCallBackend(CeedVectorGetLength(v, &v_len));
++  len_required = (CeedSize)num_comp * (CeedSize)q_comp * (CeedSize)num_elem * (CeedSize)max_num_points;
++  CeedCheck(v_len >= len_required, ceed, CEED_ERROR_BACKEND,
++            "Vector at points must be padded to the same number of points in each element for BasisApplyAtPoints on GPU backends."
++            " Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++            v_len, len_required);
++
++  {
++    const CeedInt num_bytes = num_elem * sizeof(CeedInt);
++
++    if (num_elem != data->num_elem_at_points) {
++      data->num_elem_at_points = num_elem;
++      if (data->d_points_per_elem) CeedCallCuda(ceed, cudaFree(data->d_points_per_elem));
++      CeedCallCuda(ceed, cudaMalloc((void **)&data->d_points_per_elem, num_bytes));
++      CeedCallBackend(CeedFree(&data->h_points_per_elem));
++      CeedCallBackend(CeedCalloc(num_elem, &data->h_points_per_elem));
++    }
++    if (memcmp(data->h_points_per_elem, num_points, num_bytes)) {
++      memcpy(data->h_points_per_elem, num_points, num_bytes);
++      CeedCallCuda(ceed, cudaMemcpy(data->d_points_per_elem, num_points, num_bytes, cudaMemcpyHostToDevice));
++    }
++  }
++
++  if (eval_mode == CEED_EVAL_INTERP && !data->d_interp_at_points) CeedCallBackend(CeedBasisBuildNonTensorInterpAtPoints_Cuda(basis, data));
++  if (eval_mode == CEED_EVAL_GRAD && !data->d_grad_at_points) CeedCallBackend(CeedBasisBuildNonTensorGradAtPoints_Cuda(basis, data));
++  degree_at_points    = eval_mode == CEED_EVAL_INTERP ? data->interp_degree_at_points : data->grad_degree_at_points;
++  num_modes_at_points = eval_mode == CEED_EVAL_INTERP ? data->interp_num_modes_at_points : data->grad_num_modes_at_points;
++
++  {
++    CUmodule   *module_at_points  = eval_mode == CEED_EVAL_INTERP ? &data->moduleInterpAtPoints : &data->moduleGradAtPoints;
++    CUfunction *kernel_at_points  = eval_mode == CEED_EVAL_INTERP ? &data->InterpAtPoints : &data->GradAtPoints;
++    CeedInt    *kernel_num_points = eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_num_points : &data->grad_kernel_num_points;
++    CeedInt    *kernel_degree     = eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_degree_at_points : &data->grad_kernel_degree_at_points;
++    CeedInt    *kernel_num_modes  = eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_num_modes_at_points : &data->grad_kernel_num_modes_at_points;
++    CeedInt    *kernel_modal_topology =
++        eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_modal_topology_at_points : &data->grad_kernel_modal_topology_at_points;
++
++    if (*kernel_num_points != max_num_points || *kernel_degree != degree_at_points || *kernel_num_modes != num_modes_at_points ||
++        *kernel_modal_topology != modal_topology) {
++      const char basis_kernel_source[] = "// Nontensor basis AtPoints source\n#include <ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h>\n";
++      CeedInt    q_comp_interp;
++
++      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++      *kernel_num_points     = max_num_points;
++      *kernel_degree         = degree_at_points;
++      *kernel_num_modes      = num_modes_at_points;
++      *kernel_modal_topology = modal_topology;
++      if (*module_at_points) CeedCallCuda(ceed, cuModuleUnload(*module_at_points));
++      CeedCallBackend(CeedCompile_Cuda(ceed, basis_kernel_source, "basis_nontensor_at_points", module_at_points, 8, "BASIS_P", num_nodes,
++                                       "BASIS_NUM_COMP", num_comp, "BASIS_Q_COMP_INTERP", q_comp_interp, "BASIS_NUM_PTS", max_num_points,
++                                       "BASIS_POLY_DEGREE", degree_at_points, "BASIS_NUM_MODES", num_modes_at_points, "BASIS_DIM", dim,
++                                       "BASIS_MODAL_TOPOLOGY", modal_topology));
++      CeedCallBackend(CeedGetKernel_Cuda(ceed, *module_at_points, eval_mode == CEED_EVAL_INTERP ? "InterpAtPoints" : "GradAtPoints",
++                                         kernel_at_points));
++    }
++  }
++
++  CeedCallBackend(CeedVectorGetArrayRead(x_ref, CEED_MEM_DEVICE, &d_x));
++  CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
++  CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
++  {
++    CeedScalar   *d_B          = eval_mode == CEED_EVAL_INTERP ? data->d_interp_at_points : data->d_grad_at_points;
++    CUfunction    kernel       = eval_mode == CEED_EVAL_INTERP ? data->InterpAtPoints : data->GradAtPoints;
++    void         *basis_args[] = {(void *)&num_elem, &d_B, &data->d_points_per_elem, &d_x, &d_u, &d_v};
++    const CeedInt block_size   = CeedIntMin(max_num_points, 128);
++
++    CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, num_elem, block_size, basis_args));
++  }
++  CeedCallBackend(CeedVectorRestoreArrayRead(x_ref, &d_x));
++  CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
++  CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Cuda(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Cuda(basis, false, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAddAtPointsNonTensor_Cuda(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                   CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Cuda(basis, true, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
+ //------------------------------------------------------------------------------
+ // Basis apply - non-tensor
+ //------------------------------------------------------------------------------
+@@ -392,11 +810,17 @@ static int CeedBasisDestroyNonTensor_Cuda(CeedBasis basis) {
+   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
+   CeedCallBackend(CeedBasisGetData(basis, &data));
+   CeedCallCuda(ceed, cuModuleUnload(data->module));
++  if (data->moduleInterpAtPoints) CeedCallCuda(ceed, cuModuleUnload(data->moduleInterpAtPoints));
++  if (data->moduleGradAtPoints) CeedCallCuda(ceed, cuModuleUnload(data->moduleGradAtPoints));
+   if (data->d_q_weight) CeedCallCuda(ceed, cudaFree(data->d_q_weight));
++  CeedCallBackend(CeedFree(&data->h_points_per_elem));
++  if (data->d_points_per_elem) CeedCallCuda(ceed, cudaFree(data->d_points_per_elem));
+   CeedCallCuda(ceed, cudaFree(data->d_interp));
+   CeedCallCuda(ceed, cudaFree(data->d_grad));
+   CeedCallCuda(ceed, cudaFree(data->d_div));
+   CeedCallCuda(ceed, cudaFree(data->d_curl));
++  if (data->d_interp_at_points) CeedCallCuda(ceed, cudaFree(data->d_interp_at_points));
++  if (data->d_grad_at_points) CeedCallCuda(ceed, cudaFree(data->d_grad_at_points));
+   CeedCallBackend(CeedFree(&data));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -499,6 +923,8 @@ int CeedBasisCreateH1_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -554,6 +980,8 @@ int CeedBasisCreateHdiv_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_nod
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -609,6 +1037,8 @@ int CeedBasisCreateHcurl_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_no
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+diff --git a/backends/cuda-ref/ceed-cuda-ref.h b/backends/cuda-ref/ceed-cuda-ref.h
+index 11b45f34..40808780 100644
+--- a/backends/cuda-ref/ceed-cuda-ref.h
++++ b/backends/cuda-ref/ceed-cuda-ref.h
+@@ -89,11 +89,33 @@ typedef struct {
+   CUfunction  Deriv;
+   CUfunction  DerivTranspose;
+   CUfunction  Weight;
++  CUmodule    moduleInterpAtPoints;
++  CUmodule    moduleGradAtPoints;
++  CUfunction  InterpAtPoints;
++  CUfunction  GradAtPoints;
+   CeedScalar *d_interp;
+   CeedScalar *d_grad;
+   CeedScalar *d_div;
+   CeedScalar *d_curl;
+   CeedScalar *d_q_weight;
++  CeedScalar *d_interp_at_points;
++  CeedScalar *d_grad_at_points;
++  CeedInt     num_points;
++  CeedInt     num_elem_at_points;
++  CeedInt    *h_points_per_elem;
++  CeedInt    *d_points_per_elem;
++  CeedInt     interp_num_modes_at_points;
++  CeedInt     interp_degree_at_points;
++  CeedInt     grad_num_modes_at_points;
++  CeedInt     grad_degree_at_points;
++  CeedInt     interp_kernel_num_points;
++  CeedInt     interp_kernel_num_modes_at_points;
++  CeedInt     interp_kernel_degree_at_points;
++  CeedInt     interp_kernel_modal_topology_at_points;
++  CeedInt     grad_kernel_num_points;
++  CeedInt     grad_kernel_num_modes_at_points;
++  CeedInt     grad_kernel_degree_at_points;
++  CeedInt     grad_kernel_modal_topology_at_points;
+ } CeedBasisNonTensor_Cuda;
+
+ typedef struct {
+diff --git a/backends/magma/ceed-magma-basis.c b/backends/magma/ceed-magma-basis.c
+index 85cc251d..ae64605c 100644
+--- a/backends/magma/ceed-magma-basis.c
++++ b/backends/magma/ceed-magma-basis.c
+@@ -8,6 +8,7 @@
+ #include <ceed.h>
+ #include <ceed/backend.h>
+ #include <ceed/jit-tools.h>
++#include <math.h>
+ #include <string.h>
+
+ #ifdef CEED_MAGMA_USE_HIP
+@@ -277,6 +278,441 @@ int CeedBasisApplyAtPoints_Magma(CeedBasis basis, const CeedInt num_elem, const
+   return CeedError(CeedBasisReturnCeed(basis), CEED_ERROR_BACKEND, "Backend does not implement CeedBasisApplyAtPoints");
+ }
+
++//------------------------------------------------------------------------------
++// Basis apply - non-tensor AtPoints
++//------------------------------------------------------------------------------
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++static int CeedBasisNonTensorModalTopologyAtPoints_Magma(CeedElemTopology topo, CeedInt *modal_topology) {
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_LINE;
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TRIANGLE;
++      break;
++    case CEED_TOPOLOGY_TET:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TET;
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PRISM;
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PYRAMID;
++      break;
++    default:
++      *modal_topology = 0;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static CeedInt CeedBasisNonTensorNumModesAtPoints_Magma(CeedElemTopology topo, CeedInt degree) {
++  const CeedInt tri_modes = (degree + 1) * (degree + 2) / 2;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      return degree + 1;
++    case CEED_TOPOLOGY_TRIANGLE:
++      return tri_modes;
++    case CEED_TOPOLOGY_TET:
++      return tri_modes * (degree + 3) / 3;
++    case CEED_TOPOLOGY_PRISM:
++      return tri_modes * (degree + 1);
++    case CEED_TOPOLOGY_PYRAMID:
++      return (degree + 1) * (degree + 2) * (2 * degree + 3) / 6;
++    default:
++      return 0;
++  }
++}
++
++static bool CeedBasisNonTensorDegreeAtPoints_Magma(CeedElemTopology topo, CeedInt num_modes, CeedInt *degree) {
++  for (CeedInt p = 0; p <= 16; p++) {
++    if (CeedBasisNonTensorNumModesAtPoints_Magma(topo, p) == num_modes) {
++      *degree = p;
++      return true;
++    }
++  }
++  return false;
++}
++
++static CeedScalar CeedBasisPowIntAtPoints_Magma(CeedScalar x, CeedInt p) {
++  CeedScalar y = 1.0;
++
++  for (CeedInt i = 0; i < p; i++) y *= x;
++  return y;
++}
++
++static int CeedBasisNonTensorModesAtPoint_Magma(CeedElemTopology topo, CeedInt degree, CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *phi) {
++  CeedInt mode = 0;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      for (CeedInt i = 0; i <= degree; i++) phi[mode++] = CeedBasisPowIntAtPoints_Magma(x, i);
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          const CeedInt j = total - i;
++
++          phi[mode++] = CeedBasisPowIntAtPoints_Magma(x, i) * CeedBasisPowIntAtPoints_Magma(y, j);
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_TET:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          for (CeedInt j = 0; j <= total - i; j++) {
++            const CeedInt k = total - i - j;
++
++            phi[mode++] = CeedBasisPowIntAtPoints_Magma(x, i) * CeedBasisPowIntAtPoints_Magma(y, j) * CeedBasisPowIntAtPoints_Magma(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      for (CeedInt k = 0; k <= degree; k++) {
++        for (CeedInt total = 0; total <= degree; total++) {
++          for (CeedInt i = 0; i <= total; i++) {
++            const CeedInt j = total - i;
++
++            phi[mode++] = CeedBasisPowIntAtPoints_Magma(x, i) * CeedBasisPowIntAtPoints_Magma(y, j) * CeedBasisPowIntAtPoints_Magma(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      for (CeedInt k = 0; k <= degree; k++) {
++        const CeedInt xy_degree = degree - k;
++
++        for (CeedInt i = 0; i <= xy_degree; i++) {
++          for (CeedInt j = 0; j <= xy_degree; j++) {
++            phi[mode++] = CeedBasisPowIntAtPoints_Magma(x, i) * CeedBasisPowIntAtPoints_Magma(y, j) * CeedBasisPowIntAtPoints_Magma(z, k);
++          }
++        }
++      }
++      break;
++    default:
++      break;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildModalAtPoints_Magma(Ceed ceed, CeedElemTopology topo, CeedInt dim, CeedInt num_qpts, const CeedScalar *q_ref, CeedInt q_comp,
++                                             CeedInt num_nodes, const CeedScalar *tabulation, CeedInt requested_degree, bool require_overdetermined,
++                                             const char *label, CeedInt *degree, CeedInt *num_modes, CeedScalar **modal_at_points) {
++  const CeedScalar tolerance    = 10000. * CEED_EPSILON;
++  const CeedInt    first_degree = requested_degree >= 0 ? requested_degree : 0;
++  const CeedInt    last_degree  = requested_degree >= 0 ? requested_degree : 16;
++
++  for (CeedInt p = first_degree; p <= last_degree; p++) {
++    const CeedInt modes       = CeedBasisNonTensorNumModesAtPoints_Magma(topo, p);
++    CeedScalar   *vandermonde = NULL, *vandermonde_pinv = NULL, *candidate = NULL;
++    CeedScalar    max_error = 0.0;
++
++    if (!modes || modes > num_qpts) break;
++    if (require_overdetermined && num_qpts <= modes) continue;
++
++    CeedCallBackend(CeedCalloc(num_qpts * modes, &vandermonde));
++    CeedCallBackend(CeedCalloc(modes * num_qpts, &vandermonde_pinv));
++    CeedCallBackend(CeedCalloc(q_comp * modes * num_nodes, &candidate));
++
++    for (CeedInt q = 0; q < num_qpts; q++) {
++      const CeedScalar x = q_ref[0 * num_qpts + q];
++      const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++      const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++      CeedCallBackend(CeedBasisNonTensorModesAtPoint_Magma(topo, p, x, y, z, &vandermonde[q * modes]));
++    }
++    CeedCallBackend(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, modes, vandermonde_pinv));
++    for (CeedInt d = 0; d < q_comp; d++) {
++      CeedCallBackend(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &tabulation[d * num_qpts * num_nodes], &candidate[d * modes * num_nodes],
++                                               modes, num_nodes, num_qpts));
++    }
++
++    for (CeedInt d = 0; d < q_comp; d++) {
++      for (CeedInt q = 0; q < num_qpts; q++) {
++        for (CeedInt node = 0; node < num_nodes; node++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt mode = 0; mode < modes; mode++)
++            value += vandermonde[q * modes + mode] * candidate[d * modes * num_nodes + mode * num_nodes + node];
++          const CeedScalar error = fabs(value - tabulation[d * num_qpts * num_nodes + q * num_nodes + node]);
++
++          max_error = max_error > error ? max_error : error;
++        }
++      }
++    }
++
++    CeedCallBackend(CeedFree(&vandermonde));
++    CeedCallBackend(CeedFree(&vandermonde_pinv));
++    if (max_error <= tolerance) {
++      *degree          = p;
++      *num_modes       = modes;
++      *modal_at_points = candidate;
++      return CEED_ERROR_SUCCESS;
++    }
++    CeedCallBackend(CeedFree(&candidate));
++  }
++
++  return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
++                   "%s AtPoints requires tabulation points that overdetermine a complete polynomial reconstruction for non-standard spaces", label);
++}
++
++static int CeedBasisBuildNonTensorInterpAtPoints_Magma(CeedBasis basis, CeedBasisNonTensor_Magma *impl) {
++  Ceed              ceed;
++  Ceed_Magma       *data;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree = -1, num_modes, modal_topology, q_comp_interp;
++  const CeedScalar *interp, *q_ref;
++  CeedScalar       *interp_at_points = NULL;
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedGetData(ceed, &data));
++  CeedCallBackend(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++  CeedCallBackend(CeedBasisGetInterp(basis, &interp));
++  CeedCallBackend(CeedBasisGetQRef(basis, &q_ref));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Magma(topo, &modal_topology));
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints interpolation is not supported for this element topology");
++  CeedCheck(interp && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor interpolation AtPoints requires interp and q_ref tables");
++  if (!(fe_space == CEED_FE_SPACE_H1 && CeedBasisNonTensorDegreeAtPoints_Magma(topo, num_nodes, &degree))) degree = -1;
++  CeedCallBackend(CeedBasisBuildModalAtPoints_Magma(ceed, topo, dim, num_qpts, q_ref, q_comp_interp, num_nodes, interp, degree, degree < 0,
++                                                    "Non-tensor interpolation", &degree, &num_modes, &interp_at_points));
++
++  CeedCallBackend(magma_malloc((void **)&impl->d_interp_at_points, q_comp_interp * num_modes * num_nodes * sizeof(CeedScalar)));
++  magma_setvector(q_comp_interp * num_modes * num_nodes, sizeof(CeedScalar), interp_at_points, 1, impl->d_interp_at_points, 1, data->queue);
++  impl->interp_num_modes_at_points = num_modes;
++  impl->interp_degree_at_points    = degree;
++
++  CeedCallBackend(CeedFree(&interp_at_points));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildNonTensorGradAtPoints_Magma(CeedBasis basis, CeedBasisNonTensor_Magma *impl) {
++  Ceed              ceed;
++  Ceed_Magma       *data;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree, grad_degree, num_modes, modal_topology;
++  const CeedScalar *grad, *q_ref;
++  CeedScalar       *vandermonde = NULL, *vandermonde_pinv = NULL, *grad_at_points = NULL;
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedGetData(ceed, &data));
++  CeedCallBackend(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCallBackend(CeedBasisGetGrad(basis, &grad));
++  CeedCallBackend(CeedBasisGetQRef(basis, &q_ref));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Magma(topo, &modal_topology));
++  CeedCheck(fe_space == CEED_FE_SPACE_H1 && modal_topology, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints gradients are only supported for H^1 bases with supported topologies");
++  CeedCheck(grad && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "H^1 non-tensor gradient AtPoints requires grad and q_ref tables");
++  CeedCheck(CeedBasisNonTensorDegreeAtPoints_Magma(topo, num_nodes, &degree), ceed, CEED_ERROR_UNSUPPORTED,
++            "Cannot infer non-tensor H^1 polynomial degree from %" CeedInt_FMT " nodes", num_nodes);
++
++  grad_degree = degree;
++  num_modes   = CeedBasisNonTensorNumModesAtPoints_Magma(topo, grad_degree);
++  if (num_qpts < num_modes) {
++    CeedInt reduced_degree = CeedIntMax(0, degree - 1), reduced_num_modes = CeedBasisNonTensorNumModesAtPoints_Magma(topo, reduced_degree);
++
++    CeedCheck(topo == CEED_TOPOLOGY_LINE || topo == CEED_TOPOLOGY_TRIANGLE || topo == CEED_TOPOLOGY_TET, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, num_modes, num_qpts);
++    CeedCheck(num_qpts >= reduced_num_modes, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, reduced_num_modes, num_qpts);
++    grad_degree = reduced_degree;
++    num_modes   = reduced_num_modes;
++  }
++
++  CeedCallBackend(CeedCalloc(num_qpts * num_modes, &vandermonde));
++  CeedCallBackend(CeedCalloc(num_modes * num_qpts, &vandermonde_pinv));
++  CeedCallBackend(CeedCalloc(dim * num_modes * num_nodes, &grad_at_points));
++
++  for (CeedInt q = 0; q < num_qpts; q++) {
++    const CeedScalar x = q_ref[0 * num_qpts + q];
++    const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++    const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++    CeedCallBackend(CeedBasisNonTensorModesAtPoint_Magma(topo, grad_degree, x, y, z, &vandermonde[q * num_modes]));
++  }
++  CeedCallBackend(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, num_modes, vandermonde_pinv));
++  for (CeedInt d = 0; d < dim; d++) {
++    CeedCallBackend(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &grad[d * num_qpts * num_nodes], &grad_at_points[d * num_modes * num_nodes],
++                                             num_modes, num_nodes, num_qpts));
++  }
++
++  CeedCallBackend(magma_malloc((void **)&impl->d_grad_at_points, dim * num_modes * num_nodes * sizeof(CeedScalar)));
++  magma_setvector(dim * num_modes * num_nodes, sizeof(CeedScalar), grad_at_points, 1, impl->d_grad_at_points, 1, data->queue);
++  impl->grad_num_modes_at_points = num_modes;
++  impl->grad_degree_at_points    = grad_degree;
++
++  CeedCallBackend(CeedFree(&vandermonde));
++  CeedCallBackend(CeedFree(&vandermonde_pinv));
++  CeedCallBackend(CeedFree(&grad_at_points));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensorCore_Magma(CeedBasis basis, bool apply_add, const CeedInt num_elem, const CeedInt *num_points,
++                                                     CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed                      ceed;
++  Ceed_Magma               *data;
++  CeedElemTopology          topo;
++  CeedInt                   dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, max_num_points = 0;
++  CeedSize                  x_len, u_len, v_len, len_required;
++  const CeedScalar         *d_x, *d_u;
++  CeedScalar               *d_v;
++  CeedBasisNonTensor_Magma *impl;
++
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCallBackend(CeedVectorSetValue(v, 1.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
++  CeedCallBackend(CeedGetData(ceed, &data));
++  CeedCallBackend(CeedBasisGetData(basis, &impl));
++  CeedCallBackend(CeedBasisGetTopology(basis, &topo));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCallBackend(CeedBasisNonTensorModalTopologyAtPoints_Magma(topo, &modal_topology));
++
++  CeedCheck(!apply_add, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints does not support ApplyAdd");
++  CeedCheck(t_mode == CEED_NOTRANSPOSE, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints only supports CEED_NOTRANSPOSE");
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints is not supported for this element topology");
++
++  for (CeedInt i = 0; i < num_elem; i++) max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  if (max_num_points == 0) {
++    CeedCallBackend(CeedDestroy(&ceed));
++    return CEED_ERROR_SUCCESS;
++  }
++  CeedCallBackend(CeedVectorGetLength(x_ref, &x_len));
++  len_required = (CeedSize)dim * (CeedSize)num_elem * (CeedSize)max_num_points;
++  CeedCheck(
++      x_len >= len_required, ceed, CEED_ERROR_BACKEND,
++      "Reference coordinate vector at points must be padded to the same number of points in each element for BasisApplyAtPoints on GPU backends."
++      " Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++      x_len, len_required);
++  CeedCallBackend(CeedVectorGetLength(u, &u_len));
++  len_required = (CeedSize)num_comp * (CeedSize)num_elem * (CeedSize)num_nodes;
++  CeedCheck(u_len >= len_required, ceed, CEED_ERROR_BACKEND,
++            "Input vector incompatible with non-tensor BasisApplyAtPoints. Found %" CeedSize_FMT ", Required %" CeedSize_FMT, u_len, len_required);
++  CeedCallBackend(CeedVectorGetLength(v, &v_len));
++  len_required = (CeedSize)num_comp * (CeedSize)q_comp * (CeedSize)num_elem * (CeedSize)max_num_points;
++  CeedCheck(v_len >= len_required, ceed, CEED_ERROR_BACKEND,
++            "Vector at points must be padded to the same number of points in each element for BasisApplyAtPoints on GPU backends."
++            " Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++            v_len, len_required);
++
++  {
++    const CeedInt num_bytes = num_elem * sizeof(CeedInt);
++
++    if (num_elem != impl->num_elem_at_points) {
++      impl->num_elem_at_points = num_elem;
++      if (impl->d_points_per_elem) CeedCallBackend(magma_free(impl->d_points_per_elem));
++      CeedCallBackend(magma_malloc((void **)&impl->d_points_per_elem, num_bytes));
++      CeedCallBackend(CeedFree(&impl->h_points_per_elem));
++      CeedCallBackend(CeedCalloc(num_elem, &impl->h_points_per_elem));
++    }
++    if (memcmp(impl->h_points_per_elem, num_points, num_bytes)) {
++      memcpy(impl->h_points_per_elem, num_points, num_bytes);
++      magma_setvector(num_elem, sizeof(CeedInt), num_points, 1, impl->d_points_per_elem, 1, data->queue);
++    }
++  }
++
++  if (eval_mode == CEED_EVAL_INTERP && !impl->d_interp_at_points) CeedCallBackend(CeedBasisBuildNonTensorInterpAtPoints_Magma(basis, impl));
++  if (eval_mode == CEED_EVAL_GRAD && !impl->d_grad_at_points) CeedCallBackend(CeedBasisBuildNonTensorGradAtPoints_Magma(basis, impl));
++  degree_at_points    = eval_mode == CEED_EVAL_INTERP ? impl->interp_degree_at_points : impl->grad_degree_at_points;
++  num_modes_at_points = eval_mode == CEED_EVAL_INTERP ? impl->interp_num_modes_at_points : impl->grad_num_modes_at_points;
++
++  {
++    CeedMagmaModule   *module_at_points  = eval_mode == CEED_EVAL_INTERP ? &impl->moduleInterpAtPoints : &impl->moduleGradAtPoints;
++    CeedMagmaFunction *kernel_at_points  = eval_mode == CEED_EVAL_INTERP ? &impl->InterpAtPoints : &impl->GradAtPoints;
++    CeedInt           *kernel_num_points = eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_num_points : &impl->grad_kernel_num_points;
++    CeedInt           *kernel_degree = eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_degree_at_points : &impl->grad_kernel_degree_at_points;
++    CeedInt *kernel_num_modes = eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_num_modes_at_points : &impl->grad_kernel_num_modes_at_points;
++    CeedInt *kernel_modal_topology =
++        eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_modal_topology_at_points : &impl->grad_kernel_modal_topology_at_points;
++
++    if (*kernel_num_points != max_num_points || *kernel_degree != degree_at_points || *kernel_num_modes != num_modes_at_points ||
++        *kernel_modal_topology != modal_topology) {
++      const char basis_kernel_source[] = "// Nontensor basis AtPoints source\n#include <ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h>\n";
++      CeedInt    q_comp_interp;
++
++      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++      *kernel_num_points     = max_num_points;
++      *kernel_degree         = degree_at_points;
++      *kernel_num_modes      = num_modes_at_points;
++      *kernel_modal_topology = modal_topology;
++      if (*module_at_points) {
++#ifdef CEED_MAGMA_USE_HIP
++        CeedCallHip(ceed, hipModuleUnload(*module_at_points));
++#else
++        CeedCallCuda(ceed, cuModuleUnload(*module_at_points));
++#endif
++      }
++      {
++        Ceed ceed_delegate;
++
++        CeedCallBackend(CeedGetDelegate(ceed, &ceed_delegate));
++        CeedCallBackend(CeedCompileMagma(ceed_delegate, basis_kernel_source, "basis_nontensor_at_points", module_at_points, 8, "BASIS_P", num_nodes,
++                                         "BASIS_NUM_COMP", num_comp, "BASIS_Q_COMP_INTERP", q_comp_interp, "BASIS_NUM_PTS", max_num_points,
++                                         "BASIS_POLY_DEGREE", degree_at_points, "BASIS_NUM_MODES", num_modes_at_points, "BASIS_DIM", dim,
++                                         "BASIS_MODAL_TOPOLOGY", modal_topology));
++        CeedCallBackend(CeedDestroy(&ceed_delegate));
++      }
++      CeedCallBackend(CeedGetKernelMagma(ceed, *module_at_points, eval_mode == CEED_EVAL_INTERP ? "InterpAtPoints" : "GradAtPoints",
++                                         kernel_at_points));
++    }
++  }
++
++  CeedCallBackend(CeedVectorGetArrayRead(x_ref, CEED_MEM_DEVICE, &d_x));
++  CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
++  CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
++  {
++    CeedScalar       *d_B          = eval_mode == CEED_EVAL_INTERP ? impl->d_interp_at_points : impl->d_grad_at_points;
++    CeedMagmaFunction kernel       = eval_mode == CEED_EVAL_INTERP ? impl->InterpAtPoints : impl->GradAtPoints;
++    void             *basis_args[] = {(void *)&num_elem, &d_B, &impl->d_points_per_elem, &d_x, &d_u, &d_v};
++    const CeedInt     block_size   = CeedIntMin(max_num_points, 128);
++
++    CeedCallBackend(CeedRunKernelMagma(ceed, kernel, num_elem, block_size, basis_args));
++  }
++  ceed_magma_queue_sync(data->queue);
++  CeedCallBackend(CeedVectorRestoreArrayRead(x_ref, &d_x));
++  CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
++  CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
++  CeedCallBackend(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Magma(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                 CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Magma(basis, false, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAddAtPointsNonTensor_Magma(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                    CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Magma(basis, true, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
+ //------------------------------------------------------------------------------
+ // Basis apply - non-tensor
+ //------------------------------------------------------------------------------
+@@ -516,11 +952,29 @@ static int CeedBasisDestroyNonTensor_Magma(CeedBasis basis) {
+ #endif
+     }
+   }
++  if (impl->moduleInterpAtPoints) {
++#ifdef CEED_MAGMA_USE_HIP
++    CeedCallHip(ceed, hipModuleUnload(impl->moduleInterpAtPoints));
++#else
++    CeedCallCuda(ceed, cuModuleUnload(impl->moduleInterpAtPoints));
++#endif
++  }
++  if (impl->moduleGradAtPoints) {
++#ifdef CEED_MAGMA_USE_HIP
++    CeedCallHip(ceed, hipModuleUnload(impl->moduleGradAtPoints));
++#else
++    CeedCallCuda(ceed, cuModuleUnload(impl->moduleGradAtPoints));
++#endif
++  }
+   CeedCallBackend(magma_free(impl->d_interp));
+   CeedCallBackend(magma_free(impl->d_grad));
+   CeedCallBackend(magma_free(impl->d_div));
+   CeedCallBackend(magma_free(impl->d_curl));
+   if (impl->d_q_weight) CeedCallBackend(magma_free(impl->d_q_weight));
++  CeedCallBackend(CeedFree(&impl->h_points_per_elem));
++  if (impl->d_points_per_elem) CeedCallBackend(magma_free(impl->d_points_per_elem));
++  if (impl->d_interp_at_points) CeedCallBackend(magma_free(impl->d_interp_at_points));
++  if (impl->d_grad_at_points) CeedCallBackend(magma_free(impl->d_grad_at_points));
+   CeedCallBackend(CeedFree(&impl));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -663,6 +1117,8 @@ int CeedBasisCreateH1_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_node
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -721,6 +1177,8 @@ int CeedBasisCreateHdiv_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_no
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -779,6 +1237,8 @@ int CeedBasisCreateHcurl_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_n
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+diff --git a/backends/magma/ceed-magma.h b/backends/magma/ceed-magma.h
+index c800f2a6..e889a0c6 100644
+--- a/backends/magma/ceed-magma.h
++++ b/backends/magma/ceed-magma.h
+@@ -66,6 +66,10 @@ typedef struct {
+   CeedMagmaFunction DerivTranspose[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedMagmaFunction DerivTransposeAdd[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedMagmaFunction Weight;
++  CeedMagmaModule   moduleInterpAtPoints;
++  CeedMagmaModule   moduleGradAtPoints;
++  CeedMagmaFunction InterpAtPoints;
++  CeedMagmaFunction GradAtPoints;
+   CeedInt           NB_interp[MAGMA_NONTENSOR_KERNEL_INSTANCES], NB_interp_t[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedInt           NB_deriv[MAGMA_NONTENSOR_KERNEL_INSTANCES], NB_deriv_t[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedScalar       *d_interp;
+@@ -73,6 +77,24 @@ typedef struct {
+   CeedScalar       *d_div;
+   CeedScalar       *d_curl;
+   CeedScalar       *d_q_weight;
++  CeedScalar       *d_interp_at_points;
++  CeedScalar       *d_grad_at_points;
++  CeedInt           num_points;
++  CeedInt           num_elem_at_points;
++  CeedInt          *h_points_per_elem;
++  CeedInt          *d_points_per_elem;
++  CeedInt           interp_num_modes_at_points;
++  CeedInt           interp_degree_at_points;
++  CeedInt           grad_num_modes_at_points;
++  CeedInt           grad_degree_at_points;
++  CeedInt           interp_kernel_num_points;
++  CeedInt           interp_kernel_num_modes_at_points;
++  CeedInt           interp_kernel_degree_at_points;
++  CeedInt           interp_kernel_modal_topology_at_points;
++  CeedInt           grad_kernel_num_points;
++  CeedInt           grad_kernel_num_modes_at_points;
++  CeedInt           grad_kernel_degree_at_points;
++  CeedInt           grad_kernel_modal_topology_at_points;
+ } CeedBasisNonTensor_Magma;
+
+ CEED_INTERN int CeedBasisCreateTensorH1_Magma(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
+diff --git a/include/ceed-impl.h b/include/ceed-impl.h
+index 549dde83..921aa5e8 100644
+--- a/include/ceed-impl.h
++++ b/include/ceed-impl.h
+@@ -229,6 +229,10 @@ struct CeedBasis_private {
+   CeedScalar *div; /* row-major matrix of shape [Q, P] expressing the divergence of basis functions at quadrature points for H(div) discretizations */
+   CeedScalar *curl; /* row-major matrix of shape [curl_dim * Q, P], curl_dim = 1 if dim < 3 else dim, expressing the curl of basis functions at
+                        quadrature points for H(curl) discretizations */
++  CeedScalar *interp_at_points; /* modal reconstruction coefficients for non-tensor interpolation at arbitrary points */
++  CeedScalar *grad_at_points;   /* modal reconstruction coefficients for non-tensor H1 gradients at arbitrary points */
++  CeedInt     interp_degree_at_points, interp_num_modes_at_points;
++  CeedInt     grad_degree_at_points, grad_num_modes_at_points;
+   CeedVector  vec_chebyshev;
+   CeedBasis   basis_chebyshev; /* basis interpolating from nodes to Chebyshev polynomial coefficients */
+   void       *data;            /* place for the backend to store any data */
+diff --git a/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h
+new file mode 100644
+index 00000000..b04c3a4a
+--- /dev/null
++++ b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h
+@@ -0,0 +1,179 @@
++// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
++// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
++//
++// SPDX-License-Identifier: BSD-2-Clause
++//
++// This file is part of CEED:  http://github.com/ceed
++
++/// @file
++/// Internal header for CUDA non-tensor product basis with AtPoints evaluation
++#include <ceed/types.h>
++
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++//------------------------------------------------------------------------------
++// Non-tensor modal values
++//------------------------------------------------------------------------------
++template <int DEGREE>
++inline __device__ void PowersAtPoint(const CeedScalar x, CeedScalar *x_pow) {
++  x_pow[0] = 1.0;
++  for (CeedInt i = 1; i <= DEGREE; i++) x_pow[i] = x * x_pow[i - 1];
++}
++
++template <int DEGREE, int NUM_MODES>
++inline __device__ void NonTensorModesAtPoint(const CeedScalar x, const CeedScalar y, const CeedScalar z, CeedScalar *phi) {
++  CeedScalar x_pow[DEGREE + 1], y_pow[DEGREE + 1], z_pow[DEGREE + 1];
++  CeedInt    mode = 0;
++
++  PowersAtPoint<DEGREE>(x, x_pow);
++  PowersAtPoint<DEGREE>(y, y_pow);
++  PowersAtPoint<DEGREE>(z, z_pow);
++
++#if BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_LINE
++  for (CeedInt i = 0; i <= DEGREE; i++) phi[mode++] = x_pow[i];
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_TRIANGLE
++  for (CeedInt total = 0; total <= DEGREE; total++) {
++    for (CeedInt i = 0; i <= total; i++) {
++      const CeedInt j = total - i;
++
++      phi[mode++] = x_pow[i] * y_pow[j];
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_TET
++  for (CeedInt total = 0; total <= DEGREE; total++) {
++    for (CeedInt i = 0; i <= total; i++) {
++      for (CeedInt j = 0; j <= total - i; j++) {
++        const CeedInt k = total - i - j;
++
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_PRISM
++  for (CeedInt k = 0; k <= DEGREE; k++) {
++    for (CeedInt total = 0; total <= DEGREE; total++) {
++      for (CeedInt i = 0; i <= total; i++) {
++        const CeedInt j = total - i;
++
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_PYRAMID
++  for (CeedInt k = 0; k <= DEGREE; k++) {
++    const CeedInt xy_degree = DEGREE - k;
++
++    for (CeedInt i = 0; i <= xy_degree; i++) {
++      for (CeedInt j = 0; j <= xy_degree; j++) {
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#endif
++}
++
++//------------------------------------------------------------------------------
++// Non-tensor interpolation at points
++//------------------------------------------------------------------------------
++extern "C" __global__ void InterpAtPoints(const CeedInt num_elem, const CeedScalar *__restrict__ d_B, const CeedInt *__restrict__ points_per_elem,
++                                          const CeedScalar *__restrict__ d_X, const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt t_id          = threadIdx.x;
++  const CeedInt u_elem_stride = BASIS_P;
++  const CeedInt v_elem_stride = BASIS_NUM_PTS;
++  const CeedInt u_comp_stride = num_elem * BASIS_P;
++  const CeedInt v_comp_stride = num_elem * BASIS_NUM_PTS;
++  const CeedInt v_q_stride    = BASIS_NUM_COMP * num_elem * BASIS_NUM_PTS;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt p = t_id; p < num_points; p += blockDim.x) {
++      const CeedScalar x = d_X[elem * v_elem_stride + 0 * v_comp_stride + p];
++#if BASIS_DIM > 1
++      const CeedScalar y = d_X[elem * v_elem_stride + 1 * v_comp_stride + p];
++#else
++      const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++      const CeedScalar z = d_X[elem * v_elem_stride + 2 * v_comp_stride + p];
++#else
++      const CeedScalar z = 0.0;
++#endif
++      CeedScalar phi[BASIS_NUM_MODES];
++
++      NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        const CeedScalar *U = &d_U[elem * u_elem_stride + comp * u_comp_stride];
++
++        for (CeedInt d = 0; d < BASIS_Q_COMP_INTERP; d++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt node = 0; node < BASIS_P; node++) {
++            CeedScalar shape = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape += d_B[node + mode * BASIS_P + d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape * U[node];
++          }
++          d_V[elem * v_elem_stride + comp * v_comp_stride + d * v_q_stride + p] = value;
++        }
++      }
++    }
++  }
++}
++
++//------------------------------------------------------------------------------
++// Non-tensor H^1 gradient at points
++//------------------------------------------------------------------------------
++extern "C" __global__ void GradAtPoints(const CeedInt num_elem, const CeedScalar *__restrict__ d_B, const CeedInt *__restrict__ points_per_elem,
++                                        const CeedScalar *__restrict__ d_X, const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt t_id          = threadIdx.x;
++  const CeedInt u_elem_stride = BASIS_P;
++  const CeedInt v_elem_stride = BASIS_NUM_PTS;
++  const CeedInt u_comp_stride = num_elem * BASIS_P;
++  const CeedInt v_comp_stride = num_elem * BASIS_NUM_PTS;
++  const CeedInt v_dim_stride  = BASIS_NUM_COMP * num_elem * BASIS_NUM_PTS;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt p = t_id; p < num_points; p += blockDim.x) {
++      const CeedScalar x = d_X[elem * v_elem_stride + 0 * v_comp_stride + p];
++#if BASIS_DIM > 1
++      const CeedScalar y = d_X[elem * v_elem_stride + 1 * v_comp_stride + p];
++#else
++      const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++      const CeedScalar z = d_X[elem * v_elem_stride + 2 * v_comp_stride + p];
++#else
++      const CeedScalar z = 0.0;
++#endif
++      CeedScalar phi[BASIS_NUM_MODES];
++
++      NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        const CeedScalar *U = &d_U[elem * u_elem_stride + comp * u_comp_stride];
++
++        for (CeedInt d = 0; d < BASIS_DIM; d++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt node = 0; node < BASIS_P; node++) {
++            CeedScalar shape_grad = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape_grad += d_B[node + mode * BASIS_P + d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape_grad * U[node];
++          }
++          d_V[elem * v_elem_stride + comp * v_comp_stride + d * v_dim_stride + p] = value;
++        }
++      }
++    }
++  }
++}
+diff --git a/interface/ceed-basis.c b/interface/ceed-basis.c
+index e90f7d1a..cae7368c 100644
+--- a/interface/ceed-basis.c
++++ b/interface/ceed-basis.c
+@@ -402,12 +402,10 @@ static int CeedBasisApplyCheckDims(CeedBasis basis, CeedInt num_elem, CeedTransp
+ **/
+ static int CeedBasisApplyAtPointsCheckDims(CeedBasis basis, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
+                                            CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
+-  CeedInt  dim, num_comp, num_q_comp, num_nodes, P_1d = 1, Q_1d = 1, total_num_points = 0;
++  CeedInt  dim, num_comp, num_q_comp, num_nodes, total_num_points = 0;
+   CeedSize x_length = 0, u_length = 0, v_length;
+
+   CeedCall(CeedBasisGetDimension(basis, &dim));
+-  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
+-  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+   CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+   CeedCall(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &num_q_comp));
+   CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
+@@ -478,6 +476,401 @@ static int CeedBasisApplyAtPointsCheckDims(CeedBasis basis, CeedInt num_elem, co
+
+   @ref Developer
+ **/
++//------------------------------------------------------------------------------
++// Basis apply at points - non-tensor host implementation
++//------------------------------------------------------------------------------
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++static int CeedBasisNonTensorModalTopologyAtPoints(CeedElemTopology topo, CeedInt *modal_topology) {
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_LINE;
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TRIANGLE;
++      break;
++    case CEED_TOPOLOGY_TET:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TET;
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PRISM;
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PYRAMID;
++      break;
++    default:
++      *modal_topology = 0;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static CeedInt CeedBasisNonTensorNumModesAtPoints(CeedElemTopology topo, CeedInt degree) {
++  const CeedInt tri_modes = (degree + 1) * (degree + 2) / 2;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      return degree + 1;
++    case CEED_TOPOLOGY_TRIANGLE:
++      return tri_modes;
++    case CEED_TOPOLOGY_TET:
++      return tri_modes * (degree + 3) / 3;
++    case CEED_TOPOLOGY_PRISM:
++      return tri_modes * (degree + 1);
++    case CEED_TOPOLOGY_PYRAMID:
++      return (degree + 1) * (degree + 2) * (2 * degree + 3) / 6;
++    default:
++      return 0;
++  }
++}
++
++static bool CeedBasisNonTensorDegreeAtPoints(CeedElemTopology topo, CeedInt num_modes, CeedInt *degree) {
++  for (CeedInt p = 0; p <= 16; p++) {
++    if (CeedBasisNonTensorNumModesAtPoints(topo, p) == num_modes) {
++      *degree = p;
++      return true;
++    }
++  }
++  return false;
++}
++
++static CeedScalar CeedBasisPowIntAtPoints(CeedScalar x, CeedInt p) {
++  CeedScalar y = 1.0;
++
++  for (CeedInt i = 0; i < p; i++) y *= x;
++  return y;
++}
++
++static int CeedBasisNonTensorModesAtPoint(CeedElemTopology topo, CeedInt degree, CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *phi) {
++  CeedInt mode = 0;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      for (CeedInt i = 0; i <= degree; i++) phi[mode++] = CeedBasisPowIntAtPoints(x, i);
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          const CeedInt j = total - i;
++
++          phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j);
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_TET:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          for (CeedInt j = 0; j <= total - i; j++) {
++            const CeedInt k = total - i - j;
++
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      for (CeedInt k = 0; k <= degree; k++) {
++        for (CeedInt total = 0; total <= degree; total++) {
++          for (CeedInt i = 0; i <= total; i++) {
++            const CeedInt j = total - i;
++
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      for (CeedInt k = 0; k <= degree; k++) {
++        const CeedInt xy_degree = degree - k;
++
++        for (CeedInt i = 0; i <= xy_degree; i++) {
++          for (CeedInt j = 0; j <= xy_degree; j++) {
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    default:
++      break;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildModalAtPoints(Ceed ceed, CeedElemTopology topo, CeedInt dim, CeedInt num_qpts, const CeedScalar *q_ref, CeedInt q_comp,
++                                       CeedInt num_nodes, const CeedScalar *tabulation, CeedInt requested_degree, bool require_overdetermined,
++                                       const char *label, CeedInt *degree, CeedInt *num_modes, CeedScalar **modal_at_points) {
++  const CeedScalar tolerance    = 10000. * CEED_EPSILON;
++  const CeedInt    first_degree = requested_degree >= 0 ? requested_degree : 0;
++  const CeedInt    last_degree  = requested_degree >= 0 ? requested_degree : 16;
++
++  for (CeedInt p = first_degree; p <= last_degree; p++) {
++    const CeedInt modes       = CeedBasisNonTensorNumModesAtPoints(topo, p);
++    CeedScalar   *vandermonde = NULL, *vandermonde_pinv = NULL, *candidate = NULL;
++    CeedScalar    max_error = 0.0;
++
++    if (!modes || modes > num_qpts) break;
++    if (require_overdetermined && num_qpts <= modes) continue;
++
++    CeedCall(CeedCalloc(num_qpts * modes, &vandermonde));
++    CeedCall(CeedCalloc(modes * num_qpts, &vandermonde_pinv));
++    CeedCall(CeedCalloc(q_comp * modes * num_nodes, &candidate));
++
++    for (CeedInt q = 0; q < num_qpts; q++) {
++      const CeedScalar x = q_ref[0 * num_qpts + q];
++      const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++      const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++      CeedCall(CeedBasisNonTensorModesAtPoint(topo, p, x, y, z, &vandermonde[q * modes]));
++    }
++    CeedCall(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, modes, vandermonde_pinv));
++    for (CeedInt d = 0; d < q_comp; d++) {
++      CeedCall(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &tabulation[d * num_qpts * num_nodes], &candidate[d * modes * num_nodes], modes,
++                                        num_nodes, num_qpts));
++    }
++
++    for (CeedInt d = 0; d < q_comp; d++) {
++      for (CeedInt q = 0; q < num_qpts; q++) {
++        for (CeedInt node = 0; node < num_nodes; node++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt mode = 0; mode < modes; mode++)
++            value += vandermonde[q * modes + mode] * candidate[d * modes * num_nodes + mode * num_nodes + node];
++          const CeedScalar error = fabs(value - tabulation[d * num_qpts * num_nodes + q * num_nodes + node]);
++
++          max_error = max_error > error ? max_error : error;
++        }
++      }
++    }
++
++    CeedCall(CeedFree(&vandermonde));
++    CeedCall(CeedFree(&vandermonde_pinv));
++    if (max_error <= tolerance) {
++      *degree          = p;
++      *num_modes       = modes;
++      *modal_at_points = candidate;
++      return CEED_ERROR_SUCCESS;
++    }
++    CeedCall(CeedFree(&candidate));
++  }
++
++  return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
++                   "%s AtPoints requires tabulation points that overdetermine a complete polynomial reconstruction for non-standard spaces", label);
++}
++
++static int CeedBasisBuildNonTensorInterpAtPoints(CeedBasis basis) {
++  Ceed              ceed;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree = -1, num_modes, modal_topology, q_comp_interp;
++  const CeedScalar *interp, *q_ref;
++
++  CeedCall(CeedBasisGetCeed(basis, &ceed));
++  CeedCall(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCall(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++  CeedCall(CeedBasisGetInterp(basis, &interp));
++  CeedCall(CeedBasisGetQRef(basis, &q_ref));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, &modal_topology));
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints interpolation is not supported for this element topology");
++  CeedCheck(interp && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor interpolation AtPoints requires interp and q_ref tables");
++  if (!(fe_space == CEED_FE_SPACE_H1 && CeedBasisNonTensorDegreeAtPoints(topo, num_nodes, &degree))) degree = -1;
++  CeedCall(CeedBasisBuildModalAtPoints(ceed, topo, dim, num_qpts, q_ref, q_comp_interp, num_nodes, interp, degree, degree < 0,
++                                       "Non-tensor interpolation", &degree, &num_modes, &basis->interp_at_points));
++  basis->interp_num_modes_at_points = num_modes;
++  basis->interp_degree_at_points    = degree;
++  CeedCall(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildNonTensorGradAtPoints(CeedBasis basis) {
++  Ceed              ceed;
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree, grad_degree, num_modes, modal_topology;
++  const CeedScalar *grad, *q_ref;
++  CeedScalar       *vandermonde = NULL, *vandermonde_pinv = NULL;
++
++  CeedCall(CeedBasisGetCeed(basis, &ceed));
++  CeedCall(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCall(CeedBasisGetGrad(basis, &grad));
++  CeedCall(CeedBasisGetQRef(basis, &q_ref));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, &modal_topology));
++  CeedCheck(fe_space == CEED_FE_SPACE_H1 && modal_topology, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints gradients are only supported for H^1 bases with supported topologies");
++  CeedCheck(grad && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "H^1 non-tensor gradient AtPoints requires grad and q_ref tables");
++  CeedCheck(CeedBasisNonTensorDegreeAtPoints(topo, num_nodes, &degree), ceed, CEED_ERROR_UNSUPPORTED,
++            "Cannot infer non-tensor H^1 polynomial degree from %" CeedInt_FMT " nodes", num_nodes);
++
++  grad_degree = degree;
++  num_modes   = CeedBasisNonTensorNumModesAtPoints(topo, grad_degree);
++  if (num_qpts < num_modes) {
++    CeedInt reduced_degree = CeedIntMax(0, degree - 1), reduced_num_modes = CeedBasisNonTensorNumModesAtPoints(topo, reduced_degree);
++
++    CeedCheck(topo == CEED_TOPOLOGY_LINE || topo == CEED_TOPOLOGY_TRIANGLE || topo == CEED_TOPOLOGY_TET, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, num_modes, num_qpts);
++    CeedCheck(num_qpts >= reduced_num_modes, ceed, CEED_ERROR_UNSUPPORTED,
++              "H^1 non-tensor gradient AtPoints needs at least %" CeedInt_FMT " tabulation points, found %" CeedInt_FMT, reduced_num_modes, num_qpts);
++    grad_degree = reduced_degree;
++    num_modes   = reduced_num_modes;
++  }
++
++  CeedCall(CeedCalloc(num_qpts * num_modes, &vandermonde));
++  CeedCall(CeedCalloc(num_modes * num_qpts, &vandermonde_pinv));
++  CeedCall(CeedCalloc(dim * num_modes * num_nodes, &basis->grad_at_points));
++
++  for (CeedInt q = 0; q < num_qpts; q++) {
++    const CeedScalar x = q_ref[0 * num_qpts + q];
++    const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++    const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++    CeedCall(CeedBasisNonTensorModesAtPoint(topo, grad_degree, x, y, z, &vandermonde[q * num_modes]));
++  }
++  CeedCall(CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, num_modes, vandermonde_pinv));
++  for (CeedInt d = 0; d < dim; d++) {
++    CeedCall(CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &grad[d * num_qpts * num_nodes], &basis->grad_at_points[d * num_modes * num_nodes],
++                                      num_modes, num_nodes, num_qpts));
++  }
++
++  basis->grad_num_modes_at_points = num_modes;
++  basis->grad_degree_at_points    = grad_degree;
++
++  CeedCall(CeedFree(&vandermonde));
++  CeedCall(CeedFree(&vandermonde_pinv));
++  CeedCall(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Core(CeedBasis basis, bool apply_add, CeedInt num_elem, const CeedInt *num_points,
++                                                CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed              ceed;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, total_num_points = 0, max_num_points = 0;
++  CeedSize          x_len = 0, u_len = 0, v_len = 0, points_stride;
++  const CeedScalar *x_array = NULL, *u_array = NULL, *modal;
++  CeedScalar       *v_array;
++  bool              is_padded;
++
++  CeedCall(CeedBasisGetCeed(basis, &ceed));
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCall(CeedVectorSetValue(v, 1.0));
++    CeedCall(CeedDestroy(&ceed));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCall(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, &modal_topology));
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints is not supported for this element topology");
++
++  for (CeedInt i = 0; i < num_elem; i++) {
++    total_num_points += num_points[i];
++    max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  }
++  if (max_num_points == 0) {
++    CeedCall(CeedDestroy(&ceed));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  if (eval_mode == CEED_EVAL_INTERP && !basis->interp_at_points) CeedCall(CeedBasisBuildNonTensorInterpAtPoints(basis));
++  if (eval_mode == CEED_EVAL_GRAD && !basis->grad_at_points) CeedCall(CeedBasisBuildNonTensorGradAtPoints(basis));
++  degree_at_points    = eval_mode == CEED_EVAL_INTERP ? basis->interp_degree_at_points : basis->grad_degree_at_points;
++  num_modes_at_points = eval_mode == CEED_EVAL_INTERP ? basis->interp_num_modes_at_points : basis->grad_num_modes_at_points;
++  modal               = eval_mode == CEED_EVAL_INTERP ? basis->interp_at_points : basis->grad_at_points;
++
++  CeedCall(CeedVectorGetLength(x_ref, &x_len));
++  CeedCall(CeedVectorGetLength(u, &u_len));
++  CeedCall(CeedVectorGetLength(v, &v_len));
++  points_stride = (CeedSize)num_elem * (CeedSize)max_num_points;
++  is_padded =
++      x_len >= (CeedSize)dim * points_stride && ((t_mode == CEED_NOTRANSPOSE && v_len >= (CeedSize)num_comp * (CeedSize)q_comp * points_stride) ||
++                                                 (t_mode == CEED_TRANSPOSE && u_len >= (CeedSize)num_comp * (CeedSize)q_comp * points_stride));
++  if (!is_padded) points_stride = total_num_points;
++
++  CeedCall(CeedVectorGetArrayRead(x_ref, CEED_MEM_HOST, &x_array));
++  CeedCall(CeedVectorGetArrayRead(u, CEED_MEM_HOST, &u_array));
++  if (apply_add) {
++    CeedCall(CeedVectorGetArray(v, CEED_MEM_HOST, &v_array));
++  } else {
++    CeedCall(CeedVectorGetArrayWrite(v, CEED_MEM_HOST, &v_array));
++  }
++  if (t_mode == CEED_TRANSPOSE && !apply_add) {
++    for (CeedSize i = 0; i < v_len; i++) v_array[i] = 0.0;
++  }
++
++  CeedInt point_offset = 0;
++  for (CeedInt elem = 0; elem < num_elem; elem++) {
++    for (CeedInt p = 0; p < num_points[elem]; p++) {
++      const CeedInt    point_index = is_padded ? elem * max_num_points + p : point_offset + p;
++      const CeedScalar x           = x_array[0 * points_stride + point_index];
++      const CeedScalar y           = dim > 1 ? x_array[1 * points_stride + point_index] : 0.0;
++      const CeedScalar z           = dim > 2 ? x_array[2 * points_stride + point_index] : 0.0;
++      CeedScalar       phi[num_modes_at_points];
++
++      CeedCall(CeedBasisNonTensorModesAtPoint(topo, degree_at_points, x, y, z, phi));
++      if (t_mode == CEED_NOTRANSPOSE) {
++        for (CeedInt comp = 0; comp < num_comp; comp++) {
++          const CeedScalar *U = &u_array[elem * num_nodes + comp * num_elem * num_nodes];
++
++          for (CeedInt q = 0; q < q_comp; q++) {
++            CeedScalar value = 0.0;
++
++            for (CeedInt node = 0; node < num_nodes; node++) {
++              CeedScalar shape = 0.0;
++
++              for (CeedInt mode = 0; mode < num_modes_at_points; mode++) {
++                shape += modal[node + mode * num_nodes + q * num_nodes * num_modes_at_points] * phi[mode];
++              }
++              value += shape * U[node];
++            }
++            const CeedSize v_index = (CeedSize)point_index + ((CeedSize)comp + (CeedSize)q * (CeedSize)num_comp) * points_stride;
++
++            v_array[v_index] = value;
++          }
++        }
++      } else {
++        for (CeedInt comp = 0; comp < num_comp; comp++) {
++          CeedScalar *V = &v_array[elem * num_nodes + comp * num_elem * num_nodes];
++
++          for (CeedInt q = 0; q < q_comp; q++) {
++            const CeedScalar value = u_array[(CeedSize)point_index + ((CeedSize)comp + (CeedSize)q * (CeedSize)num_comp) * points_stride];
++
++            for (CeedInt node = 0; node < num_nodes; node++) {
++              CeedScalar shape = 0.0;
++
++              for (CeedInt mode = 0; mode < num_modes_at_points; mode++) {
++                shape += modal[node + mode * num_nodes + q * num_nodes * num_modes_at_points] * phi[mode];
++              }
++              V[node] += shape * value;
++            }
++          }
++        }
++      }
++    }
++    point_offset += num_points[elem];
++  }
++
++  CeedCall(CeedVectorRestoreArrayRead(x_ref, &x_array));
++  CeedCall(CeedVectorRestoreArrayRead(u, &u_array));
++  CeedCall(CeedVectorRestoreArray(v, &v_array));
++  CeedCall(CeedDestroy(&ceed));
++  return CEED_ERROR_SUCCESS;
++}
++
+ static int CeedBasisApplyAtPoints_Core(CeedBasis basis, bool apply_add, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
+                                        CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
+   CeedInt dim, num_comp, P_1d = 1, Q_1d = 1, total_num_points = num_points[0];
+@@ -485,18 +878,20 @@ static int CeedBasisApplyAtPoints_Core(CeedBasis basis, bool apply_add, CeedInt
+   CeedCall(CeedBasisGetDimension(basis, &dim));
+   // Inserting check because clang-tidy doesn't understand this cannot occur
+   CeedCheck(dim > 0, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED, "Malformed CeedBasis, dim > 0 is required");
+-  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
+-  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+-  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+
+   // Default implementation
+   {
+     bool is_tensor_basis;
+
+     CeedCall(CeedBasisIsTensor(basis, &is_tensor_basis));
+-    CeedCheck(is_tensor_basis, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
+-              "Evaluation at arbitrary points only supported for tensor product bases");
++    if (!is_tensor_basis) {
++      CeedCall(CeedBasisApplyAtPointsNonTensor_Core(basis, apply_add, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++      return CEED_ERROR_SUCCESS;
++    }
+   }
++  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
++  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
++  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+   CeedCheck(num_elem == 1, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
+             "Evaluation at arbitrary  points only supported for a single element at a time");
+   if (eval_mode == CEED_EVAL_WEIGHT) {
+@@ -956,7 +1351,6 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
+   bool is_tensor;
+
+   CeedCall(CeedBasisIsTensor(basis, &is_tensor));
+-  CeedCheck(!is_at_points || is_tensor, CeedBasisReturnCeed(basis), CEED_ERROR_INCOMPATIBLE, "Can only evaluate tensor-product bases at points");
+   if (is_tensor) {
+     CeedInt dim, num_comp, P_1d, Q_1d;
+
+@@ -1072,7 +1466,7 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
+       case CEED_EVAL_GRAD:
+       case CEED_EVAL_DIV:
+       case CEED_EVAL_CURL:
+-        *flops = num_nodes * num_qpts * num_comp * q_comp;
++        *flops = num_nodes * (is_at_points ? num_points : num_qpts) * num_comp * q_comp;
+         break;
+       case CEED_EVAL_WEIGHT:
+         *flops = 0;
+@@ -2508,6 +2902,8 @@ int CeedBasisDestroy(CeedBasis *basis) {
+   CeedCall(CeedFree(&(*basis)->grad_1d));
+   CeedCall(CeedFree(&(*basis)->div));
+   CeedCall(CeedFree(&(*basis)->curl));
++  CeedCall(CeedFree(&(*basis)->interp_at_points));
++  CeedCall(CeedFree(&(*basis)->grad_at_points));
+   CeedCall(CeedVectorDestroy(&(*basis)->vec_chebyshev));
+   CeedCall(CeedBasisDestroy(&(*basis)->basis_chebyshev));
+   CeedCall(CeedObjectDestroy_Private(&(*basis)->obj));
+diff --git a/tests/t366-basis.c b/tests/t366-basis.c
+new file mode 100644
+index 00000000..7d446fd8
+--- /dev/null
++++ b/tests/t366-basis.c
+@@ -0,0 +1,139 @@
++/// @file
++/// Test non-tensor H^1 tetrahedron gradient at arbitrary points
++/// \test Test non-tensor H^1 tetrahedron gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define NUM_COMP 3
++#define P 10
++#define Q 4
++#define NUM_POINTS 3
++
++static void P2TetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  const CeedScalar l[4]     = {1. - x - y - z, x, y, z};
++  const CeedScalar dl[4][3] = {
++      {-1., -1., -1.},
++      {1.,  0.,  0. },
++      {0.,  1.,  0. },
++      {0.,  0.,  1. }
++  };
++  const CeedInt edge[6][2] = {
++      {0, 1},
++      {1, 2},
++      {0, 2},
++      {0, 3},
++      {1, 3},
++      {2, 3}
++  };
++
++  for (CeedInt i = 0; i < 4; i++) {
++    interp[i] = l[i] * (2. * l[i] - 1.);
++    for (CeedInt d = 0; d < 3; d++) grad[d * P + i] = (4. * l[i] - 1.) * dl[i][d];
++  }
++  for (CeedInt e = 0; e < 6; e++) {
++    const CeedInt i = edge[e][0], j = edge[e][1], node = 4 + e;
++
++    interp[node] = 4. * l[i] * l[j];
++    for (CeedInt d = 0; d < 3; d++) grad[d * P + node] = 4. * (dl[i][d] * l[j] + l[i] * dl[j][d]);
++  }
++}
++
++static CeedScalar Eval(const CeedScalar c[10], CeedScalar x, CeedScalar y, CeedScalar z) {
++  return c[0] + c[1] * x + c[2] * y + c[3] * z + c[4] * x * y + c[5] * x * z + c[6] * y * z + c[7] * x * x + c[8] * y * y + c[9] * z * z;
++}
++
++static CeedScalar EvalGrad(const CeedScalar c[10], CeedInt d, CeedScalar x, CeedScalar y, CeedScalar z) {
++  switch (d) {
++    case 0:
++      return c[1] + c[4] * y + c[5] * z + 2. * c[7] * x;
++    case 1:
++      return c[2] + c[4] * x + c[6] * z + 2. * c[8] * y;
++    default:
++      return c[3] + c[5] * x + c[6] * y + 2. * c[9] * z;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.2, 0.1, 0.6, 0.1, 0.3, 0.1, 0.1, 0.6};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar g[3 * P];
++
++    P2TetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], &interp[q * P], g);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, NUM_COMP, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_COMP * P, &u);
++  CeedVectorCreate(ceed, NUM_COMP * 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    const CeedScalar coeffs[NUM_COMP][10] = {
++        {1.,  2.,  -1., 3.,  4.,  -2., 5.,  7.,  -3., 6. },
++        {-2., 1.,  4.,  -1., 3.,  2.,  -4., 5.,  6.,  -7.},
++        {3.,  -5., 2.,  1.,  -6., 4.,  3.,  -2., 8.,  5. }
++    };
++    const CeedScalar nodes[3 * P] = {0.,  1.,  0., 0., 0.5, 0.5, 0., 0., 0.5, 0., 0., 0., 1.,  0.,  0.,
++                                     0.5, 0.5, 0., 0., 0.5, 0.,  0., 0., 1.,  0., 0., 0., 0.5, 0.5, 0.5};
++    CeedScalar       u_array[NUM_COMP * P];
++
++    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
++      for (CeedInt i = 0; i < P; i++) {
++        u_array[comp * P + i] = Eval(coeffs[comp], nodes[0 * P + i], nodes[1 * P + i], nodes[2 * P + i]);
++      }
++    }
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v);
++  }
++
++  {
++    const CeedScalar coeffs[NUM_COMP][10] = {
++        {1.,  2.,  -1., 3.,  4.,  -2., 5.,  7.,  -3., 6. },
++        {-2., 1.,  4.,  -1., 3.,  2.,  -4., 5.,  6.,  -7.},
++        {3.,  -5., 2.,  1.,  -6., 4.,  3.,  -2., 8.,  5. }
++    };
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
++      for (CeedInt d = 0; d < 3; d++) {
++        for (CeedInt p = 0; p < NUM_POINTS; p++) {
++          const CeedScalar expected =
++              EvalGrad(coeffs[comp], d, x_array[0 * NUM_POINTS + p], x_array[1 * NUM_POINTS + p], x_array[2 * NUM_POINTS + p]);
++          const CeedScalar actual = v_array[comp * NUM_POINTS + d * NUM_COMP * NUM_POINTS + p];
++
++          if (fabs(actual - expected) > 500. * CEED_EPSILON)
++            printf("%f != %f at comp %" CeedInt_FMT ", dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected, comp, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t367-basis.c b/tests/t367-basis.c
+new file mode 100644
+index 00000000..bccc75ad
+--- /dev/null
++++ b/tests/t367-basis.c
+@@ -0,0 +1,86 @@
++/// @file
++/// Test non-tensor H(curl) tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H(curl) tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 5
++#define NUM_POINTS 3
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.25, 0.2, 0.1, 0.6, 0.1, 0.25, 0.3, 0.1, 0.1, 0.6, 0.25};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], curl[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) curl[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  CeedBasisCreateHcurl(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, curl, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P] = {2., -3., 5., 7., -11., 13.};
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar expected[3] = {2. + 7. * x_array[0 * NUM_POINTS + p], -3. - 11. * x_array[1 * NUM_POINTS + p],
++                                      5. + 13. * x_array[2 * NUM_POINTS + p]};
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar actual = v_array[d * NUM_POINTS + p];
++
++        if (fabs(actual - expected[d]) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected[d], d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t368-basis.c b/tests/t368-basis.c
+new file mode 100644
+index 00000000..cc2ed6e6
+--- /dev/null
++++ b/tests/t368-basis.c
+@@ -0,0 +1,86 @@
++/// @file
++/// Test non-tensor H(div) tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H(div) tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 5
++#define NUM_POINTS 3
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.25, 0.2, 0.1, 0.6, 0.1, 0.25, 0.3, 0.1, 0.1, 0.6, 0.25};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], div[Q * P];
++  for (CeedInt i = 0; i < Q * P; i++) div[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  CeedBasisCreateHdiv(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, div, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P] = {2., -3., 5., 7., -11., 13.};
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar expected[3] = {2. + 7. * x_array[0 * NUM_POINTS + p], -3. - 11. * x_array[1 * NUM_POINTS + p],
++                                      5. + 13. * x_array[2 * NUM_POINTS + p]};
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar actual = v_array[d * NUM_POINTS + p];
++
++        if (fabs(actual - expected[d]) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected[d], d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t369-basis.c b/tests/t369-basis.c
+new file mode 100644
+index 00000000..6bbb19e8
+--- /dev/null
++++ b/tests/t369-basis.c
+@@ -0,0 +1,94 @@
++/// @file
++/// Test non-tensor H^1 tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H^1 tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++#define MAX_NUM_POINTS 3
++
++static CeedScalar Linear(CeedInt elem, CeedScalar x, CeedScalar y, CeedScalar z) { return 2.0 + elem - 3.0 * x + 5.0 * y - 7.0 * z; }
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_ELEM * MAX_NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, NUM_ELEM * MAX_NUM_POINTS, &v);
++  {
++    // Dimension-major, padded by MAX_NUM_POINTS in each element.
++    CeedScalar x_array[3 * NUM_ELEM * MAX_NUM_POINTS] = {
++        0.2, 0.4, 0.1, 0.3, 0.2, 0.0,  // x
++        0.1, 0.2, 0.3, 0.2, 0.4, 0.0,  // y
++        0.1, 0.1, 0.4, 0.1, 0.2, 0.0   // z
++    };
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[NUM_ELEM * P];
++
++    for (CeedInt elem = 0; elem < NUM_ELEM; elem++) {
++      u_array[elem * P + 0] = Linear(elem, 0., 0., 0.);
++      u_array[elem * P + 1] = Linear(elem, 1., 0., 0.);
++      u_array[elem * P + 2] = Linear(elem, 0., 1., 0.);
++      u_array[elem * P + 3] = Linear(elem, 0., 0., 1.);
++    }
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedInt     num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt elem = 0; elem < NUM_ELEM; elem++) {
++      for (CeedInt p = 0; p < num_points[elem]; p++) {
++        const CeedScalar x        = x_array[0 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar y        = x_array[1 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar z        = x_array[2 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar expected = Linear(elem, x, y, z);
++        const CeedScalar actual   = v_array[elem * MAX_NUM_POINTS + p];
++
++        if (fabs(actual - expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at elem %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected, elem, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t370-basis.c b/tests/t370-basis.c
+new file mode 100644
+index 00000000..35801ec2
+--- /dev/null
++++ b/tests/t370-basis.c
+@@ -0,0 +1,125 @@
++/// @file
++/// Test non-tensor H^1 prism interpolation and gradient at arbitrary points
++/// \test Test non-tensor H^1 prism interpolation and gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 6
++#define NUM_POINTS 3
++
++static void P1PrismBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  const CeedScalar l[3]     = {1. - x - y, x, y};
++  const CeedScalar dl[3][2] = {
++      {-1., -1.},
++      {1.,  0. },
++      {0.,  1. }
++  };
++
++  for (CeedInt i = 0; i < 3; i++) {
++    interp[i]     = l[i] * (1. - z);
++    interp[3 + i] = l[i] * z;
++
++    grad[0 * P + i]     = dl[i][0] * (1. - z);
++    grad[1 * P + i]     = dl[i][1] * (1. - z);
++    grad[2 * P + i]     = -l[i];
++    grad[0 * P + 3 + i] = dl[i][0] * z;
++    grad[1 * P + 3 + i] = dl[i][1] * z;
++    grad[2 * P + 3 + i] = l[i];
++  }
++}
++
++static CeedScalar PrismPoly(CeedScalar x, CeedScalar y, CeedScalar z) { return 1. + 2. * x - 3. * y + 5. * z + 7. * x * z - 11. * y * z; }
++
++static CeedScalar PrismPolyGrad(CeedInt d, CeedScalar x, CeedScalar y, CeedScalar z) {
++  switch (d) {
++    case 0:
++      return 2. + 7. * z;
++    case 1:
++      return -3. - 11. * z;
++    default:
++      return 5. + 7. * x - 11. * y;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v_interp, v_grad;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 1., 0., 0., 0., 1., 0., 0., 1., 0., 0., 0., 1., 1., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[P], g[3 * P];
++
++    P1PrismBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b, g);
++    for (CeedInt i = 0; i < P; i++) interp[q * P + i] = b[i];
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_PRISM, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.25, 0.75, 0.5};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P];
++
++    for (CeedInt i = 0; i < P; i++) u_array[i] = PrismPoly(q_ref[0 * Q + i], q_ref[1 * Q + i], q_ref[2 * Q + i]);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  }
++
++  {
++    const CeedScalar *x_array, *interp_array, *grad_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &interp_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &grad_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar x               = x_array[0 * NUM_POINTS + p];
++      const CeedScalar y               = x_array[1 * NUM_POINTS + p];
++      const CeedScalar z               = x_array[2 * NUM_POINTS + p];
++      const CeedScalar interp_expected = PrismPoly(x, y, z);
++
++      if (fabs(interp_array[p] - interp_expected) > 500. * CEED_EPSILON) {
++        printf("%f != %f at point %" CeedInt_FMT "\n", interp_array[p], interp_expected, p);
++      }
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar grad_expected = PrismPolyGrad(d, x, y, z);
++        const CeedScalar grad_actual   = grad_array[d * NUM_POINTS + p];
++
++        if (fabs(grad_actual - grad_expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", grad_actual, grad_expected, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v_interp, &interp_array);
++    CeedVectorRestoreArrayRead(v_grad, &grad_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t371-basis.c b/tests/t371-basis.c
+new file mode 100644
+index 00000000..00254ba5
+--- /dev/null
++++ b/tests/t371-basis.c
+@@ -0,0 +1,128 @@
++/// @file
++/// Test non-tensor H^1 pyramid interpolation and gradient at arbitrary points
++/// \test Test non-tensor H^1 pyramid interpolation and gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 5
++#define Q 5
++#define NUM_POINTS 3
++
++static void P1PyramidBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  interp[0] = 1. - x - y + x * y - z;
++  interp[1] = x - x * y;
++  interp[2] = y - x * y;
++  interp[3] = x * y;
++  interp[4] = z;
++
++  grad[0 * P + 0] = -1. + y;
++  grad[1 * P + 0] = -1. + x;
++  grad[2 * P + 0] = -1.;
++  grad[0 * P + 1] = 1. - y;
++  grad[1 * P + 1] = -x;
++  grad[2 * P + 1] = 0.;
++  grad[0 * P + 2] = -y;
++  grad[1 * P + 2] = 1. - x;
++  grad[2 * P + 2] = 0.;
++  grad[0 * P + 3] = y;
++  grad[1 * P + 3] = x;
++  grad[2 * P + 3] = 0.;
++  grad[0 * P + 4] = 0.;
++  grad[1 * P + 4] = 0.;
++  grad[2 * P + 4] = 1.;
++}
++
++static CeedScalar PyramidPoly(CeedScalar x, CeedScalar y, CeedScalar z) { return 1. + 2. * x - 3. * y + 5. * x * y - 7. * z; }
++
++static CeedScalar PyramidPolyGrad(CeedInt d, CeedScalar x, CeedScalar y) {
++  switch (d) {
++    case 0:
++      return 2. + 5. * y;
++    case 1:
++      return -3. + 5. * x;
++    default:
++      return -7.;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v_interp, v_grad;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 1., 0., 0., 0., 1., 1., 0., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[P], g[3 * P];
++
++    P1PyramidBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b, g);
++    for (CeedInt i = 0; i < P; i++) interp[q * P + i] = b[i];
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_PYRAMID, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.25, 0.1, 0.5};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P];
++
++    for (CeedInt i = 0; i < P; i++) u_array[i] = PyramidPoly(q_ref[0 * Q + i], q_ref[1 * Q + i], q_ref[2 * Q + i]);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  }
++
++  {
++    const CeedScalar *x_array, *interp_array, *grad_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &interp_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &grad_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar x               = x_array[0 * NUM_POINTS + p];
++      const CeedScalar y               = x_array[1 * NUM_POINTS + p];
++      const CeedScalar z               = x_array[2 * NUM_POINTS + p];
++      const CeedScalar interp_expected = PyramidPoly(x, y, z);
++
++      if (fabs(interp_array[p] - interp_expected) > 500. * CEED_EPSILON) {
++        printf("%f != %f at point %" CeedInt_FMT "\n", interp_array[p], interp_expected, p);
++      }
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar grad_expected = PyramidPolyGrad(d, x, y);
++        const CeedScalar grad_actual   = grad_array[d * NUM_POINTS + p];
++
++        if (fabs(grad_actual - grad_expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", grad_actual, grad_expected, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v_interp, &interp_array);
++    CeedVectorRestoreArrayRead(v_grad, &grad_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t372-basis.c b/tests/t372-basis.c
+new file mode 100644
+index 00000000..9239c1f1
+--- /dev/null
++++ b/tests/t372-basis.c
+@@ -0,0 +1,73 @@
++/// @file
++/// Test CUDA/MAGMA non-tensor AtPoints rejects unpadded coordinate vectors
++/// \test Test CUDA/MAGMA non-tensor AtPoints rejects unpadded coordinate vectors
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++#define MAX_NUM_POINTS 3
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  {
++    const char *resource;
++
++    CeedGetResource(ceed, &resource);
++    if (!strstr(resource, "/gpu/cuda/ref") && !strstr(resource, "/gpu/cuda/magma")) {
++      CeedDestroy(&ceed);
++      return 0;
++    }
++  }
++
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  // Packed length is valid for the interface total-point contract, but GPU AtPoints
++  // kernels require element-padded coordinates: dim * NUM_ELEM * MAX_NUM_POINTS.
++  CeedVectorCreate(ceed, 3 * (MAX_NUM_POINTS + MAX_NUM_POINTS - 1), &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, NUM_ELEM * MAX_NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * (MAX_NUM_POINTS + MAX_NUM_POINTS - 1)] = {0.2, 0.4, 0.1, 0.3, 0.2, 0.1, 0.2, 0.3, 0.2, 0.4, 0.1, 0.1, 0.4, 0.1, 0.2};
++    CeedScalar u_array[NUM_ELEM * P]                              = {1., 2., 3., 4., 5., 6., 7., 8.};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  {
++    const CeedInt num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    const int     ierr                 = CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected unpadded coordinate vector error\n");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "Reference coordinate vector at points must be padded")) printf("Unexpected error message: %s\n", err_msg);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t373-basis.c b/tests/t373-basis.c
+new file mode 100644
+index 00000000..a8069673
+--- /dev/null
++++ b/tests/t373-basis.c
+@@ -0,0 +1,84 @@
++/// @file
++/// Test non-H1 non-tensor AtPoints rejects underdetermined tabulation
++/// \test Test non-H1 non-tensor AtPoints rejects underdetermined tabulation
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 4
++#define NUM_POINTS 2
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++static int CheckUnderdetermined(Ceed ceed, bool hcurl) {
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.2, 0.1, 0.6, 0.1, 0.3, 0.1, 0.1, 0.6};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], curl[3 * Q * P], div[Q * P];
++
++  for (CeedInt i = 0; i < 3 * Q * P; i++) curl[i] = 0.0;
++  for (CeedInt i = 0; i < Q * P; i++) div[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  if (hcurl) {
++    CeedBasisCreateHcurl(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, curl, q_ref, q_weight, &basis);
++  } else {
++    CeedBasisCreateHdiv(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, div, q_ref, q_weight, &basis);
++  }
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.2, 0.1, 0.1};
++    CeedScalar u_array[P]              = {2., -3., 5., 7., -11., 13.};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    const int     ierr       = CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected underdetermined %s AtPoints error\n", hcurl ? "Hcurl" : "Hdiv");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "overdetermine a complete polynomial reconstruction")) printf("Unexpected error message: %s\n", err_msg);
++    CeedResetErrorMessage(ceed, &err_msg);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  return 0;
++}
++
++int main(int argc, char **argv) {
++  Ceed ceed;
++
++  CeedInit(argv[1], &ceed);
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  CheckUnderdetermined(ceed, true);
++  CheckUnderdetermined(ceed, false);
++
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t374-basis.c b/tests/t374-basis.c
+new file mode 100644
+index 00000000..5f7a7a4b
+--- /dev/null
++++ b/tests/t374-basis.c
+@@ -0,0 +1,54 @@
++/// @file
++/// Test non-tensor AtPoints with no points
++/// \test Test non-tensor AtPoints with no points
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 0, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, 0, &v);
++  {
++    CeedScalar u_array[NUM_ELEM * P] = {1., 2., 3., 4., 5., 6., 7., 8.};
++
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points[NUM_ELEM] = {0, 0};
++    const int     ierr                 = CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++
++    if (ierr) printf("Expected zero-point AtPoints apply to succeed\n");
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t375-basis.c b/tests/t375-basis.c
+new file mode 100644
+index 00000000..97f124a2
+--- /dev/null
++++ b/tests/t375-basis.c
+@@ -0,0 +1,80 @@
++/// @file
++/// Test CUDA/MAGMA non-tensor AtPoints unsupported transpose and ApplyAdd paths
++/// \test Test CUDA/MAGMA non-tensor AtPoints unsupported transpose and ApplyAdd paths
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_POINTS 2
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u_points, v_nodes;
++
++  CeedInit(argv[1], &ceed);
++  {
++    const char *resource;
++
++    CeedGetResource(ceed, &resource);
++    if (!strstr(resource, "/gpu/cuda/ref") && !strstr(resource, "/gpu/cuda/magma")) {
++      CeedDestroy(&ceed);
++      return 0;
++    }
++  }
++
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_POINTS, &u_points);
++  CeedVectorCreate(ceed, P, &v_nodes);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.2, 0.1, 0.1};
++    CeedScalar point_array[NUM_POINTS] = {5., 6.};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u_points, CEED_MEM_HOST, CEED_COPY_VALUES, point_array);
++  }
++
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  {
++    const CeedInt num_points = NUM_POINTS;
++    const int     ierr       = CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, u_points, v_nodes);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected transpose AtPoints error\n");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "only supports CEED_NOTRANSPOSE")) printf("Unexpected transpose error message: %s\n", err_msg);
++    CeedResetErrorMessage(ceed, &err_msg);
++  }
++  {
++    const CeedInt num_points = NUM_POINTS;
++    const int     ierr       = CeedBasisApplyAddAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, u_points, v_nodes);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected ApplyAdd AtPoints error\n");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "does not support ApplyAdd")) printf("Unexpected ApplyAdd error message: %s\n", err_msg);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u_points);
++  CeedVectorDestroy(&v_nodes);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -9,13 +9,17 @@ target_sources(${LIB_TARGET_NAME}
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/bilinearform.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ceed_group_operator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/facenbrexchange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gridfunction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integrator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/interpolator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/lumpedelement.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/output_functionals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/postprocessing_backend.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurlmass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/diffusion.cpp
@@ -30,6 +34,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/basis.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/ceed.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/coefficient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libceed/functional.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/integrator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/operator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/restriction.cpp

--- a/palace/fem/ceed_group_operator.cpp
+++ b/palace/fem/ceed_group_operator.cpp
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fem/ceed_group_operator.hpp"
+
+#include <mfem.hpp>
+
+namespace palace
+{
+
+namespace fem
+{
+
+void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups)
+{
+  for (auto &group : groups)
+  {
+    for (auto &[field_vec, source] : group.field_vec_sources)
+    {
+      (void)source;
+      PalaceCeedCall(group.ceed, CeedVectorDestroy(&field_vec));
+    }
+    group.field_vec_sources.clear();
+    if (group.out_vec)
+    {
+      PalaceCeedCall(group.ceed, CeedVectorDestroy(&group.out_vec));
+      group.out_size = 0;
+    }
+    if (group.ctx)
+    {
+      PalaceCeedCall(group.ceed, CeedQFunctionContextDestroy(&group.ctx));
+    }
+    if (group.op)
+    {
+      PalaceCeedCall(group.ceed, CeedOperatorDestroy(&group.op));
+    }
+    group.field_sources.clear();
+  }
+  groups.clear();
+}
+
+void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
+                            const std::array<const Vector *, 4> &srcs, const Vector &out,
+                            const Vector *imported)
+{
+  for (const auto &group : groups)
+  {
+    if (group.field_vec_sources.size() != group.field_sources.size())
+    {
+      group.field_vec_sources.clear();
+      group.field_vec_sources.reserve(group.field_sources.size());
+      for (const auto &[name, source] : group.field_sources)
+      {
+        CeedOperatorField field;
+        CeedVector field_vec;
+        PalaceCeedCall(group.ceed,
+                       CeedOperatorGetFieldByName(group.op, name.c_str(), &field));
+        PalaceCeedCall(group.ceed, CeedOperatorFieldGetVector(field, &field_vec));
+        group.field_vec_sources.emplace_back(field_vec, source);
+      }
+    }
+    for (auto &[field_vec, source] : group.field_vec_sources)
+    {
+      // Source index 4 selects an optional imported vector, used by surface reductions
+      // and boundary point fields for face-neighbor field values. The operator's
+      // restriction slices and transposes the shared vector to the per-element layout.
+      const Vector *sv = (source < 4) ? srcs[source] : imported;
+      MFEM_ASSERT(sv, "Missing source vector for libCEED field input!");
+      ceed::InitCeedVector(*sv, group.ceed, &field_vec, false);
+    }
+    CeedMemType out_mem;
+    PalaceCeedCall(group.ceed, CeedGetPreferredMemType(group.ceed, &out_mem));
+    if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && out_mem == CEED_MEM_DEVICE)
+    {
+      out_mem = CEED_MEM_HOST;
+    }
+    auto *out_data = const_cast<Vector &>(out).ReadWrite(out_mem == CEED_MEM_DEVICE);
+    const CeedSize out_size = out.Size();
+    if (!group.out_vec || group.out_size != out_size)
+    {
+      if (group.out_vec)
+      {
+        PalaceCeedCall(group.ceed, CeedVectorDestroy(&group.out_vec));
+      }
+      PalaceCeedCall(group.ceed, CeedVectorCreate(group.ceed, out_size, &group.out_vec));
+      group.out_size = out_size;
+    }
+    PalaceCeedCall(group.ceed,
+                   CeedVectorSetArray(group.out_vec, out_mem, CEED_USE_POINTER, out_data));
+    PalaceCeedCall(group.ceed, CeedOperatorApplyAdd(group.op, CEED_VECTOR_NONE,
+                                                    group.out_vec, CEED_REQUEST_IMMEDIATE));
+    PalaceCeedCall(group.ceed, CeedVectorTakeArray(group.out_vec, out_mem, nullptr));
+  }
+}
+
+}  // namespace fem
+
+}  // namespace palace

--- a/palace/fem/ceed_group_operator.hpp
+++ b/palace/fem/ceed_group_operator.hpp
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_CEED_GROUP_OPERATOR_HPP
+#define PALACE_FEM_CEED_GROUP_OPERATOR_HPP
+
+#include <array>
+#include <string>
+#include <utility>
+#include <vector>
+#include "fem/libceed/ceed.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+namespace fem
+{
+
+// An assembled libCEED operator over one group of elements, with the named passive field
+// inputs re-pointed at caller data (by source vector index) on each evaluation.
+struct CeedGroupOperator
+{
+  Ceed ceed = nullptr;
+  CeedOperator op = nullptr;
+  std::vector<std::pair<std::string, int>> field_sources;
+  // Optional retained QFunction context handle for in-place runtime updates (e.g.
+  // far-field frequency) without reassembly; nullptr if the operator has no context or
+  // the context is not updated. Owned by the group (destroyed with it).
+  CeedQFunctionContext ctx = nullptr;
+  // Cached passive field vectors for field_sources, populated on first apply to avoid
+  // repeated string lookups in libCEED during ParaView point-field output.
+  mutable std::vector<std::pair<CeedVector, int>> field_vec_sources;
+  // Reusable output vector wrapper. The pointed-to MFEM Vector data is supplied at
+  // apply time, but the libCEED vector object itself can be retained across repeated
+  // postprocessing evaluations instead of being created/destroyed for every group apply.
+  mutable CeedVector out_vec = nullptr;
+  mutable CeedSize out_size = 0;
+};
+
+// Re-point the passive field inputs of each group operator at the given source vectors
+// and accumulate into the output vector with CeedOperatorApplyAdd. A field source index
+// of 4 (out of the srcs range) selects the optional imported vector instead, used to
+// feed face-neighbor (ghost) field values exchanged for two-sided interior boundaries on
+// parallel interfaces.
+void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
+                            const std::array<const Vector *, 4> &srcs, const Vector &out,
+                            const Vector *imported = nullptr);
+
+// Destroy the libCEED references owned by a group-operator vector and clear it. The Ceed
+// context itself is borrowed and is not destroyed here.
+void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups);
+
+}  // namespace fem
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_CEED_GROUP_OPERATOR_HPP

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -596,18 +596,20 @@ template <>
 inline double EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>::GetLocalEnergyDensity(
     mfem::ElementTransformation &T) const
 {
-  if (T.GetSpaceDim() == 2)
+  if (T.GetSpaceDim() == 2 && U.Real().VectorDim() == 1)
   {
-    // In 2D, B is the scalar out-of-plane component Bz (L2). The magnetic energy density
-    // is 1/2 μ⁻¹_zz |Bz|², matching the integrated domain energy.
+    // In 2D, B is scalar-valued and represents the out-of-plane flux density B_z.
+    // Magnetic energy density is therefore 1/2 * mu^{-1}_{zz} * |B_z|^2, matching
+    // the integrated domain energy.
+    const double invmu_zz = mat_op.GetInvPermeabilityZZ(T.Attribute);
     double Bz = U.Real().GetValue(T, T.GetIntPoint());
-    double dot = Bz * Bz;
+    double dot = invmu_zz * Bz * Bz;
     if (U.HasImag())
     {
       Bz = U.Imag().GetValue(T, T.GetIntPoint());
-      dot += Bz * Bz;
+      dot += invmu_zz * Bz * Bz;
     }
-    return 0.5 * mat_op.GetInvPermeabilityZZ(T.Attribute) * dot * scaling;
+    return 0.5 * dot * scaling;
   }
   double V_data[3];
   mfem::Vector V(V_data, T.GetSpaceDim());

--- a/palace/fem/facenbrexchange.cpp
+++ b/palace/fem/facenbrexchange.cpp
@@ -1,0 +1,588 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "facenbrexchange.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include "fem/fespace.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/mesh.hpp"
+#include "utils/communication.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/22/eval_22_qf.h"
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
+
+namespace palace
+{
+
+namespace
+{
+
+// Key identifying one export point-evaluator group. The request supplies an
+// integer/topological point_key (reference-face topology/orientation/subface identity),
+// so grouping never depends on rounded physical or reference point coordinates. Ad-hoc
+// requests with an empty point_key receive a unique request-order key.
+using PointConfigKey = std::vector<long long>;
+
+// Message tags for the setup (payload size, payload) and evaluation exchanges. A
+// single evaluation tag is sufficient: all processes perform the evaluation calls of
+// every exchange object in the same order, so per-pair messages match in order (MPI
+// non-overtaking guarantee).
+constexpr int TAG_SETUP_SIZE = 1741, TAG_SETUP_PAYLOAD = 1742, TAG_EVAL = 1743;
+
+// Registry of evaluation point integration rules with application lifetime (as in
+// output_functionals.cpp): mfem::FiniteElement::GetDofToQuad caches tabulations keyed by
+// the IntegrationRule pointer inside the (global, shared) FiniteElement objects, so
+// destroying an IntegrationRule which was used for tabulation would leave a dangling
+// cache entry.
+const mfem::IntegrationRule *GetRegisteredIr(const PointConfigKey &key,
+                                             const std::vector<mfem::IntegrationPoint> &pts)
+{
+  static std::map<PointConfigKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::mutex registry_mutex;
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  auto it = registry.find(key);
+  if (it == registry.end())
+  {
+    auto ir = std::make_unique<mfem::IntegrationRule>(static_cast<int>(pts.size()));
+    for (std::size_t q = 0; q < pts.size(); q++)
+    {
+      ir->IntPoint(static_cast<int>(q)) = pts[q];
+    }
+    it = registry.emplace(key, std::move(ir)).first;
+  }
+  return it->second.get();
+}
+
+bool CeedSupportsNonTensorAtPoints(Ceed ceed)
+{
+  const char *resource;
+  PalaceCeedCall(ceed, CeedGetResource(ceed, &resource));
+  return std::strstr(resource, "/cpu/self") || std::strstr(resource, "/gpu/cuda/ref") ||
+         std::strstr(resource, "/gpu/cuda/magma");
+}
+
+int TetNumModes(int degree)
+{
+  return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+}
+
+mfem::IntegrationRule MakeTetLatticeRule(int degree)
+{
+  mfem::IntegrationRule ir(TetNumModes(degree));
+  int q = 0;
+  if (degree == 0)
+  {
+    ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    ir.IntPoint(q++).weight = 1.0;
+  }
+  else
+  {
+    for (int total = 0; total <= degree; total++)
+    {
+      for (int i = 0; i <= total; i++)
+      {
+        for (int j = 0; j <= total - i; j++)
+        {
+          const int k = total - i - j;
+          ir.IntPoint(q).Set3(static_cast<double>(i) / degree,
+                              static_cast<double>(j) / degree,
+                              static_cast<double>(k) / degree);
+          ir.IntPoint(q++).weight = 1.0;
+        }
+      }
+    }
+  }
+  return ir;
+}
+
+void InitTetBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
+                             CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+{
+  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
+              "FaceNbrFieldExchange AtPoints export currently supports tetrahedral "
+              "volume elements only!");
+  // MAGMA's hardened non-tensor AtPoints basis construction (libCEED
+  // cuda-nontensor-atpoints branch) requires tabulation points that overdetermine the
+  // complete polynomial space for non-H1 spaces; square tabulations are rejected. Bump the
+  // lattice by one degree, matching the InitTetBasisForAtPoints copy in
+  // output_functionals.cpp, since this exchange builds bases for the same ND/RT field
+  // spaces.
+  const int degree = std::max(0, fe.GetOrder() - (grad_only ? 1 : 0) + 1);
+  const mfem::IntegrationRule ir = MakeTetLatticeRule(degree);
+  ceed::InitBasisAtPoints(fe, ir, num_comp, ceed, basis);
+}
+
+void CreateSequentialPointRestriction(Ceed ceed, std::size_t num_elem, int nq, int num_comp,
+                                      CeedSize l_size, CeedElemRestriction *restr)
+{
+  const CeedInt total_pts = static_cast<CeedInt>(num_elem * nq);
+  std::vector<CeedInt> offsets(num_elem + 1 + total_pts);
+  for (std::size_t e = 0; e <= num_elem; e++)
+  {
+    offsets[e] = static_cast<CeedInt>(num_elem + 1 + e * nq);
+  }
+  for (CeedInt i = 0; i < total_pts; i++)
+  {
+    offsets[num_elem + 1 + i] = i;
+  }
+  PalaceCeedCall(ceed, CeedElemRestrictionCreateAtPoints(
+                           ceed, static_cast<CeedInt>(num_elem), total_pts, num_comp,
+                           l_size, CEED_MEM_HOST, CEED_COPY_VALUES, offsets.data(), restr));
+}
+
+}  // namespace
+
+FaceNbrFieldExchange::FaceNbrFieldExchange(
+    const Mesh &mesh,
+    const std::array<const mfem::ParFiniteElementSpace *, MaxSources> &fespaces,
+    const std::vector<Request> &requests)
+  : comm(mesh.GetComm())
+{
+  const mfem::ParMesh &pmesh = mesh.Get();
+  const int num_nbr = pmesh.GetNFaceNeighbors();
+  const int value_dim = pmesh.SpaceDimension();
+  MFEM_VERIFY(value_dim == 2 || value_dim == 3,
+              "FaceNbrFieldExchange requires 2D or 3D physical-space fields!");
+  MFEM_VERIFY(requests.empty() || num_nbr > 0,
+              "FaceNbrFieldExchange requires face neighbor data "
+              "(ParMesh::ExchangeFaceNbrData)!");
+
+  // Route each request to its face neighbor process: ghost element index fn falls in
+  // the contiguous block [offset[i], offset[i+1]) of face neighbor i, and the ghost at
+  // position p = fn - offset[i] of the block is the element at position p of the
+  // neighbor's send_face_nbr_elements row for this process. This is the same
+  // correspondence ParMesh::ExchangeFaceNbrData (and the face neighbor dof data of
+  // ParFiniteElementSpace) relies on, for both conformal and nonconforming meshes.
+  const auto &elem_offsets = pmesh.face_nbr_elements_offset;
+  std::vector<std::vector<int>> nbr_reqs(num_nbr);
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const auto &req = requests[r];
+    MFEM_VERIFY(req.face_nbr_elem >= 0 &&
+                    req.face_nbr_elem < pmesh.GetNFaceNeighborElements() &&
+                    req.source_mask != 0 && !req.pts.empty(),
+                "Invalid face neighbor field exchange request!");
+    const int *it =
+        std::upper_bound(elem_offsets.begin(), elem_offsets.end(), req.face_nbr_elem);
+    nbr_reqs[static_cast<int>(it - elem_offsets.begin()) - 1].push_back(
+        static_cast<int>(r));
+  }
+
+  // Serialize the requests per neighbor (as doubles: position in the neighbor's send
+  // element list, number of points, source mask, integer point-key length and entries,
+  // then the point coordinates), and assign the import offsets (per neighbor, in
+  // request construction order, source slots in ascending order; the serving process
+  // lays out the reply values in exactly
+  // this order).
+  import_offsets.resize(requests.size());
+  for (auto &offsets : import_offsets)
+  {
+    offsets.fill(-1);
+  }
+  std::vector<std::vector<double>> send_payload(num_nbr);
+  int import_size = 0;
+  for (int i = 0; i < num_nbr; i++)
+  {
+    if (nbr_reqs[i].empty())
+    {
+      continue;
+    }
+    auto &payload = send_payload[i];
+    const int block_start = import_size;
+    for (const int r : nbr_reqs[i])
+    {
+      const auto &req = requests[r];
+      const int nq = static_cast<int>(req.pts.size());
+      payload.push_back(static_cast<double>(req.face_nbr_elem - elem_offsets[i]));
+      payload.push_back(static_cast<double>(nq));
+      payload.push_back(static_cast<double>(req.source_mask));
+      payload.push_back(static_cast<double>(req.point_key.size()));
+      for (auto v : req.point_key)
+      {
+        payload.push_back(static_cast<double>(v));
+      }
+      for (const auto &ip : req.pts)
+      {
+        payload.push_back(ip.x);
+        payload.push_back(ip.y);
+        payload.push_back(ip.z);
+      }
+      for (int s = 0; s < MaxSources; s++)
+      {
+        if (req.source_mask & (1u << s))
+        {
+          MFEM_VERIFY(fespaces[s],
+                      "Missing finite element space for requested source slot!");
+          import_offsets[r][s] = import_size;
+          import_size += value_dim * nq;
+        }
+      }
+    }
+    recv_msgs.push_back({pmesh.GetFaceNbrRank(i), block_start, import_size - block_start});
+  }
+
+  // Symmetric setup exchange with all face neighbors (every pair exchanges, possibly
+  // empty): payload sizes, then the payloads.
+  std::vector<int> send_len(num_nbr), recv_len(num_nbr);
+  {
+    std::vector<MPI_Request> mpi_reqs(2 * num_nbr);
+    for (int i = 0; i < num_nbr; i++)
+    {
+      send_len[i] = static_cast<int>(send_payload[i].size());
+      MPI_Irecv(&recv_len[i], 1, MPI_INT, pmesh.GetFaceNbrRank(i), TAG_SETUP_SIZE, comm,
+                &mpi_reqs[2 * i]);
+      MPI_Isend(&send_len[i], 1, MPI_INT, pmesh.GetFaceNbrRank(i), TAG_SETUP_SIZE, comm,
+                &mpi_reqs[2 * i + 1]);
+    }
+    MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+  }
+  std::vector<std::vector<double>> recv_payload(num_nbr);
+  {
+    std::vector<MPI_Request> mpi_reqs;
+    mpi_reqs.reserve(2 * num_nbr);
+    for (int i = 0; i < num_nbr; i++)
+    {
+      if (recv_len[i] > 0)
+      {
+        recv_payload[i].resize(recv_len[i]);
+        MPI_Irecv(recv_payload[i].data(), recv_len[i], MPI_DOUBLE, pmesh.GetFaceNbrRank(i),
+                  TAG_SETUP_PAYLOAD, comm, &mpi_reqs.emplace_back());
+      }
+      if (send_len[i] > 0)
+      {
+        MPI_Isend(send_payload[i].data(), send_len[i], MPI_DOUBLE, pmesh.GetFaceNbrRank(i),
+                  TAG_SETUP_PAYLOAD, comm, &mpi_reqs.emplace_back());
+      }
+    }
+    MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+  }
+
+  Ceed ceed = ceed::internal::GetCeedObjects()[0];
+  const bool use_at_points = CeedSupportsNonTensorAtPoints(ceed);
+
+  // Parse the received requests, assigning export offsets with the same layout rules
+  // as the import offsets above. On AtPoints-capable libCEED backends, tetrahedral
+  // export evaluators use runtime point coordinates so requests with the same
+  // source/geometry/point count can share one operator even when their finite NC trace
+  // maps differ. Other backends keep the mapped-integration-rule grouping by
+  // integer/topological point-key data; empty keys intentionally fall back to unique
+  // request-order groups.
+  struct ExportGroup
+  {
+    bool at_points = false;
+    std::vector<mfem::IntegrationPoint> pts;  // Representative IR or concatenated AtPoints
+    std::vector<int> elems;
+    std::vector<int> bases;  // Export vector base offset per element entry
+  };
+  std::map<PointConfigKey, ExportGroup> export_map;
+  int export_group_id = 0;
+  int export_size = 0;
+  for (int i = 0; i < num_nbr; i++)
+  {
+    const auto &payload = recv_payload[i];
+    const int block_start = export_size;
+    std::size_t k = 0;
+    while (k < payload.size())
+    {
+      const int p = static_cast<int>(std::llround(payload[k++]));
+      const int nq = static_cast<int>(std::llround(payload[k++]));
+      const auto mask = static_cast<unsigned int>(std::llround(payload[k++]));
+      const int point_key_size = static_cast<int>(std::llround(payload[k++]));
+      MFEM_VERIFY(point_key_size >= 0,
+                  "Invalid face neighbor point-key size in received field exchange "
+                  "request!");
+      std::vector<long long> point_key(point_key_size);
+      for (int q = 0; q < point_key_size; q++)
+      {
+        point_key[q] = std::llround(payload[k++]);
+      }
+      MFEM_VERIFY(p >= 0 && p < pmesh.send_face_nbr_elements.RowSize(i),
+                  "Invalid face neighbor element position in received field exchange "
+                  "request!");
+      const int elem = pmesh.send_face_nbr_elements.GetRow(i)[p];
+      std::vector<mfem::IntegrationPoint> pts(nq);
+      for (int q = 0; q < nq; q++)
+      {
+        pts[q].Set3(payload[k], payload[k + 1], payload[k + 2]);
+        pts[q].weight = 1.0;
+        k += 3;
+      }
+      const auto geom = pmesh.GetElementGeometry(elem);
+      for (int s = 0; s < MaxSources; s++)
+      {
+        if (mask & (1u << s))
+        {
+          MFEM_VERIFY(fespaces[s],
+                      "Missing finite element space for received source slot!");
+          const bool at_points_group = use_at_points && geom == mfem::Geometry::TETRAHEDRON;
+          PointConfigKey key;
+          key.reserve(5 + point_key.size());
+          key.push_back(s);
+          key.push_back(static_cast<long long>(geom));
+          key.push_back(nq);
+          key.push_back(static_cast<long long>(at_points_group));
+          if (!at_points_group)
+          {
+            if (point_key.empty())
+            {
+              key.push_back(export_group_id++);
+            }
+            else
+            {
+              key.insert(key.end(), point_key.begin(), point_key.end());
+            }
+          }
+          auto &group = export_map[key];
+          group.at_points = at_points_group;
+          if (at_points_group)
+          {
+            group.pts.insert(group.pts.end(), pts.begin(), pts.end());
+          }
+          else if (group.pts.empty())
+          {
+            group.pts = pts;
+          }
+          group.elems.push_back(elem);
+          group.bases.push_back(export_size);
+          export_size += value_dim * nq;
+        }
+      }
+    }
+    if (export_size > block_start)
+    {
+      send_msgs.push_back(
+          {pmesh.GetFaceNbrRank(i), block_start, export_size - block_start});
+    }
+  }
+
+  imported.SetSize(import_size);
+  imported.UseDevice(true);
+  imported = 0.0;
+  exported.SetSize(export_size);
+  exported.UseDevice(true);
+  if (export_size == 0)
+  {
+    return;
+  }
+
+  // Assemble a libCEED point evaluator for each export group, writing the
+  // physical-space field values (space-dimension components per point, point-major)
+  // into the exported vector at the assigned offsets.
+  int max_vsize = 0;
+  for (const auto *fespace : fespaces)
+  {
+    max_vsize = std::max(max_vsize, fespace ? fespace->GetVSize() : 0);
+  }
+  field_staging.SetSize(max_vsize);
+  field_staging.UseDevice(true);
+  field_staging = 0.0;
+  const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
+  for (const auto &[key, group] : export_map)
+  {
+    const int s = static_cast<int>(key[0]);
+    const auto geom = static_cast<mfem::Geometry::Type>(key[1]);
+    const int nq = static_cast<int>(key[2]);
+    const std::size_t num_elem = group.elems.size();
+    const auto &fespace = *fespaces[s];
+    MFEM_VERIFY(!group.at_points ||
+                    group.pts.size() == num_elem * static_cast<std::size_t>(nq),
+                "Invalid AtPoints export point layout for face neighbor exchange!");
+    const mfem::IntegrationRule *ir =
+        group.at_points ? nullptr : GetRegisteredIr(key, group.pts);
+
+    // Inputs: mesh node gradients (on-the-fly geometry for the Piola transformations)
+    // and the field, both evaluated at the points.
+    std::vector<ceed::CeedFunctionalFieldInput> inputs;
+    std::vector<std::pair<std::string, int>> field_sources;
+    CeedElemRestriction points_restr = nullptr;
+    CeedVector points_vec = nullptr;
+    if (group.at_points)
+    {
+      auto &points = export_attrs.emplace_back(3 * num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int q = 0; q < nq; q++)
+        {
+          const auto &ip = group.pts[e * nq + q];
+          const std::size_t off = 3 * (e * nq + q);
+          points[off + 0] = ip.x;
+          points[off + 1] = ip.y;
+          points[off + 2] = ip.z;
+        }
+      }
+      CreateSequentialPointRestriction(ceed, num_elem, nq, 3, points.Size(), &points_restr);
+      ceed::InitCeedVector(points, ceed, &points_vec);
+    }
+    CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+        mesh_fespace, ceed, geom, group.elems, /*is_interp*/ true);
+    const mfem::FiniteElement *mesh_fe =
+        mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+    CeedBasis mesh_basis;
+    if (group.at_points)
+    {
+      InitTetBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(), ceed,
+                              &mesh_basis);
+    }
+    else
+    {
+      ceed::InitBasisAtPoints(*mesh_fe, *ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+    }
+    CeedVector mesh_nodes_vec;
+    ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+    inputs.push_back({"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+    CeedElemRestriction field_restr;
+    ceed::InitRestriction(fespace, group.elems, false, /*is_interp*/ true, false, ceed,
+                          &field_restr);
+    const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+    MFEM_VERIFY(fe, "Unable to get field finite element for face neighbor exchange!");
+    CeedBasis field_basis;
+    if (group.at_points)
+    {
+      InitTetBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
+                              &field_basis);
+    }
+    else
+    {
+      ceed::InitBasisAtPoints(*fe, *ir, fespace.GetVDim(), ceed, &field_basis);
+    }
+    CeedVector field_vec;
+    ceed::InitCeedVector(field_staging, ceed, &field_vec);
+    inputs.push_back({"u_1", field_vec, field_restr, field_basis, ceed::EvalMode::Interp});
+    field_sources.emplace_back("u_1", s);
+
+    // Output restriction: one physical-space vector per point at the assigned export
+    // offsets.
+    std::vector<CeedInt> offsets(num_elem * nq);
+    for (std::size_t e = 0; e < num_elem; e++)
+    {
+      for (int j = 0; j < nq; j++)
+      {
+        offsets[e * nq + j] = group.bases[e] + value_dim * j;
+      }
+    }
+    CeedElemRestriction out_restr;
+    PalaceCeedCall(ceed, CeedElemRestrictionCreate(ceed, static_cast<CeedInt>(num_elem), nq,
+                                                   value_dim, 1, (CeedSize)export_size,
+                                                   CEED_MEM_HOST, CEED_COPY_VALUES,
+                                                   offsets.data(), &out_restr));
+
+    // The reply contains physical-space field values: the Piola transformation
+    // (H(curl) or H(div) depending on the source space) is applied here so the
+    // requester needs no neighbor element geometry.
+    const auto map_type = fespace.FEColl()->GetMapType(pmesh.Dimension());
+    MFEM_VERIFY(map_type == mfem::FiniteElement::H_CURL ||
+                    map_type == mfem::FiniteElement::H_DIV,
+                "FaceNbrFieldExchange requires H(curl) or H(div) source spaces!");
+    ceed::CeedQFunctionInfo info;
+    if (map_type == mfem::FiniteElement::H_CURL)
+    {
+      if (value_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_hcurl_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_hcurl_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+      }
+    }
+    else
+    {
+      if (value_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_hdiv_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_hdiv_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+      }
+    }
+    CeedOperator op;
+    if (group.at_points)
+    {
+      ceed::AssembleCeedPointEvaluatorAtPoints(info, nullptr, 0, ceed, inputs, points_restr,
+                                               points_vec, value_dim, out_restr, &op);
+    }
+    else
+    {
+      ceed::AssembleCeedPointEvaluator(info, nullptr, 0, ceed, inputs, value_dim, out_restr,
+                                       &op);
+    }
+    export_groups.push_back({ceed, op, std::move(field_sources)});
+
+    // Cleanup (the assembled operator holds its own references).
+    if (points_vec)
+    {
+      PalaceCeedCall(ceed, CeedVectorDestroy(&points_vec));
+    }
+    if (points_restr)
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&points_restr));
+    }
+    PalaceCeedCall(ceed, CeedVectorDestroy(&mesh_nodes_vec));
+    PalaceCeedCall(ceed, CeedVectorDestroy(&field_vec));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_restr));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&field_restr));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&out_restr));
+    PalaceCeedCall(ceed, CeedBasisDestroy(&mesh_basis));
+    PalaceCeedCall(ceed, CeedBasisDestroy(&field_basis));
+  }
+}
+
+FaceNbrFieldExchange::~FaceNbrFieldExchange()
+{
+  fem::DestroyGroupOperators(export_groups);
+}
+
+void FaceNbrFieldExchange::Exchange(
+    const std::array<const Vector *, MaxSources> &srcs) const
+{
+  // Evaluate the values requested by the neighbors (on the device).
+  if (exported.Size() > 0)
+  {
+    exported = 0.0;
+    fem::ApplyAddGroupOperators(export_groups, srcs, exported);
+  }
+  if (recv_msgs.empty() && send_msgs.empty())
+  {
+    return;
+  }
+
+  // Exchange: receive directly into the imported vector (contiguous per neighbor by
+  // construction), send directly from the exported vector.
+  std::vector<MPI_Request> mpi_reqs;
+  mpi_reqs.reserve(recv_msgs.size() + send_msgs.size());
+  double *dst = (imported.Size() > 0) ? imported.HostWrite() : nullptr;
+  for (const auto &msg : recv_msgs)
+  {
+    MPI_Irecv(dst + msg.start, msg.size, MPI_DOUBLE, msg.rank, TAG_EVAL, comm,
+              &mpi_reqs.emplace_back());
+  }
+  const double *src = (exported.Size() > 0) ? exported.HostRead() : nullptr;
+  for (const auto &msg : send_msgs)
+  {
+    MPI_Isend(src + msg.start, msg.size, MPI_DOUBLE, msg.rank, TAG_EVAL, comm,
+              &mpi_reqs.emplace_back());
+  }
+  MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+}
+
+}  // namespace palace

--- a/palace/fem/facenbrexchange.hpp
+++ b/palace/fem/facenbrexchange.hpp
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_FACE_NBR_EXCHANGE_HPP
+#define PALACE_FEM_FACE_NBR_EXCHANGE_HPP
+
+#include <array>
+#include <deque>
+#include <vector>
+#include <mfem.hpp>
+#include "fem/ceed_group_operator.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+class Mesh;
+
+//
+// Exchanges field values evaluated at prescribed reference points of face neighbor
+// (ghost) elements between processes. This enables libCEED surface functionals to
+// evaluate two-sided integrands on interior boundaries crossing parallel interfaces
+// without exchanging field dofs (the legacy approach of
+// ParGridFunction::ExchangeFaceNbrData): each process posts requests against ghost
+// elements (by face neighbor index, with evaluation points in the neighbor element's
+// reference space, e.g. mapped through FaceElementTransformations::Loc2). At setup, the
+// requests are routed to the owning processes through the pairwise face neighbor
+// communication structure of the ParMesh (the same correspondence
+// ParMesh::ExchangeFaceNbrData relies on, valid for conformal and nonconforming
+// meshes). At evaluation, the owning process evaluates the requested fields at the
+// points with libCEED point evaluators (on the device) and replies with physical-space
+// field values (Piola transformations applied by the evaluating process, so the
+// requester needs no neighbor element geometry; material properties are applied by the
+// requester using the ghost element attributes).
+//
+class FaceNbrFieldExchange
+{
+public:
+  // Number of source field slots (matching the source vectors of the surface
+  // functional evaluation calls).
+  static constexpr int MaxSources = 4;
+
+  struct Request
+  {
+    // Face neighbor (ghost) element index, in [0, ParMesh::GetNFaceNeighborElements()),
+    // e.g. FaceElementTransformations::Elem2No - ParMesh::GetNE() for a shared
+    // interior face.
+    int face_nbr_elem;
+
+    // Bitmask over the source field slots to evaluate (bit s set: source slot s).
+    unsigned int source_mask;
+
+    // Integer/topological identity of the point set, independent of physical or
+    // floating-point coordinates. SurfaceFunctional fills this with the reference-face
+    // topology/orientation/subface key used to generate pts. Requests with the same
+    // point_key, source slot, element geometry, and point count can share one libCEED
+    // point evaluator. Empty keys are allowed for ad-hoc requests and force a unique
+    // evaluator group.
+    std::vector<long long> point_key;
+
+    // Evaluation points in the neighbor element's reference space (the ghost element
+    // reference space coincides with the owning process' local element reference
+    // space, as the ghost elements preserve the neighbor's vertex ordering). These
+    // coordinates are used only to evaluate the requested points, not to decide point
+    // identity/grouping.
+    std::vector<mfem::IntegrationPoint> pts;
+  };
+
+private:
+  MPI_Comm comm;
+
+  // Pairwise evaluation-time messages with face neighbor ranks. Receives fill
+  // [start, start + size) of the imported vector; sends read [start, start + size) of
+  // the exported vector (both contiguous per neighbor by construction).
+  struct Message
+  {
+    int rank;
+    int start, size;
+  };
+  std::vector<Message> recv_msgs, send_msgs;
+
+  // For request r (construction order), base offset of the values for source slot s in
+  // the imported vector (-1 when not requested). Values are space-dimension components
+  // per point, point-major: [x0 y0 (z0) x1 y1 (z1) ...].
+  std::vector<std::array<int, MaxSources>> import_offsets;
+
+  // Assembled libCEED point evaluators serving the requests of neighboring processes,
+  // writing into the exported vector.
+  std::vector<fem::CeedGroupOperator> export_groups;
+
+  // Staging vector used to initialize the field input CeedVectors at construction (the
+  // field CeedVectors are re-pointed at the caller's data on each Exchange() call), and
+  // the exported / imported value vectors. export_attrs holds persistent AtPoints
+  // coordinate buffers referenced by export operators.
+  mutable Vector field_staging, exported, imported;
+  std::deque<Vector> export_attrs;
+
+public:
+  // Construct the exchange for the given requests against ghost elements of the mesh.
+  // fespaces[s] provides the evaluation space for source slot s (may be nullptr for
+  // unused slots; all processes must pass the same spaces). Collective on the mesh
+  // communicator: the requests are routed to the owning processes following the face
+  // neighbor communication structure of ParMesh::ExchangeFaceNbrData (which must have
+  // been called for the mesh already, see fem/mesh.cpp).
+  FaceNbrFieldExchange(
+      const Mesh &mesh,
+      const std::array<const mfem::ParFiniteElementSpace *, MaxSources> &fespaces,
+      const std::vector<Request> &requests);
+  ~FaceNbrFieldExchange();
+
+  FaceNbrFieldExchange(const FaceNbrFieldExchange &) = delete;
+  FaceNbrFieldExchange &operator=(const FaceNbrFieldExchange &) = delete;
+
+  // Size of the imported values vector.
+  int ImportSize() const { return imported.Size(); }
+
+  // Base offset in the imported vector of the values of source slot s for request r
+  // (construction order), or -1 when source s was not requested. Layout per request
+  // and source: space-dimension components per point, point-major.
+  int ImportOffset(int r, int s) const { return import_offsets[r][s]; }
+
+  // The imported values vector (filled by Exchange()).
+  const Vector &Imported() const { return imported; }
+
+  // Evaluate the exported field values for the neighbors' requests from the given
+  // source vectors (L-vectors of the corresponding source spaces), exchange with the
+  // face neighbor processes, and fill the imported vector with this process' requested
+  // values. All processes must call in the same order with the corresponding sources
+  // (point-to-point communication with the face neighbor ranks; processes with no
+  // requests and no exports perform no communication).
+  void Exchange(const std::array<const Vector *, MaxSources> &srcs) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_FACE_NBR_EXCHANGE_HPP

--- a/palace/fem/integrator.cpp
+++ b/palace/fem/integrator.cpp
@@ -33,8 +33,18 @@ int DefaultIntegrationOrder::Get(const mfem::ElementTransformation &T)
 int DefaultIntegrationOrder::Get(const mfem::Mesh &mesh, mfem::Geometry::Type geom)
 {
   MFEM_VERIFY(mesh.GetNodes(), "The mesh has no nodal FE space!");
+  const auto *fec = mesh.GetNodalFESpace()->FEColl();
+  const mfem::FiniteElement *fe = fec->FiniteElementForGeometry(geom);
+  if (!fe)
+  {
+    // Periodic meshes use a discontinuous nodal space so that identified vertices can
+    // retain distinct physical coordinates. Such collections only provide lower-
+    // dimensional mesh geometry through their trace finite elements.
+    fe = fec->TraceFiniteElementForGeometry(geom);
+  }
+  MFEM_VERIFY(fe, "Unable to get mesh finite element for geometry " << geom << "!");
   mfem::IsoparametricTransformation T;
-  T.SetFE(mesh.GetNodalFESpace()->FEColl()->FiniteElementForGeometry(geom));
+  T.SetFE(fe);
   return Get(T);
 }
 

--- a/palace/fem/interpolator.cpp
+++ b/palace/fem/interpolator.cpp
@@ -3,12 +3,31 @@
 
 #include "interpolator.hpp"
 
+#include <deque>
+#include <limits>
+#include <memory>
+
 #include <algorithm>
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
 #include "utils/communication.hpp"
 #include "utils/iodata.hpp"
 #include "utils/units.hpp"
+
+#include "fem/ceed_group_operator.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/postprocessing_backend.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
 
 namespace palace
 {
@@ -20,6 +39,157 @@ constexpr auto GSLIB_BB_TOL = 0.01;  // MFEM defaults, slightly reduced bounding
 constexpr auto GSLIB_NEWTON_TOL = 1.0e-12;
 
 }  // namespace
+
+#if defined(MFEM_USE_GSLIB)
+
+// Evaluates fields at the (fixed, located) probe points through libCEED: one small
+// operator per locally owned point (volume element restriction and basis tabulated at
+// the point, geometry on the fly from mesh node gradients). Results for all points are
+// reduced over all processes (unowned and not-found points contribute zero, matching
+// the GSLIB default interpolation value).
+class CeedProbeEvaluator
+{
+private:
+  std::vector<fem::CeedGroupOperator> groups;
+  std::deque<std::unique_ptr<mfem::IntegrationRule>> point_irs;  // Tabulation lifetime
+  mutable Vector field_staging, local_out;
+  MPI_Comm comm;
+  bool valid = true;
+
+public:
+  CeedProbeEvaluator(const mfem::FindPointsGSLIB &op,
+                     const mfem::ParFiniteElementSpace &fespace)
+    : comm(fespace.GetComm())
+  {
+    const auto &mesh = *fespace.GetParMesh();
+    const auto map_type = fespace.FEColl()->GetMapType(mesh.Dimension());
+    if (mesh.Dimension() != 3 || mesh.SpaceDimension() != 3 ||
+        (map_type != mfem::FiniteElement::H_CURL && map_type != mfem::FiniteElement::H_DIV))
+    {
+      valid = false;
+      return;
+    }
+    const mfem::FiniteElementSpace &mesh_fespace = *mesh.GetNodes()->FESpace();
+    const int npts = op.GetCode().Size();
+    const int rank = Mpi::Rank(comm);
+    field_staging.SetSize(fespace.GetVSize());
+    field_staging.UseDevice(true);
+    field_staging = 0.0;
+    local_out.SetSize(npts * 3);
+    local_out.UseDevice(true);
+
+    // Claim each point on exactly one process: for points on element borders the GSLIB
+    // ownership may not be consistent across the (all) searching processes, so resolve
+    // ties globally with a minimum reduction.
+    std::vector<int> owner(npts);
+    for (int i = 0; i < npts; i++)
+    {
+      owner[i] =
+          (op.GetCode()[i] != 2 && op.GetProc()[i] == static_cast<unsigned int>(rank))
+              ? rank
+              : std::numeric_limits<int>::max();
+    }
+    Mpi::GlobalMin(npts, owner.data(), comm);
+
+    Ceed ceed = ceed::internal::GetCeedObjects()[0];
+    for (int i = 0; i < npts; i++)
+    {
+      if (owner[i] != rank)
+      {
+        continue;  // Not found (default value 0) or owned by another process
+      }
+      const int elem = op.GetElem()[i];
+      const auto geom = mesh.GetElementGeometry(elem);
+      const int dim = mesh.Dimension();
+
+      // FindPointsGSLIB::GetReferencePosition returns mfem reference coordinates of
+      // the original mesh element (point-major).
+      auto ir = std::make_unique<mfem::IntegrationRule>(1);
+      mfem::IntegrationPoint &ip = ir->IntPoint(0);
+      ip.Set3(op.GetReferencePosition()[i * dim + 0],
+              op.GetReferencePosition()[i * dim + 1],
+              op.GetReferencePosition()[i * dim + 2]);
+      ip.weight = 1.0;
+      const std::vector<int> indices = {elem};
+
+      std::vector<ceed::CeedFunctionalFieldInput> inputs;
+      std::vector<std::pair<std::string, int>> field_sources;
+      {
+        CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+        const mfem::FiniteElement *mesh_fe =
+            mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+        CeedBasis mesh_basis;
+        ceed::InitBasisAtPoints(*mesh_fe, *ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+        CeedVector mesh_nodes_vec;
+        ceed::InitCeedVector(*mesh.GetNodes(), ceed, &mesh_nodes_vec);
+        inputs.push_back(
+            {"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+        CeedElemRestriction field_restr;
+        ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                              &field_restr);
+        const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+        CeedBasis field_basis;
+        ceed::InitBasisAtPoints(*fe, *ir, fespace.GetVDim(), ceed, &field_basis);
+        CeedVector field_vec;
+        ceed::InitCeedVector(field_staging, ceed, &field_vec);
+        inputs.push_back(
+            {"u_1", field_vec, field_restr, field_basis, ceed::EvalMode::Interp});
+        field_sources.emplace_back("u_1", 0);
+
+        // Output: 3 components for point i (byVDIM layout).
+        CeedElemRestriction out_restr;
+        const CeedInt offset[1] = {3 * i};
+        PalaceCeedCall(ceed, CeedElemRestrictionCreate(ceed, 1, 1, 3, 1, (CeedSize)npts * 3,
+                                                       CEED_MEM_HOST, CEED_COPY_VALUES,
+                                                       offset, &out_restr));
+
+        ceed::CeedQFunctionInfo info;
+        if (map_type == mfem::FiniteElement::H_CURL)
+        {
+          info.apply_qf = f_eval_probe_hcurl_33;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+        }
+        else
+        {
+          info.apply_qf = f_eval_probe_hdiv_33;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+        }
+        CeedOperator point_op;
+        ceed::AssembleCeedPointEvaluator(info, nullptr, 0, ceed, inputs, 3, out_restr,
+                                         &point_op);
+        groups.push_back({ceed, point_op, std::move(field_sources)});
+
+        PalaceCeedCall(ceed, CeedVectorDestroy(&mesh_nodes_vec));
+        PalaceCeedCall(ceed, CeedVectorDestroy(&field_vec));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_restr));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&field_restr));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&out_restr));
+        PalaceCeedCall(ceed, CeedBasisDestroy(&mesh_basis));
+        PalaceCeedCall(ceed, CeedBasisDestroy(&field_basis));
+      }
+      point_irs.push_back(std::move(ir));
+    }
+  }
+
+  ~CeedProbeEvaluator() { fem::DestroyGroupOperators(groups); }
+
+  bool IsValid() const { return valid; }
+
+  // Evaluate the field at all probe points (byVDIM ordering). Collective.
+  std::vector<double> Eval(const mfem::ParGridFunction &U) const
+  {
+    local_out = 0.0;
+    fem::ApplyAddGroupOperators(groups, {&U}, local_out);
+    std::vector<double> vals(local_out.Size());
+    const double *d = local_out.HostRead();
+    std::copy(d, d + local_out.Size(), vals.begin());
+    Mpi::GlobalSum(static_cast<int>(vals.size()), vals.data(), comm);
+    return vals;
+  }
+};
+
+#endif
 
 InterpolationOperator::InterpolationOperator(const std::map<int, config::ProbeData> &probe,
                                              const Units &units,
@@ -78,12 +248,33 @@ InterpolationOperator::InterpolationOperator(const IoData &iodata,
 {
 }
 
+InterpolationOperator::~InterpolationOperator() = default;
+
 std::vector<double> InterpolationOperator::ProbeField(const mfem::ParGridFunction &U)
 {
 #if defined(MFEM_USE_GSLIB)
+  const int npts = op.GetCode().Size();
+
+  // Use the libCEED evaluation path when supported and enough probe points are present
+  // to amortize operator assembly/JIT. Tiny probe sets are cheaper through the existing
+  // GSLIB interpolation path, especially in driven postprocessing where only a few
+  // fixed monitor points are evaluated once or twice.
+  constexpr int ceed_probe_min_points = 8;
+  if (fem::LibceedPostprocessingEnabled() && npts >= ceed_probe_min_points)
+  {
+    auto &eval = ceed_probes[U.FESpace()];
+    if (!eval)
+    {
+      eval = std::make_unique<CeedProbeEvaluator>(op, *U.ParFESpace());
+    }
+    if (eval->IsValid())
+    {
+      return eval->Eval(U);
+    }
+  }
+
   // Interpolated vector values are returned from GSLIB interpolator with the same ordering
   // as the source grid function, which we transform to byVDIM for output.
-  const int npts = op.GetCode().Size();
   const int vdim = U.VectorDim();
   std::vector<double> vals(npts * vdim);
   if (U.FESpace()->GetOrdering() == mfem::Ordering::byVDIM)

--- a/palace/fem/interpolator.hpp
+++ b/palace/fem/interpolator.hpp
@@ -6,6 +6,7 @@
 
 #include <complex>
 #include <map>
+#include <memory>
 #include <vector>
 #include <mfem.hpp>
 #include "utils/configfile.hpp"
@@ -24,6 +25,7 @@ class FindPointsGSLIB;
 namespace palace
 {
 
+class CeedProbeEvaluator;
 class GridFunction;
 class IoData;
 class Units;
@@ -37,6 +39,11 @@ class InterpolationOperator
 private:
 #if defined(MFEM_USE_GSLIB)
   mfem::FindPointsGSLIB op;
+
+  // libCEED evaluators at the located probe points, avoiding per-sample GSLIB
+  // interpolation), constructed lazily per source finite element space.
+  mutable std::map<const mfem::FiniteElementSpace *, std::unique_ptr<CeedProbeEvaluator>>
+      ceed_probes;
 #endif
   std::vector<int> op_idx;
 
@@ -48,6 +55,7 @@ public:
   InterpolationOperator(const std::map<int, config::ProbeData> &probe, const Units &units,
                         FiniteElementSpace &nd_space);
   InterpolationOperator(const IoData &iodata, FiniteElementSpace &nd_space);
+  ~InterpolationOperator();
 
   auto GetVDim() const { return v_dim_fes; }
   const auto &GetProbes() const { return op_idx; }

--- a/palace/fem/libceed/basis.cpp
+++ b/palace/fem/libceed/basis.cpp
@@ -44,19 +44,23 @@ void InitNonTensorBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRu
   const int dim = fe.GetDim();
   const int P = maps.ndof;
   const int Q = maps.nqpt;
-  mfem::DenseMatrix qX(dim, Q);
+  // libCEED expects reference coordinates in component-major layout,
+  // q_ref[d * Q + q].  MFEM DenseMatrix is column-major, so store the logical
+  // transpose (points as rows, dimensions as columns): qX(q, d) has exactly the
+  // layout libCEED expects while keeping matrix-style indexing.
+  mfem::DenseMatrix qX(Q, dim);
   mfem::Vector qW(Q);
   for (int i = 0; i < Q; i++)
   {
     const mfem::IntegrationPoint &ip = ir.IntPoint(i);
-    qX(0, i) = ip.x;
+    qX(i, 0) = ip.x;
     if (dim > 1)
     {
-      qX(1, i) = ip.y;
+      qX(i, 1) = ip.y;
     }
     if (dim > 2)
     {
-      qX(2, i) = ip.z;
+      qX(i, 2) = ip.z;
     }
     qW(i) = ip.weight;
   }
@@ -183,6 +187,15 @@ void InitBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
   {
     InitNonTensorBasis(fe, ir, num_comp, ceed, basis);
   }
+}
+
+void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
+                       CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+{
+  // Always use full tabulation: the integration rule points may be arbitrary (not a
+  // tensor-product rule), which the tensor basis construction cannot represent. The
+  // corresponding element restriction must use native dof ordering.
+  InitNonTensorBasis(fe, ir, num_comp, ceed, basis);
 }
 
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,

--- a/palace/fem/libceed/basis.hpp
+++ b/palace/fem/libceed/basis.hpp
@@ -20,6 +20,14 @@ namespace palace::ceed
 void InitBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir, int num_comp,
                Ceed ceed, CeedBasis *basis);
 
+// Initialize a basis tabulated at arbitrary integration rule points (which need not
+// correspond to a tensor-product quadrature rule, for example points lying on a face of
+// the reference element). Always uses full (non-lexicographic, native dof ordering)
+// tabulation, so the corresponding element restriction must also use native ordering
+// (is_interp = true for InitRestriction of scalar tensor-product elements).
+void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
+                       int num_comp, Ceed ceed, CeedBasis *basis);
+
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,
                            const mfem::FiniteElement &test_fe, int trial_num_comp,
                            int test_num_comp, Ceed ceed, CeedBasis *basis);

--- a/palace/fem/libceed/functional.cpp
+++ b/palace/fem/libceed/functional.cpp
@@ -1,0 +1,264 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "functional.hpp"
+
+#include <ceed/backend.h>
+#include <mfem.hpp>
+
+namespace palace::ceed
+{
+
+namespace
+{
+
+void AddQFunctionFieldInput(const CeedFunctionalFieldInput &input, Ceed ceed,
+                            CeedQFunction qf)
+{
+  if (input.ops & EvalMode::None)
+  {
+    // EvalMode::None inputs may have no basis (e.g. quadrature point data passed
+    // through directly), so get the component count from the restriction.
+    CeedInt num_comp;
+    PalaceCeedCall(ceed, CeedElemRestrictionGetNumComponents(input.restr, &num_comp));
+    PalaceCeedCall(ceed,
+                   CeedQFunctionAddInput(qf, input.name.c_str(), num_comp, CEED_EVAL_NONE));
+  }
+  if (input.ops & EvalMode::Interp)
+  {
+    CeedInt num_comp, q_comp;
+    PalaceCeedCall(ceed, CeedBasisGetNumComponents(input.basis, &num_comp));
+    PalaceCeedCall(
+        ceed, CeedBasisGetNumQuadratureComponents(input.basis, CEED_EVAL_INTERP, &q_comp));
+    PalaceCeedCall(ceed, CeedQFunctionAddInput(qf, input.name.c_str(), num_comp * q_comp,
+                                               CEED_EVAL_INTERP));
+  }
+  if (input.ops & EvalMode::Grad)
+  {
+    CeedInt num_comp, q_comp;
+    PalaceCeedCall(ceed, CeedBasisGetNumComponents(input.basis, &num_comp));
+    PalaceCeedCall(
+        ceed, CeedBasisGetNumQuadratureComponents(input.basis, CEED_EVAL_GRAD, &q_comp));
+    PalaceCeedCall(ceed, CeedQFunctionAddInput(qf, ("grad_" + input.name).c_str(),
+                                               num_comp * q_comp, CEED_EVAL_GRAD));
+  }
+  if (input.ops & EvalMode::Weight)
+  {
+    PalaceCeedCall(ceed,
+                   CeedQFunctionAddInput(qf, input.name.c_str(), 1, CEED_EVAL_WEIGHT));
+  }
+  MFEM_VERIFY(!(input.ops & (EvalMode::Div | EvalMode::Curl)),
+              "Unsupported evaluation mode for surface functional field input '"
+                  << input.name << "'!");
+}
+
+void AddOperatorFieldInput(const CeedFunctionalFieldInput &input, Ceed ceed,
+                           CeedOperator op)
+{
+  if (input.ops & EvalMode::None)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, input.name.c_str(), input.restr,
+                                              CEED_BASIS_NONE, input.vec));
+  }
+  if (input.ops & EvalMode::Interp)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, input.name.c_str(), input.restr,
+                                              input.basis, input.vec));
+  }
+  if (input.ops & EvalMode::Grad)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, ("grad_" + input.name).c_str(),
+                                              input.restr, input.basis, input.vec));
+  }
+  if (input.ops & EvalMode::Weight)
+  {
+    PalaceCeedCall(ceed,
+                   CeedOperatorSetField(op, input.name.c_str(), CEED_ELEMRESTRICTION_NONE,
+                                        input.basis, CEED_VECTOR_NONE));
+  }
+}
+
+}  // namespace
+
+void AssembleCeedSurfaceFunctional(const CeedQFunctionInfo &info, void *ctx,
+                                   std::size_t ctx_size, Ceed ceed,
+                                   const std::vector<CeedFunctionalFieldInput> &inputs,
+                                   CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                   CeedOperator *op, CeedQFunctionContext *ctx_out)
+{
+  MFEM_VERIFY(!info.assemble_q_data,
+              "Surface functional integrator does not support quadrature data assembly!");
+  if (ctx_out)
+  {
+    *ctx_out = nullptr;
+  }
+
+  // Create basis for summing contributions from all quadrature points on each element
+  // for each output component (all-ones interpolation matrix). The number of quadrature
+  // points comes from the first input with a basis.
+  CeedInt num_qpts = 0;
+  CeedBasis sum_basis;
+  {
+    for (const auto &input : inputs)
+    {
+      if (input.basis)
+      {
+        PalaceCeedCall(ceed, CeedBasisGetNumQuadraturePoints(input.basis, &num_qpts));
+        break;
+      }
+    }
+    MFEM_VERIFY(num_qpts > 0, "No input with a basis for surface functional assembly!");
+    mfem::Vector Bt(num_qpts), Gt(num_qpts), qX(num_qpts), qW(num_qpts);
+    Bt = 1.0;
+    Gt = 0.0;
+    qX = 0.0;
+    qW = 0.0;
+    // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
+    PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, num_out_comp, 1,
+                                           num_qpts, Bt.GetData(), Gt.GetData(),
+                                           qX.GetData(), qW.GetData(), &sum_basis));
+  }
+
+  // Create the QFunction that defines the action of the operator.
+  CeedQFunction apply_qf;
+  PalaceCeedCall(ceed, CeedQFunctionCreateInterior(ceed, 1, info.apply_qf,
+                                                   info.apply_qf_path.c_str(), &apply_qf));
+
+  if (ctx && ctx_size > 0)
+  {
+    CeedQFunctionContext apply_ctx;
+    PalaceCeedCall(ceed, CeedQFunctionContextCreate(ceed, &apply_ctx));
+    PalaceCeedCall(ceed, CeedQFunctionContextSetData(apply_ctx, CEED_MEM_HOST,
+                                                     CEED_COPY_VALUES, ctx_size, ctx));
+    PalaceCeedCall(ceed, CeedQFunctionSetContext(apply_qf, apply_ctx));
+    if (ctx_out)
+    {
+      // Transfer ownership of the context handle to the caller (for in-place runtime
+      // updates without reassembly); it must be destroyed by the caller.
+      *ctx_out = apply_ctx;
+    }
+    else
+    {
+      PalaceCeedCall(ceed, CeedQFunctionContextDestroy(&apply_ctx));
+    }
+  }
+
+  for (const auto &input : inputs)
+  {
+    AddQFunctionFieldInput(input, ceed, apply_qf);
+  }
+  PalaceCeedCall(ceed,
+                 CeedQFunctionAddOutput(apply_qf, "v", num_out_comp, CEED_EVAL_INTERP));
+
+  // Create the operator.
+  PalaceCeedCall(ceed, CeedOperatorCreate(ceed, apply_qf, nullptr, nullptr, op));
+  PalaceCeedCall(ceed, CeedQFunctionDestroy(&apply_qf));
+
+  for (const auto &input : inputs)
+  {
+    AddOperatorFieldInput(input, ceed, *op);
+  }
+  PalaceCeedCall(ceed,
+                 CeedOperatorSetField(*op, "v", out_restr, sum_basis, CEED_VECTOR_ACTIVE));
+
+  PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
+
+  // Cleanup (this is now owned by the operator).
+  PalaceCeedCall(ceed, CeedBasisDestroy(&sum_basis));
+}
+
+namespace
+{
+
+void CreatePointEvaluatorQFunction(const CeedQFunctionInfo &info, void *ctx,
+                                   std::size_t ctx_size, Ceed ceed,
+                                   const std::vector<CeedFunctionalFieldInput> &inputs,
+                                   CeedInt num_out_comp, CeedQFunction *apply_qf,
+                                   CeedQFunctionContext *ctx_out)
+{
+  MFEM_VERIFY(!info.assemble_q_data,
+              "Point evaluator does not support quadrature data assembly!");
+  if (ctx_out)
+  {
+    *ctx_out = nullptr;
+  }
+  PalaceCeedCall(ceed, CeedQFunctionCreateInterior(ceed, 1, info.apply_qf,
+                                                   info.apply_qf_path.c_str(), apply_qf));
+
+  if (ctx && ctx_size > 0)
+  {
+    CeedQFunctionContext apply_ctx;
+    PalaceCeedCall(ceed, CeedQFunctionContextCreate(ceed, &apply_ctx));
+    PalaceCeedCall(ceed, CeedQFunctionContextSetData(apply_ctx, CEED_MEM_HOST,
+                                                     CEED_COPY_VALUES, ctx_size, ctx));
+    PalaceCeedCall(ceed, CeedQFunctionSetContext(*apply_qf, apply_ctx));
+    if (ctx_out)
+    {
+      *ctx_out = apply_ctx;
+    }
+    else
+    {
+      PalaceCeedCall(ceed, CeedQFunctionContextDestroy(&apply_ctx));
+    }
+  }
+
+  for (const auto &input : inputs)
+  {
+    AddQFunctionFieldInput(input, ceed, *apply_qf);
+  }
+  PalaceCeedCall(ceed,
+                 CeedQFunctionAddOutput(*apply_qf, "v", num_out_comp, CEED_EVAL_NONE));
+}
+
+}  // namespace
+
+void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
+                                std::size_t ctx_size, Ceed ceed,
+                                const std::vector<CeedFunctionalFieldInput> &inputs,
+                                CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                CeedOperator *op, CeedQFunctionContext *ctx_out)
+{
+  CeedQFunction apply_qf;
+  CreatePointEvaluatorQFunction(info, ctx, ctx_size, ceed, inputs, num_out_comp, &apply_qf,
+                                ctx_out);
+
+  PalaceCeedCall(ceed, CeedOperatorCreate(ceed, apply_qf, nullptr, nullptr, op));
+  PalaceCeedCall(ceed, CeedQFunctionDestroy(&apply_qf));
+
+  for (const auto &input : inputs)
+  {
+    AddOperatorFieldInput(input, ceed, *op);
+  }
+  PalaceCeedCall(
+      ceed, CeedOperatorSetField(*op, "v", out_restr, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+
+  PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
+}
+
+void AssembleCeedPointEvaluatorAtPoints(const CeedQFunctionInfo &info, void *ctx,
+                                        std::size_t ctx_size, Ceed ceed,
+                                        const std::vector<CeedFunctionalFieldInput> &inputs,
+                                        CeedElemRestriction points_restr,
+                                        CeedVector points_vec, CeedInt num_out_comp,
+                                        CeedElemRestriction out_restr, CeedOperator *op,
+                                        CeedQFunctionContext *ctx_out)
+{
+  CeedQFunction apply_qf;
+  CreatePointEvaluatorQFunction(info, ctx, ctx_size, ceed, inputs, num_out_comp, &apply_qf,
+                                ctx_out);
+
+  PalaceCeedCall(ceed, CeedOperatorCreateAtPoints(ceed, apply_qf, nullptr, nullptr, op));
+  PalaceCeedCall(ceed, CeedQFunctionDestroy(&apply_qf));
+
+  for (const auto &input : inputs)
+  {
+    AddOperatorFieldInput(input, ceed, *op);
+  }
+  PalaceCeedCall(
+      ceed, CeedOperatorSetField(*op, "v", out_restr, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+  PalaceCeedCall(ceed, CeedOperatorAtPointsSetPoints(*op, points_restr, points_vec));
+
+  PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
+}
+
+}  // namespace palace::ceed

--- a/palace/fem/libceed/functional.hpp
+++ b/palace/fem/libceed/functional.hpp
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_FUNCTIONAL_HPP
+#define PALACE_LIBCEED_FUNCTIONAL_HPP
+
+#include <string>
+#include <vector>
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/integrator.hpp"
+
+namespace palace::ceed
+{
+
+// Description of a passive field input for a surface functional operator. The field
+// vector is evaluated at the (mapped face) quadrature points through the provided
+// element restriction and basis.
+struct CeedFunctionalFieldInput
+{
+  // Name of the QFunction input field (QFunction inputs are added in the order the
+  // inputs are provided, after the geometry data inputs).
+  std::string name;
+
+  // Field vector (L-vector layout matching the restriction).
+  CeedVector vec;
+
+  // Element restriction and basis for evaluation at quadrature points.
+  CeedElemRestriction restr;
+  CeedBasis basis;
+
+  // Evaluation modes (ceed::EvalMode) for the field input.
+  unsigned int ops;
+};
+
+// Construct a libCEED operator which evaluates a functional (integral of a function of
+// the provided fields) over every element described by the inputs. The element geometry
+// is computed on the fly from quadrature weight and mesh node gradient inputs (no
+// stored geometry factor data). The QFunction output "v" (size num_out_comp) is summed
+// over quadrature points via an all-ones basis, yielding num_out_comp values per
+// element in the active output vector through out_restr. Apply with
+// CeedOperatorApplyAdd(op, CEED_VECTOR_NONE, output, ...). If ctx_out is non-null and a
+// QFunction context was created, the context handle is returned (ownership transferred
+// to the caller, which must destroy it) so the caller can update runtime context values
+// in place (CeedQFunctionContextGetData/RestoreData) without reassembling the operator.
+void AssembleCeedSurfaceFunctional(const CeedQFunctionInfo &info, void *ctx,
+                                   std::size_t ctx_size, Ceed ceed,
+                                   const std::vector<CeedFunctionalFieldInput> &inputs,
+                                   CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                   CeedOperator *op,
+                                   CeedQFunctionContext *ctx_out = nullptr);
+
+// Construct a libCEED operator which evaluates a pointwise function of the provided
+// fields at arbitrary points of each element (for example the nodal points of an
+// interpolatory output space), writing num_out_comp values per point through out_restr
+// (CEED_EVAL_NONE, so the number of "quadrature" points of the operator must match the
+// element size of the output restriction). No quadrature weighting or sum over points
+// is performed, and the element geometry is computed on the fly from a mesh nodes
+// gradient input rather than stored geometry factor data. Apply with
+// CeedOperatorApplyAdd(op, CEED_VECTOR_NONE, output, ...) (contributions accumulate,
+// e.g. for the real and imaginary part applications of quadratic quantities).
+void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
+                                std::size_t ctx_size, Ceed ceed,
+                                const std::vector<CeedFunctionalFieldInput> &inputs,
+                                CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                CeedOperator *op, CeedQFunctionContext *ctx_out = nullptr);
+
+// Variant of AssembleCeedPointEvaluator for libCEED AtPoints operators: basis inputs
+// are evaluated at runtime reference coordinates described by points_restr/points_vec,
+// while CEED_EVAL_NONE inputs/outputs use point restrictions compatible with
+// points_restr. This keeps arbitrary mapped face points out of the basis/JIT key.
+void AssembleCeedPointEvaluatorAtPoints(const CeedQFunctionInfo &info, void *ctx,
+                                        std::size_t ctx_size, Ceed ceed,
+                                        const std::vector<CeedFunctionalFieldInput> &inputs,
+                                        CeedElemRestriction points_restr,
+                                        CeedVector points_vec, CeedInt num_out_comp,
+                                        CeedElemRestriction out_restr, CeedOperator *op,
+                                        CeedQFunctionContext *ctx_out = nullptr);
+
+}  // namespace palace::ceed
+
+#endif  // PALACE_LIBCEED_FUNCTIONAL_HPP

--- a/palace/fem/libceed/integrator.cpp
+++ b/palace/fem/libceed/integrator.cpp
@@ -557,21 +557,33 @@ void AssembleCeedElementErrorIntegrator(
   MFEM_VERIFY(!info.assemble_q_data,
               "Quadrature interpolator does not support quadrature data assembly!");
 
-  // Create basis for summing contributions from all quadrature points on the element.
-  CeedInt num_qpts;
+  // Create an output restriction which sums quadrature point contributions into one
+  // value per element. This avoids expressing the element-local quadrature reduction as
+  // a fake all-ones basis transpose, which is a poor fit for some device backends.
+  CeedInt num_qpts, num_elem;
+  CeedSize elem_l_size;
   PalaceCeedCall(ceed, CeedBasisGetNumQuadraturePoints(input1_basis, &num_qpts));
-  CeedBasis mesh_elem_basis;
+  PalaceCeedCall(ceed, CeedElemRestrictionGetNumElements(mesh_elem_restr, &num_elem));
+  PalaceCeedCall(ceed, CeedElemRestrictionGetLVectorSize(mesh_elem_restr, &elem_l_size));
+
+  const CeedInt *mesh_elem_offsets;
+  PalaceCeedCall(ceed, CeedElemRestrictionGetOffsets(mesh_elem_restr, CEED_MEM_HOST,
+                                                     &mesh_elem_offsets));
+  std::vector<CeedInt> elem_q_offsets(num_elem * num_qpts);
+  for (CeedInt e = 0; e < num_elem; e++)
   {
-    // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
-    mfem::Vector Bt(num_qpts), Gt(num_qpts), qX(num_qpts), qW(num_qpts);
-    Bt = 1.0;
-    Gt = 0.0;
-    qX = 0.0;
-    qW = 0.0;
-    PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_qpts,
-                                           Bt.GetData(), Gt.GetData(), qX.GetData(),
-                                           qW.GetData(), &mesh_elem_basis));
+    for (CeedInt q = 0; q < num_qpts; q++)
+    {
+      elem_q_offsets[e * num_qpts + q] = mesh_elem_offsets[e];
+    }
   }
+  PalaceCeedCall(ceed,
+                 CeedElemRestrictionRestoreOffsets(mesh_elem_restr, &mesh_elem_offsets));
+
+  CeedElemRestriction elem_q_restr;
+  PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                           ceed, num_elem, num_qpts, 1, 1, elem_l_size, CEED_MEM_HOST,
+                           CEED_COPY_VALUES, elem_q_offsets.data(), &elem_q_restr));
 
   // Create the QFunction that defines the action of the operator.
   CeedQFunction apply_qf;
@@ -599,7 +611,7 @@ void AssembleCeedElementErrorIntegrator(
   }
   AddQFunctionActiveInputs(info.trial_ops, ceed, input1_basis, apply_qf, "u_1");
   AddQFunctionActiveInputs(info.test_ops, ceed, input2_basis, apply_qf, "u_2");
-  PalaceCeedCall(ceed, CeedQFunctionAddOutput(apply_qf, "v", 1, CEED_EVAL_INTERP));
+  PalaceCeedCall(ceed, CeedQFunctionAddOutput(apply_qf, "v", 1, CEED_EVAL_NONE));
 
   // Create the operator.
   PalaceCeedCall(ceed, CeedOperatorCreate(ceed, apply_qf, nullptr, nullptr, op));
@@ -616,13 +628,13 @@ void AssembleCeedElementErrorIntegrator(
                                input1);
   AddOperatorActiveInputFields(info.test_ops, ceed, input2_restr, input2_basis, *op, "u_2",
                                input2);
-  PalaceCeedCall(ceed, CeedOperatorSetField(*op, "v", mesh_elem_restr, mesh_elem_basis,
+  PalaceCeedCall(ceed, CeedOperatorSetField(*op, "v", elem_q_restr, CEED_BASIS_NONE,
                                             CEED_VECTOR_ACTIVE));
 
   PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
 
   // Cleanup (this is now owned by the operator).
-  PalaceCeedCall(ceed, CeedBasisDestroy(&mesh_elem_basis));
+  PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&elem_q_restr));
 }
 
 }  // namespace palace::ceed

--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -49,6 +49,7 @@ public:
 
   double GetGeometryLength() const override { return l; }
   double GetGeometryWidth() const override { return w; }
+  const mfem::Vector &GetDirection() const { return direction; }
 
   std::unique_ptr<mfem::VectorCoefficient>
   GetModeCoefficient(double coeff = 1.0) const override;
@@ -72,6 +73,8 @@ public:
 
   double GetGeometryLength() const override { return std::log(r_outer / r_inner); }
   double GetGeometryWidth() const override { return 2.0 * M_PI; }
+  double GetDirection() const { return direction; }
+  const mfem::Vector &GetOrigin() const { return origin; }
 
   std::unique_ptr<mfem::VectorCoefficient>
   GetModeCoefficient(double coeff = 1.0) const override;

--- a/palace/fem/output_functionals.cpp
+++ b/palace/fem/output_functionals.cpp
@@ -1,0 +1,2566 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "output_functionals.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include "fem/coefficient.hpp"
+#include "fem/facenbrexchange.hpp"
+#include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/coefficient.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/integrator.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/mesh.hpp"
+#include "fem/postprocessing_backend.hpp"
+#include "linalg/vector.hpp"
+#include "models/materialoperator.hpp"
+#include "utils/communication.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/21/surf_21_qf.h"
+#include "fem/qfunctions/32/surf_32_qf.h"
+
+PalacePragmaDiagnosticPop
+
+namespace palace
+{
+
+namespace
+{
+
+// Key identifying a group of boundary elements that can share one libCEED operator. For
+// AtPoints-capable groups, mapped volume reference coordinates are runtime point data and
+// do not participate in the key. For the mapped-integration-rule path, nonconforming
+// trace maps are keyed by MFEM's finite face topology (local face/orientation,
+// conformity, and NCMesh point matrix class), with exact dyadic reference-vertex data as
+// a guard against missing a discrete orientation bit. This keeps grouping independent of
+// physical coordinates or arbitrary per-element point clouds.
+using FaceConfigKey = std::vector<long long>;
+
+// Registry of mapped face integration rules. The IntegrationRule objects must have
+// application lifetime: mfem::FiniteElement::GetDofToQuad caches tabulations keyed by
+// the IntegrationRule pointer inside the (global, shared) FiniteElement objects, so
+// destroying an IntegrationRule which was used for tabulation would leave a dangling
+// cache entry.
+const mfem::IntegrationRule *
+GetRegisteredMappedIr(const FaceConfigKey &key,
+                      const std::vector<mfem::IntegrationPoint> &pts)
+{
+  static std::map<FaceConfigKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::mutex registry_mutex;
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  auto it = registry.find(key);
+  if (it == registry.end())
+  {
+    auto ir = std::make_unique<mfem::IntegrationRule>(static_cast<int>(pts.size()));
+    for (std::size_t q = 0; q < pts.size(); q++)
+    {
+      ir->IntPoint(static_cast<int>(q)) = pts[q];
+    }
+    it = registry.emplace(key, std::move(ir)).first;
+  }
+  return it->second.get();
+}
+
+// Evaluation plan for a single marked boundary element: which volume element(s) the
+// field is evaluated from, and the face quadrature point positions mapped into the
+// volume element reference space(s). elem_b >= 0 indicates two-sided evaluation.
+struct ElemPlan
+{
+  int bdr_elem;
+  int elem_a = -1, elem_b = -1;
+  std::vector<mfem::IntegrationPoint> pts_a, pts_b;
+  bool flip = false;  // Boundary element and face have the same orientation (o % 2 == 0),
+                      // legacy coefficients invert the boundary element normal
+  // A side whose volume element is a face neighbor (ghost) on another process: its field
+  // is not in the local vector, so it is pulled via FaceNbrFieldExchange and fed to the
+  // operator at the mapped points (only Elem2 can be a ghost, so at most one side).
+  bool ghost_a = false, ghost_b = false;
+  int face_nbr = -1;   // Face neighbor element index (Elem2No - ParMesh::GetNE())
+  int ghost_attr = 0;  // Ghost element mesh attribute (material lookup on the requester)
+  mfem::Geometry::Type ghost_geom = mfem::Geometry::INVALID;  // Ghost element geometry
+  // Integer/topological identities of ghost-side pts_a/pts_b: reference-face rule/order
+  // plus the reference-face-to-volume subface/orientation map. These are passed to
+  // FaceNbrFieldExchange so remote point-evaluator grouping never depends on floating
+  // point coordinates.
+  std::vector<long long> point_key_a, point_key_b;
+};
+
+// Data for one group of boundary elements sharing the same face configuration.
+struct FaceGroup
+{
+  mfem::Geometry::Type bdr_geom;
+  mfem::Geometry::Type vol_geom_a = mfem::Geometry::INVALID;
+  mfem::Geometry::Type vol_geom_b = mfem::Geometry::INVALID;
+  bool flip_normal = false;
+  const mfem::IntegrationRule *mapped_ir_a = nullptr;  // Registry, application lifetime
+  const mfem::IntegrationRule *mapped_ir_b = nullptr;
+  std::vector<int> bdr_indices, vol_indices_a, vol_indices_b;
+  std::vector<int> out_slots;  // Output vector slot for each boundary element
+  // Ghost (face neighbor) side, if any: at most one of ghost_a/ghost_b is set (only
+  // Elem2 can be a ghost). For the ghost side, vol_indices are empty; face_nbr and
+  // ghost_attr hold the per-element face neighbor index and mesh attribute, and req_idx
+  // the FaceNbrFieldExchange request index (filled when the exchange is built).
+  bool ghost_a = false, ghost_b = false;
+  bool at_points = false;
+  // Split two-sided boundary-visualization groups into one-sided AtPoints operators.
+  // ApplyAdd accumulation combines the side contributions in the shared output buffer;
+  // side_scale handles averages, normal_scale handles signed jump quantities.
+  double side_scale = 1.0;
+  double normal_scale = 1.0;
+  std::vector<int> face_nbr, ghost_attr, req_idx;
+  std::vector<std::vector<long long>> face_nbr_point_keys;
+  std::vector<std::vector<mfem::IntegrationPoint>> face_nbr_points;
+  // For AtPoints groups, the mapped volume reference coordinates vary by boundary
+  // element and are stored in boundary-element order, nq entries per element. Local
+  // split SURFACE_FLUX groups may also carry a per-entry normal scale folded into the
+  // precomputed face Jacobian so opposite sides can share one AtPoints operator.
+  std::vector<mfem::IntegrationPoint> mapped_pts_a, mapped_pts_b;
+  std::vector<double> normal_scales;
+};
+
+long long EncodeReferenceCoordinate(double x)
+{
+  // Most NC trace maps have exact dyadic reference coordinates, but conforming/curved or
+  // generated boundary-mode examples can arrive here with ordinary floating-point
+  // reference coordinates from MFEM transformations. Quantize finely enough to keep the
+  // topology key deterministic; VerifyMappedRuleMatches below remains the safety net
+  // against accidentally reusing one mapped integration rule for different points.
+  constexpr long long denom = 1LL << 40;
+  MFEM_VERIFY(std::isfinite(x), "Invalid reference coordinate in trace-map key!");
+  return std::llround(denom * x);
+}
+
+void AppendDenseMatrixTopologyKey(const mfem::DenseMatrix *pm, FaceConfigKey &key)
+{
+  if (!pm)
+  {
+    key.push_back(0);  // No NC point matrix.
+    return;
+  }
+  key.push_back(1);
+  key.push_back(pm->Height());
+  key.push_back(pm->Width());
+  for (int j = 0; j < pm->Width(); j++)
+  {
+    for (int i = 0; i < pm->Height(); i++)
+    {
+      key.push_back(EncodeReferenceCoordinate((*pm)(i, j)));
+    }
+  }
+}
+
+int FaceInformationSide(const mfem::Mesh::FaceInformation &face, int elem, bool ghost,
+                        int face_nbr)
+{
+  for (int side = 0; side < 2; side++)
+  {
+    if (ghost)
+    {
+      if (face.element[side].location == mfem::Mesh::ElementLocation::FaceNbr &&
+          face.element[side].index == face_nbr)
+      {
+        return side;
+      }
+    }
+    else if (face.element[side].location == mfem::Mesh::ElementLocation::Local &&
+             face.element[side].index == elem)
+    {
+      return side;
+    }
+  }
+  MFEM_VERIFY(false, "Unable to match boundary trace side to MFEM FaceInformation!");
+  return -1;
+}
+
+std::vector<long long> MakeTraceMapTopologyKey(const mfem::Mesh::FaceInformation &face,
+                                               int side, mfem::Geometry::Type vol_geom,
+                                               mfem::Geometry::Type face_geom,
+                                               const mfem::IntegrationRule &face_ir,
+                                               int bdr_to_face_orientation,
+                                               mfem::IntegrationPointTransformation &loc)
+{
+  // The primary identity is MFEM/NCMesh topology: face tag, side role, local face id,
+  // orientation, element conformity, and the finite NC point-matrix class. The encoded
+  // reference-vertex image is not a fuzzy point-cloud key; it is an exact dyadic guard
+  // for the reference trace map that catches omitted orientation/subface bits.
+  FaceConfigKey key;
+  const mfem::IntegrationRule *verts = mfem::Geometries.GetVertices(face_geom);
+  key.reserve(
+      24 + 3 * verts->GetNPoints() +
+      (face.point_matrix ? face.point_matrix->Height() * face.point_matrix->Width() : 0));
+  key.push_back(static_cast<long long>(vol_geom));
+  key.push_back(static_cast<long long>(face_geom));
+  key.push_back(static_cast<long long>(face_ir.GetOrder()));
+  key.push_back(static_cast<long long>(face_ir.GetNPoints()));
+  key.push_back(static_cast<long long>(bdr_to_face_orientation));
+  key.push_back(static_cast<long long>(face.topology));
+  key.push_back(static_cast<long long>(face.tag));
+  key.push_back(static_cast<long long>(side));
+  key.push_back(static_cast<long long>(face.element[side].location));
+  key.push_back(static_cast<long long>(face.element[side].conformity));
+  key.push_back(static_cast<long long>(face.element[side].local_face_id));
+  key.push_back(static_cast<long long>(face.element[side].orientation));
+  key.push_back(face.ncface >= 0 ? 1 : 0);
+  AppendDenseMatrixTopologyKey(face.point_matrix, key);
+  for (int i = 0; i < verts->GetNPoints(); i++)
+  {
+    mfem::IntegrationPoint fip = mfem::Mesh::TransformBdrElementToFace(
+        face_geom, bdr_to_face_orientation, verts->IntPoint(i));
+    mfem::IntegrationPoint ip;
+    loc.Transform(fip, ip);
+    key.push_back(EncodeReferenceCoordinate(ip.x));
+    key.push_back(EncodeReferenceCoordinate(ip.y));
+    key.push_back(EncodeReferenceCoordinate(ip.z));
+  }
+  return key;
+}
+
+void VerifyMappedRuleMatches(const mfem::IntegrationRule &ir,
+                             const std::vector<mfem::IntegrationPoint> &pts)
+{
+  MFEM_VERIFY(ir.GetNPoints() == static_cast<int>(pts.size()),
+              "NC trace-map key reused with a different number of mapped points!");
+  for (int q = 0; q < ir.GetNPoints(); q++)
+  {
+    const auto &a = ir.IntPoint(q);
+    const auto &b = pts[static_cast<std::size_t>(q)];
+    const double err = std::max({std::abs(a.x - b.x), std::abs(a.y - b.y),
+                                 std::abs(a.z - b.z), std::abs(a.weight - b.weight)});
+    MFEM_VERIFY(err <= 1.0e-12,
+                "NC trace-map key reused for different mapped reference points; "
+                "refine the finite MFEM/NCMesh face-map key before using this group!");
+  }
+}
+
+void FoldNormalScaleIntoFaceJacobian(const mfem::DenseMatrix &J, double normal_scale,
+                                     double *Jf)
+{
+  // Surface flux kernels recover the unnormalized physical normal from the columns of
+  // the face Jacobian. Multiplying one column by s multiplies both the surface measure
+  // and the oriented normal by s, including flipping the normal direction for s < 0.
+  // Split local two-sided SURFACE_FLUX AtPoints groups use this to carry the per-entry
+  // signed jump/average convention in geometry while sharing one operator across sides.
+  for (int d = 0; d < 2; d++)
+  {
+    for (int c = 0; c < 3; c++)
+    {
+      Jf[c + 3 * d] = (d == 0 ? normal_scale : 1.0) * J(c, d);
+    }
+  }
+}
+
+bool CeedSupportsNonTensorAtPoints(Ceed ceed)
+{
+  // Palace carries libCEED non-tensor AtPoints support for the CPU host path and the
+  // CUDA ref/MAGMA device paths. Other backends keep the mapped-point tabulation path.
+  const char *resource;
+  PalaceCeedCall(ceed, CeedGetResource(ceed, &resource));
+  return std::strstr(resource, "/cpu/self") || std::strstr(resource, "/gpu/cuda/ref") ||
+         std::strstr(resource, "/gpu/cuda/magma");
+}
+
+int TetNumModes(int degree)
+{
+  return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+}
+
+mfem::IntegrationRule MakeTetLatticeRule(int degree)
+{
+  mfem::IntegrationRule ir(TetNumModes(degree));
+  int q = 0;
+  if (degree == 0)
+  {
+    ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    ir.IntPoint(q++).weight = 1.0;
+  }
+  else
+  {
+    for (int total = 0; total <= degree; total++)
+    {
+      for (int i = 0; i <= total; i++)
+      {
+        for (int j = 0; j <= total - i; j++)
+        {
+          const int k = total - i - j;
+          ir.IntPoint(q).Set3(static_cast<double>(i) / degree,
+                              static_cast<double>(j) / degree,
+                              static_cast<double>(k) / degree);
+          ir.IntPoint(q++).weight = 1.0;
+        }
+      }
+    }
+  }
+  return ir;
+}
+
+void InitTetBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
+                             CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+{
+  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
+              "AtPoints surface output proof currently supports tetrahedral volume "
+              "elements only!");
+  // MAGMA's non-tensor AtPoints basis construction requires tabulation points that
+  // overdetermine the complete polynomial space. Use one extra lattice degree to provide
+  // a small, deterministic overdetermined reconstruction while keeping AtPoints grouping.
+  const int degree = std::max(0, fe.GetOrder() - (grad_only ? 1 : 0) + 1);
+  const mfem::IntegrationRule ir = MakeTetLatticeRule(degree);
+  ceed::InitBasisAtPoints(fe, ir, num_comp, ceed, basis);
+}
+
+void CreateSequentialPointRestriction(Ceed ceed, std::size_t num_elem, int nq, int num_comp,
+                                      CeedSize l_size, CeedElemRestriction *restr)
+{
+  const CeedInt total_pts = static_cast<CeedInt>(num_elem * nq);
+  std::vector<CeedInt> offsets(num_elem + 1 + total_pts);
+  for (std::size_t e = 0; e <= num_elem; e++)
+  {
+    offsets[e] = static_cast<CeedInt>(num_elem + 1 + e * nq);
+  }
+  for (CeedInt i = 0; i < total_pts; i++)
+  {
+    offsets[num_elem + 1 + i] = i;
+  }
+  PalaceCeedCall(ceed, CeedElemRestrictionCreateAtPoints(
+                           ceed, static_cast<CeedInt>(num_elem), total_pts, num_comp,
+                           l_size, CEED_MEM_HOST, CEED_COPY_VALUES, offsets.data(), restr));
+}
+
+// Holds libCEED object references created during operator assembly for destruction once
+// the assembled operator owns them.
+struct CeedAssemblyScratch
+{
+  Ceed ceed;
+  std::vector<CeedVector> vecs;
+  std::vector<CeedElemRestriction> restrs;
+  std::vector<CeedBasis> bases;
+
+  CeedAssemblyScratch(Ceed ceed) : ceed(ceed) {}
+  CeedAssemblyScratch(const CeedAssemblyScratch &) = delete;
+  CeedAssemblyScratch &operator=(const CeedAssemblyScratch &) = delete;
+
+  ~CeedAssemblyScratch()
+  {
+    for (auto &v : vecs)
+    {
+      PalaceCeedCall(ceed, CeedVectorDestroy(&v));
+    }
+    for (auto &r : restrs)
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&r));
+    }
+    for (auto &b : bases)
+    {
+      PalaceCeedCall(ceed, CeedBasisDestroy(&b));
+    }
+  }
+};
+
+}  // namespace
+
+SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(Kind kind)
+{
+  switch (kind)
+  {
+    case Kind::AREA:
+      return KernelKind::AREA;
+    case Kind::HCURL_NORM2:
+      return KernelKind::HCURL_NORM2;
+    case Kind::INTERFACE_EPR:
+      return KernelKind::INTERFACE_EPR;
+    case Kind::SURFACE_FLUX:
+      return KernelKind::SURFACE_FLUX;
+    case Kind::FARFIELD:
+      return KernelKind::FARFIELD;
+  }
+  MFEM_ABORT("Unknown surface functional kind!");
+}
+
+SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(PointFieldKind kind)
+{
+  switch (kind)
+  {
+    case PointFieldKind::FIELD_E:
+      return KernelKind::BDR_FIELD_E;
+    case PointFieldKind::FIELD_B:
+      return KernelKind::BDR_FIELD_B;
+    case PointFieldKind::FLUX_Q:
+      return KernelKind::BDR_FLUX_Q;
+    case PointFieldKind::CURRENT_J:
+      return KernelKind::BDR_CURRENT_J;
+    case PointFieldKind::ENERGY_E:
+      return KernelKind::BDR_ENERGY_E;
+    case PointFieldKind::ENERGY_M:
+      return KernelKind::BDR_ENERGY_M;
+    case PointFieldKind::POYNTING:
+      return KernelKind::BDR_POYNTING;
+  }
+  MFEM_ABORT("Unknown point field kind!");
+}
+
+const char *SurfaceFunctional::KindName(KernelKind kind)
+{
+  switch (kind)
+  {
+    case KernelKind::AREA:
+      return "AREA";
+    case KernelKind::HCURL_NORM2:
+      return "HCURL_NORM2";
+    case KernelKind::INTERFACE_EPR:
+      return "INTERFACE_EPR";
+    case KernelKind::SURFACE_FLUX:
+      return "SURFACE_FLUX";
+    case KernelKind::FARFIELD:
+      return "FARFIELD";
+    case KernelKind::MODE_OVERLAP:
+      return "MODE_OVERLAP";
+    case KernelKind::BDR_FIELD_E:
+      return "BDR_FIELD_E";
+    case KernelKind::BDR_FIELD_B:
+      return "BDR_FIELD_B";
+    case KernelKind::BDR_FLUX_Q:
+      return "BDR_FLUX_Q";
+    case KernelKind::BDR_CURRENT_J:
+      return "BDR_CURRENT_J";
+    case KernelKind::BDR_ENERGY_E:
+      return "BDR_ENERGY_E";
+    case KernelKind::BDR_ENERGY_M:
+      return "BDR_ENERGY_M";
+    case KernelKind::BDR_POYNTING:
+      return "BDR_POYNTING";
+  }
+  return "UNKNOWN";
+}
+
+SurfaceFunctional::SurfaceFunctional(Kind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace *fespace)
+  : kind(ToKernelKind(kind)), nd_fespace(fespace), rt_fespace(nullptr), mat_op(nullptr),
+    comm(mesh.GetComm())
+{
+  MFEM_VERIFY(kind == Kind::AREA || kind == Kind::HCURL_NORM2,
+              "Invalid SurfaceFunctional constructor for the requested functional kind!");
+  MFEM_VERIFY(kind == Kind::AREA || fespace,
+              "SurfaceFunctional requires a field finite element space for functionals "
+              "with field inputs!");
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &fespace, int lod)
+  : kind(ToKernelKind(kind)),
+    nd_fespace(kind == PointFieldKind::FIELD_E ? &fespace : nullptr),
+    rt_fespace(kind == PointFieldKind::FIELD_B ? &fespace : nullptr), mat_op(nullptr),
+    comm(mesh.GetComm()), viz_lod(lod)
+{
+  MFEM_VERIFY(kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_B,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &fespace,
+                                     const MaterialOperator &mat_op, int lod,
+                                     double scaling)
+  : kind(ToKernelKind(kind)),
+    nd_fespace((kind == PointFieldKind::FLUX_Q || kind == PointFieldKind::ENERGY_E)
+                   ? &fespace
+                   : nullptr),
+    rt_fespace((kind == PointFieldKind::CURRENT_J || kind == PointFieldKind::ENERGY_M)
+                   ? &fespace
+                   : nullptr),
+    mat_op(&mat_op), comm(mesh.GetComm()), viz_lod(lod), viz_scaling(scaling)
+{
+  MFEM_VERIFY(kind == PointFieldKind::FLUX_Q || kind == PointFieldKind::CURRENT_J ||
+                  kind == PointFieldKind::ENERGY_E || kind == PointFieldKind::ENERGY_M,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &nd_fespace,
+                                     const mfem::ParFiniteElementSpace &rt_fespace,
+                                     const MaterialOperator &mat_op, int lod,
+                                     double scaling)
+  : kind(ToKernelKind(kind)), nd_fespace(&nd_fespace), rt_fespace(&rt_fespace),
+    mat_op(&mat_op), comm(mesh.GetComm()), viz_lod(lod), viz_scaling(scaling)
+{
+  MFEM_VERIFY(kind == PointFieldKind::POYNTING,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &nd_fespace,
+                                     const MaterialOperator &mat_op,
+                                     InterfaceDielectric type, double t_i, double epsilon_i)
+  : kind(KernelKind::INTERFACE_EPR), epr_type(type), epr_t(t_i), epr_epsilon(epsilon_i),
+    nd_fespace(&nd_fespace), rt_fespace(nullptr), mat_op(&mat_op), comm(mesh.GetComm())
+{
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace *nd_fespace,
+                                     const mfem::ParFiniteElementSpace *rt_fespace,
+                                     const MaterialOperator &mat_op, SurfaceFlux type,
+                                     bool two_sided, const mfem::Vector &x0)
+  : kind(KernelKind::SURFACE_FLUX), flux_type(type), flux_two_sided(two_sided), flux_x0(x0),
+    nd_fespace(nd_fespace), rt_fespace(rt_fespace), mat_op(&mat_op), comm(mesh.GetComm())
+{
+  MFEM_VERIFY(
+      (nd_fespace || (type != SurfaceFlux::ELECTRIC && type != SurfaceFlux::POWER)) &&
+          (rt_fespace || (type != SurfaceFlux::MAGNETIC && type != SurfaceFlux::POWER)),
+      "Missing finite element space for surface flux functional!");
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &nd_fespace,
+                                     const mfem::ParFiniteElementSpace &rt_fespace,
+                                     const MaterialOperator &mat_op,
+                                     const std::vector<std::array<double, 3>> &r_naughts)
+  : kind(KernelKind::FARFIELD), farfield_dirs(r_naughts), nd_fespace(&nd_fespace),
+    rt_fespace(&rt_fespace), mat_op(&mat_op), comm(mesh.GetComm())
+{
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
+                                     const mfem::ParFiniteElementSpace &nd_fespace,
+                                     const std::vector<SurfaceModeCoefficient> &mode_coeffs)
+  : kind(KernelKind::MODE_OVERLAP), nd_fespace(&nd_fespace), rt_fespace(nullptr),
+    mat_op(nullptr), comm(mesh.GetComm())
+{
+  const mfem::ParMesh &pmesh = mesh.Get();
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> bdr_attr_marker(bdr_attr_max);
+  bdr_attr_marker = 0;
+  for (const auto &coeff : mode_coeffs)
+  {
+    for (int attr : coeff.attr_list)
+    {
+      MFEM_VERIFY(attr > 0 && attr <= bdr_attr_max,
+                  "Invalid boundary attribute for surface mode-overlap functional!");
+      bdr_attr_marker[attr - 1] = 1;
+      const bool inserted = mode_coeff_by_attr.emplace(attr, coeff).second;
+      MFEM_VERIFY(inserted,
+                  "Surface mode-overlap functional does not support overlapping mode "
+                  "coefficient attributes!");
+    }
+  }
+  Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::~SurfaceFunctional()
+{
+  fem::DestroyGroupOperators(groups);
+}
+
+bool SurfaceFunctional::Enabled()
+{
+  return fem::LibceedPostprocessingEnabled();
+}
+
+void SurfaceFunctional::Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker)
+{
+  AssembleLocal(mesh, bdr_attr_marker);
+
+  // The validity decision must be globally consistent: a rank may locally encounter an
+  // unsupported configuration while others do not. All ranks must agree on whether the
+  // libCEED path is valid so that collective evaluation calls match; model-level callers
+  // decide whether invalid means an explicit unsupported-case legacy path or an error for
+  // a supported path.
+  bool global_valid = valid;
+  Mpi::GlobalAnd(1, &global_valid, comm);
+  if (!global_valid && valid)
+  {
+    // Discard locally assembled state; the legacy path will be used.
+    fem::DestroyGroupOperators(groups);
+    face_nbr_exchange.reset();
+    elem_attrs.clear();
+    field_staging.SetSize(0);
+    local_out.SetSize(0);
+    local_out_attrs.clear();
+    buffer_bases.clear();
+    buffer_size = 0;
+    valid = false;
+  }
+}
+
+void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
+                                      const mfem::Array<int> &bdr_attr_marker)
+{
+  const int dim = mesh.Dimension();
+  const int sdim = mesh.SpaceDimension();
+  const bool is_2d = (dim == 2 && sdim == 2);
+  const bool is_3d = (dim == 3 && sdim == 3);
+  if (!is_2d && !is_3d)
+  {
+    valid = false;
+    return;
+  }
+  if (is_2d && kind != KernelKind::AREA && kind != KernelKind::HCURL_NORM2 &&
+      kind != KernelKind::INTERFACE_EPR)
+  {
+    // Initial 2D support covers line integrals needed by interface dielectric
+    // postprocessing. Other boundary-output, surface-flux, and mode-overlap kinds still
+    // use the legacy paths until their 2D scalar/vector conventions are implemented.
+    valid = false;
+    return;
+  }
+  const mfem::ParMesh &pmesh = mesh.Get();
+  MFEM_VERIFY(pmesh.GetNodes(), "The mesh has no nodal FE space!");
+  const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
+  const bool need_field = (kind != KernelKind::AREA);
+  Ceed ceed = ceed::internal::GetCeedObjects()[0];
+  const bool use_at_points = is_3d && CeedSupportsNonTensorAtPoints(ceed);
+
+  if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+  {
+    // Continuous trace fields live on the MFEM boundary/face DOFs. Keep the VTU geometry
+    // on the existing boundary elements (including NC slave/leaf faces), but do not map
+    // visualization points into attached volume elements or assemble two-sided/ghost
+    // operators. EvalTraceFieldBuffer samples those boundary DOFs directly.
+    buffer_bases.resize(pmesh.GetNBE(), -1);
+    trace_bdr_indices.clear();
+    trace_bdr_indices.reserve(pmesh.GetNBE());
+    int num_marked = 0;
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const int attr = pmesh.GetBdrAttribute(i);
+      if (!bdr_attr_marker[attr - 1])
+      {
+        continue;
+      }
+      int face_id, face_orientation;
+      pmesh.GetBdrElementFace(i, &face_id, &face_orientation);
+      MFEM_VERIFY(face_id >= 0,
+                  "Boundary trace field output requires a valid MFEM face id!");
+      const auto bdr_geom = pmesh.GetBdrElementGeometry(i);
+      const mfem::IntegrationRule &face_ir =
+          mfem::GlobGeometryRefiner.Refine(bdr_geom, viz_lod, 1)->RefPts;
+      trace_bdr_indices.push_back(i);
+      buffer_bases[i] = buffer_size / BufferNumComp(kind);
+      buffer_size += face_ir.GetNPoints() * BufferNumComp(kind);
+      num_marked++;
+    }
+    if (std::getenv("PALACE_SURFACE_PROFILE") != nullptr)
+    {
+      long long profile_counts[2] = {static_cast<long long>(num_marked), 0};
+      Mpi::GlobalSum(2, profile_counts, comm);
+      Mpi::Print(comm,
+                 "SurfaceFunctional profile kind={} groups=0 elems={} "
+                 "at_points_groups=0 at_points_elems=0 mapped_groups=0 mapped_elems=0 "
+                 "two_sided_groups=0 ghost_groups=0 max_group_elems=0 trace_elems={}\n",
+                 KindName(kind), profile_counts[0], profile_counts[0]);
+    }
+    return;
+  }
+
+  // Plan the evaluation for each marked boundary element and group the elements by
+  // their face configuration. AtPoints groups share tabulated bases and carry mapped
+  // reference points as runtime data. Non-AtPoints groups use a finite trace-map key
+  // derived from MFEM/NCMesh face topology instead of creating one operator per boundary
+  // element.
+  static std::atomic<long long> next_mapped_assembly_id{0};
+  const long long mapped_assembly_id = next_mapped_assembly_id++;
+  std::map<FaceConfigKey, FaceGroup> face_groups;
+  int num_marked = 0;
+  {
+    constexpr double threshold = 1.0 - 1.0e-6;
+    mfem::FaceElementTransformations FET;
+    mfem::IsoparametricTransformation T1, T2;
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const int attr = pmesh.GetBdrAttribute(i);
+      if (!bdr_attr_marker[attr - 1])
+      {
+        continue;
+      }
+
+      // Get the face and attached element transformations following the same
+      // conventions as the legacy BdrGridFunctionCoefficient evaluation path
+      // (FET.Elem1 always exists and is local, FET.Elem2 exists for interior
+      // boundaries and may correspond to a face neighbor element on another process
+      // for boundaries on parallel interfaces).
+      const bool flip = BdrGridFunctionCoefficient::GetBdrElementNeighborTransformations(
+          i, pmesh, FET, T1, T2);
+      const bool has_elem2 = (FET.Elem2 != nullptr);
+      const bool elem2_local = has_elem2 && (FET.Elem2No < pmesh.GetNE());
+
+      // Decide which side(s) the field is evaluated from following the conventions of
+      // the legacy coefficients (see InterfaceDielectricCoefficient and
+      // BdrSurfaceFluxCoefficient).
+      ElemPlan plan;
+      plan.bdr_elem = i;
+      plan.flip = flip;
+      if (!need_field)
+      {
+        // No field inputs (side selection does not apply).
+      }
+      else if (kind == KernelKind::HCURL_NORM2 || kind == KernelKind::MODE_OVERLAP)
+      {
+        plan.elem_a = FET.Elem1No;
+      }
+      else if (kind == KernelKind::FARFIELD)
+      {
+        if (has_elem2)
+        {
+          // Far-field computations are only supported on external boundaries (the
+          // legacy path errors in this case as well).
+          valid = false;
+          return;
+        }
+        plan.elem_a = FET.Elem1No;
+      }
+      else if (kind == KernelKind::SURFACE_FLUX || IsBufferKind(kind) ||
+               (kind == KernelKind::INTERFACE_EPR &&
+                epr_type == InterfaceDielectric::DEFAULT))
+      {
+        plan.elem_a = FET.Elem1No;
+        if (has_elem2)
+        {
+          plan.elem_b = FET.Elem2No;
+        }
+      }
+      else  // INTERFACE_EPR with MA, MS, or SA
+      {
+        // Single-sided evaluation on the vacuum (MA, SA) or substrate (MS) side, with
+        // averaging if both sides qualify, skipping the element if neither does.
+        const bool vacuum_side = (epr_type != InterfaceDielectric::MS);
+        auto OnSide = [&](int elem_attr)
+        {
+          const double ls = mat_op->GetLightSpeedMax(elem_attr);
+          return vacuum_side ? (ls >= threshold) : (ls < threshold);
+        };
+        const bool use_elem1 = OnSide(FET.Elem1->Attribute);
+        const bool use_elem2 = has_elem2 && OnSide(FET.Elem2->Attribute);
+        if (use_elem1)
+        {
+          plan.elem_a = FET.Elem1No;
+          if (use_elem2)
+          {
+            plan.elem_b = FET.Elem2No;
+          }
+        }
+        else if (use_elem2)
+        {
+          plan.elem_a = FET.Elem2No;
+        }
+        else
+        {
+          // Neither side qualifies: the element contributes zero, skip it.
+          continue;
+        }
+      }
+
+      // A two-sided interior boundary on a parallel interface: the Elem2 side is a face
+      // neighbor (ghost) element on another process. Its field is not in the local
+      // vector; it is pulled via FaceNbrFieldExchange (built below from the mapped
+      // points) and fed to the ghost side of the operator, so the libCEED path handles
+      // it without falling back to the legacy coefficients. Only Elem2 can be a ghost.
+      if (plan.elem_a >= 0 && plan.elem_a >= pmesh.GetNE())
+      {
+        plan.ghost_a = true;
+      }
+      if (plan.elem_b >= 0 && !elem2_local)
+      {
+        plan.ghost_b = true;
+      }
+      if (plan.ghost_a || plan.ghost_b)
+      {
+        plan.face_nbr = FET.Elem2No - pmesh.GetNE();
+        plan.ghost_attr = FET.Elem2->Attribute;
+        // The ghost element index is out of range for pmesh.GetElementGeometry; capture
+        // its geometry here while the face neighbor transformation is in scope.
+        plan.ghost_geom = FET.Elem2->GetGeometryType();
+      }
+
+      // Map the face quadrature points to the volume element reference space(s):
+      // boundary element reference coordinates -> face reference coordinates
+      // (TransformBdrElementToFace with the boundary element to face orientation) ->
+      // element 1/2 reference coordinates (FET.Loc1/Loc2).
+      const auto bdr_geom = pmesh.GetBdrElementGeometry(i);
+      const bool buffer_kind = IsBufferKind(kind);
+      const mfem::IntegrationRule &face_ir =
+          buffer_kind ? mfem::GlobGeometryRefiner.Refine(bdr_geom, viz_lod, 1)->RefPts
+                      : mfem::IntRules.Get(
+                            bdr_geom, fem::DefaultIntegrationOrder::Get(pmesh, bdr_geom));
+      const int nq = face_ir.GetNPoints();
+      int f, o;
+      pmesh.GetBdrElementFace(i, &f, &o);
+      auto MapPoints = [&](mfem::IntegrationPointTransformation &loc,
+                           std::vector<mfem::IntegrationPoint> &pts)
+      {
+        pts.resize(nq);
+        for (int q = 0; q < nq; q++)
+        {
+          mfem::IntegrationPoint fip = mfem::Mesh::TransformBdrElementToFace(
+              FET.GetGeometryType(), o, face_ir.IntPoint(q));
+          loc.Transform(fip, pts[q]);
+          pts[q].weight = face_ir.IntPoint(q).weight;
+        }
+      };
+      if (plan.elem_a >= 0)
+      {
+        MapPoints(plan.elem_a == FET.Elem1No ? FET.Loc1 : FET.Loc2, plan.pts_a);
+      }
+      if (plan.elem_b >= 0)
+      {
+        MapPoints(FET.Loc2, plan.pts_b);
+      }
+
+      // Build the group key. For AtPoints-capable groups, the mapped volume reference
+      // coordinates are runtime data rather than part of the basis/JIT key. For mapped
+      // integration rules, the finite MFEM/NCMesh trace-map keys distinguish the small
+      // set of conforming/NC subface maps without using per-element identities.
+      const auto vol_geom_a = plan.ghost_a         ? plan.ghost_geom
+                              : (plan.elem_a >= 0) ? pmesh.GetElementGeometry(plan.elem_a)
+                                                   : mfem::Geometry::INVALID;
+      const auto vol_geom_b = plan.ghost_b         ? plan.ghost_geom
+                              : (plan.elem_b >= 0) ? pmesh.GetElementGeometry(plan.elem_b)
+                                                   : mfem::Geometry::INVALID;
+      const mfem::Mesh::FaceInformation face_info = pmesh.GetFaceInformation(f);
+      if (plan.elem_a >= 0)
+      {
+        const int side =
+            FaceInformationSide(face_info, plan.elem_a, plan.ghost_a, plan.face_nbr);
+        plan.point_key_a =
+            MakeTraceMapTopologyKey(face_info, side, vol_geom_a, bdr_geom, face_ir, o,
+                                    (plan.elem_a == FET.Elem1No) ? FET.Loc1 : FET.Loc2);
+      }
+      if (plan.elem_b >= 0)
+      {
+        const int side =
+            FaceInformationSide(face_info, plan.elem_b, plan.ghost_b, plan.face_nbr);
+        plan.point_key_b = MakeTraceMapTopologyKey(face_info, side, vol_geom_b, bdr_geom,
+                                                   face_ir, o, FET.Loc2);
+      }
+      const bool can_surface_flux_at_points_a =
+          use_at_points && kind == KernelKind::SURFACE_FLUX && plan.elem_a >= 0 &&
+          !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
+      const bool can_surface_flux_at_points_b =
+          use_at_points && kind == KernelKind::SURFACE_FLUX && plan.elem_b >= 0 &&
+          !plan.ghost_b && vol_geom_b == mfem::Geometry::TETRAHEDRON;
+      const bool can_epr_at_points = use_at_points && kind == KernelKind::INTERFACE_EPR &&
+                                     plan.elem_a >= 0 && plan.elem_b < 0 && !plan.ghost_a &&
+                                     vol_geom_a == mfem::Geometry::TETRAHEDRON;
+      const bool can_farfield_at_points =
+          use_at_points && kind == KernelKind::FARFIELD && plan.elem_a >= 0 &&
+          plan.elem_b < 0 && !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
+      const bool can_mode_overlap_at_points =
+          use_at_points && kind == KernelKind::MODE_OVERLAP && plan.elem_a >= 0 &&
+          plan.elem_b < 0 && !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
+      const bool can_at_points_a =
+          (use_at_points && buffer_kind && plan.elem_a >= 0 && !plan.ghost_a &&
+           vol_geom_a == mfem::Geometry::TETRAHEDRON) ||
+          can_surface_flux_at_points_a || can_epr_at_points || can_farfield_at_points ||
+          can_mode_overlap_at_points;
+      const bool can_at_points_b =
+          (use_at_points && buffer_kind && plan.elem_b >= 0 && !plan.ghost_b &&
+           vol_geom_b == mfem::Geometry::TETRAHEDRON) ||
+          can_surface_flux_at_points_b;
+
+      int out_slot;
+      if (IsBufferKind(kind))
+      {
+        if (buffer_bases.empty())
+        {
+          buffer_bases.resize(pmesh.GetNBE(), -1);
+        }
+        const int nc = BufferNumComp(kind);
+        out_slot = buffer_size / nc;
+        buffer_bases[i] = out_slot;
+        buffer_size += nq * nc;
+        num_marked++;
+      }
+      else
+      {
+        out_slot = num_marked++;
+        local_out_attrs.push_back(attr);
+      }
+
+      auto AddGroup = [&](int elem_a, bool ghost_a, mfem::Geometry::Type geom_a,
+                          const std::vector<mfem::IntegrationPoint> &pts_a,
+                          const std::vector<long long> &point_key_a, int elem_b,
+                          bool ghost_b, mfem::Geometry::Type geom_b,
+                          const std::vector<mfem::IntegrationPoint> &pts_b,
+                          const std::vector<long long> &point_key_b, bool at_points_group,
+                          double side_scale, double normal_scale)
+      {
+        FaceConfigKey key;
+        key.reserve(12);
+        key.push_back(mapped_assembly_id);
+        key.push_back(static_cast<long long>(bdr_geom));
+        key.push_back(static_cast<long long>(geom_a));
+        key.push_back(static_cast<long long>(geom_b));
+        key.push_back(static_cast<long long>(plan.flip));
+        key.push_back(static_cast<long long>(ghost_a));
+        key.push_back(static_cast<long long>(ghost_b));
+        key.push_back(static_cast<long long>(nq));
+        key.push_back(static_cast<long long>(at_points_group));
+        // Current side/normal scales are exact multiples of 1/2 from the split-side
+        // conventions. Encode those discrete states directly rather than carrying a
+        // floating-point grouping key.
+        key.push_back(static_cast<long long>(std::llround(2.0 * side_scale)));
+        key.push_back(
+            static_cast<long long>((at_points_group && kind == KernelKind::SURFACE_FLUX)
+                                       ? 0
+                                       : std::llround(2.0 * normal_scale)));
+        if (kind == KernelKind::MODE_OVERLAP)
+        {
+          // The mode coefficient is boundary-attribute dependent. Keep each attribute in
+          // a separate operator group so the qfunction context can remain group-constant.
+          key.push_back(static_cast<long long>(attr));
+        }
+        const bool ghost_only_mapped_group =
+            !at_points_group && elem_a >= 0 && ghost_a && elem_b < 0;
+        if (!at_points_group)
+        {
+          auto AppendTraceKey = [&key](const std::vector<long long> &trace_key)
+          {
+            key.push_back(static_cast<long long>(trace_key.size()));
+            key.insert(key.end(), trace_key.begin(), trace_key.end());
+          };
+          // A one-sided ghost group consumes already-imported point values with EVAL_NONE;
+          // its local libCEED operator only needs the point count. Keep the per-request
+          // trace key/points for FaceNbrFieldExchange, but do not let remote trace-map
+          // variants fragment the local ghost accumulation operator.
+          AppendTraceKey((elem_a >= 0 && !ghost_only_mapped_group)
+                             ? point_key_a
+                             : std::vector<long long>());
+          AppendTraceKey(elem_b >= 0 ? point_key_b : std::vector<long long>());
+        }
+
+        auto it = face_groups.find(key);
+        if (it == face_groups.end())
+        {
+          FaceGroup group;
+          group.bdr_geom = bdr_geom;
+          group.vol_geom_a = geom_a;
+          group.vol_geom_b = geom_b;
+          group.flip_normal = plan.flip;
+          group.ghost_a = ghost_a;
+          group.ghost_b = ghost_b;
+          group.at_points = at_points_group;
+          group.side_scale = side_scale;
+          group.normal_scale = normal_scale;
+          if (!at_points_group && elem_a >= 0)
+          {
+            FaceConfigKey key_a = key;
+            key_a.push_back(0);  // Side tag
+            group.mapped_ir_a = GetRegisteredMappedIr(key_a, pts_a);
+          }
+          if (!at_points_group && elem_b >= 0)
+          {
+            FaceConfigKey key_b = key;
+            key_b.push_back(1);  // Side tag
+            group.mapped_ir_b = GetRegisteredMappedIr(key_b, pts_b);
+          }
+          it = face_groups.emplace(key, std::move(group)).first;
+        }
+        else if (!at_points_group)
+        {
+          if (elem_a >= 0 && !ghost_only_mapped_group)
+          {
+            MFEM_VERIFY(it->second.mapped_ir_a,
+                        "Missing representative side-A mapped rule for NC trace group!");
+            VerifyMappedRuleMatches(*it->second.mapped_ir_a, pts_a);
+          }
+          if (elem_b >= 0)
+          {
+            MFEM_VERIFY(it->second.mapped_ir_b,
+                        "Missing representative side-B mapped rule for NC trace group!");
+            VerifyMappedRuleMatches(*it->second.mapped_ir_b, pts_b);
+          }
+        }
+        it->second.bdr_indices.push_back(i);
+        if (at_points_group)
+        {
+          it->second.mapped_pts_a.insert(it->second.mapped_pts_a.end(), pts_a.begin(),
+                                         pts_a.end());
+          if (kind == KernelKind::SURFACE_FLUX)
+          {
+            it->second.normal_scales.push_back(normal_scale);
+          }
+        }
+        if (elem_a >= 0)
+        {
+          if (ghost_a)
+          {
+            it->second.face_nbr.push_back(plan.face_nbr);
+            it->second.ghost_attr.push_back(plan.ghost_attr);
+            it->second.face_nbr_point_keys.push_back(point_key_a);
+            it->second.face_nbr_points.push_back(pts_a);
+          }
+          else
+          {
+            it->second.vol_indices_a.push_back(elem_a);
+          }
+        }
+        if (elem_b >= 0)
+        {
+          if (ghost_b)
+          {
+            it->second.face_nbr.push_back(plan.face_nbr);
+            it->second.ghost_attr.push_back(plan.ghost_attr);
+            it->second.face_nbr_point_keys.push_back(point_key_b);
+            it->second.face_nbr_points.push_back(pts_b);
+          }
+          else
+          {
+            it->second.vol_indices_b.push_back(elem_b);
+          }
+        }
+        it->second.out_slots.push_back(out_slot);
+      };
+
+      if (kind == KernelKind::SURFACE_FLUX && can_surface_flux_at_points_a &&
+          can_surface_flux_at_points_b)
+      {
+        // Split local two-sided flux into one-sided AtPoints operators so each side's
+        // mapped volume reference coordinates are runtime data. The shared output slot
+        // preserves the original two-sided difference or non-two-sided average.
+        const double scale_a = flux_two_sided ? 1.0 : 0.5;
+        const double scale_b = flux_two_sided ? -1.0 : 0.5;
+        AddGroup(plan.elem_a, false, vol_geom_a, plan.pts_a, plan.point_key_a, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, 1.0, scale_a);
+        AddGroup(plan.elem_b, false, vol_geom_b, plan.pts_b, plan.point_key_b, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, 1.0, scale_b);
+      }
+      else if (buffer_kind && can_at_points_a && can_at_points_b)
+      {
+        // Split two-sided boundary visualization into two one-sided AtPoints operators
+        // that accumulate into the same output slot. One AtPoints operator can only own
+        // one point-coordinate set; the two sides generally use different mapped
+        // reference coordinates, so preserving the two-sided kernels would reintroduce
+        // mapped-point specialization.
+        const bool average_quantity =
+            kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
+            kind == KernelKind::BDR_POYNTING;
+        const double side_weight = average_quantity ? 0.5 : 1.0;
+        AddGroup(plan.elem_a, false, vol_geom_a, plan.pts_a, plan.point_key_a, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, side_weight, 1.0);
+        AddGroup(plan.elem_b, false, vol_geom_b, plan.pts_b, plan.point_key_b, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, side_weight, -1.0);
+      }
+      else if (buffer_kind && plan.elem_a >= 0 && plan.elem_b >= 0 &&
+               ((can_at_points_a && plan.ghost_b) || (can_at_points_b && plan.ghost_a)))
+      {
+        // For shared NC faces, only the local side can use libCEED AtPoints; the ghost
+        // side must first be imported through FaceNbrFieldExchange. Split the trace so
+        // the local contribution still batches with other AtPoints boundary fields, and
+        // only the ghost contribution uses the finite mapped trace key.
+        const bool average_quantity =
+            kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
+            kind == KernelKind::BDR_POYNTING;
+        const double side_weight = average_quantity ? 0.5 : 1.0;
+        AddGroup(plan.elem_a, plan.ghost_a, vol_geom_a, plan.pts_a, plan.point_key_a, -1,
+                 false, mfem::Geometry::INVALID, {}, {}, can_at_points_a, side_weight, 1.0);
+        AddGroup(plan.elem_b, plan.ghost_b, vol_geom_b, plan.pts_b, plan.point_key_b, -1,
+                 false, mfem::Geometry::INVALID, {}, {}, can_at_points_b, side_weight,
+                 -1.0);
+      }
+      else
+      {
+        const bool at_points_group = can_at_points_a && plan.elem_b < 0;
+        AddGroup(plan.elem_a, plan.ghost_a, vol_geom_a, plan.pts_a, plan.point_key_a,
+                 plan.elem_b, plan.ghost_b, vol_geom_b, plan.pts_b, plan.point_key_b,
+                 at_points_group, 1.0, 1.0);
+      }
+    }
+  }
+
+  // Initialize the local output vector and field staging vector. Far-field operators
+  // produce 6 values (Re/Im of a 3-vector) per direction per element.
+  const int num_out =
+      (kind == KernelKind::FARFIELD) ? 6 * static_cast<int>(farfield_dirs.size()) : 1;
+  local_out.SetSize((kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+                        ? 0
+                        : num_marked * num_out);
+  local_out.UseDevice(true);
+  if (need_field)
+  {
+    const int max_vsize = std::max(nd_fespace ? nd_fespace->GetVSize() : 0,
+                                   rt_fespace ? rt_fespace->GetVSize() : 0);
+    field_staging.SetSize(max_vsize);
+    field_staging.UseDevice(true);
+    field_staging = 0.0;
+  }
+
+  // Build the (group independent part of the) QFunction context for the integrand.
+  std::vector<CeedIntScalar> base_ctx;
+  if (kind == KernelKind::INTERFACE_EPR)
+  {
+    // CeedIntScalar is a union, so the runtime integrand selector (epr_type) needs its
+    // own slot: [0].first = epr_type (0 = DEFAULT, 1 = MA, 2 = MS, 3 = SA), then
+    // [1].second = scale0, [2].second = scale1, then (MS only) the material context. The
+    // shared kernel passes ctx + 1 to the per-type helpers so their relative layout
+    // (scale0, scale1, material) is unchanged.
+    base_ctx.resize(3);
+    base_ctx[1].second = 0.0;
+    base_ctx[2].second = 0.0;
+    switch (epr_type)
+    {
+      case InterfaceDielectric::DEFAULT:
+        base_ctx[0].first = 0;
+        base_ctx[1].second = 0.5 * epr_t * epr_epsilon;
+        break;
+      case InterfaceDielectric::MA:
+        base_ctx[0].first = 1;
+        base_ctx[1].second = 0.5 * epr_t / epr_epsilon;
+        break;
+      case InterfaceDielectric::MS:
+        {
+          base_ctx[0].first = 2;
+          base_ctx[1].second = 0.5 * epr_t / epr_epsilon;
+          MaterialPropertyCoefficient epsilon_func(mat_op->GetAttributeToMaterial(),
+                                                   mat_op->GetPermittivityReal());
+          auto mat_ctx = ceed::PopulateCoefficientContext(dim, &epsilon_func);
+          base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+        }
+        break;
+      case InterfaceDielectric::SA:
+        base_ctx[0].first = 3;
+        base_ctx[1].second = 0.5 * epr_t * epr_epsilon;
+        base_ctx[2].second = 0.5 * epr_t / epr_epsilon;
+        break;
+    }
+  }
+  else if (kind == KernelKind::SURFACE_FLUX)
+  {
+    base_ctx.resize(5);
+    base_ctx[0].second = 1.0;  // Normal sign, set per group
+    base_ctx[1].first = flux_two_sided;
+    for (int d = 0; d < 3; d++)
+    {
+      base_ctx[2 + d].second = (flux_x0.Size() > d) ? flux_x0(d) : 0.0;
+    }
+    if (flux_type == SurfaceFlux::ELECTRIC)
+    {
+      MaterialPropertyCoefficient epsilon_func(mat_op->GetAttributeToMaterial(),
+                                               mat_op->GetPermittivityReal());
+      auto mat_ctx = ceed::PopulateCoefficientContext(3, &epsilon_func);
+      base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+    }
+    else if (flux_type == SurfaceFlux::POWER)
+    {
+      MaterialPropertyCoefficient invmu_func(mat_op->GetAttributeToMaterial(),
+                                             mat_op->GetInvPermeability());
+      auto mat_ctx = ceed::PopulateCoefficientContext(3, &invmu_func);
+      base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+    }
+  }
+  else if (kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_CURRENT_J)
+  {
+    base_ctx.resize(2);
+    base_ctx[0].second = 1.0;  // Normal sign, set per group
+    base_ctx[1].second = viz_scaling;
+    MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
+                                           (kind == KernelKind::BDR_FLUX_Q)
+                                               ? mat_op->GetPermittivityReal()
+                                               : mat_op->GetInvPermeability());
+    auto mat_ctx = ceed::PopulateCoefficientContext(3, &coeff_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else if (kind == KernelKind::BDR_POYNTING)
+  {
+    // Pointwise S = scale * E x (mu^-1 B). For split two-sided AtPoints groups,
+    // group.side_scale folds in the legacy 1/2 side average.
+    base_ctx.resize(1);
+    base_ctx[0].second = viz_scaling;
+    MaterialPropertyCoefficient invmu_func(mat_op->GetAttributeToMaterial(),
+                                           mat_op->GetInvPermeability());
+    auto mat_ctx = ceed::PopulateCoefficientContext(3, &invmu_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else if (kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M)
+  {
+    // Shared energy kernel: [0].first = piola (0 = ND/E, 1 = RT/B), [1].second = scaling,
+    // material table at +2.
+    base_ctx.resize(2);
+    base_ctx[0].first = (kind == KernelKind::BDR_ENERGY_M) ? 1 : 0;
+    base_ctx[1].second = viz_scaling;
+    MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
+                                           (kind == KernelKind::BDR_ENERGY_E)
+                                               ? mat_op->GetPermittivityReal()
+                                               : mat_op->GetInvPermeability());
+    auto mat_ctx = ceed::PopulateCoefficientContext(3, &coeff_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else if (kind == KernelKind::MODE_OVERLAP)
+  {
+    // Group-specific entries are filled after selecting the boundary attribute:
+    // [0].first = type, [1].second = scale, [2..4].second = direction/origin.
+    base_ctx.resize(5);
+  }
+  else if (kind == KernelKind::FARFIELD)
+  {
+    const int N = static_cast<int>(farfield_dirs.size());
+    const auto b_map_type = rt_fespace->FEColl()->GetMapType(dim);
+    MFEM_VERIFY(b_map_type == mfem::FiniteElement::H_CURL ||
+                    b_map_type == mfem::FiniteElement::H_DIV,
+                "Far-field postprocessing requires an H(curl) or H(div) magnetic field "
+                "space!");
+    base_ctx.resize(5 + 3 * N);
+    base_ctx[0].second = 1.0;  // Normal sign, set per group
+    base_ctx[1].second = farfield_omega.real();
+    base_ctx[2].second = farfield_omega.imag();
+    base_ctx[3].first = N;
+    base_ctx[4].first = (b_map_type == mfem::FiniteElement::H_DIV) ? 1 : 0;
+    for (int d = 0; d < N; d++)
+    {
+      for (int c = 0; c < 3; c++)
+      {
+        base_ctx[5 + 3 * d + c].second = farfield_dirs[d][c];
+      }
+    }
+    MaterialPropertyCoefficient c0_func(mat_op->GetAttributeToMaterial(),
+                                        mat_op->GetLightSpeed());
+    auto mat_ctx = ceed::PopulateCoefficientContext(3, &c0_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else
+  {
+    base_ctx.resize(2);
+    base_ctx[0].second = 0.0;
+    base_ctx[1].second = 1.0;
+    if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+    {
+      // Shared field kernel: [0].first = piola (0 = ND/E, 1 = RT/B),
+      // [1].second = output scale (used when split AtPoints sides accumulate).
+      base_ctx[0].first = (kind == KernelKind::BDR_FIELD_B) ? 1 : 0;
+    }
+  }
+
+  // Build the face neighbor field exchange for any ghost (face neighbor) sides of
+  // two-sided interior boundaries on parallel interfaces. Collective: all processes
+  // participate (those without ghost faces pose no requests), so the decision is reduced
+  // globally. Each ghost face requests the neighbor's volume field at the mapped face
+  // quadrature points; the returned physical-space values feed the ghost side below.
+  {
+    int any_ghost = 0;
+    for (const auto &[k, g] : face_groups)
+    {
+      if (g.ghost_a || g.ghost_b)
+      {
+        any_ghost = 1;
+        break;
+      }
+    }
+    Mpi::GlobalSum(1, &any_ghost, comm);
+    if (any_ghost > 0)
+    {
+      // Source slots match the field inputs: SURFACE_FLUX uses slot 0 = E (nd_fespace)
+      // and slot 1 = B (rt_fespace); all other kinds carry a single field at slot 0.
+      std::array<const mfem::ParFiniteElementSpace *, FaceNbrFieldExchange::MaxSources>
+          ex_fes = {nullptr, nullptr, nullptr, nullptr};
+      unsigned int source_mask;
+      if (kind == KernelKind::SURFACE_FLUX)
+      {
+        ex_fes[0] = nd_fespace;
+        ex_fes[1] = rt_fespace;
+        source_mask = (flux_type == SurfaceFlux::ELECTRIC)   ? 0b01u
+                      : (flux_type == SurfaceFlux::MAGNETIC) ? 0b10u
+                                                             : 0b11u;
+      }
+      else if (kind == KernelKind::BDR_POYNTING)
+      {
+        ex_fes[0] = nd_fespace;
+        ex_fes[1] = rt_fespace;
+        source_mask = 0b11u;
+      }
+      else
+      {
+        ex_fes[0] = rt_fespace ? rt_fespace : nd_fespace;
+        source_mask = 0b01u;
+      }
+      std::vector<FaceNbrFieldExchange::Request> requests;
+      for (auto &[k, g] : face_groups)
+      {
+        if (!(g.ghost_a || g.ghost_b))
+        {
+          continue;
+        }
+        const mfem::IntegrationRule &ir = g.ghost_a ? *g.mapped_ir_a : *g.mapped_ir_b;
+        std::vector<mfem::IntegrationPoint> pts(ir.GetNPoints());
+        for (int q = 0; q < ir.GetNPoints(); q++)
+        {
+          pts[q] = ir.IntPoint(q);
+        }
+        MFEM_VERIFY(g.face_nbr_point_keys.size() == g.face_nbr.size() &&
+                        g.face_nbr_points.size() == g.face_nbr.size(),
+                    "Invalid face-neighbor point-key layout for surface functional!");
+        g.req_idx.resize(g.face_nbr.size());
+        for (std::size_t e = 0; e < g.face_nbr.size(); e++)
+        {
+          g.req_idx[e] = static_cast<int>(requests.size());
+          auto &req = requests.emplace_back();
+          req.face_nbr_elem = g.face_nbr[e];
+          req.source_mask = source_mask;
+          req.point_key = g.face_nbr_point_keys[e];
+          req.pts = g.face_nbr_points[e].empty() ? pts : g.face_nbr_points[e];
+        }
+      }
+      face_nbr_exchange = std::make_unique<FaceNbrFieldExchange>(mesh, ex_fes, requests);
+    }
+  }
+
+  // Assemble a libCEED operator for each group. For now, all operators are constructed
+  // on a single Ceed context (no OpenMP parallel assembly or application; correctness
+  // first, this can be extended with the thread partitioning of fem/mesh.cpp later).
+  const bool profile = (std::getenv("PALACE_SURFACE_PROFILE") != nullptr);
+  // groups, elems, AtPoints groups/elems, mapped groups/elems, two-sided groups,
+  // ghost groups.
+  long long profile_counts[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  long long profile_max_group_elems = 0;
+  for (auto &face_group : face_groups)
+  {
+    auto &group = face_group.second;
+    const std::size_t num_elem = group.bdr_indices.size();
+    const bool has_b = !group.vol_indices_b.empty() || group.ghost_b;
+    if (profile)
+    {
+      profile_counts[0]++;
+      profile_counts[1] += static_cast<long long>(num_elem);
+      profile_max_group_elems =
+          std::max(profile_max_group_elems, static_cast<long long>(num_elem));
+      if (group.at_points)
+      {
+        profile_counts[2]++;
+        profile_counts[3] += static_cast<long long>(num_elem);
+      }
+      else
+      {
+        profile_counts[4]++;
+        profile_counts[5] += static_cast<long long>(num_elem);
+      }
+      if (has_b)
+      {
+        profile_counts[6]++;
+      }
+      if (group.ghost_a || group.ghost_b)
+      {
+        profile_counts[7]++;
+      }
+    }
+    const bool buffer_kind = IsBufferKind(kind);
+    const mfem::IntegrationRule &face_ir =
+        buffer_kind
+            ? mfem::GlobGeometryRefiner.Refine(group.bdr_geom, viz_lod, 1)->RefPts
+            : mfem::IntRules.Get(group.bdr_geom,
+                                 fem::DefaultIntegrationOrder::Get(pmesh, group.bdr_geom));
+
+    // Objects are owned by the assembled operator; scratch destroys our references.
+    CeedAssemblyScratch scratch(ceed);
+    CeedElemRestriction points_restr = nullptr;
+    CeedVector points_vec = nullptr;
+    if (group.at_points)
+    {
+      const int nq = face_ir.GetNPoints();
+      MFEM_VERIFY(group.mapped_pts_a.size() == num_elem * static_cast<std::size_t>(nq),
+                  "Invalid AtPoints coordinate data for surface output group!");
+      auto &points = elem_attrs.emplace_back(3 * num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int q = 0; q < nq; q++)
+        {
+          const auto &ip = group.mapped_pts_a[e * nq + q];
+          const std::size_t off = 3 * (e * nq + q);
+          points[off + 0] = ip.x;
+          points[off + 1] = ip.y;
+          points[off + 2] = ip.z;
+        }
+      }
+      CreateSequentialPointRestriction(ceed, num_elem, nq, 3, points.Size(), &points_restr);
+      ceed::InitCeedVector(points, ceed, &points_vec);
+      scratch.restrs.push_back(points_restr);
+      scratch.vecs.push_back(points_vec);
+    }
+
+    // Assemble the inputs in the order expected by the QFunctions: quadrature weights
+    // and boundary element mesh node gradients (surface measure and normal), per-side
+    // volume element attributes (material lookup) and mesh node gradients at the mapped
+    // points (Piola transformations), coordinates (SURFACE_FLUX only), then the field
+    // inputs (side 1 fields, then side 2 fields). The geometry is computed on the fly
+    // in the QFunctions (no stored geometry factor data).
+    std::vector<ceed::CeedFunctionalFieldInput> inputs;
+    std::vector<std::pair<std::string, int>> field_sources;
+    const mfem::FiniteElement *face_mesh_fe =
+        mesh_fespace.FEColl()->FiniteElementForGeometry(group.bdr_geom);
+    if (!face_mesh_fe)
+    {
+      face_mesh_fe = mesh_fespace.FEColl()->TraceFiniteElementForGeometry(group.bdr_geom);
+    }
+    auto AddSequentialPointInput = [&](const std::string &name, Vector &data, int num_comp)
+    {
+      const int nq = face_ir.GetNPoints();
+      CeedElemRestriction restr;
+      CeedVector vec;
+      CreateSequentialPointRestriction(ceed, num_elem, nq, num_comp, data.Size(), &restr);
+      ceed::InitCeedVector(data, ceed, &vec);
+      inputs.push_back({name, vec, restr, nullptr, ceed::EvalMode::None});
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+    };
+    auto AddFaceGeomInputAtPoints = [&]()
+    {
+      const int nq = face_ir.GetNPoints();
+      if (!buffer_kind)
+      {
+        auto &qw = elem_attrs.emplace_back(num_elem * nq);
+        for (std::size_t e = 0; e < num_elem; e++)
+        {
+          for (int q = 0; q < nq; q++)
+          {
+            qw[e * nq + q] = face_ir.IntPoint(q).weight;
+          }
+        }
+        AddSequentialPointInput("qw", qw, 1);
+      }
+      if (kind == KernelKind::SURFACE_FLUX && !group.normal_scales.empty())
+      {
+        MFEM_VERIFY(group.normal_scales.size() == num_elem,
+                    "SURFACE_FLUX AtPoints normal scales must be entry-indexed!");
+      }
+      auto &face_geom = elem_attrs.emplace_back(num_elem * nq * 6);
+      face_geom = 0.0;
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        mfem::IsoparametricTransformation T;
+        pmesh.GetBdrElementTransformation(group.bdr_indices[e], &T);
+        for (int q = 0; q < nq; q++)
+        {
+          const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
+          T.SetIntPoint(&ip);
+          const mfem::DenseMatrix &J = T.Jacobian();
+          const double normal_scale =
+              (kind == KernelKind::SURFACE_FLUX && !group.normal_scales.empty())
+                  ? group.normal_scales[e]
+                  : 1.0;
+          const std::size_t off = 6 * (e * nq + q);
+          FoldNormalScaleIntoFaceJacobian(J, normal_scale, face_geom.HostReadWrite() + off);
+        }
+      }
+      AddSequentialPointInput("grad_x_f", face_geom, 6);
+    };
+    const bool field_value_kind =
+        kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B;
+    const bool needs_face_geom = !field_value_kind && kind != KernelKind::BDR_ENERGY_E &&
+                                 kind != KernelKind::BDR_ENERGY_M &&
+                                 kind != KernelKind::BDR_POYNTING;
+    const bool needs_elem_attr = !field_value_kind && kind != KernelKind::MODE_OVERLAP;
+    if (needs_face_geom)
+    {
+      if (group.at_points)
+      {
+        AddFaceGeomInputAtPoints();
+      }
+      else
+      {
+        CeedBasis face_mesh_basis;
+        ceed::InitBasisAtPoints(*face_mesh_fe, face_ir, mesh_fespace.GetVDim(), ceed,
+                                &face_mesh_basis);
+        CeedElemRestriction face_mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, group.bdr_geom, group.bdr_indices, /*is_interp*/ true);
+        CeedVector mesh_nodes_vec;
+        ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+        if (!buffer_kind)
+        {
+          inputs.push_back(
+              {"qw", nullptr, nullptr, face_mesh_basis, ceed::EvalMode::Weight});
+        }
+        inputs.push_back({"x_f", mesh_nodes_vec, face_mesh_restr, face_mesh_basis,
+                          ceed::EvalMode::Grad});
+        scratch.vecs.push_back(mesh_nodes_vec);
+        scratch.restrs.push_back(face_mesh_restr);
+        scratch.bases.push_back(face_mesh_basis);
+      }
+    }
+    auto AddVolGeomInputs = [&](const std::string &suffix, const std::vector<int> &indices,
+                                mfem::Geometry::Type geom, const mfem::IntegrationRule &ir)
+    {
+      const int num_pts = group.at_points ? face_ir.GetNPoints() : ir.GetNPoints();
+      if (group.at_points)
+      {
+        if (needs_elem_attr)
+        {
+          const auto &loc_attr = mesh.GetCeedAttributes();
+          auto &elem_attr_pts = elem_attrs.emplace_back(indices.size() * num_pts);
+          for (std::size_t k = 0; k < indices.size(); k++)
+          {
+            const double attr = loc_attr.at(pmesh.GetAttribute(indices[k]));
+            for (int q = 0; q < num_pts; q++)
+            {
+              elem_attr_pts[k * num_pts + q] = attr;
+            }
+          }
+          AddSequentialPointInput("attr_" + suffix, elem_attr_pts, 1);
+        }
+
+        CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+        const mfem::FiniteElement *mesh_fe =
+            mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+        CeedBasis mesh_basis;
+        InitTetBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(), ceed,
+                                &mesh_basis);
+        CeedVector mesh_nodes_vec;
+        ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+        inputs.push_back(
+            {"x_" + suffix, mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+        scratch.vecs.push_back(mesh_nodes_vec);
+        scratch.restrs.push_back(mesh_restr);
+        scratch.bases.push_back(mesh_basis);
+        return;
+      }
+
+      CeedElemRestriction attr_restr = nullptr;
+      CeedBasis attr_basis = nullptr;
+      CeedVector attr_vec = nullptr;
+      if (needs_elem_attr)
+      {
+        const auto &loc_attr = mesh.GetCeedAttributes();
+        auto &elem_attr = elem_attrs.emplace_back(indices.size());
+        for (std::size_t k = 0; k < indices.size(); k++)
+        {
+          elem_attr[k] = loc_attr.at(pmesh.GetAttribute(indices[k]));
+        }
+        PalaceCeedCall(ceed, CeedElemRestrictionCreateStrided(
+                                 ceed, indices.size(), 1, 1, indices.size(),
+                                 CEED_STRIDES_BACKEND, &attr_restr));
+        {
+          // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
+          mfem::Vector Bt(num_pts), Gt(num_pts), qX(num_pts), qW(num_pts);
+          Bt = 1.0;
+          Gt = 0.0;
+          qX = 0.0;
+          qW = 0.0;
+          PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_pts,
+                                                 Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                                 qW.GetData(), &attr_basis));
+        }
+        ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+        inputs.push_back(
+            {"attr_" + suffix, attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      }
+      CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+          mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+      const mfem::FiniteElement *mesh_fe =
+          mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+      CeedBasis mesh_basis;
+      ceed::InitBasisAtPoints(*mesh_fe, ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+      CeedVector mesh_nodes_vec;
+      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+      inputs.push_back(
+          {"x_" + suffix, mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      if (needs_elem_attr)
+      {
+        scratch.vecs.push_back(attr_vec);
+        scratch.restrs.push_back(attr_restr);
+        scratch.bases.push_back(attr_basis);
+      }
+      scratch.vecs.push_back(mesh_nodes_vec);
+      scratch.restrs.push_back(mesh_restr);
+      scratch.bases.push_back(mesh_basis);
+    };
+    // Ghost (face neighbor) side variant: the volume element lives on another process,
+    // so its attributes come from group.ghost_attr and the Piola Jacobian is replaced by
+    // a constant identity. The exchanged field values are already physical (the owning
+    // process applied the Piola map), so Piola(I) = I in the shared kernels reproduces
+    // them. Same input names/positions as AddVolGeomInputs ("grad_x_<suffix>" via
+    // EVAL_NONE matches the EVAL_GRAD naming), so the kernels are unchanged.
+    auto AddVolGeomInputsGhost =
+        [&](const std::string &suffix, const mfem::IntegrationRule &ir)
+    {
+      const int num_pts = ir.GetNPoints();
+      CeedElemRestriction attr_restr = nullptr;
+      CeedBasis attr_basis = nullptr;
+      CeedVector attr_vec = nullptr;
+      if (needs_elem_attr)
+      {
+        auto &elem_attr = elem_attrs.emplace_back(group.ghost_attr.size());
+        const auto &loc_attr = mesh.GetCeedAttributes();
+        for (std::size_t k = 0; k < group.ghost_attr.size(); k++)
+        {
+          elem_attr[k] = loc_attr.at(group.ghost_attr[k]);
+        }
+        PalaceCeedCall(ceed,
+                       CeedElemRestrictionCreateStrided(ceed, group.ghost_attr.size(), 1, 1,
+                                                        group.ghost_attr.size(),
+                                                        CEED_STRIDES_BACKEND, &attr_restr));
+        {
+          mfem::Vector Bt(num_pts), Gt(num_pts), qX(num_pts), qW(num_pts);
+          Bt = 1.0;
+          Gt = 0.0;
+          qX = 0.0;
+          qW = 0.0;
+          PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_pts,
+                                                 Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                                 qW.GetData(), &attr_basis));
+        }
+        ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+        inputs.push_back(
+            {"attr_" + suffix, attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      }
+
+      // Constant identity Jacobian (component-major [elem][comp][pt]), passed directly
+      // to the kernel's grad_x_<suffix> input (EVAL_NONE). It is 2x2 for 2D line
+      // integrals and 3x3 for 3D surface integrals.
+      const int geom_comp = dim * sdim;
+      auto &ident = elem_attrs.emplace_back(num_elem * geom_comp * num_pts);
+      ident = 0.0;
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int d = 0; d < dim; d++)
+        {
+          const int c = d * (sdim + 1);
+          for (int i = 0; i < num_pts; i++)
+          {
+            ident[e * geom_comp * num_pts + c * num_pts + i] = 1.0;
+          }
+        }
+      }
+      CeedElemRestriction ident_restr;
+      const CeedInt strides[3] = {1, num_pts, geom_comp * num_pts};
+      PalaceCeedCall(ceed,
+                     CeedElemRestrictionCreateStrided(
+                         ceed, static_cast<CeedInt>(num_elem), num_pts, geom_comp,
+                         (CeedSize)num_elem * geom_comp * num_pts, strides, &ident_restr));
+      CeedVector ident_vec;
+      ceed::InitCeedVector(ident, ceed, &ident_vec);
+      inputs.push_back(
+          {"grad_x_" + suffix, ident_vec, ident_restr, nullptr, ceed::EvalMode::None});
+      if (needs_elem_attr)
+      {
+        scratch.vecs.push_back(attr_vec);
+        scratch.restrs.push_back(attr_restr);
+        scratch.bases.push_back(attr_basis);
+      }
+      scratch.vecs.push_back(ident_vec);
+      scratch.restrs.push_back(ident_restr);
+    };
+    if (group.ghost_a)
+    {
+      AddVolGeomInputsGhost("1", *group.mapped_ir_a);
+    }
+    else if (!group.vol_indices_a.empty())
+    {
+      AddVolGeomInputs("1", group.vol_indices_a, group.vol_geom_a,
+                       group.at_points ? face_ir : *group.mapped_ir_a);
+    }
+    if (group.ghost_b)
+    {
+      AddVolGeomInputsGhost("2", *group.mapped_ir_b);
+    }
+    else if (!group.vol_indices_b.empty())
+    {
+      AddVolGeomInputs("2", group.vol_indices_b, group.vol_geom_b,
+                       group.at_points ? face_ir : *group.mapped_ir_b);
+    }
+    if (kind == KernelKind::SURFACE_FLUX || kind == KernelKind::FARFIELD ||
+        kind == KernelKind::MODE_OVERLAP)
+    {
+      if (group.at_points)
+      {
+        // Physical coordinates are surface-only data. Keep them on the boundary
+        // quadrature rule rather than evaluating the boundary basis at the volume
+        // reference points used by the AtPoints trace operator. Two-sided surface flux
+        // kernels never use x (their normal orientation is fixed by side convention), so
+        // avoid the host boundary-coordinate transform for those large trace surfaces.
+        const int nq = face_ir.GetNPoints();
+        auto &x_pts = elem_attrs.emplace_back(num_elem * nq * 3);
+        x_pts = 0.0;
+        if (!(kind == KernelKind::SURFACE_FLUX && flux_two_sided))
+        {
+          for (std::size_t e = 0; e < num_elem; e++)
+          {
+            mfem::IsoparametricTransformation T;
+            pmesh.GetBdrElementTransformation(group.bdr_indices[e], &T);
+            for (int q = 0; q < nq; q++)
+            {
+              const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
+              mfem::Vector x_loc(3);
+              T.Transform(ip, x_loc);
+              const std::size_t off = 3 * (e * nq + q);
+              x_pts[off + 0] = x_loc(0);
+              x_pts[off + 1] = x_loc(1);
+              x_pts[off + 2] = x_loc(2);
+            }
+          }
+        }
+        AddSequentialPointInput("x", x_pts, 3);
+      }
+      else
+      {
+        // Coordinates at the face quadrature points, interpolated from the mesh nodes
+        // with the boundary element basis (constant input, never re-pointed).
+        CeedElemRestriction x_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, group.bdr_geom, group.bdr_indices, /*is_interp*/ true);
+        CeedBasis x_basis;
+        ceed::InitBasisAtPoints(*face_mesh_fe, face_ir, mesh_fespace.GetVDim(), ceed,
+                                &x_basis);
+        CeedVector x_vec;
+        ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &x_vec);
+        inputs.push_back({"x", x_vec, x_restr, x_basis, ceed::EvalMode::Interp});
+        scratch.vecs.push_back(x_vec);
+        scratch.restrs.push_back(x_restr);
+        scratch.bases.push_back(x_basis);
+      }
+    }
+    auto AddFieldInput = [&](const std::string &name, int source,
+                             const mfem::ParFiniteElementSpace &fespace,
+                             const std::vector<int> &indices, mfem::Geometry::Type geom,
+                             const mfem::IntegrationRule &ir)
+    {
+      CeedElemRestriction restr;
+      CeedBasis basis;
+      CeedVector vec;
+      ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                            &restr);
+      const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+      MFEM_VERIFY(fe, "Unable to get field finite element for surface functional!");
+      if (group.at_points)
+      {
+        InitTetBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed, &basis);
+      }
+      else
+      {
+        ceed::InitBasisAtPoints(*fe, ir, fespace.GetVDim(), ceed, &basis);
+      }
+      ceed::InitCeedVector(field_staging, ceed, &vec);
+      inputs.push_back({name, vec, restr, basis, ceed::EvalMode::Interp});
+      field_sources.emplace_back(name, source);
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+      scratch.bases.push_back(basis);
+    };
+    // Ghost (face neighbor) field input: the neighbor's physical field values at the
+    // mapped points, imported via FaceNbrFieldExchange. The indexed restriction slices
+    // the shared imported vector per element (base = ImportOffset) and transposes its
+    // point-major layout ([pt][comp]) to the component-major layout the kernel reads
+    // (offset base + sdim*pt, comp_stride 1). Re-pointed at the imported vector on each
+    // apply via source index 4 (see fem::ApplyAddGroupOperators).
+    auto AddFieldInputGhost =
+        [&](const std::string &name, int slot, const mfem::IntegrationRule &ir)
+    {
+      const int nq = ir.GetNPoints();
+      std::vector<CeedInt> offsets(num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        const int base = face_nbr_exchange->ImportOffset(group.req_idx[e], slot);
+        for (int i = 0; i < nq; i++)
+        {
+          offsets[e * nq + i] = base + sdim * i;
+        }
+      }
+      CeedElemRestriction restr;
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(num_elem), nq, sdim, 1,
+                               (CeedSize)face_nbr_exchange->ImportSize(), CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &restr));
+      CeedVector vec;
+      ceed::InitCeedVector(face_nbr_exchange->Imported(), ceed, &vec);
+      inputs.push_back({name, vec, restr, nullptr, ceed::EvalMode::None});
+      field_sources.emplace_back(name, 4);  // 4 -> imported (see ApplyAddGroupOperators)
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+    };
+    if (kind == KernelKind::BDR_POYNTING)
+    {
+      auto AddPoyntingSide = [&](const std::string &suffix, const std::vector<int> &indices,
+                                 mfem::Geometry::Type geom, const mfem::IntegrationRule &ir,
+                                 bool ghost)
+      {
+        const std::string e_name = "u_e_" + suffix;
+        const std::string b_name = "u_b_" + suffix;
+        if (ghost)
+        {
+          AddFieldInputGhost(e_name, 0, ir);
+          AddFieldInputGhost(b_name, 1, ir);
+        }
+        else
+        {
+          AddFieldInput(e_name, 0, *nd_fespace, indices, geom, ir);
+          AddFieldInput(b_name, 1, *rt_fespace, indices, geom, ir);
+        }
+      };
+      AddPoyntingSide("1", group.vol_indices_a, group.vol_geom_a,
+                      group.at_points ? face_ir : *group.mapped_ir_a, group.ghost_a);
+      if (has_b)
+      {
+        AddPoyntingSide("2", group.vol_indices_b, group.vol_geom_b,
+                        group.at_points ? face_ir : *group.mapped_ir_b, group.ghost_b);
+      }
+    }
+    else if (kind == KernelKind::HCURL_NORM2 || kind == KernelKind::INTERFACE_EPR ||
+             kind == KernelKind::MODE_OVERLAP || buffer_kind)
+    {
+      const auto &field_fespace = rt_fespace ? *rt_fespace : *nd_fespace;
+      if (group.ghost_a)
+      {
+        AddFieldInputGhost("u_1", 0, *group.mapped_ir_a);
+      }
+      else
+      {
+        AddFieldInput("u_1", 0, field_fespace, group.vol_indices_a, group.vol_geom_a,
+                      group.at_points ? face_ir : *group.mapped_ir_a);
+      }
+      if (has_b)
+      {
+        if (group.ghost_b)
+        {
+          AddFieldInputGhost("u_2", 0, *group.mapped_ir_b);
+        }
+        else
+        {
+          AddFieldInput("u_2", 0, field_fespace, group.vol_indices_b, group.vol_geom_b,
+                        group.at_points ? face_ir : *group.mapped_ir_b);
+        }
+      }
+    }
+    else if (kind == KernelKind::FARFIELD)
+    {
+      const mfem::IntegrationRule &ir = group.at_points ? face_ir : *group.mapped_ir_a;
+      AddFieldInput("u_1", 0, *nd_fespace, group.vol_indices_a, group.vol_geom_a, ir);
+      AddFieldInput("u_2", 1, *nd_fespace, group.vol_indices_a, group.vol_geom_a, ir);
+      AddFieldInput("u_3", 2, *rt_fespace, group.vol_indices_a, group.vol_geom_a, ir);
+      AddFieldInput("u_4", 3, *rt_fespace, group.vol_indices_a, group.vol_geom_a, ir);
+    }
+    else if (kind == KernelKind::SURFACE_FLUX)
+    {
+      int count = 0;
+      auto AddSide = [&](const std::vector<int> &indices, mfem::Geometry::Type geom,
+                         const mfem::IntegrationRule &ir, bool ghost)
+      {
+        if (flux_type == SurfaceFlux::ELECTRIC || flux_type == SurfaceFlux::POWER)
+        {
+          const std::string nm = "u_" + std::to_string(++count);
+          if (ghost)
+          {
+            AddFieldInputGhost(nm, 0, ir);
+          }
+          else
+          {
+            AddFieldInput(nm, 0, *nd_fespace, indices, geom, ir);
+          }
+        }
+        if (flux_type == SurfaceFlux::MAGNETIC || flux_type == SurfaceFlux::POWER)
+        {
+          const std::string nm = "u_" + std::to_string(++count);
+          if (ghost)
+          {
+            AddFieldInputGhost(nm, 1, ir);
+          }
+          else
+          {
+            AddFieldInput(nm, 1, *rt_fespace, indices, geom, ir);
+          }
+        }
+      };
+      AddSide(group.vol_indices_a, group.vol_geom_a,
+              group.at_points ? face_ir : *group.mapped_ir_a, group.ghost_a);
+      if (has_b)
+      {
+        AddSide(group.vol_indices_b, group.vol_geom_b,
+                group.at_points ? face_ir : *group.mapped_ir_b, group.ghost_b);
+      }
+    }
+
+    // Output restriction: for integral kinds, num_out slots per boundary element in
+    // the local output vector (component stride num_marked); for the boundary
+    // visualization field kinds, component-major lanes over all lattice points scatter
+    // into the output buffer at the per-element point-base offsets.
+    CeedElemRestriction out_restr;
+    if (buffer_kind)
+    {
+      const int nq = face_ir.GetNPoints();
+      const int nc = BufferNumComp(kind);
+      const int component_stride = buffer_size / nc;
+      std::vector<CeedInt> offsets(num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int j = 0; j < nq; j++)
+        {
+          offsets[e * nq + j] = group.out_slots[e] + j;
+        }
+      }
+      // Even for AtPoints operators, keep the output as an ordinary EVAL_NONE
+      // restriction. libCEED requires all AtPoints restrictions on the same operator to
+      // use identical point-offset layouts; the output buffer is intentionally scattered
+      // by boundary-element slot and should not constrain the point-coordinate layout.
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(num_elem), nq, nc,
+                               component_stride, (CeedSize)buffer_size, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &out_restr));
+    }
+    else if (group.at_points)
+    {
+      const int nq = face_ir.GetNPoints();
+      std::vector<CeedInt> offsets(num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int j = 0; j < nq; j++)
+        {
+          offsets[e * nq + j] = group.out_slots[e];
+        }
+      }
+      // Each quadrature-point contribution scatters to the element's output slot;
+      // ApplyAdd performs the reduction over the duplicate offsets.
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(num_elem), nq, num_out,
+                               num_marked, (CeedSize)num_marked * num_out, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &out_restr));
+    }
+    else
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(num_elem), 1, num_out, num_marked,
+                               (CeedSize)num_marked * num_out, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, group.out_slots.data(), &out_restr));
+    }
+    scratch.restrs.push_back(out_restr);
+
+    // Select the QFunction and finalize the (group dependent) context.
+    std::vector<CeedIntScalar> ctx = base_ctx;
+    ceed::CeedQFunctionInfo info;
+    switch (kind)
+    {
+      case KernelKind::AREA:
+        info.apply_qf = is_2d ? f_integ_surf_area_21 : f_integ_surf_area_32;
+        info.apply_qf_path = is_2d ? PalaceQFunctionRelativePath(f_integ_surf_area_21_loc)
+                                   : PalaceQFunctionRelativePath(f_integ_surf_area_32_loc);
+        break;
+      case KernelKind::HCURL_NORM2:
+        info.apply_qf = is_2d ? f_integ_surf_hcurl_norm2_21 : f_integ_surf_hcurl_norm2_32;
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(f_integ_surf_hcurl_norm2_21_loc)
+                  : PalaceQFunctionRelativePath(f_integ_surf_hcurl_norm2_32_loc);
+        break;
+      case KernelKind::INTERFACE_EPR:
+        // All four interface types share one kernel; epr_type is set in base_ctx[0].first.
+        info.apply_qf = is_2d ? (has_b ? f_integ_surf_epr_2_21 : f_integ_surf_epr_1_21)
+                              : (has_b ? f_integ_surf_epr_2_32 : f_integ_surf_epr_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_integ_surf_epr_2_21_loc
+                                                      : f_integ_surf_epr_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_integ_surf_epr_2_32_loc
+                                                      : f_integ_surf_epr_1_32_loc);
+        break;
+      case KernelKind::BDR_FIELD_E:
+      case KernelKind::BDR_FIELD_B:
+        // Shared kernel; the ND/RT Piola is set in base_ctx[0].first.
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = has_b ? f_eval_bdr_field_2_32 : f_eval_bdr_field_1_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_32_loc
+                                                               : f_eval_bdr_field_1_32_loc);
+        break;
+      case KernelKind::BDR_FLUX_Q:
+        ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
+        info.apply_qf = has_b ? f_eval_bdr_flux_q_2_32 : f_eval_bdr_flux_q_1_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(
+            has_b ? f_eval_bdr_flux_q_2_32_loc : f_eval_bdr_flux_q_1_32_loc);
+        break;
+      case KernelKind::BDR_CURRENT_J:
+        ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
+        info.apply_qf = has_b ? f_eval_bdr_current_j_2_32 : f_eval_bdr_current_j_1_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(
+            has_b ? f_eval_bdr_current_j_2_32_loc : f_eval_bdr_current_j_1_32_loc);
+        break;
+      case KernelKind::BDR_ENERGY_E:
+      case KernelKind::BDR_ENERGY_M:
+        // Shared kernel; the ND/RT Piola is set in base_ctx[0].first.
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = has_b ? f_eval_bdr_energy_2_32 : f_eval_bdr_energy_1_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(
+            has_b ? f_eval_bdr_energy_2_32_loc : f_eval_bdr_energy_1_32_loc);
+        break;
+      case KernelKind::BDR_POYNTING:
+        ctx[0].second *= group.side_scale;
+        info.apply_qf = has_b ? f_eval_bdr_poynting_2_32 : f_eval_bdr_poynting_1_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(
+            has_b ? f_eval_bdr_poynting_2_32_loc : f_eval_bdr_poynting_1_32_loc);
+        break;
+      case KernelKind::FARFIELD:
+        ctx[0].second = group.flip_normal ? -1.0 : 1.0;
+        info.apply_qf = f_integ_surf_farfield_32;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_integ_surf_farfield_32_loc);
+        break;
+      case KernelKind::MODE_OVERLAP:
+        {
+          MFEM_VERIFY(!group.bdr_indices.empty(),
+                      "Empty boundary group for mode-overlap functional!");
+          const int attr = pmesh.GetBdrAttribute(group.bdr_indices.front());
+          auto mode_it = mode_coeff_by_attr.find(attr);
+          MFEM_VERIFY(mode_it != mode_coeff_by_attr.end(),
+                      "Missing mode coefficient for marked boundary attribute!");
+          const auto &mode = mode_it->second;
+          ctx[0].first = (mode.type == SurfaceModeCoefficient::Type::COAXIAL) ? 1 : 0;
+          ctx[1].second = mode.scale;
+          const auto &data = (mode.type == SurfaceModeCoefficient::Type::COAXIAL)
+                                 ? mode.origin
+                                 : mode.direction;
+          for (int d = 0; d < 3; d++)
+          {
+            ctx[2 + d].second = data[d];
+          }
+          info.apply_qf = f_integ_surf_mode_32;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_integ_surf_mode_32_loc);
+        }
+        break;
+      case KernelKind::SURFACE_FLUX:
+        ctx[0].second = (group.flip_normal ? -1.0 : 1.0) *
+                        ((group.at_points && !group.normal_scales.empty())
+                             ? 1.0  // Per-entry normal_scale is folded into face geometry.
+                             : group.normal_scale);
+        switch (flux_type)
+        {
+          case SurfaceFlux::ELECTRIC:
+            info.apply_qf = has_b ? f_integ_surf_flux_e_2_32 : f_integ_surf_flux_e_1_32;
+            info.apply_qf_path = PalaceQFunctionRelativePath(
+                has_b ? f_integ_surf_flux_e_2_32_loc : f_integ_surf_flux_e_1_32_loc);
+            break;
+          case SurfaceFlux::MAGNETIC:
+            info.apply_qf = has_b ? f_integ_surf_flux_m_2_32 : f_integ_surf_flux_m_1_32;
+            info.apply_qf_path = PalaceQFunctionRelativePath(
+                has_b ? f_integ_surf_flux_m_2_32_loc : f_integ_surf_flux_m_1_32_loc);
+            break;
+          case SurfaceFlux::POWER:
+            info.apply_qf = has_b ? f_integ_surf_flux_p_2_32 : f_integ_surf_flux_p_1_32;
+            info.apply_qf_path = PalaceQFunctionRelativePath(
+                has_b ? f_integ_surf_flux_p_2_32_loc : f_integ_surf_flux_p_1_32_loc);
+            break;
+        }
+        break;
+    }
+
+    // Assemble the operator.
+    CeedOperator op;
+    CeedQFunctionContext op_ctx = nullptr;
+    if (buffer_kind)
+    {
+      if (group.at_points)
+      {
+        ceed::AssembleCeedPointEvaluatorAtPoints(
+            info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+            points_restr, points_vec, BufferNumComp(kind), out_restr, &op);
+      }
+      else
+      {
+        ceed::AssembleCeedPointEvaluator(info, ctx.data(),
+                                         ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+                                         BufferNumComp(kind), out_restr, &op);
+      }
+    }
+    else if (group.at_points)
+    {
+      ceed::AssembleCeedPointEvaluatorAtPoints(
+          info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs, points_restr,
+          points_vec, num_out, out_restr, &op,
+          (kind == KernelKind::FARFIELD) ? &op_ctx : nullptr);
+    }
+    else
+    {
+      ceed::AssembleCeedSurfaceFunctional(
+          info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs, num_out,
+          out_restr, &op, (kind == KernelKind::FARFIELD) ? &op_ctx : nullptr);
+    }
+    groups.push_back({ceed, op, std::move(field_sources), op_ctx});
+  }
+  if (profile)
+  {
+    Mpi::GlobalSum(8, profile_counts, comm);
+    Mpi::GlobalMax(1, &profile_max_group_elems, comm);
+    Mpi::Print(comm,
+               "SurfaceFunctional profile kind={} groups={} elems={} at_points_groups={} "
+               "at_points_elems={} mapped_groups={} mapped_elems={} two_sided_groups={} "
+               "ghost_groups={} max_group_elems={}\n",
+               KindName(kind), profile_counts[0], profile_counts[1], profile_counts[2],
+               profile_counts[3], profile_counts[4], profile_counts[5], profile_counts[6],
+               profile_counts[7], profile_max_group_elems);
+  }
+}
+
+void SurfaceFunctional::ApplyAdd(const std::array<const Vector *, 4> &srcs) const
+{
+  if (face_nbr_exchange)
+  {
+    face_nbr_exchange->Exchange(srcs);
+    fem::ApplyAddGroupOperators(groups, srcs, local_out, &face_nbr_exchange->Imported());
+  }
+  else
+  {
+    fem::ApplyAddGroupOperators(groups, srcs, local_out);
+  }
+}
+
+double SurfaceFunctional::EvalLocal(const std::array<const Vector *, 4> &srcs) const
+{
+  MFEM_VERIFY(valid, "Eval called on an invalid (unassembled) SurfaceFunctional!");
+  // A process holding the face neighbor exchange must still apply (the exchange is
+  // collective: it may need to export its local field for a neighbor's ghost request
+  // even with no local marked elements). ApplyAdd is a no-op on the empty group set.
+  if (local_out.Size() == 0 && !face_nbr_exchange)
+  {
+    return 0.0;
+  }
+  if (local_out.Size() > 0)
+  {
+    local_out = 0.0;
+  }
+  ApplyAdd(srcs);
+  return (local_out.Size() > 0) ? linalg::LocalSum(local_out) : 0.0;
+}
+
+double SurfaceFunctional::Eval(const Vector *u) const
+{
+  MFEM_VERIFY(kind == KernelKind::AREA || u,
+              "SurfaceFunctional::Eval requires a field vector for functionals with "
+              "field inputs!");
+  double dot = EvalLocal({u, nullptr});
+  Mpi::GlobalSum(1, &dot, comm);
+  return dot;
+}
+
+double SurfaceFunctional::Eval(const GridFunction &u) const
+{
+  MFEM_VERIFY(valid, "Eval called on an invalid (unassembled) SurfaceFunctional!");
+  MFEM_VERIFY(kind == KernelKind::HCURL_NORM2 || kind == KernelKind::INTERFACE_EPR,
+              "SurfaceFunctional::Eval with a grid function is only valid for functionals "
+              "quadratic in a single field!");
+  double dot = 0.0;
+  if (local_out.Size() > 0 || face_nbr_exchange)
+  {
+    if (local_out.Size() > 0)
+    {
+      local_out = 0.0;
+    }
+    ApplyAdd({&u.Real(), nullptr});
+    if (u.HasImag())
+    {
+      ApplyAdd({&u.Imag(), nullptr});
+    }
+    if (local_out.Size() > 0)
+    {
+      dot = linalg::LocalSum(local_out);
+    }
+  }
+  Mpi::GlobalSum(1, &dot, comm);
+  return dot;
+}
+
+std::complex<double> SurfaceFunctional::EvalModeOverlap(const GridFunction &E) const
+{
+  MFEM_VERIFY(kind == KernelKind::MODE_OVERLAP,
+              "SurfaceFunctional::EvalModeOverlap is only valid for mode-overlap "
+              "functionals!");
+  std::complex<double> dot(EvalLocal({&E.Real(), nullptr}), 0.0);
+  if (E.HasImag())
+  {
+    dot.imag(EvalLocal({&E.Imag(), nullptr}));
+  }
+  Mpi::GlobalSum(1, &dot, comm);
+  return dot;
+}
+
+std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
+                                                 const GridFunction *B) const
+{
+  MFEM_VERIFY(kind == KernelKind::SURFACE_FLUX,
+              "SurfaceFunctional::EvalFlux is only valid for surface flux functionals!");
+  MFEM_VERIFY(
+      (E || (flux_type != SurfaceFlux::ELECTRIC && flux_type != SurfaceFlux::POWER)) &&
+          (B || (flux_type != SurfaceFlux::MAGNETIC && flux_type != SurfaceFlux::POWER)),
+      "Missing E or B field grid function for surface flux evaluation!");
+
+  // For complex-valued fields, output the separate real and imaginary parts for the
+  // time-harmonic quantity. For power flux (Poynting vector), output only the
+  // stationary real part and not the part which has double the frequency (the real and
+  // imaginary part contributions add).
+  const bool has_imag = E ? E->HasImag() : B->HasImag();
+  std::complex<double> dot(EvalLocal({E ? &E->Real() : nullptr, B ? &B->Real() : nullptr}),
+                           0.0);
+  if (has_imag)
+  {
+    const double doti = EvalLocal({E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr});
+    if (flux_type == SurfaceFlux::POWER)
+    {
+      dot += doti;
+    }
+    else
+    {
+      dot.imag(doti);
+    }
+  }
+  Mpi::GlobalSum(1, &dot, comm);
+  return dot;
+}
+
+void SurfaceFunctional::EvalTraceFieldBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B,
+              "Trace-field buffer evaluation is only valid for boundary E/B fields!");
+  const mfem::ParFiniteElementSpace *fespace =
+      (kind == KernelKind::BDR_FIELD_E) ? nd_fespace : rt_fespace;
+  MFEM_VERIFY(fespace, "Missing finite element space for boundary trace field output!");
+  const mfem::ParMesh &pmesh = *fespace->GetParMesh();
+  const int nc = BufferNumComp(kind);
+  MFEM_VERIFY(nc == 3, "Boundary trace field output expects ambient 3-vector buffers!");
+  MFEM_VERIFY(buffer.Size() == buffer_size && buffer_size % nc == 0,
+              "Invalid boundary trace field buffer size!");
+  const int component_stride = buffer_size / nc;
+  double *out = buffer.HostReadWrite();
+
+  mfem::Array<int> vdofs;
+  mfem::DofTransformation dof_trans;
+  mfem::Vector loc_data, shape, val, normal;
+  mfem::DenseMatrix vshape;
+  mfem::IsoparametricTransformation T;
+  for (const int i : trace_bdr_indices)
+  {
+    const int base = buffer_bases[i];
+    MFEM_VERIFY(base >= 0, "Boundary trace field output has an invalid buffer base!");
+    const mfem::FiniteElement *fe = fespace->GetBE(i);
+    MFEM_VERIFY(fe, "Unable to get boundary trace finite element for E_t/B_n output!");
+    const mfem::IntegrationRule &face_ir =
+        mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), viz_lod, 1)
+            ->RefPts;
+    MFEM_VERIFY(base + face_ir.GetNPoints() <= component_stride,
+                "Boundary trace field buffer base is out of range!");
+
+    fespace->GetBdrElementVDofs(i, vdofs, dof_trans);
+    u.GetSubVector(vdofs, loc_data);
+    dof_trans.InvTransformPrimal(loc_data);
+    pmesh.GetBdrElementTransformation(i, &T);
+
+    if (kind == KernelKind::BDR_FIELD_B)
+    {
+      // RT trace elements are scalar H^{-1/2} normal flux densities on the boundary
+      // element. Output the signed normal trace as an ambient normal vector to preserve
+      // the existing three-component ParaView field shape while avoiding any attached
+      // volume-element evaluation.
+      MFEM_VERIFY(fe->GetRangeType() == mfem::FiniteElement::SCALAR,
+                  "Expected scalar RT trace finite element for B_n output!");
+      shape.SetSize(fe->GetDof());
+      normal.SetSize(3);
+      for (int q = 0; q < face_ir.GetNPoints(); q++)
+      {
+        const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
+        T.SetIntPoint(&ip);
+        if (fe->GetMapType() == mfem::FiniteElement::VALUE)
+        {
+          fe->CalcShape(ip, shape);
+        }
+        else
+        {
+          fe->CalcPhysShape(T, shape);
+        }
+        const double bn = shape * loc_data;
+        mfem::CalcOrtho(T.Jacobian(), normal);
+        const double normal_norm = normal.Norml2();
+        MFEM_VERIFY(normal_norm > 0.0, "Invalid boundary normal for B_n output!");
+        normal /= normal_norm;
+        for (int c = 0; c < 3; c++)
+        {
+          out[base + q + c * component_stride] += bn * normal(c);
+        }
+      }
+    }
+    else
+    {
+      // ND trace elements evaluate the tangential trace as an ambient vector on the
+      // boundary element. NC slave/leaf face constraints are already represented in the
+      // boundary DOF restriction, so no Elem2/master-side mapping is needed.
+      MFEM_VERIFY(fe->GetRangeType() == mfem::FiniteElement::VECTOR,
+                  "Expected vector ND trace finite element for E_t output!");
+      const int vdim = std::max(pmesh.SpaceDimension(), fe->GetRangeDim());
+      vshape.SetSize(fe->GetDof(), vdim);
+      val.SetSize(vdim);
+      for (int q = 0; q < face_ir.GetNPoints(); q++)
+      {
+        const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
+        T.SetIntPoint(&ip);
+        fe->CalcVShape(T, vshape);
+        vshape.MultTranspose(loc_data, val);
+        for (int c = 0; c < 3; c++)
+        {
+          out[base + q + c * component_stride] += (c < val.Size()) ? val(c) : 0.0;
+        }
+      }
+    }
+  }
+}
+
+void SurfaceFunctional::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(
+      valid && IsBufferKind(kind) && kind != KernelKind::BDR_POYNTING,
+      "EvalBuffer requires a valid single-field boundary visualization functional!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+  {
+    EvalTraceFieldBuffer(u, buffer);
+    return;
+  }
+  if (face_nbr_exchange)
+  {
+    face_nbr_exchange->Exchange({&u});
+    fem::ApplyAddGroupOperators(groups, {&u}, buffer, &face_nbr_exchange->Imported());
+  }
+  else
+  {
+    fem::ApplyAddGroupOperators(groups, {&u}, buffer);
+  }
+}
+
+void SurfaceFunctional::EvalBuffer(const GridFunction &u, Vector &buffer) const
+{
+  MFEM_VERIFY(
+      valid && IsBufferKind(kind) && kind != KernelKind::BDR_POYNTING,
+      "EvalBuffer requires a valid single-field boundary visualization functional!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  auto Apply = [&](const Vector &v)
+  {
+    if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+    {
+      EvalTraceFieldBuffer(v, buffer);
+    }
+    else if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&v});
+      fem::ApplyAddGroupOperators(groups, {&v}, buffer, &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&v}, buffer);
+    }
+  };
+  Apply(u.Real());
+  if (u.HasImag())
+  {
+    Apply(u.Imag());
+  }
+}
+
+void SurfaceFunctional::EvalBuffer(const GridFunction &E, const GridFunction &B,
+                                   Vector &buffer) const
+{
+  MFEM_VERIFY(valid && kind == KernelKind::BDR_POYNTING,
+              "EvalBuffer requires a valid boundary Poynting visualization functional!");
+  MFEM_VERIFY(E.HasImag() == B.HasImag(),
+              "Mismatch between real- and complex-valued E and B fields in boundary "
+              "Poynting visualization!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  auto Apply = [&](const Vector &e, const Vector &b)
+  {
+    if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&e, &b});
+      fem::ApplyAddGroupOperators(groups, {&e, &b}, buffer, &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&e, &b}, buffer);
+    }
+  };
+  Apply(E.Real(), B.Real());
+  if (E.HasImag())
+  {
+    Apply(E.Imag(), B.Imag());
+  }
+}
+
+std::vector<std::array<std::complex<double>, 3>>
+SurfaceFunctional::EvalFarField(const GridFunction &E, const GridFunction &B,
+                                std::complex<double> omega)
+{
+  MFEM_VERIFY(kind == KernelKind::FARFIELD && E.HasImag() && B.HasImag(),
+              "SurfaceFunctional::EvalFarField requires a far-field functional and "
+              "complex-valued fields!");
+  MFEM_VERIFY(valid, "EvalFarField called on an invalid (unassembled) SurfaceFunctional!");
+
+  // The frequency enters only the QFunction context (the omega slots); update it in
+  // place rather than reassembling the operators. Reassembly would rebuild the bases,
+  // restrictions, and on-the-fly geometry inputs and re-JIT the (expensive) far-field
+  // kernel on every frequency -- none of which depend on omega. FARFIELD context layout
+  // (see Assemble): [0] normal sign, [1] omega_re, [2] omega_im, [3] N,
+  // [4] B Piola map, [5..] directions, then the material context.
+  if (omega != farfield_omega)
+  {
+    farfield_omega = omega;
+    for (auto &group : groups)
+    {
+      if (!group.ctx)
+      {
+        continue;
+      }
+      CeedIntScalar *data;
+      PalaceCeedCall(group.ceed,
+                     CeedQFunctionContextGetData(group.ctx, CEED_MEM_HOST, &data));
+      data[1].second = omega.real();
+      data[2].second = omega.imag();
+      PalaceCeedCall(group.ceed, CeedQFunctionContextRestoreData(group.ctx, &data));
+    }
+  }
+
+  // Integrate, reduce each component over the local elements and all processes, and
+  // apply the final cross products (following GetFarFieldrE).
+  const int N = static_cast<int>(farfield_dirs.size());
+  const int num_marked = local_out.Size() / std::max(6 * N, 1);
+  std::vector<double> integrals(6 * N, 0.0);
+  if (local_out.Size() > 0)
+  {
+    local_out = 0.0;
+    fem::ApplyAddGroupOperators(groups, {&E.Real(), &E.Imag(), &B.Real(), &B.Imag()},
+                                local_out);
+    Vector slice;
+    slice.UseDevice(true);
+    for (int c = 0; c < 6 * N; c++)
+    {
+      slice.MakeRef(local_out, c * num_marked, num_marked);
+      integrals[c] = linalg::LocalSum(slice);
+    }
+  }
+  Mpi::GlobalSum(6 * N, integrals.data(), comm);
+
+  std::vector<std::array<std::complex<double>, 3>> result(N);
+  for (int d = 0; d < N; d++)
+  {
+    const auto &r = farfield_dirs[d];
+    const double *Ir = integrals.data() + 6 * d, *Ii = integrals.data() + 6 * d + 3;
+    const double cr[3] = {r[1] * Ir[2] - r[2] * Ir[1], r[2] * Ir[0] - r[0] * Ir[2],
+                          r[0] * Ir[1] - r[1] * Ir[0]};
+    const double ci[3] = {r[1] * Ii[2] - r[2] * Ii[1], r[2] * Ii[0] - r[0] * Ii[2],
+                          r[0] * Ii[1] - r[1] * Ii[0]};
+    for (int c = 0; c < 3; c++)
+    {
+      result[d][c] = {cr[c], ci[c]};
+    }
+  }
+  return result;
+}
+
+std::complex<double> SurfaceFunctional::EvalComplexPower(const GridFunction &E,
+                                                         const GridFunction &B) const
+{
+  MFEM_VERIFY(kind == KernelKind::SURFACE_FLUX && flux_type == SurfaceFlux::POWER &&
+                  flux_two_sided,
+              "SurfaceFunctional::EvalComplexPower is only valid for two-sided POWER "
+              "flux functionals!");
+  MFEM_VERIFY(E.HasImag() == B.HasImag(),
+              "Mismatch between real- and complex-valued E and B fields in port power "
+              "calculation!");
+
+  // Following LumpedPortData::GetPower: P = ∫ E ⋅ (n x H) dS with H = μ⁻¹ B and n the
+  // normal oriented into element 1 (contributions from both sides of an interior
+  // boundary add). With S(e, b) = ∫ (e x μ⁻¹ b) ⋅ n dS (the two-sided POWER flux
+  // functional), E ⋅ (n x H) = -(E x H) ⋅ n gives
+  //   Re{P} = S(E_re, B_re) + S(E_im, B_im)
+  //   Im{P} = S(E_im, B_re) - S(E_re, B_im) .
+  const bool has_imag = E.HasImag();
+  std::complex<double> dot(EvalLocal({&E.Real(), &B.Real()}), 0.0);
+  if (has_imag)
+  {
+    dot += EvalLocal({&E.Imag(), &B.Imag()});
+    dot.imag(EvalLocal({&E.Imag(), &B.Real()}) - EvalLocal({&E.Real(), &B.Imag()}));
+  }
+  Mpi::GlobalSum(1, &dot, comm);
+  return dot;
+}
+
+std::vector<std::complex<double>>
+SurfaceFunctional::EvalComplexPowerByAttribute(const GridFunction &E, const GridFunction &B,
+                                               const mfem::Array<int> &attr_to_bin,
+                                               int num_bins) const
+{
+  MFEM_VERIFY(kind == KernelKind::SURFACE_FLUX && flux_type == SurfaceFlux::POWER &&
+                  flux_two_sided,
+              "SurfaceFunctional::EvalComplexPowerByAttribute is only valid for "
+              "two-sided POWER flux functionals!");
+  MFEM_VERIFY(E.HasImag() == B.HasImag(),
+              "Mismatch between real- and complex-valued E and B fields in batched "
+              "port power calculation!");
+  MFEM_VERIFY(num_bins >= 0, "Invalid number of output bins!");
+  MFEM_VERIFY(local_out_attrs.size() == static_cast<std::size_t>(local_out.Size()),
+              "SurfaceFunctional attribute bins require one output slot per element!");
+
+  auto AccumulateBins = [&](const std::array<const Vector *, 4> &srcs,
+                            std::vector<double> &bins, double scale)
+  {
+    if (local_out.Size() > 0)
+    {
+      local_out = 0.0;
+    }
+    // Keep the apply collective even on ranks with no local marked elements, since a
+    // face-neighbor exchange may need this rank to export field data for another rank's
+    // processor-boundary side.
+    ApplyAdd(srcs);
+    if (local_out.Size() == 0)
+    {
+      return;
+    }
+    const double *vals = local_out.HostRead();
+    for (int i = 0; i < local_out.Size(); i++)
+    {
+      const int attr = local_out_attrs[i];
+      const int bin = (attr > 0 && attr <= attr_to_bin.Size()) ? attr_to_bin[attr - 1] : -1;
+      if (bin >= 0)
+      {
+        MFEM_VERIFY(bin < num_bins, "SurfaceFunctional attribute bin out of range!");
+        bins[bin] += scale * vals[i];
+      }
+    }
+  };
+
+  std::vector<double> real(num_bins, 0.0), imag(num_bins, 0.0);
+  AccumulateBins({&E.Real(), &B.Real()}, real, 1.0);
+  if (E.HasImag())
+  {
+    AccumulateBins({&E.Imag(), &B.Imag()}, real, 1.0);
+    AccumulateBins({&E.Imag(), &B.Real()}, imag, 1.0);
+    AccumulateBins({&E.Real(), &B.Imag()}, imag, -1.0);
+  }
+
+  std::vector<double> packed(2 * num_bins, 0.0);
+  for (int i = 0; i < num_bins; i++)
+  {
+    packed[2 * i + 0] = real[i];
+    packed[2 * i + 1] = imag[i];
+  }
+  Mpi::GlobalSum(static_cast<int>(packed.size()), packed.data(), comm);
+
+  std::vector<std::complex<double>> result(num_bins);
+  for (int i = 0; i < num_bins; i++)
+  {
+    result[i] = {packed[2 * i + 0], packed[2 * i + 1]};
+  }
+  return result;
+}
+
+}  // namespace palace

--- a/palace/fem/output_functionals.hpp
+++ b/palace/fem/output_functionals.hpp
@@ -1,0 +1,333 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_OUTPUT_FUNCTIONALS_HPP
+#define PALACE_FEM_OUTPUT_FUNCTIONALS_HPP
+
+#include <array>
+#include <complex>
+#include <deque>
+#include <map>
+#include <memory>
+#include <vector>
+#include <mfem.hpp>
+#include "fem/ceed_group_operator.hpp"
+#include "linalg/vector.hpp"
+#include "utils/labels.hpp"
+
+namespace palace
+{
+
+class GridFunction;
+class MaterialOperator;
+class Mesh;
+class PointFieldEvaluator;
+class FaceNbrFieldExchange;
+
+// Non-reducing boundary point field kinds. These are private SurfaceFunctional backend
+// hooks used by the ParaView/GridFunction follow-up; the output-functional PR keeps the
+// enum here so the reducing functional implementation is self-contained without pulling
+// in the point-field evaluator API.
+enum class PointFieldKind : char
+{
+  FIELD_E,    // H(curl) E field values
+  FIELD_B,    // H(div) B field values
+  FLUX_Q,     // Surface charge (eps E) . n
+  CURRENT_J,  // Surface current n x (mu^-1 B)
+  ENERGY_E,   // Electric energy density
+  ENERGY_M,   // Magnetic energy density
+  POYNTING    // Poynting vector E x (mu^-1 B)
+};
+
+// Description of a real vector-valued mode coefficient on a marked boundary surface.
+// UNIFORM represents scale * direction. COAXIAL represents scale * (x - origin) /
+// |x - origin|^2, matching CoaxialElementData::GetModeCoefficient.
+struct SurfaceModeCoefficient
+{
+  enum class Type
+  {
+    UNIFORM,
+    COAXIAL
+  };
+
+  Type type = Type::UNIFORM;
+  mfem::Array<int> attr_list;
+  double scale = 1.0;
+  std::array<double, 3> direction = {0.0, 0.0, 0.0};
+  std::array<double, 3> origin = {0.0, 0.0, 0.0};
+};
+
+//
+// Class to compute reducing output functionals (integrals of functions of solution
+// fields) over boundary element sets using libCEED, supporting full (non-trace)
+// evaluation of volume fields at boundary element quadrature points. Non-reducing
+// visualization point fields are exposed through PointFieldEvaluator, which uses private
+// boundary point-field assembly hooks here. This enables postprocessing measurements
+// (interface dielectric energy participation, surface fluxes, port powers, etc.) to
+// execute on the device, in contrast to the legacy mfem::Coefficient-based paths which
+// are host-only.
+//
+// The key construction: for each boundary element, the field is evaluated from an
+// attached volume element (or both, with averaging or differencing, for interior
+// boundaries, following the conventions of BdrGridFunctionCoefficient and its derived
+// legacy coefficients). AtPoints-capable groups keep mapped reference points as runtime
+// data; mapped-integration-rule groups use per-assembly integer identities rather than
+// rounded coordinate keys. Processor-boundary ghost values are requested through
+// FaceNbrFieldExchange with integer/topological reference-face orientation keys so point
+// identity never depends on fuzzy coordinate matching.
+//
+class SurfaceFunctional
+{
+public:
+  enum class Kind
+  {
+    AREA,           // ∫ dS (no field input, for validation)
+    HCURL_NORM2,    // ∫ |u|² dS for an H(curl) field u (single-sided, for validation)
+    INTERFACE_EPR,  // Interface dielectric energy following InterfaceDielectricCoefficient
+    SURFACE_FLUX,   // Surface flux following BdrSurfaceFluxCoefficient
+    FARFIELD        // Stratton-Chu far-field following AddStrattonChuIntegrandAtElement
+  };
+
+private:
+  friend class PointFieldEvaluator;
+
+  // Internal backend selector. Public SurfaceFunctional::Kind is reduction-only;
+  // non-reducing boundary visualization entries are reachable only through
+  // PointFieldEvaluator's private backend hooks.
+  enum class KernelKind
+  {
+    AREA,
+    HCURL_NORM2,
+    INTERFACE_EPR,
+    SURFACE_FLUX,
+    FARFIELD,
+    MODE_OVERLAP,
+    BDR_FIELD_E,
+    BDR_FIELD_B,
+    BDR_FLUX_Q,
+    BDR_CURRENT_J,
+    BDR_ENERGY_E,
+    BDR_ENERGY_M,
+    BDR_POYNTING
+  };
+
+  static KernelKind ToKernelKind(Kind kind);
+  static KernelKind ToKernelKind(PointFieldKind kind);
+  static const char *KindName(KernelKind kind);
+
+  // Whether the backend kind fills a per-point visualization buffer (vs. computing
+  // reductions).
+  static bool IsBufferKind(KernelKind kind)
+  {
+    return kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+           kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_CURRENT_J ||
+           kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
+           kind == KernelKind::BDR_POYNTING;
+  }
+
+  // Number of components per visualization point for buffer kinds.
+  static int BufferNumComp(KernelKind kind)
+  {
+    return (kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_ENERGY_E ||
+            kind == KernelKind::BDR_ENERGY_M)
+               ? 1
+               : 3;
+  }
+
+  // Total buffer size (all boundary elements, lattice points, components) and
+  // per-element point-base offsets for the boundary visualization field kinds. Vector
+  // buffers are component-major: x[points], y[points], z[points].
+  int BufferSize() const { return buffer_size; }
+  const std::vector<int> &BufferBases() const { return buffer_bases; }
+
+  // Computation kind and integrand parameters.
+  KernelKind kind;
+  InterfaceDielectric epr_type = InterfaceDielectric::DEFAULT;
+  double epr_t = 0.0, epr_epsilon = 0.0;
+  SurfaceFlux flux_type = SurfaceFlux::ELECTRIC;
+  bool flux_two_sided = false;
+  mfem::Vector flux_x0;
+  std::vector<std::array<double, 3>> farfield_dirs;
+  std::complex<double> farfield_omega = 0.0;
+  std::map<int, SurfaceModeCoefficient> mode_coeff_by_attr;
+
+  // Boundary visualization field kinds: lattice refinement level, output scaling,
+  // total output buffer size, and per-boundary-element point-base offsets into the
+  // component-major buffer.
+  int viz_lod = 0;
+  double viz_scaling = 1.0;
+  int buffer_size = 0;
+  std::vector<int> buffer_bases;
+  std::vector<int> trace_bdr_indices;
+
+  // Field finite element spaces (not owned): nd_fespace for H(curl) fields (source index
+  // 0), rt_fespace for H(div) fields (source index 1). Either may be nullptr depending
+  // on the functional kind. Material operator (not owned) for material property lookups
+  // and side selection.
+  const mfem::ParFiniteElementSpace *nd_fespace;
+  const mfem::ParFiniteElementSpace *rt_fespace;
+  const MaterialOperator *mat_op;
+
+  // Whether the functional could be assembled. False means the configuration is outside
+  // the current support matrix; model-level callers may explicitly use legacy code for
+  // those cases, but supported cases should treat invalid assembly as an error rather
+  // than silently falling back.
+  bool valid = true;
+
+  // MPI communicator from the mesh.
+  MPI_Comm comm;
+
+  // Per-group assembled libCEED operators, accumulating per-element integrals into the
+  // local output vector. The element attribute vectors are operator inputs and must
+  // outlive the operators.
+  std::vector<fem::CeedGroupOperator> groups;
+  std::deque<Vector> elem_attrs;
+
+  // Face neighbor field exchange for two-sided interior boundaries crossing parallel
+  // interfaces: the owning process pulls the neighbor (ghost) volume field values at the
+  // face quadrature points, fed to the ghost side of the two-sided operators (nullptr
+  // when no marked boundary element has a ghost neighbor). Refilled before each apply.
+  std::unique_ptr<FaceNbrFieldExchange> face_nbr_exchange;
+
+  // Staging vector used to initialize the field input CeedVectors at construction. The
+  // field CeedVectors are re-pointed at the caller's data on each Eval() call.
+  mutable Vector field_staging;
+
+  // Local output vector with one slot per marked boundary element on this process.
+  // Integral functionals also keep the originating boundary attribute for each slot so
+  // batched model-level callers can recover several independent reductions from one
+  // assembled operator without changing the per-element libCEED kernels.
+  mutable Vector local_out;
+  std::vector<int> local_out_attrs;
+
+  void Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
+  void AssembleLocal(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
+
+  // Apply all group operators with the field inputs pointed at the given source
+  // vectors, accumulating into the local output vector.
+  void ApplyAdd(const std::array<const Vector *, 4> &srcs) const;
+
+  // Zero the local output vector, apply, and return the local sum (no MPI reduction).
+  double EvalLocal(const std::array<const Vector *, 4> &srcs) const;
+
+  // Construct boundary point-field evaluators. These are intentionally private to keep
+  // SurfaceFunctional reduction-oriented at call sites; PointFieldEvaluator owns the
+  // non-reducing visualization API.
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &fespace, int lod);
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &fespace,
+                    const MaterialOperator &mat_op, int lod, double scaling);
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &nd_fespace,
+                    const mfem::ParFiniteElementSpace &rt_fespace,
+                    const MaterialOperator &mat_op, int lod, double scaling);
+
+  // Fill boundary visualization buffers. Friend-only; non-reducing callers use
+  // PointFieldEvaluator. Continuous trace fields (E_t/B_n) use boundary/face DOFs
+  // directly on the MFEM boundary-element tessellation.
+  void EvalTraceFieldBuffer(const Vector &u, Vector &buffer) const;
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &E, const GridFunction &B, Vector &buffer) const;
+
+public:
+  // Returns false when libCEED surface functionals have been globally disabled via the
+  // PALACE_LEGACY_SURFACE_POSTPRO environment variable (legacy mfem::Coefficient paths
+  // are used instead, for debugging and benchmarking).
+  static bool Enabled();
+
+  // Construct a functional over the boundary elements with marked attributes (marker
+  // over global mfem boundary attributes). For field-less functionals (AREA), fespace
+  // may be nullptr but the mesh is still required.
+  SurfaceFunctional(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace *fespace = nullptr);
+
+  // Construct an interface dielectric energy participation functional with the given
+  // interface type, thickness, and permittivity (see InterfaceDielectricCoefficient).
+  SurfaceFunctional(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &nd_fespace,
+                    const MaterialOperator &mat_op, InterfaceDielectric type, double t_i,
+                    double epsilon_i);
+
+  // Construct a surface flux functional (see BdrSurfaceFluxCoefficient). The required
+  // finite element spaces depend on the flux type: ELECTRIC requires nd_fespace,
+  // MAGNETIC requires rt_fespace, POWER requires both.
+  SurfaceFunctional(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace *nd_fespace,
+                    const mfem::ParFiniteElementSpace *rt_fespace,
+                    const MaterialOperator &mat_op, SurfaceFlux type, bool two_sided,
+                    const mfem::Vector &x0);
+
+  // Construct a Stratton-Chu far-field functional for the given observation directions
+  // (see AddStrattonChuIntegrandAtElement; external boundaries only).
+  SurfaceFunctional(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &nd_fespace,
+                    const mfem::ParFiniteElementSpace &rt_fespace,
+                    const MaterialOperator &mat_op,
+                    const std::vector<std::array<double, 3>> &r_naughts);
+
+  // Construct a linear H(curl) mode-overlap functional, ∫ E · f_mode dS, for lumped-port
+  // voltage and S-parameter extraction. The mode coefficient data is real-valued; complex
+  // fields are evaluated by applying the same functional to the real and imaginary parts.
+  SurfaceFunctional(const Mesh &mesh, const mfem::ParFiniteElementSpace &nd_fespace,
+                    const std::vector<SurfaceModeCoefficient> &mode_coeffs);
+
+  ~SurfaceFunctional();
+
+  SurfaceFunctional(const SurfaceFunctional &) = delete;
+  SurfaceFunctional &operator=(const SurfaceFunctional &) = delete;
+
+  // Whether the functional was successfully assembled. When false, evaluation is not
+  // possible. Supported model-level paths should error rather than silently falling back;
+  // explicit legacy/oracle paths remain available for unsupported configurations and
+  // validation.
+  bool IsValid() const { return valid; }
+
+  // Evaluate the functional for the given field (L-vector, e.g. the local vector of a
+  // GridFunction on the field space). Collective on the mesh communicator. For
+  // field-less functionals, u is ignored and may be nullptr.
+  double Eval(const Vector *u = nullptr) const;
+
+  // Evaluate the functional for the given (possibly complex-valued) grid function. For
+  // complex fields, the real and imaginary part contributions add (the implemented
+  // integrands are quadratic in the field). Collective on the mesh communicator.
+  double Eval(const GridFunction &u) const;
+
+  // Evaluate a surface flux functional for the given fields (either of which may be
+  // nullptr if not required by the flux type). For complex-valued fields, returns the
+  // real and imaginary parts of the flux (ELECTRIC, MAGNETIC), or the stationary real
+  // power (POWER). Collective on the mesh communicator.
+  std::complex<double> EvalFlux(const GridFunction *E, const GridFunction *B) const;
+
+  // Evaluate the complex power P = ∫ E ⋅ (n x H) dS following the conventions of
+  // LumpedPortData::GetPower (two-sided POWER flux functionals only). Collective on the
+  // mesh communicator.
+  std::complex<double> EvalComplexPower(const GridFunction &E, const GridFunction &B) const;
+
+  // Same complex-power convention as EvalComplexPower, but return one result per
+  // boundary-attribute bin. attr_to_bin is indexed by boundary attribute - 1 and uses -1
+  // for attributes not assigned to any output bin. This enables safe batching of many
+  // disjoint port surfaces while retaining per-port scalar outputs. Collective on the
+  // mesh communicator.
+  std::vector<std::complex<double>>
+  EvalComplexPowerByAttribute(const GridFunction &E, const GridFunction &B,
+                              const mfem::Array<int> &attr_to_bin, int num_bins) const;
+
+  // Evaluate the far-field rE integrals for all observation directions at the given
+  // (complex) frequency, following SurfacePostOperator::GetFarFieldrE. Reassembles when
+  // the frequency changes. Collective on the mesh communicator.
+  std::vector<std::array<std::complex<double>, 3>>
+  EvalFarField(const GridFunction &E, const GridFunction &B, std::complex<double> omega);
+
+  // Evaluate the linear mode-overlap functional, returning the complex integral when the
+  // supplied field has real and imaginary parts.
+  std::complex<double> EvalModeOverlap(const GridFunction &E) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_OUTPUT_FUNCTIONALS_HPP

--- a/palace/fem/postprocessing_backend.cpp
+++ b/palace/fem/postprocessing_backend.cpp
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fem/postprocessing_backend.hpp"
+
+namespace palace
+{
+
+namespace fem
+{
+
+bool LibceedPostprocessingEnabled()
+{
+  return true;
+}
+
+}  // namespace fem
+
+}  // namespace palace

--- a/palace/fem/postprocessing_backend.hpp
+++ b/palace/fem/postprocessing_backend.hpp
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_POSTPROCESSING_BACKEND_HPP
+#define PALACE_FEM_POSTPROCESSING_BACKEND_HPP
+
+namespace palace
+{
+
+namespace fem
+{
+
+// Central query for libCEED-backed postprocessing availability. Supported production
+// postprocessing paths use the libCEED backend directly; coefficient implementations are
+// retained only as reference semantics in tests and for explicitly unsupported features.
+bool LibceedPostprocessingEnabled();
+
+}  // namespace fem
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_POSTPROCESSING_BACKEND_HPP

--- a/palace/fem/qfunctions/21/surf_21_qf.h
+++ b/palace/fem/qfunctions/21/surf_21_qf.h
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_SURF_21_QF_H
+#define PALACE_LIBCEED_SURF_21_QF_H
+
+#include "../22/utils_22_qf.h"
+#include "../coeff/coeff_2_qf.h"
+#include "utils_21_qf.h"
+
+// QFunctions for line output functionals (integrals of functions of fields over boundary
+// elements of a 2D mesh). This mirrors the 3D surface functional kernels in surf_32_qf.h,
+// but the boundary element is a segment embedded in 2D and H(curl) fields are 2-vectors.
+
+// Line measure qw * |J_f| and unit normal from the raw boundary element Jacobian. This
+// matches mfem::CalcOrtho for 2x1 Jacobians: n = (dy, -dx), then normalized.
+CEED_QFUNCTION_HELPER CeedScalar SurfMeasure21(const CeedScalar J_f[2], CeedScalar n[2])
+{
+  n[0] = J_f[1];
+  n[1] = -J_f[0];
+  const CeedScalar detJ = sqrt(n[0] * n[0] + n[1] * n[1]);
+  n[0] /= detJ;
+  n[1] /= detJ;
+  return detJ;
+}
+
+// H(curl) field at a point from the raw volume Jacobian: E = adj(J_v)^T/detJ_v u.
+CEED_QFUNCTION_HELPER void SurfHcurlField21(CeedInt i, CeedInt Q, const CeedScalar *J_v,
+                                            const CeedScalar *u, CeedScalar E[2])
+{
+  const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+  CeedScalar J_loc[4], adjJt_loc[4];
+  MatUnpack22(J_v + i, Q, J_loc);
+  const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+  MultBx22(adjJt_loc, u_loc, E);
+  E[0] /= detJ;
+  E[1] /= detJ;
+}
+
+// Two-sided H(curl) average: E = 1/2 (E_1 + E_2).
+CEED_QFUNCTION_HELPER void
+SurfHcurlField2Avg21(CeedInt i, CeedInt Q, const CeedScalar *J_v1, const CeedScalar *J_v2,
+                     const CeedScalar *u_1, const CeedScalar *u_2, CeedScalar E[2])
+{
+  CeedScalar E_2[2];
+  SurfHcurlField21(i, Q, J_v1, u_1, E);
+  SurfHcurlField21(i, Q, J_v2, u_2, E_2);
+  E[0] = 0.5 * (E[0] + E_2[0]);
+  E[1] = 0.5 * (E[1] + E_2[1]);
+}
+
+// Line measure: v = qw * |J_f|. Inputs: qw, grad_x_f.
+CEED_QFUNCTION(f_integ_surf_area_21)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *qw = in[0], *J_f = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    v[i] = qw[i] * SurfMeasure21(J_f_loc, n);
+  }
+  return 0;
+}
+
+// Squared L2 norm of an H(curl) field: v = qw * |J_f| * |E|^2. Inputs: qw,
+// grad_x_f, attr_1, grad_x_1, u_1.
+CEED_QFUNCTION(f_integ_surf_hcurl_norm2_21)(void *, CeedInt Q, const CeedScalar *const *in,
+                                            CeedScalar *const *out)
+{
+  const CeedScalar *qw = in[0], *J_f = in[1], *J_v = in[3], *u = in[4];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfHcurlField21(i, Q, J_v, u, E);
+    v[i] = qw[i] * SurfMeasure21(J_f_loc, n) * (E[0] * E[0] + E[1] * E[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprDefault21(const CeedIntScalar *ctx,
+                                                  const CeedScalar E[2])
+{
+  return ctx[0].second * (E[0] * E[0] + E[1] * E[1]);
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprMA21(const CeedIntScalar *ctx,
+                                             const CeedScalar n[2], const CeedScalar E[2])
+{
+  const CeedScalar En = n[0] * E[0] + n[1] * E[1];
+  return ctx[0].second * En * En;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprMS21(const CeedIntScalar *ctx, CeedInt attr,
+                                             const CeedScalar n[2], const CeedScalar E[2])
+{
+  CeedScalar eps[4], D[2];
+  CoeffUnpack2(ctx + 2, attr, eps);
+  MultBx22(eps, E, D);
+  const CeedScalar Dn = n[0] * D[0] + n[1] * D[1];
+  return ctx[0].second * Dn * Dn;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprSA21(const CeedIntScalar *ctx,
+                                             const CeedScalar n[2], const CeedScalar E[2])
+{
+  const CeedScalar En = n[0] * E[0] + n[1] * E[1];
+  const CeedScalar Et2 = E[0] * E[0] + E[1] * E[1] - En * En;
+  return ctx[0].second * Et2 + ctx[1].second * En * En;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEpr21(const CeedIntScalar *ctx, CeedInt attr,
+                                           const CeedScalar n[2], const CeedScalar E[2])
+{
+  switch (ctx[0].first)
+  {
+    case 0:
+      return SurfEprDefault21(ctx + 1, E);
+    case 1:
+      return SurfEprMA21(ctx + 1, n, E);
+    case 2:
+      return SurfEprMS21(ctx + 1, attr, n, E);
+    default:  // 3: SA
+      return SurfEprSA21(ctx + 1, n, E);
+  }
+}
+
+// Single-sided interface dielectric. Inputs: qw, grad_x_f, attr_1, grad_x_1, u_1.
+CEED_QFUNCTION(f_integ_surf_epr_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v = in[3], *u = in[4];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure21(J_f_loc, n);
+    SurfHcurlField21(i, Q, J_v, u, E);
+    v[i] = wdetJ * SurfEpr21(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+// Two-sided (averaged) interface dielectric. Inputs: qw, grad_x_f, attr_1, grad_x_1,
+// attr_2, grad_x_2, u_1, u_2.
+CEED_QFUNCTION(f_integ_surf_epr_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v1 = in[3], *J_v2 = in[5],
+                   *u_1 = in[6], *u_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure21(J_f_loc, n);
+    SurfHcurlField2Avg21(i, Q, J_v1, J_v2, u_1, u_2, E);
+    v[i] = wdetJ * SurfEpr21(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_SURF_21_QF_H

--- a/palace/fem/qfunctions/22/eval_22_qf.h
+++ b/palace/fem/qfunctions/22/eval_22_qf.h
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_EVAL_22_QF_H
+#define PALACE_LIBCEED_EVAL_22_QF_H
+
+#include "../coeff/coeff_1_qf.h"
+#include "../coeff/coeff_2_qf.h"
+#include "utils_22_qf.h"
+
+// QFunctions for pointwise evaluation of derived field quantities at arbitrary points
+// of 2D volume elements. No quadrature weighting is applied. H(curl):
+// E = adj(J)^T / detJ u. The 2D magnetic flux density B is scalar-valued (out of
+// plane), with H_z = mu^{-1}_{zz} B_z supplied through a scalar coefficient context.
+
+// Electric energy density: v = 0.5 * scale * (eps_r E) . E.
+CEED_QFUNCTION(f_eval_energy_e_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2], eps[4], D[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, u_loc, E);
+    CoeffUnpack2(ctx + 1, (CeedInt)attr[i], eps);
+    MultBx22(eps, E, D);
+    v[i] = 0.5 * ctx[0].second * (D[0] * E[0] + D[1] * E[1]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Magnetic energy density: v = 0.5 * scale * mu^{-1}_{zz} B_z^2.
+CEED_QFUNCTION(f_eval_energy_m_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar invmu_zz = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]);
+    v[i] = 0.5 * ctx[0].second * invmu_zz * u[i] * u[i];
+  }
+  return 0;
+}
+
+// Poynting vector: v = scale * E x (H_z zhat) = scale * H_z * (E_y, -E_x).
+CEED_QFUNCTION(f_eval_poynting_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[2] = {u_e[i + Q * 0], u_e[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, ue_loc, E);
+    const CeedScalar H_z = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]) * u_b[i];
+    const CeedScalar s = ctx[0].second * H_z / detJ;
+    v[i + Q * 0] = s * E[1];
+    v[i + Q * 1] = -s * E[0];
+  }
+  return 0;
+}
+
+// Pointwise H(curl) field value: v = adj(J)^T/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hcurl_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, u_loc, E);
+    v[i + Q * 0] = E[0] / detJ;
+    v[i + Q * 1] = E[1] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise H(div) field value: v = J/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hdiv_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], B[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = DetJ22(J_loc);
+    MultBx22(J_loc, u_loc, B);
+    v[i + Q * 0] = B[0] / detJ;
+    v[i + Q * 1] = B[1] / detJ;
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_EVAL_22_QF_H

--- a/palace/fem/qfunctions/32/surf_32_qf.h
+++ b/palace/fem/qfunctions/32/surf_32_qf.h
@@ -1,0 +1,841 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_SURF_32_QF_H
+#define PALACE_LIBCEED_SURF_32_QF_H
+
+#include "../33/utils_33_qf.h"
+#include "../coeff/coeff_3_qf.h"
+#include "utils_32_qf.h"
+
+// QFunctions for surface output functionals (integrals of functions of fields over
+// boundary elements of a 3D mesh). The element geometry is computed on the fly from
+// mesh node gradients (as in geom_qf.h) instead of stored geometry factor data:
+//  - "qw": quadrature weights (CEED_EVAL_WEIGHT).
+//  - "grad_x_f": boundary element mesh node Jacobians J_f, shape [3x2, Q]. The surface
+//    measure is qw * detJ_f and the surface normal is the normalized cross product of
+//    the columns of J_f (matching mfem::CalcOrtho orientation: outward for exterior
+//    boundaries, out of element 1 in general; the legacy boundary element orientation
+//    flip is applied via the context normal sign).
+//  - "attr_k" / "grad_x_k": attached volume element attributes (for material lookup)
+//    and mesh node Jacobians J_v at the mapped face quadrature points, for the Piola
+//    transformations H(curl): E = adj(J_v)ᵀ/detJ_v u, H(div): B = J_v/detJ_v u, for
+//    evaluation side k = 1 (and 2 for two-sided interior boundary evaluation).
+//  - "x": coordinates at the face quadrature points (surface flux only).
+//  - "u_k": field inputs (reference components at the mapped face quadrature points).
+// The output is the integrand times the surface measure, summed over quadrature points
+// by the all-ones output element basis, yielding one value per boundary element.
+
+// Surface measure qw * detJ_f and unit normal from the raw boundary element Jacobian.
+CEED_QFUNCTION_HELPER CeedScalar SurfMeasure32(const CeedScalar J_f[6], CeedScalar n[3])
+{
+  n[0] = J_f[1] * J_f[5] - J_f[2] * J_f[4];
+  n[1] = J_f[2] * J_f[3] - J_f[0] * J_f[5];
+  n[2] = J_f[0] * J_f[4] - J_f[1] * J_f[3];
+  const CeedScalar detJ = sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+  n[0] /= detJ;
+  n[1] /= detJ;
+  n[2] /= detJ;
+  return detJ;
+}
+
+// H(curl) field at a point from the raw volume Jacobian: E = adj(J_v)ᵀ/detJ_v u.
+CEED_QFUNCTION_HELPER void SurfHcurlField32(CeedInt i, CeedInt Q, const CeedScalar *J_v,
+                                            const CeedScalar *u, CeedScalar E[3])
+{
+  const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+  CeedScalar J_loc[9], adjJt_loc[9];
+  MatUnpack33(J_v + i, Q, J_loc);
+  const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+  MultAx33(adjJt_loc, u_loc, E);
+  E[0] /= detJ;
+  E[1] /= detJ;
+  E[2] /= detJ;
+}
+
+// H(div) field at a point from the raw volume Jacobian: B = J_v/detJ_v u.
+CEED_QFUNCTION_HELPER void SurfHdivField32(CeedInt i, CeedInt Q, const CeedScalar *J_v,
+                                           const CeedScalar *u, CeedScalar B[3])
+{
+  const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+  CeedScalar J_loc[9], adjJt_loc[9];
+  MatUnpack33(J_v + i, Q, J_loc);
+  const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+  MultAx33(J_loc, u_loc, B);
+  B[0] /= detJ;
+  B[1] /= detJ;
+  B[2] /= detJ;
+}
+
+// Two-sided H(curl) average: E = 1/2 (E_1 + E_2).
+CEED_QFUNCTION_HELPER void
+SurfHcurlField2Avg32(CeedInt i, CeedInt Q, const CeedScalar *J_v1, const CeedScalar *J_v2,
+                     const CeedScalar *u_1, const CeedScalar *u_2, CeedScalar E[3])
+{
+  CeedScalar E_2[3];
+  SurfHcurlField32(i, Q, J_v1, u_1, E);
+  SurfHcurlField32(i, Q, J_v2, u_2, E_2);
+  E[0] = 0.5 * (E[0] + E_2[0]);
+  E[1] = 0.5 * (E[1] + E_2[1]);
+  E[2] = 0.5 * (E[2] + E_2[2]);
+}
+
+// Surface area: v = qw * detJ_f. Inputs: qw, grad_x_f.
+CEED_QFUNCTION(f_integ_surf_area_32)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *qw = in[0], *J_f = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    v[i] = qw[i] * SurfMeasure32(J_f_loc, n);
+  }
+  return 0;
+}
+
+// Squared L2 norm of an H(curl) field: v = qw * detJ_f * |E|². Inputs: qw, grad_x_f,
+// attr_1, grad_x_1, u_1.
+CEED_QFUNCTION(f_integ_surf_hcurl_norm2_32)(void *, CeedInt Q, const CeedScalar *const *in,
+                                            CeedScalar *const *out)
+{
+  const CeedScalar *qw = in[0], *J_f = in[1], *J_v = in[3], *u = in[4];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfHcurlField32(i, Q, J_v, u, E);
+    v[i] = qw[i] * SurfMeasure32(J_f_loc, n) * (E[0] * E[0] + E[1] * E[1] + E[2] * E[2]);
+  }
+  return 0;
+}
+
+// Interface dielectric energy participation integrands following
+// InterfaceDielectricCoefficient (fem/coefficient.hpp):
+//   DEFAULT: v = scale0 * |E|²,           scale0 = 0.5 * t * eps
+//   MA:      v = scale0 * |n.E|²,         scale0 = 0.5 * t / eps
+//   MS:      v = scale0 * |n.(eps_S E)|², scale0 = 0.5 * t / eps, eps_S from the
+//            material table looked up with the side 1 volume attribute
+//   SA:      v = scale0 * |E_t|² + scale1 * |E_n|², scale0 = 0.5 * t * eps,
+//            scale1 = 0.5 * t / eps
+// all times the surface measure. The context is a CeedIntScalar array: [0].first =
+// epr_type (0 = DEFAULT, 1 = MA, 2 = MS, 3 = SA; selects the integrand at runtime, in its
+// own slot since CeedIntScalar is a union), [1].second = scale0, [2].second = scale1,
+// followed by an (optional, MS only) material property coefficient context. The shared
+// kernel passes ctx + 1 to the per-type helpers. The "_1" variants evaluate from a single
+// element; the "_2" variants average the fields from both sides of an interior
+// boundary. The normal direction sign is irrelevant (quadratic in n . E).
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprDefault(const CeedIntScalar *ctx,
+                                                const CeedScalar E[3])
+{
+  return ctx[0].second * (E[0] * E[0] + E[1] * E[1] + E[2] * E[2]);
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprMA(const CeedIntScalar *ctx, const CeedScalar n[3],
+                                           const CeedScalar E[3])
+{
+  const CeedScalar En = n[0] * E[0] + n[1] * E[1] + n[2] * E[2];
+  return ctx[0].second * En * En;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprMS(const CeedIntScalar *ctx, CeedInt attr,
+                                           const CeedScalar n[3], const CeedScalar E[3])
+{
+  CeedScalar eps[9], D[3];
+  CoeffUnpack3(ctx + 2, attr, eps);
+  MultAx33(eps, E, D);
+  const CeedScalar Dn = n[0] * D[0] + n[1] * D[1] + n[2] * D[2];
+  return ctx[0].second * Dn * Dn;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEprSA(const CeedIntScalar *ctx, const CeedScalar n[3],
+                                           const CeedScalar E[3])
+{
+  const CeedScalar En = n[0] * E[0] + n[1] * E[1] + n[2] * E[2];
+  const CeedScalar Et2 = E[0] * E[0] + E[1] * E[1] + E[2] * E[2] - En * En;
+  return ctx[0].second * Et2 + ctx[1].second * En * En;
+}
+
+// Single-sided / two-sided interface dielectric. The four interface types (DEFAULT,
+// MA, MS, SA) share one compiled kernel: the type is selected at runtime from
+// ctx[0].first (0 = DEFAULT, 1 = MA, 2 = MS, 3 = SA). Because the type is uniform across
+// the operator this is a divergence-free branch over the existing per-type helpers, so a
+// single kernel replaces the per-type specializations at no runtime cost. The type sits
+// in its own slot (CeedIntScalar is a union, so .first and .second of one slot alias);
+// the per-type helpers see the rest of the context via ctx + 1 (scale0, scale1, ...).
+CEED_QFUNCTION_HELPER CeedScalar SurfEpr(const CeedIntScalar *ctx, CeedInt attr,
+                                         const CeedScalar n[3], const CeedScalar E[3])
+{
+  switch (ctx[0].first)
+  {
+    case 0:
+      return SurfEprDefault(ctx + 1, E);
+    case 1:
+      return SurfEprMA(ctx + 1, n, E);
+    case 2:
+      return SurfEprMS(ctx + 1, attr, n, E);
+    default:  // 3: SA
+      return SurfEprSA(ctx + 1, n, E);
+  }
+}
+
+// Single-sided interface dielectric. Inputs: qw, grad_x_f, attr_1, grad_x_1, u_1.
+CEED_QFUNCTION(f_integ_surf_epr_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v = in[3], *u = in[4];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfHcurlField32(i, Q, J_v, u, E);
+    v[i] = wdetJ * SurfEpr(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+// Two-sided (averaged) interface dielectric. Inputs: qw, grad_x_f, attr_1, grad_x_1,
+// attr_2, grad_x_2, u_1, u_2.
+CEED_QFUNCTION(f_integ_surf_epr_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v1 = in[3], *J_v2 = in[5],
+                   *u_1 = in[6], *u_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfHcurlField2Avg32(i, Q, J_v1, J_v2, u_1, u_2, E);
+    v[i] = wdetJ * SurfEpr(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+// Linear H(curl) mode-overlap integral for lumped-port voltage and S-parameter
+// extraction: v = qw * detJ_f * E . f_mode. Context layout:
+// [0].first = mode type (0 = uniform, 1 = coaxial), [1].second = scale,
+// [2..4].second = direction (uniform) or origin (coaxial). Inputs: qw, grad_x_f,
+// grad_x_1, x, u_1.
+CEED_QFUNCTION(f_integ_surf_mode_32)(void *__restrict__ ctx_, CeedInt Q,
+                                     const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *J_v = in[2], *x = in[3], *u = in[4];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3], f[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfHcurlField32(i, Q, J_v, u, E);
+    if (ctx[0].first == 0)
+    {
+      const CeedScalar scale = ctx[1].second;
+      f[0] = scale * ctx[2].second;
+      f[1] = scale * ctx[3].second;
+      f[2] = scale * ctx[4].second;
+    }
+    else
+    {
+      f[0] = x[i + Q * 0] - ctx[2].second;
+      f[1] = x[i + Q * 1] - ctx[3].second;
+      f[2] = x[i + Q * 2] - ctx[4].second;
+      const CeedScalar r2 = f[0] * f[0] + f[1] * f[1] + f[2] * f[2];
+      const CeedScalar scale = ctx[1].second / r2;
+      f[0] *= scale;
+      f[1] *= scale;
+      f[2] *= scale;
+    }
+    v[i] = qw[i] * SurfMeasure32(J_f_loc, n) * (E[0] * f[0] + E[1] * f[1] + E[2] * f[2]);
+  }
+  return 0;
+}
+
+// Surface flux integrands following BdrSurfaceFluxCoefficient (fem/coefficient.hpp):
+//   ELECTRIC: V = eps E, MAGNETIC: V = B, POWER: V = E x (mu⁻¹ B),
+// with v = V . n times the surface measure. The context is a CeedIntScalar array:
+// [0].second = normal sign (legacy boundary element orientation flip), [1].first =
+// two_sided flag, [2..4].second = x0, followed by the material property context
+// (ELECTRIC: permittivity, POWER: inverse permeability). Two-sided contributions add
+// with opposite normals (V_1 - V_2); otherwise interior values average and the flux
+// sign is chosen per point so the normal points away from x0. The "_2" variants take
+// both sides. Inputs: qw, grad_x_f, attr_1, grad_x_1, [attr_2, grad_x_2,] x, u_k...
+
+CEED_QFUNCTION_HELPER CeedScalar SurfFluxFinalize(const CeedIntScalar *ctx, CeedInt i,
+                                                  CeedInt Q, CeedScalar n[3],
+                                                  const CeedScalar *x,
+                                                  const CeedScalar V[3])
+{
+  const CeedScalar s_n = ctx[0].second;
+  n[0] *= s_n;
+  n[1] *= s_n;
+  n[2] *= s_n;
+  CeedScalar flux = V[0] * n[0] + V[1] * n[1] + V[2] * n[2];
+  if (!ctx[1].first)
+  {
+    // Orient outward from the surface with the given center.
+    const CeedScalar dx[3] = {x[i + Q * 0] - ctx[2].second, x[i + Q * 1] - ctx[3].second,
+                              x[i + Q * 2] - ctx[4].second};
+    if (dx[0] * n[0] + dx[1] * n[1] + dx[2] * n[2] < 0.0)
+    {
+      flux = -flux;
+    }
+  }
+  return flux;
+}
+
+CEED_QFUNCTION_HELPER void SurfFluxCombine(const CeedIntScalar *ctx,
+                                           const CeedScalar V_2[3], CeedScalar V[3])
+{
+  if (ctx[1].first)
+  {
+    // Two-sided: add the contributions from opposite sides with opposite normals.
+    V[0] -= V_2[0];
+    V[1] -= V_2[1];
+    V[2] -= V_2[2];
+  }
+  else
+  {
+    // Average the values from both sides.
+    V[0] = 0.5 * (V[0] + V_2[0]);
+    V[1] = 0.5 * (V[1] + V_2[1]);
+    V[2] = 0.5 * (V[2] + V_2[2]);
+  }
+}
+
+CEED_QFUNCTION_HELPER void SurfFluxElectric(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                            CeedInt attr, const CeedScalar *J_v,
+                                            const CeedScalar *u, CeedScalar V[3])
+{
+  CeedScalar E[3], eps[9];
+  SurfHcurlField32(i, Q, J_v, u, E);
+  CoeffUnpack3(ctx + 5, attr, eps);
+  MultAx33(eps, E, V);
+}
+
+CEED_QFUNCTION_HELPER void SurfFluxPoynting(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                            CeedInt attr, const CeedScalar *J_v,
+                                            const CeedScalar *u_e, const CeedScalar *u_b,
+                                            CeedScalar V[3])
+{
+  CeedScalar E[3], B[3], invmu[9], H[3];
+  SurfHcurlField32(i, Q, J_v, u_e, E);
+  SurfHdivField32(i, Q, J_v, u_b, B);
+  CoeffUnpack3(ctx + 5, attr, invmu);
+  MultAx33(invmu, B, H);
+  V[0] = E[1] * H[2] - E[2] * H[1];
+  V[1] = E[2] * H[0] - E[0] * H[2];
+  V[2] = E[0] * H[1] - E[1] * H[0];
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_e_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v = in[3], *x = in[4],
+                   *u = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], V[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfFluxElectric(ctx, i, Q, (CeedInt)attr[i], J_v, u, V);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, V);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_e_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr_1 = in[2], *J_v1 = in[3],
+                   *attr_2 = in[4], *J_v2 = in[5], *x = in[6], *u_1 = in[7], *u_2 = in[8];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], V[3], V_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfFluxElectric(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_1, V);
+    SurfFluxElectric(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_2, V_2);
+    SurfFluxCombine(ctx, V_2, V);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, V);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_m_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *J_v = in[3], *x = in[4], *u = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v, u, B);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, B);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_m_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *J_v1 = in[3], *J_v2 = in[5], *x = in[6],
+                   *u_1 = in[7], *u_2 = in[8];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3], B_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v1, u_1, B);
+    SurfHdivField32(i, Q, J_v2, u_2, B_2);
+    SurfFluxCombine(ctx, B_2, B);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, B);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_p_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v = in[3], *x = in[4],
+                   *u_e = in[5], *u_b = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], S[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfFluxPoynting(ctx, i, Q, (CeedInt)attr[i], J_v, u_e, u_b, S);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, S);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_integ_surf_flux_p_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr_1 = in[2], *J_v1 = in[3],
+                   *attr_2 = in[4], *J_v2 = in[5], *x = in[6], *u_e_1 = in[7],
+                   *u_b_1 = in[8], *u_e_2 = in[9], *u_b_2 = in[10];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], S[3], S_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    SurfFluxPoynting(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_e_1, u_b_1, S);
+    SurfFluxPoynting(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_e_2, u_b_2, S_2);
+    SurfFluxCombine(ctx, S_2, S);
+    v[i] = wdetJ * SurfFluxFinalize(ctx, i, Q, n, x, S);
+  }
+  return 0;
+}
+
+// Stratton-Chu far-field integrand following AddStrattonChuIntegrandAtElement
+// (models/strattonchu.cpp): for each observation direction r0,
+//   I = (ik/4pi) [n x E - r0 x (n x ZH)] e^{ik r0.r'} dS,  ZH = c0 B, k = omega/c0,
+// with complex omega and fields. The context is a CeedIntScalar array: [0].second =
+// normal sign, [1].second = omega_re, [2].second = omega_im, [3].first = number of
+// directions N, [4].first = B-field Piola map (0 = H(curl), 1 = H(div)),
+// [5..5+3N).second = directions, followed by the (isotropic) light speed material
+// property context. The B-field Piola map matches GridFunction::GetVectorValue for the
+// supplied B space. Output: 6N components per element (Re I, Im I per direction, 3
+// each).
+// Inputs: qw, grad_x_f, attr_1, grad_x_1, x, u_1..u_4 = E_re, E_im, B_re, B_im
+// (external boundaries only).
+CEED_QFUNCTION(f_integ_surf_farfield_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *qw = in[0], *J_f = in[1], *attr = in[2], *J_v = in[3], *x = in[4],
+                   *u_er = in[5], *u_ei = in[6], *u_br = in[7], *u_bi = in[8];
+  CeedScalar *v = out[0];
+  const CeedScalar s_n = ctx[0].second, omega_re = ctx[1].second, omega_im = ctx[2].second;
+  const CeedInt N = ctx[3].first, b_hdiv = ctx[4].first;
+  const CeedIntScalar *dirs = ctx + 5, *mat = ctx + 5 + 3 * N;
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E_r[3], E_i[3], B_r[3], B_i[3], c0_mat[9], ZH_r[3],
+        ZH_i[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    const CeedScalar wdetJ = qw[i] * SurfMeasure32(J_f_loc, n);
+    n[0] *= s_n;
+    n[1] *= s_n;
+    n[2] *= s_n;
+    SurfHcurlField32(i, Q, J_v, u_er, E_r);
+    SurfHcurlField32(i, Q, J_v, u_ei, E_i);
+    if (b_hdiv)
+    {
+      SurfHdivField32(i, Q, J_v, u_br, B_r);
+      SurfHdivField32(i, Q, J_v, u_bi, B_i);
+    }
+    else
+    {
+      SurfHcurlField32(i, Q, J_v, u_br, B_r);
+      SurfHcurlField32(i, Q, J_v, u_bi, B_i);
+    }
+    CoeffUnpack3(mat, (CeedInt)attr[i], c0_mat);
+    MultAx33(c0_mat, B_r, ZH_r);
+    MultAx33(c0_mat, B_i, ZH_i);
+    const CeedScalar c0 = c0_mat[0];  // Isotropic (verified at setup)
+    const CeedScalar k_re = omega_re / c0, k_im = omega_im / c0;
+    const CeedScalar pre_re = -wdetJ * k_im / 12.566370614359172;
+    const CeedScalar pre_im = wdetJ * k_re / 12.566370614359172;
+
+    // n x E and n x ZH (real and imaginary parts).
+    const CeedScalar nxEr[3] = {n[1] * E_r[2] - n[2] * E_r[1],
+                                n[2] * E_r[0] - n[0] * E_r[2],
+                                n[0] * E_r[1] - n[1] * E_r[0]};
+    const CeedScalar nxEi[3] = {n[1] * E_i[2] - n[2] * E_i[1],
+                                n[2] * E_i[0] - n[0] * E_i[2],
+                                n[0] * E_i[1] - n[1] * E_i[0]};
+    const CeedScalar nxZHr[3] = {n[1] * ZH_r[2] - n[2] * ZH_r[1],
+                                 n[2] * ZH_r[0] - n[0] * ZH_r[2],
+                                 n[0] * ZH_r[1] - n[1] * ZH_r[0]};
+    const CeedScalar nxZHi[3] = {n[1] * ZH_i[2] - n[2] * ZH_i[1],
+                                 n[2] * ZH_i[0] - n[0] * ZH_i[2],
+                                 n[0] * ZH_i[1] - n[1] * ZH_i[0]};
+    const CeedScalar xp[3] = {x[i + Q * 0], x[i + Q * 1], x[i + Q * 2]};
+
+    for (CeedInt d = 0; d < N; d++)
+    {
+      const CeedScalar r0 = dirs[3 * d].second, r1 = dirs[3 * d + 1].second,
+                       r2 = dirs[3 * d + 2].second;
+      const CeedScalar dot = r0 * xp[0] + r1 * xp[1] + r2 * xp[2];
+      const CeedScalar amp = exp(-k_im * dot);
+      const CeedScalar cph = cos(k_re * dot), sph = sin(k_re * dot);
+      const CeedScalar w_re = amp * (pre_re * cph - pre_im * sph);
+      const CeedScalar w_im = amp * (pre_re * sph + pre_im * cph);
+
+      // A + iB = n x E - r0 x (n x ZH).
+      const CeedScalar A[3] = {nxEr[0] - (r1 * nxZHr[2] - r2 * nxZHr[1]),
+                               nxEr[1] - (r2 * nxZHr[0] - r0 * nxZHr[2]),
+                               nxEr[2] - (r0 * nxZHr[1] - r1 * nxZHr[0])};
+      const CeedScalar Bv[3] = {nxEi[0] - (r1 * nxZHi[2] - r2 * nxZHi[1]),
+                                nxEi[1] - (r2 * nxZHi[0] - r0 * nxZHi[2]),
+                                nxEi[2] - (r0 * nxZHi[1] - r1 * nxZHi[0])};
+      for (CeedInt c = 0; c < 3; c++)
+      {
+        v[i + Q * (6 * d + c)] = A[c] * w_re - Bv[c] * w_im;
+        v[i + Q * (6 * d + 3 + c)] = A[c] * w_im + Bv[c] * w_re;
+      }
+    }
+  }
+  return 0;
+}
+
+// Combined Piola transform selected at runtime by piola: H(curl) (0, E = adj(J)^T u /
+// detJ) or H(div) (1, B = J u / detJ). Lets the field and energy boundary-viz kernels
+// share one compiled kernel across the ND and RT field spaces.
+CEED_QFUNCTION_HELPER void SurfField32(CeedInt piola, CeedInt i, CeedInt Q,
+                                       const CeedScalar *J_v, const CeedScalar *u,
+                                       CeedScalar V[3])
+{
+  if (piola)
+  {
+    SurfHdivField32(i, Q, J_v, u, V);
+  }
+  else
+  {
+    SurfHcurlField32(i, Q, J_v, u, V);
+  }
+}
+
+// Pointwise boundary field values (no quadrature weighting; for visualization output at
+// the boundary element lattice points), following BdrFieldVectorCoefficient: the field
+// from the attached volume element, averaged over both sides for interior boundaries.
+// The H(curl)/H(div) space is selected at runtime from ctx[0].first, so the E (ND) and
+// B (RT) boundary fields share one kernel. Inputs ("_1"): grad_x_1, u_1; ("_2"):
+// grad_x_1, grad_x_2, u_1, u_2. Output: 3 components per point.
+CEED_QFUNCTION(f_eval_bdr_field_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[3];
+    SurfField32(ctx[0].first, i, Q, J_v, u, V);
+    v[i + Q * 0] = ctx[1].second * V[0];
+    v[i + Q * 1] = ctx[1].second * V[1];
+    v[i + Q * 2] = ctx[1].second * V[2];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v1 = in[0], *J_v2 = in[1], *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[3], V_2[3];
+    SurfField32(ctx[0].first, i, Q, J_v1, u_1, V);
+    SurfField32(ctx[0].first, i, Q, J_v2, u_2, V_2);
+    v[i + Q * 0] = ctx[1].second * 0.5 * (V[0] + V_2[0]);
+    v[i + Q * 1] = ctx[1].second * 0.5 * (V[1] + V_2[1]);
+    v[i + Q * 2] = ctx[1].second * 0.5 * (V[2] + V_2[2]);
+  }
+  return 0;
+}
+
+// Pointwise boundary surface charge, surface current, and energy density values at the
+// visualization lattice points, following BdrSurfaceFluxCoefficient<ELECTRIC>
+// (two-sided), BdrSurfaceCurrentVectorCoefficient, and EnergyDensityCoefficient
+// (boundary branch: per-side energies averaged). Context: [0].second = normal sign,
+// [1].second = scaling, material table at +2. Inputs ("_1"): grad_x_f, attr_1,
+// grad_x_1, u_1; ("_2"): grad_x_f, attr_1, grad_x_1, attr_2, grad_x_2, u_1, u_2.
+CEED_QFUNCTION(f_eval_bdr_flux_q_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3], eps[9], D[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHcurlField32(i, Q, J_v, u, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], eps);
+    MultAx33(eps, E, D);
+    v[i] = ctx[0].second * ctx[1].second * (D[0] * n[0] + D[1] * n[1] + D[2] * n[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_flux_q_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3], eps[9], D[3], D_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHcurlField32(i, Q, J_v1, u_1, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], eps);
+    MultAx33(eps, E, D);
+    SurfHcurlField32(i, Q, J_v2, u_2, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], eps);
+    MultAx33(eps, E, D_2);
+    // Two-sided: contributions from opposite sides add with opposite normals.
+    v[i] = ctx[0].second * ctx[1].second *
+           ((D[0] - D_2[0]) * n[0] + (D[1] - D_2[1]) * n[1] + (D[2] - D_2[2]) * n[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3], invmu[9], H[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v, u, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * (n[1] * H[2] - n[2] * H[1]);
+    v[i + Q * 1] = s * (n[2] * H[0] - n[0] * H[2]);
+    v[i + Q * 2] = s * (n[0] * H[1] - n[1] * H[0]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3], invmu[9], H[3], H_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v1, u_1, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], invmu);
+    MultAx33(invmu, B, H);
+    SurfHdivField32(i, Q, J_v2, u_2, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], invmu);
+    MultAx33(invmu, B, H_2);
+    H[0] -= H_2[0];
+    H[1] -= H_2[1];
+    H[2] -= H_2[2];
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * (n[1] * H[2] - n[2] * H[1]);
+    v[i + Q * 1] = s * (n[2] * H[0] - n[0] * H[2]);
+    v[i + Q * 2] = s * (n[0] * H[1] - n[1] * H[0]);
+  }
+  return 0;
+}
+
+// Boundary Poynting vector: per-side S = scale * E x (mu^-1 B), averaged over both
+// sides for interior boundaries. This matches PoyntingVectorCoefficient's boundary
+// branch: full vector, no n-dot, no 1/2 time-average factor. Context: [0].second =
+// scaling, material table at +1. Inputs ("_1"): attr_1, grad_x_1, u_e_1, u_b_1;
+// ("_2"): attr_1, grad_x_1, attr_2, grad_x_2, u_e_1, u_b_1, u_e_2, u_b_2.
+CEED_QFUNCTION_HELPER void SurfPoynting32(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                          CeedInt attr, const CeedScalar *J_v,
+                                          const CeedScalar *u_e, const CeedScalar *u_b,
+                                          CeedScalar S[3])
+{
+  CeedScalar E[3], B[3], invmu[9], H[3];
+  SurfHcurlField32(i, Q, J_v, u_e, E);
+  SurfHdivField32(i, Q, J_v, u_b, B);
+  CoeffUnpack3(ctx + 1, attr, invmu);
+  MultAx33(invmu, B, H);
+  S[0] = E[1] * H[2] - E[2] * H[1];
+  S[1] = E[2] * H[0] - E[0] * H[2];
+  S[2] = E[0] * H[1] - E[1] * H[0];
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[3];
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr[i], J_v, u_e, u_b, S);
+    const CeedScalar s = ctx[0].second;
+    v[i + Q * 0] = s * S[0];
+    v[i + Q * 1] = s * S[1];
+    v[i + Q * 2] = s * S[2];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_e_1 = in[4], *u_b_1 = in[5], *u_e_2 = in[6], *u_b_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[3], S_2[3];
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_e_1, u_b_1, S);
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_e_2, u_b_2, S_2);
+    const CeedScalar s = 0.5 * ctx[0].second;
+    v[i + Q * 0] = s * (S[0] + S_2[0]);
+    v[i + Q * 1] = s * (S[1] + S_2[1]);
+    v[i + Q * 2] = s * (S[2] + S_2[2]);
+  }
+  return 0;
+}
+
+// Boundary energy densities: per-side 1/2 (mat F).F with the side attribute, averaged
+// over both sides for interior boundaries. The H(curl)/H(div) space is selected at
+// runtime from ctx[0].first; ctx[1].second = scaling, material table at +2. Inputs
+// ("_1"): attr_1, grad_x_1, u_1; ("_2"): attr_1, grad_x_1, attr_2, grad_x_2, u_1,
+// u_2.
+CEED_QFUNCTION(f_eval_bdr_energy_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar F[3], mat[9], G[3];
+    SurfField32(ctx[0].first, i, Q, J_v, u, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], mat);
+    MultAx33(mat, F, G);
+    v[i] = 0.5 * ctx[1].second * (G[0] * F[0] + G[1] * F[1] + G[2] * F[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_1 = in[4], *u_2 = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar F[3], mat[9], G[3];
+    SurfField32(ctx[0].first, i, Q, J_v1, u_1, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], mat);
+    MultAx33(mat, F, G);
+    CeedScalar U = G[0] * F[0] + G[1] * F[1] + G[2] * F[2];
+    SurfField32(ctx[0].first, i, Q, J_v2, u_2, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], mat);
+    MultAx33(mat, F, G);
+    U = 0.5 * (U + G[0] * F[0] + G[1] * F[1] + G[2] * F[2]);
+    v[i] = 0.5 * ctx[1].second * U;
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_SURF_32_QF_H

--- a/palace/fem/qfunctions/33/eval_33_qf.h
+++ b/palace/fem/qfunctions/33/eval_33_qf.h
@@ -1,0 +1,137 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_EVAL_33_QF_H
+#define PALACE_LIBCEED_EVAL_33_QF_H
+
+#include "../coeff/coeff_3_qf.h"
+#include "utils_33_qf.h"
+
+// QFunctions for pointwise evaluation of derived field quantities at arbitrary points
+// of 3D volume elements (for example the nodal points of an interpolatory output space
+// for visualization). No quadrature weighting is applied; the element geometry is
+// computed on the fly from the mesh nodes gradient (as in geom_qf.h) instead of stored
+// geometry factor data. Contributions of repeated applications accumulate at the output
+// L-vector (CeedOperatorApplyAdd), which implements the real/imaginary part sums of the
+// quadratic quantities.
+//
+// Inputs: in[0] is element attributes, shape [Q]
+//         in[1] is mesh node Jacobians, shape [qcomp=dim, ncomp=space_dim, Q]
+//         in[2], in[3] are field inputs (reference components at the points)
+// The context is a CeedIntScalar array: [0].second = scale, followed by a material
+// property coefficient context. H(curl): E = adj(J)ᵀ/detJ u, H(div): B = J/detJ u.
+
+// Electric energy density: v = 0.5 * scale * (eps_r E) . E.
+CEED_QFUNCTION(f_eval_energy_e_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3], eps[9], D[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, u_loc, E);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], eps);
+    MultAx33(eps, E, D);
+    v[i] = 0.5 * ctx[0].second * (D[0] * E[0] + D[1] * E[1] + D[2] * E[2]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Magnetic energy density: v = 0.5 * scale * (mu⁻¹ B) . B.
+CEED_QFUNCTION(f_eval_energy_m_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], B[3], invmu[9], H[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(J_loc, u_loc, B);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    v[i] = 0.5 * ctx[0].second * (H[0] * B[0] + H[1] * B[1] + H[2] * B[2]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Poynting vector: v = scale * E x (mu⁻¹ B).
+CEED_QFUNCTION(f_eval_poynting_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[3] = {u_e[i + Q * 0], u_e[i + Q * 1], u_e[i + Q * 2]};
+    const CeedScalar ub_loc[3] = {u_b[i + Q * 0], u_b[i + Q * 1], u_b[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3], B[3], invmu[9], H[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, ue_loc, E);
+    MultAx33(J_loc, ub_loc, B);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    const CeedScalar s = ctx[0].second / (detJ * detJ);
+    v[i + Q * 0] = s * (E[1] * H[2] - E[2] * H[1]);
+    v[i + Q * 1] = s * (E[2] * H[0] - E[0] * H[2]);
+    v[i + Q * 2] = s * (E[0] * H[1] - E[1] * H[0]);
+  }
+  return 0;
+}
+
+// Pointwise H(curl) field value: v = adj(J)ᵀ/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, u_loc, E);
+    v[i + Q * 0] = E[0] / detJ;
+    v[i + Q * 1] = E[1] / detJ;
+    v[i + Q * 2] = E[2] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise H(div) field value: v = J/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hdiv_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], B[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(J_loc, u_loc, B);
+    v[i + Q * 0] = B[0] / detJ;
+    v[i + Q * 1] = B[1] / detJ;
+    v[i + Q * 2] = B[2] / detJ;
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_EVAL_33_QF_H

--- a/palace/fem/qfunctions/33/utils_33_qf.h
+++ b/palace/fem/qfunctions/33/utils_33_qf.h
@@ -36,6 +36,15 @@ CEED_QFUNCTION_HELPER CeedScalar AdjJt33(const CeedScalar J[9], CeedScalar adjJt
   return ComputeDet ? (J[0] * adjJt[0] + J[1] * adjJt[1] + J[2] * adjJt[2]) : 0.0;
 }
 
+// Compute y = A x for a 3x3 matrix A stored column-major.
+CEED_QFUNCTION_HELPER void MultAx33(const CeedScalar A[9], const CeedScalar x[3],
+                                    CeedScalar y[3])
+{
+  y[0] = A[0] * x[0] + A[3] * x[1] + A[6] * x[2];
+  y[1] = A[1] * x[0] + A[4] * x[1] + A[7] * x[2];
+  y[2] = A[2] * x[0] + A[5] * x[1] + A[8] * x[2];
+}
+
 CEED_QFUNCTION_HELPER void MatUnpack33(const CeedScalar *A, const CeedInt A_stride,
                                        CeedScalar A_loc[9])
 {

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -3,6 +3,7 @@
 
 #include "lumpedportoperator.hpp"
 
+#include <set>
 #include <fmt/ranges.h>
 #include "fem/coefficient.hpp"
 #include "fem/gridfunction.hpp"
@@ -160,6 +161,38 @@ double LumpedPortData::GetExcitationVoltage() const
   }
 }
 
+SurfaceModeCoefficient LumpedPortData::GetModeCoefficient(const LumpedElementData &elem,
+                                                          double coeff) const
+{
+  SurfaceModeCoefficient mode;
+  mode.attr_list = elem.GetAttrList();
+  mode.scale = coeff;
+  if (const auto *uniform = dynamic_cast<const UniformElementData *>(&elem))
+  {
+    mode.type = SurfaceModeCoefficient::Type::UNIFORM;
+    const auto &dir = uniform->GetDirection();
+    for (int d = 0; d < 3; d++)
+    {
+      mode.direction[d] = (d < dir.Size()) ? dir(d) : 0.0;
+    }
+  }
+  else if (const auto *coax = dynamic_cast<const CoaxialElementData *>(&elem))
+  {
+    mode.type = SurfaceModeCoefficient::Type::COAXIAL;
+    mode.scale *= coax->GetDirection();
+    const auto &origin = coax->GetOrigin();
+    for (int d = 0; d < 3; d++)
+    {
+      mode.origin[d] = (d < origin.Size()) ? origin(d) : 0.0;
+    }
+  }
+  else
+  {
+    MFEM_ABORT("Unknown lumped element type for mode-overlap coefficient!");
+  }
+  return mode;
+}
+
 void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespace) const
 {
   const auto &mesh = *nd_fespace.GetParMesh();
@@ -234,6 +267,49 @@ std::complex<double> LumpedPortData::GetPower(GridFunction &E, GridFunction &B) 
   const bool has_imag = E.HasImag();
   auto &nd_fespace = *E.ParFESpace();
   const auto &mesh = *nd_fespace.GetParMesh();
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  if (!power_func && SurfaceFunctional::Enabled())
+  {
+    mfem::Array<int> attr_list;
+    for (const auto &elem : elems)
+    {
+      attr_list.Append(elem->GetAttrList());
+    }
+    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+    mfem::Vector x0(mesh.SpaceDimension());
+    x0 = 0.0;
+    power_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), mat_op,
+        SurfaceFlux::POWER, /*two_sided*/ true, x0);
+  }
+  if (power_func && power_func->IsValid())
+  {
+    return power_func->EvalComplexPower(E, B);
+  }
+  if (SurfaceFunctional::Enabled() && mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(power_func && power_func->IsValid(),
+                "libCEED lumped-port power postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+  return GetPowerLegacy(E, B);
+}
+
+std::complex<double> LumpedPortData::GetPowerLegacy(GridFunction &E, GridFunction &B) const
+{
+  // Host fallback matching the original coefficient/linear-form implementation. This is
+  // still the cheapest path for very small port surfaces before libCEED JIT costs can be
+  // amortized over many samples.
+  MFEM_VERIFY((E.HasImag() && B.HasImag()) || (!E.HasImag() && !B.HasImag()),
+              "Mismatch between real- and complex-valued E and B fields in port power "
+              "calculation!");
+  const bool has_imag = E.HasImag();
+  auto &nd_fespace = *E.ParFESpace();
+  const auto &mesh = *nd_fespace.GetParMesh();
+
   SumVectorCoefficient fbr(mesh.SpaceDimension()), fbi(mesh.SpaceDimension());
   mfem::Array<int> attr_list;
   for (const auto &elem : elems)
@@ -283,20 +359,43 @@ std::complex<double> LumpedPortData::GetPower(GridFunction &E, GridFunction &B) 
 
 std::complex<double> LumpedPortData::GetSParameter(GridFunction &E) const
 {
-  // Compute port S-parameter, or the projection of the field onto the port mode.
-  InitializeLinearForms(*E.ParFESpace());
-  std::complex<double> dot((*s) * E.Real(), 0.0);
-  if (E.HasImag())
+  // The S-parameter mode coefficient is the voltage coefficient scaled by 1/sqrt(R):
+  // H_inc = 1 / sqrt((R W/L n) W L n) = 1 / (W n sqrt(R)). Reuse the device-backed
+  // voltage overlap and preserve the legacy zero result for ports without resistance.
+  if (std::abs(R) == 0.0)
   {
-    dot.imag((*s) * E.Imag());
+    return 0.0;
   }
-  Mpi::GlobalSum(1, &dot, E.GetComm());
-  return dot;
+  return GetVoltage(E) / std::sqrt(R);
 }
 
 std::complex<double> LumpedPortData::GetVoltage(GridFunction &E) const
 {
-  // Compute the average voltage across the port.
+  // Compute the average voltage across the port using the same mode-overlap machinery as
+  // S-parameters, with the voltage normalization coefficient.
+  if (!v_func && SurfaceFunctional::Enabled())
+  {
+    std::vector<SurfaceModeCoefficient> modes;
+    modes.reserve(elems.size());
+    for (const auto &elem : elems)
+    {
+      modes.push_back(
+          GetModeCoefficient(*elem, 1.0 / (elem->GetGeometryWidth() * elems.size())));
+    }
+    v_func = std::make_unique<SurfaceFunctional>(mat_op.GetMesh(), *E.ParFESpace(), modes);
+  }
+  if (v_func && v_func->IsValid())
+  {
+    return v_func->EvalModeOverlap(E);
+  }
+  const auto &mesh = *E.ParFESpace()->GetParMesh();
+  if (SurfaceFunctional::Enabled() && mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(v_func && v_func->IsValid(),
+                "libCEED lumped-port voltage postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+
   InitializeLinearForms(*E.ParFESpace());
   std::complex<double> dot((*v) * E.Real(), 0.0);
   if (E.HasImag())
@@ -470,6 +569,113 @@ const LumpedPortData &LumpedPortOperator::GetPort(int idx) const
   auto it = ports.find(idx);
   MFEM_VERIFY(it != ports.end(), "Unknown lumped port index requested!");
   return it->second;
+}
+
+std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &E,
+                                                                  GridFunction &B) const
+{
+  std::map<int, std::complex<double>> powers;
+  if (ports.empty())
+  {
+    return powers;
+  }
+  // Assemble one union-surface POWER functional for all disjoint lumped ports. The
+  // SurfaceFunctional still accumulates per-boundary-element slots;
+  // EvalComplexPowerByAttribute bins those slots back to the port indices, so no
+  // processor-boundary or ghost-side behavior is weakened relative to the per-port path.
+  if (!batched_power_unavailable && SurfaceFunctional::Enabled())
+  {
+    if (!batched_power_func)
+    {
+      auto &nd_fespace = *E.ParFESpace();
+      const auto &mesh = *nd_fespace.GetParMesh();
+      const int bdr_attr_max = mesh::GetMaxBdrAttribute(mesh);
+      batched_power_attr_to_port.SetSize(bdr_attr_max);
+      for (int i = 0; i < batched_power_attr_to_port.Size(); i++)
+      {
+        batched_power_attr_to_port[i] = -1;
+      }
+      batched_power_port_indices.clear();
+
+      mfem::Array<int> attr_list;
+      std::set<int> seen_attrs;
+      bool can_batch = true;
+      int bin = 0;
+      for (const auto &[idx, data] : ports)
+      {
+        batched_power_port_indices.push_back(idx);
+        for (const auto &elem : data.elems)
+        {
+          for (int attr : elem->GetAttrList())
+          {
+            if (attr <= 0 || attr > bdr_attr_max || !seen_attrs.insert(attr).second)
+            {
+              can_batch = false;
+              break;
+            }
+            attr_list.Append(attr);
+            batched_power_attr_to_port[attr - 1] = bin;
+          }
+          if (!can_batch)
+          {
+            break;
+          }
+        }
+        if (!can_batch)
+        {
+          break;
+        }
+        bin++;
+      }
+
+      Mpi::GlobalAnd(1, &can_batch, nd_fespace.GetComm());
+
+      if (can_batch && attr_list.Size() > 0)
+      {
+        const auto &data0 = ports.begin()->second;
+        mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+
+        mfem::Vector x0(mesh.SpaceDimension());
+        x0 = 0.0;
+        batched_power_func = std::make_unique<SurfaceFunctional>(
+            data0.mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), data0.mat_op,
+            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+      }
+      else
+      {
+        batched_power_unavailable = true;
+      }
+    }
+
+    if (batched_power_func && batched_power_func->IsValid())
+    {
+      auto values = batched_power_func->EvalComplexPowerByAttribute(
+          E, B, batched_power_attr_to_port,
+          static_cast<int>(batched_power_port_indices.size()));
+      for (std::size_t i = 0; i < batched_power_port_indices.size(); i++)
+      {
+        powers.emplace(batched_power_port_indices[i], values[i]);
+      }
+      return powers;
+    }
+    if (batched_power_func)
+    {
+      if (E.ParFESpace()->GetParMesh()->Dimension() == 3 &&
+          E.ParFESpace()->GetParMesh()->SpaceDimension() == 3)
+      {
+        MFEM_VERIFY(batched_power_func->IsValid(),
+                    "libCEED batched lumped-port power postprocessing could not assemble "
+                    "for supported 3D port surfaces!");
+      }
+      batched_power_unavailable = true;
+    }
+  }
+
+  for (const auto &[idx, data] : ports)
+  {
+    powers.emplace(idx, data.GetPower(E, B));
+  }
+  return powers;
 }
 
 mfem::Array<int> LumpedPortOperator::GetAttrList() const

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <mfem.hpp>
 #include "fem/lumpedelement.hpp"
+#include "fem/output_functionals.hpp"
 
 namespace palace
 {
@@ -51,7 +52,13 @@ protected:
   // Linear forms for postprocessing integrated quantities on the port.
   mutable std::unique_ptr<mfem::LinearForm> s, v;
 
+  // libCEED surface functionals for port power, voltage, and S-parameter computation,
+  // replacing host boundary LinearForm paths when supported.
+  mutable std::unique_ptr<SurfaceFunctional> power_func, v_func;
+
   void InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespace) const;
+  SurfaceModeCoefficient GetModeCoefficient(const LumpedElementData &elem,
+                                            double coeff) const;
 
 public:
   LumpedPortData(const config::LumpedPortData &data, const MaterialOperator &mat_op,
@@ -105,6 +112,7 @@ public:
   double GetExcitationVoltage() const;
 
   std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetPowerLegacy(GridFunction &E, GridFunction &B) const;
   std::complex<double> GetSParameter(GridFunction &E) const;
   std::complex<double> GetVoltage(GridFunction &E) const;
 };
@@ -119,6 +127,14 @@ private:
   // calculate circuit properties like voltage and current on lumped or multielement lumped
   // ports.
   std::map<int, LumpedPortData> ports;
+
+  // Batched libCEED surface functional for lumped-port power. The per-port
+  // LumpedPortData fallback remains authoritative when batching is unavailable (for
+  // example, overlapping boundary attributes or unsupported surface-functional cases).
+  mutable std::unique_ptr<SurfaceFunctional> batched_power_func;
+  mutable mfem::Array<int> batched_power_attr_to_port;
+  mutable std::vector<int> batched_power_port_indices;
+  mutable bool batched_power_unavailable = false;
 
   void SetUpBoundaryProperties(const std::map<int, config::LumpedPortData> &lumpedport,
                                const MaterialOperator &mat_op, const mfem::ParMesh &mesh);
@@ -138,6 +154,10 @@ public:
   auto rbegin() const { return ports.rbegin(); }
   auto rend() const { return ports.rend(); }
   auto Size() const { return ports.size(); }
+
+  // Compute port powers, batching disjoint libCEED surface-functional evaluations when
+  // possible while preserving per-port scalar outputs.
+  std::map<int, std::complex<double>> GetPowers(GridFunction &E, GridFunction &B) const;
 
   // Returns array of lumped port attributes.
   mfem::Array<int> GetAttrList() const;

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -1118,10 +1118,11 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
   if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN ||
                 solver_t == ProblemType::TRANSIENT)
   {
+    const auto port_powers = fem_op->GetLumpedPortOp().GetPowers(*E, *B);
     for (const auto &[idx, data] : fem_op->GetLumpedPortOp())
     {
       auto &vi = measurement_cache.lumped_port_vi[idx];
-      vi.P = data.GetPower(*E, *B);
+      vi.P = port_powers.at(idx);
       vi.V = data.GetVoltage(*E);
       if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN)
       {
@@ -1456,8 +1457,7 @@ void PostOperator<solver_t>::MeasureFarField() const
 
     // NOTE: measurement_cache.freq is omega (it has a factor of 2pi).
     measurement_cache.farfield.E_field = surf_post_op.GetFarFieldrE(
-        measurement_cache.farfield.thetaphis, *E, *B, measurement_cache.freq.real(),
-        measurement_cache.freq.imag());
+        measurement_cache.farfield.thetaphis, *E, *B, measurement_cache.freq);
   }
 }
 

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -5,6 +5,7 @@
 
 #include <complex>
 #include <set>
+#include <string>
 #include "fem/gridfunction.hpp"
 #include "fem/integrator.hpp"
 #include "linalg/vector.hpp"
@@ -21,6 +22,26 @@ namespace palace
 
 namespace
 {
+
+bool IsSupportedSurfaceFunctionalDimension(const mfem::ParMesh &mesh)
+{
+  return (mesh.Dimension() == 2 && mesh.SpaceDimension() == 2) ||
+         (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3);
+}
+
+bool IsSupportedSurfaceFluxDimension(const mfem::ParMesh &mesh)
+{
+  // The libCEED surface-flux kernels currently implement 3D surface integrals. 2D line
+  // flux semantics remain on the legacy path explicitly rather than by silent invalid
+  // fallback.
+  return mesh.Dimension() == 3 && mesh.SpaceDimension() == 3;
+}
+
+void RequireCeedSurfaceFunctional(const SurfaceFunctional *func, const std::string &what)
+{
+  MFEM_VERIFY(func && func->IsValid(), "libCEED postprocessing was expected for " + what +
+                                           ", but SurfaceFunctional could not assemble!");
+}
 
 template <typename T>
 mfem::Array<int> SetUpBoundaryProperties(const T &data,
@@ -300,6 +321,26 @@ std::complex<double> SurfacePostOperator::GetSurfaceFlux(int idx, const GridFunc
   const auto &mesh = *h1_fespace.GetParMesh();
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, it->second.attr_list);
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  auto &func = flux_funcs[idx];
+  if (!func && SurfaceFunctional::Enabled())
+  {
+    func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, E ? E->ParFESpace() : nullptr,
+        B ? B->ParFESpace() : nullptr, mat_op, it->second.type, it->second.two_sided,
+        it->second.center);
+  }
+  if (func && func->IsValid())
+  {
+    return func->EvalFlux(E, B);
+  }
+  if (SurfaceFunctional::Enabled() && IsSupportedSurfaceFluxDimension(mesh))
+  {
+    RequireCeedSurfaceFunctional(func.get(), "3D surface flux");
+  }
+
   auto f =
       it->second.GetCoefficient(E ? &E->Real() : nullptr, B ? &B->Real() : nullptr, mat_op);
   std::complex<double> dot(GetLocalSurfaceIntegral(*f, attr_marker), 0.0);
@@ -338,6 +379,25 @@ double SurfacePostOperator::GetInterfaceElectricFieldEnergy(int idx,
   const auto &mesh = *h1_fespace.GetParMesh();
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, it->second.attr_list);
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  auto &func = eps_funcs[idx];
+  if (!func && SurfaceFunctional::Enabled())
+  {
+    func = std::make_unique<SurfaceFunctional>(mat_op.GetMesh(), attr_marker,
+                                               *E.ParFESpace(), mat_op, it->second.type,
+                                               it->second.t, it->second.epsilon);
+  }
+  if (func && func->IsValid())
+  {
+    return func->Eval(E);
+  }
+  if (SurfaceFunctional::Enabled() && IsSupportedSurfaceFunctionalDimension(mesh))
+  {
+    RequireCeedSurfaceFunctional(func.get(), "interface dielectric postprocessing");
+  }
+
   auto f = it->second.GetCoefficient(E, mat_op);
   double dot = GetLocalSurfaceIntegral(*f, attr_marker);
   Mpi::GlobalSum(1, &dot, E.GetComm());
@@ -361,7 +421,7 @@ SurfacePostOperator::GetLocalSurfaceIntegral(mfem::Coefficient &f,
 
 std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFieldrE(
     const std::vector<std::pair<double, double>> &theta_phi_pairs, const GridFunction &E,
-    const GridFunction &B, double omega_re, double omega_im) const
+    const GridFunction &B, std::complex<double> omega) const
 {
   if (theta_phi_pairs.empty())
     return {};
@@ -384,6 +444,22 @@ std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFiel
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, farfield.attr_list);
 
+  // Use the libCEED surface functional path when supported, avoiding per-point host
+  // coefficient evaluation in the legacy path.
+  if (!farfield_func && SurfaceFunctional::Enabled() && E.HasImag() && B.HasImag())
+  {
+    farfield_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, *E.ParFESpace(), *B.ParFESpace(), mat_op, r_naughts);
+  }
+  if (farfield_func && farfield_func->IsValid())
+  {
+    return farfield_func->EvalFarField(E, B, omega);
+  }
+  if (SurfaceFunctional::Enabled() && E.HasImag() && B.HasImag())
+  {
+    RequireCeedSurfaceFunctional(farfield_func.get(), "3D far-field postprocessing");
+  }
+
   // Integrate. Each MPI process computes its contribution and we will reduce
   // everything at the end. We make them std::vector<std::array<double, 3>>
   // because we want a very simple memory layout so that we can reduce
@@ -401,8 +477,8 @@ std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFiel
     const auto *ir =
         &mfem::IntRules.Get(fe->GetGeomType(), fem::DefaultIntegrationOrder::Get(*T));
 
-    AddStrattonChuIntegrandAtElement(E, B, mat_op, omega_re, omega_im, r_naughts, *T, *ir,
-                                     integrals_r, integrals_i);
+    AddStrattonChuIntegrandAtElement(E, B, mat_op, omega.real(), omega.imag(), r_naughts,
+                                     *T, *ir, integrals_r, integrals_i);
   }
 
   double *data_r_ptr = integrals_r.data()->data();

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <mfem.hpp>
 #include "fem/coefficient.hpp"
+#include "fem/output_functionals.hpp"
 
 namespace palace
 {
@@ -93,6 +94,12 @@ private:
   double GetLocalSurfaceIntegral(mfem::Coefficient &f,
                                  const mfem::Array<int> &attr_marker) const;
 
+  // libCEED surface functionals for flux and interface dielectric postprocessing,
+  // constructed lazily per surface index to replace per-call coefficient evaluation and
+  // boundary LinearForm assembly in the legacy paths when supported.
+  mutable std::map<int, std::unique_ptr<SurfaceFunctional>> flux_funcs, eps_funcs;
+  mutable std::unique_ptr<SurfaceFunctional> farfield_func;
+
 public:
   // Data structures for postprocessing the surface with the given type.
   std::map<int, SurfaceFluxData> flux_surfs;
@@ -114,8 +121,8 @@ public:
   // Batch version for multiple theta/phi pairs
   std::vector<std::array<std::complex<double>, 3>>
   GetFarFieldrE(const std::vector<std::pair<double, double>> &theta_phi_pairs,
-                const GridFunction &E, const GridFunction &B, double omega_re,
-                double omega_im) const;
+                const GridFunction &E, const GridFunction &B,
+                std::complex<double> omega) const;
 
   // Get surface integrals computing interface dielectric energy.
   double GetInterfaceLossTangent(int idx) const;

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -19,6 +19,7 @@
 #include "fem/coefficient.hpp"
 #include "fem/integrator.hpp"
 #include "fem/interpolator.hpp"
+#include "fem/output_functionals.hpp"
 #include "linalg/amg.hpp"
 #include "linalg/ams.hpp"
 #include "linalg/arpack.hpp"
@@ -805,15 +806,41 @@ double WavePortData::GetExcitationPower() const
 
 std::complex<double> WavePortData::GetPower(GridFunction &E, GridFunction &B) const
 {
-  // Compute port power, (E x H) ⋅ n = E ⋅ (-n x H), integrated over the port surface using
-  // the computed E and H = μ⁻¹ B fields, where +n is the outward mesh normal. The
-  // BdrSurfaceCurrentVectorCoefficient computes -n x H for the outward normal. The linear
-  // form is reconstructed from scratch each time due to changing H.
+  // Compute the stationary complex power on the port, E ⋅ (-n x H⋆), integrated over the
+  // port surface with +n the outward mesh normal. Use the libCEED surface functional path
+  // when supported to avoid per-call boundary LinearForm assembly in the legacy path.
   MFEM_VERIFY(E.HasImag() && B.HasImag(),
               "Wave ports expect complex-valued E and B fields in port power "
               "calculation!");
   auto &nd_fespace = *E.ParFESpace();
   const auto &mesh = *nd_fespace.GetParMesh();
+
+  // Set two_sided = true even on the exterior port surface so the QFunction uses the
+  // fixed outward normal directly (no x0-based reorientation).
+  if (!power_func && SurfaceFunctional::Enabled())
+  {
+    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+    mfem::Vector x0(mesh.SpaceDimension());
+    x0 = 0.0;
+    power_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), mat_op,
+        SurfaceFlux::POWER, /*two_sided*/ true, x0);
+  }
+  if (power_func && power_func->IsValid())
+  {
+    // EvalComplexPower returns the complex Poynting integral with the same normal
+    // convention as the legacy BdrSurfaceCurrentVectorCoefficient path (n x H for the
+    // outward normal, contributions negated), matching LumpedPortData::GetPower.
+    return power_func->EvalComplexPower(E, B);
+  }
+  if (SurfaceFunctional::Enabled() && mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(power_func && power_func->IsValid(),
+                "libCEED wave-port power postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+
   BdrSurfaceCurrentVectorCoefficient nxHr_func(B.Real(), mat_op);
   BdrSurfaceCurrentVectorCoefficient nxHi_func(B.Imag(), mat_op);
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -30,6 +30,7 @@ class MaterialOperator;
 class MaterialPropertyCoefficient;
 class SumVectorCoefficient;
 class SurfaceConductivityOperator;
+class SurfaceFunctional;
 class SurfaceRationalImpedanceOperator;
 class SurfaceImpedanceOperator;
 class Units;
@@ -102,6 +103,10 @@ private:
   // postprocessing.
   std::unique_ptr<GridFunction> port_E0t, port_E0n, port_S0t, port_E;
   std::unique_ptr<mfem::LinearForm> port_sr, port_si;
+
+  // libCEED surface functional for port power computation, replacing per-call boundary
+  // LinearForm assembly in the legacy path when supported.
+  mutable std::unique_ptr<SurfaceFunctional> power_func;
 
   // Voltage path for line integral (optional, for impedance postprocessing).
   std::vector<mfem::Vector> voltage_path;

--- a/spack_repo/local/packages/libceed/libceed-v0.8-hip.patch
+++ b/spack_repo/local/packages/libceed/libceed-v0.8-hip.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 4f1737ee..3f1811f2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -403,6 +403,9 @@ ifneq ($(HIP_LIB_DIR),)
+     CPPFLAGS += $(subst =,,$(shell $(HIP_DIR)/bin/hipconfig -C))
+   endif
+   $(libceeds) : CPPFLAGS += -I$(HIP_DIR)/include
++  ifneq ($(HIPBLAS_DIR),)
++    PKG_LIBS += -L$(HIPBLAS_DIR)/lib
++  endif
+   PKG_LIBS += -L$(abspath $(HIP_LIB_DIR)) -lamdhip64 -lhipblas
+   LIBCEED_CONTAINS_CXX = 1
+   libceed.c   += interface/ceed-hip.c

--- a/spack_repo/local/packages/libceed/occaFree-0.2.diff
+++ b/spack_repo/local/packages/libceed/occaFree-0.2.diff
@@ -1,0 +1,41 @@
+diff --git a/backends/occa/ceed-occa-basis.c b/backends/occa/ceed-occa-basis.c
+index 85ec292..86a46ee 100644
+--- a/backends/occa/ceed-occa-basis.c
++++ b/backends/occa/ceed-occa-basis.c
+@@ -293,10 +293,6 @@ static int CeedBasisDestroy_Occa(CeedBasis basis) {
+   const Ceed ceed = basis->ceed;
+   CeedBasis_Occa *data = basis->data;
+   dbg("[CeedBasis][Destroy]");
+-  occaFree(data->kZero);
+-  occaFree(data->kInterp);
+-  occaFree(data->kGrad);
+-  occaFree(data->kWeight);
+   occaFree(data->qref1d);
+   occaFree(data->qweight1d);
+   occaFree(data->interp1d);
+diff --git a/backends/occa/ceed-occa-qfunction.c b/backends/occa/ceed-occa-qfunction.c
+index a2776c3..abf7de0 100644
+--- a/backends/occa/ceed-occa-qfunction.c
++++ b/backends/occa/ceed-occa-qfunction.c
+@@ -154,7 +154,6 @@ static int CeedQFunctionDestroy_Occa(CeedQFunction qf) {
+   CeedQFunction_Occa *data=qf->data;
+   free(data->oklPath);
+   dbg("[CeedQFunction][Destroy]");
+-  occaFree(data->kQFunctionApply);
+   if (data->ready) {
+     if (!data->op) occaFree(data->d_q);
+     occaFree(data->d_u);
+diff --git a/backends/occa/ceed-occa-restrict.c b/backends/occa/ceed-occa-restrict.c
+index 6b7786c..c5360dc 100644
+--- a/backends/occa/ceed-occa-restrict.c
++++ b/backends/occa/ceed-occa-restrict.c
+@@ -95,9 +95,6 @@ static int CeedElemRestrictionDestroy_Occa(CeedElemRestriction r) {
+   const Ceed ceed = r->ceed;
+   CeedElemRestriction_Occa *data = r->data;
+   dbg("[CeedElemRestriction][Destroy]");
+-  for (int i=0; i<9; i++) {
+-    occaFree(data->kRestrict[i]);
+-  }
+   ierr = CeedFree(&data); CeedChk(ierr);
+   return 0;
+ }

--- a/spack_repo/local/packages/libceed/package.py
+++ b/spack_repo/local/packages/libceed/package.py
@@ -1,0 +1,189 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
+from spack.package import *
+
+
+class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
+    """The CEED API Library: Code for Efficient Extensible Discretizations."""
+
+    homepage = "https://github.com/CEED/libCEED"
+    git = "https://github.com/CEED/libCEED.git"
+
+    maintainers("jedbrown", "v-dobrev", "tzanio", "jeremylt")
+
+    license("BSD-2-Clause")
+
+    version("develop", branch="main")
+    version("0.12.0", tag="v0.12.0", commit="4018a20a98d451fac24765d3ddb936861647ce8d")
+    version("0.11.0", tag="v0.11.0", commit="8ec64e9ae9d5df169dba8c8ee61d8ec8907b8f80")
+    version("0.10.1", tag="v0.10.1", commit="74532b27052d94e943eb8bc76257fbd710103614")
+    version("0.9", tag="v0.9.0", commit="d66340f5aae79e564186ab7514a1cd08b3a1b06b")
+    version("0.8", tag="v0.8", commit="e8f234590eddcce2220edb1d6e979af7a3c35f82")
+    version("0.7", tag="v0.7", commit="0bc92be5158efcbeb80d3d59240233bf5b2f748c")
+    version(
+        "0.6", commit="c7f533e01e2f3f6720fbf37aac2af2ffed225f60"
+    )  # tag v0.6 + small portability fixes
+    version("0.5", tag="v0.5", commit="12804ff7ea2ac608ae5494437379e4f626cf5cb7")
+    version("0.4", tag="v0.4", commit="40b9dad77dea06a1608fa8b93a0d8b9c993ee43d")
+    version("0.2", tag="v0.2", commit="113004cb41757b819325a4b3a8a7dfcea5156531")
+    version("0.1", tag="v0.1", commit="74e0540e2478136394f75869675056eb6aba67cc")
+
+    variant("occa", default=False, description="Enable OCCA backends")
+    variant("debug", default=False, description="Enable debug build")
+    variant("libxsmm", default=False, description="Enable LIBXSMM backend", when="@0.3:")
+    variant("magma", default=False, description="Enable MAGMA backend", when="@0.6:")
+
+    variant("openmp", default=False, description="Enable OpenMP support")
+
+    variant("shared", default=True, description="Build shared libraries")
+
+    conflicts("+rocm", when="@:0.7")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    with when("+rocm"):
+        depends_on("hip@3.8.0:", when="@0.8:")
+        depends_on("hipblas@3.8.0:", when="@0.8:")
+
+    conflicts("+occa", when="@0.9:")
+
+    with when("+occa"):
+        depends_on("occa@1.1.0", when="@0.7:")
+        depends_on("occa@1.0.8:", when="@0.4")
+        depends_on("occa@1.0.0-alpha.5,develop", when="@:0.2")
+        depends_on("occa+cuda", when="+cuda")
+        depends_on("occa~cuda", when="~cuda")
+
+    depends_on("libxsmm~shared", when="+libxsmm~shared")
+    depends_on("libxsmm+shared", when="+libxsmm+shared")
+    depends_on("blas", when="+libxsmm", type="link")
+
+    depends_on("magma~shared", when="+magma~shared")
+    depends_on("magma+shared", when="+magma+shared")
+
+    patch("libceed-v0.8-hip.patch", when="@0.8+rocm")
+    patch("pkgconfig-version-0.4.diff", when="@0.4")
+
+    # occa: do not occaFree kernels
+    # Repeated creation and freeing of kernels appears to expose a caching
+    # bug in Occa.
+    patch("occaFree-0.2.diff", when="@0.2")
+
+    @property
+    def common_make_opts(self):
+        spec = self.spec
+        compiler = self.compiler
+        # Note: The occa package exports OCCA_DIR in the environment
+
+        # Use verbose building output
+        makeopts = ["V=1"]
+
+        if spec.satisfies("@:0.2"):
+            makeopts += ["NDEBUG=%s" % ("" if spec.satisfies("+debug") else "1")]
+
+        elif spec.satisfies("@0.4:0.12"):
+            # Determine options based on the compiler:
+            if spec.satisfies("+debug"):
+                opt = "-g"
+            elif compiler.name == "gcc":
+                opt = "-O3 -g -ffp-contract=fast"
+                if compiler.version >= ver(4.9):
+                    opt += " -fopenmp-simd"
+                if self.spec.target.family in ["x86_64", "aarch64"]:
+                    opt += " -march=native"
+            elif compiler.name == "apple-clang":
+                opt = "-O3 -g -march=native -ffp-contract=fast"
+                if compiler.version >= ver(10):
+                    opt += " -fopenmp-simd"
+            elif compiler.name == "clang":
+                opt = "-O3 -g -march=native -ffp-contract=fast"
+                if compiler.version >= ver(6):
+                    opt += " -fopenmp-simd"
+            elif compiler.name in ["xl", "xl_r"]:
+                opt = "-O -g -qsimd=auto"
+            elif compiler.name == "intel":
+                opt = "-O3 -g"
+                makeopts += ["CC_VENDOR=icc"]
+            else:
+                opt = "-O -g"
+            # Note: spack will inject additional target-specific flags through
+            # the compiler wrapper.
+            makeopts += ["OPT=%s" % opt]
+
+            if spec.satisfies("@0.7") and compiler.name in ["xl", "xl_r"]:
+                makeopts += ["CXXFLAGS.XL=-qpic -std=c++11 -MMD"]
+
+            if spec.satisfies("@:0.7") and "avx" in self.spec.target:
+                makeopts.append("AVX=1")
+
+        if spec.satisfies("@0.4:"):
+            if spec.satisfies("+cuda"):
+                makeopts += ["CUDA_DIR=%s" % spec["cuda"].prefix]
+                makeopts += ["CUDA_ARCH=sm_%s" % spec.variants["cuda_arch"].value]
+                if spec.satisfies("@:0.4"):
+                    nvccflags = [
+                        '-ccbin %s -Xcompiler "%s" -Xcompiler %s'
+                        % (compiler.cxx, opt, compiler.cc_pic_flag)
+                    ]
+                    nvccflags = " ".join(nvccflags)
+                    makeopts += ["NVCCFLAGS=%s" % nvccflags]
+            else:
+                # Disable CUDA auto-detection:
+                makeopts += ["CUDA_DIR=/disable-cuda"]
+
+            if spec.satisfies("+rocm"):
+                makeopts += ["HIP_DIR=%s" % spec["hip"].prefix]
+                amdgpu_target = ",".join(spec.variants["amdgpu_target"].value)
+                makeopts += ["HIP_ARCH=%s" % amdgpu_target]
+                if spec.satisfies("@0.8"):
+                    makeopts += ["HIPBLAS_DIR=%s" % spec["hipblas"].prefix]
+
+            if spec.satisfies("+libxsmm"):
+                makeopts += ["XSMM_DIR=%s" % spec["libxsmm"].prefix]
+                makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
+
+            if spec.satisfies("+magma"):
+                makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
+
+            if spec.satisfies("+openmp"):
+                makeopts += ["OPENMP=1"]
+
+            if spec.satisfies("~shared"):
+                makeopts += ["STATIC=1"]
+
+        return makeopts
+
+    def edit(self, spec, prefix):
+        make("info", *self.common_make_opts)
+
+    @property
+    def build_targets(self):
+        return self.common_make_opts
+
+    @property
+    def install_targets(self):
+        return ["install", "prefix={0}".format(self.prefix)] + self.common_make_opts
+
+    def check(self):
+        make("prove", *self.common_make_opts, parallel=False)
+
+    @when("@0.1")
+    def install(self, spec, prefix):
+        mkdirp(prefix.include)
+        install("ceed.h", prefix.include)
+        mkdirp(prefix.lib)
+        install("libceed.%s" % dso_suffix, prefix.lib)
+        filter_file(r"^prefix=.*$", "prefix=%s" % prefix, "ceed.pc")
+        filter_file(r"^includedir=\$\{prefix\}$", "includedir=${prefix}/include", "ceed.pc")
+        filter_file(r"^libdir=\$\{prefix\}$", "libdir=${prefix}/lib", "ceed.pc")
+        filter_file(r"Version:.*$", "Version: 0.1", "ceed.pc")
+        mkdirp(prefix.lib.pkgconfig)
+        install("ceed.pc", prefix.lib.pkgconfig)

--- a/spack_repo/local/packages/libceed/pkgconfig-version-0.4.diff
+++ b/spack_repo/local/packages/libceed/pkgconfig-version-0.4.diff
@@ -1,0 +1,12 @@
+diff --git c/ceed.pc.template w/ceed.pc.template
+index 3216f08..5ada754 100644
+--- c/ceed.pc.template
++++ w/ceed.pc.template
+@@ -4,6 +4,6 @@ libdir=${prefix}/lib
+
+ Name: CEED
+ Description: Code for Efficient Extensible Discretization
+-Version: 0.2.1
++Version: 0.4
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lceed

--- a/spack_repo/local/packages/palace/libceed_nontensor_atpoints_cuda.diff
+++ b/spack_repo/local/packages/palace/libceed_nontensor_atpoints_cuda.diff
@@ -1,0 +1,1 @@
+../../../../extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -220,7 +220,12 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libxsmm+shared")
 
     with when("@0.14:"):
-        depends_on("libceed@0.13:")
+        depends_on("libceed@0.13:", when="@:0.17")
+        depends_on(
+            "libceed@0.13:",
+            patches=["libceed_nontensor_atpoints_cuda.diff"],
+            when="@0.18:",
+        )
         depends_on("libceed+openmp", when="+openmp")
         depends_on("libceed~openmp", when="~openmp")
         depends_on("libceed+shared", when="+shared")

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacefunctional.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp

--- a/test/unit/test-lumpedportintegration.cpp
+++ b/test/unit/test-lumpedportintegration.cpp
@@ -28,6 +28,10 @@ using namespace Catch::Matchers;
 class LumpedPortDataTest : public LumpedPortData
 {
 public:
+  void InitializeLinearFormsForTest(mfem::ParFiniteElementSpace &nd_fespace) const
+  {
+    InitializeLinearForms(nd_fespace);
+  }
   mfem::LinearForm *GetLinearFormS() const { return s.get(); }
   mfem::LinearForm *GetLinearFormV() const { return v.get(); }
 };
@@ -375,6 +379,7 @@ TEST_CASE("LumpedPort_BasicTests_1ElementPort_Cube321", "[lumped_port][Serial][P
   // layout Test structure from original structure. Done not to populate code with friend
   // functions, but still access private members for testing.
   const auto &port_1_test_cast = reinterpret_cast<const LumpedPortDataTest &>(port_1);
+  port_1_test_cast.InitializeLinearFormsForTest(space_op.GetNDSpace().Get());
   auto *form_s = port_1_test_cast.GetLinearFormS();
   ComplexVector VecFormS;
   VecFormS.SetSize(space_op.GetNDSpace().GetTrueVSize());
@@ -728,6 +733,7 @@ TEST_CASE("LumpedPort_BasicTests_3ElementPort_Cube321", "[lumped_port][Serial][P
   // layout Test structure from original structure. Done not to populate code with friend
   // functions, but still access private members for testing.
   const auto &port_1_test_cast = reinterpret_cast<const LumpedPortDataTest &>(port_1);
+  port_1_test_cast.InitializeLinearFormsForTest(space_op.GetNDSpace().Get());
   auto *form_s = port_1_test_cast.GetLinearFormS();
   ComplexVector VecFormS;
   VecFormS.SetSize(space_op.GetNDSpace().GetTrueVSize());

--- a/test/unit/test-strattonchu.cpp
+++ b/test/unit/test-strattonchu.cpp
@@ -245,8 +245,8 @@ void runFarFieldTest(double freq_Hz, std::unique_ptr<mfem::Mesh> serial_mesh,
   double omega_rad_per_time =
       2 * M_PI * units.Nondimensionalize<Units::ValueType::FREQUENCY>(freq_Hz / 1e9);
   constexpr double omega_im = 0.0;
-  auto rE_computed =
-      surf_post_op.GetFarFieldrE(thetaphis, E_field, B_field, omega_rad_per_time, omega_im);
+  auto rE_computed = surf_post_op.GetFarFieldrE(thetaphis, E_field, B_field,
+                                                {omega_rad_per_time, omega_im});
 
   // Validate computed far-field against analytical solution
   for (std::size_t i = 0; i < thetaphis.size(); i++)

--- a/test/unit/test-surfacefunctional.cpp
+++ b/test/unit/test-surfacefunctional.cpp
@@ -1,0 +1,1944 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <mfem.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include "fem/coefficient.hpp"
+#include "fem/facenbrexchange.hpp"
+#include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
+#include "fem/interpolator.hpp"
+#include "fem/mesh.hpp"
+#include "fem/output_functionals.hpp"
+#include "fixtures.hpp"
+#include "models/boundarymodeoperator.hpp"
+#include "models/domainpostoperator.hpp"
+#include "models/materialoperator.hpp"
+#include "models/postoperator.hpp"
+#include "models/strattonchu.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/geodata.hpp"
+#include "utils/labels.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+std::unique_ptr<Mesh> LoadTestMesh(MPI_Comm comm, const std::string &file)
+{
+  mfem::Mesh smesh(std::string(PALACE_TEST_DATA_DIR) + "/mesh/" + file, 1, 1);
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+// Reference (host, mfem-based) computation of the surface area with the same
+// quadrature order as SurfaceFunctional (mesh::GetSurfaceArea uses a different
+// quadrature order, which only matters for curved boundary elements).
+double RefSurfaceArea(mfem::ParMesh &pmesh, const mfem::Array<int> &marker)
+{
+  double area = 0.0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    if (!marker[pmesh.GetBdrAttribute(i) - 1])
+    {
+      continue;
+    }
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    const auto &ir = mfem::IntRules.Get(pmesh.GetBdrElementGeometry(i),
+                                        fem::DefaultIntegrationOrder::Get(*T));
+    for (int q = 0; q < ir.GetNPoints(); q++)
+    {
+      const auto &ip = ir.IntPoint(q);
+      T->SetIntPoint(&ip);
+      area += ip.weight * T->Weight();
+    }
+  }
+  Mpi::GlobalSum(1, &area, pmesh.GetComm());
+  return area;
+}
+
+// Reference (host, mfem-based) computation of ∫ |E|² dS over the marked boundary
+// elements, evaluating E from the attached volume element at each quadrature point in
+// the same way as the legacy BdrGridFunctionCoefficient-based postprocessing.
+double RefSurfaceHCurlNorm2(mfem::ParMesh &pmesh, const mfem::ParGridFunction &E,
+                            const mfem::Array<int> &marker)
+{
+  double sum = 0.0;
+  mfem::FaceElementTransformations FET;
+  mfem::IsoparametricTransformation T1, T2;
+  mfem::Vector Ev(pmesh.SpaceDimension());
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    if (!marker[pmesh.GetBdrAttribute(i) - 1])
+    {
+      continue;
+    }
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    const auto &ir = mfem::IntRules.Get(pmesh.GetBdrElementGeometry(i),
+                                        fem::DefaultIntegrationOrder::Get(*T));
+    for (int q = 0; q < ir.GetNPoints(); q++)
+    {
+      const auto &ip = ir.IntPoint(q);
+      T->SetIntPoint(&ip);
+      BdrGridFunctionCoefficient::GetBdrElementNeighborTransformations(i, pmesh, FET, T1,
+                                                                       T2, &ip);
+      E.GetVectorValue(*FET.Elem1, FET.Elem1->GetIntPoint(), Ev);
+      sum += ip.weight * T->Weight() * (Ev * Ev);
+    }
+  }
+  Mpi::GlobalSum(1, &sum, pmesh.GetComm());
+  return sum;
+}
+
+// Reference (host, mfem-based) integration of a legacy boundary coefficient over the
+// marked boundary elements, mirroring SurfacePostOperator::GetLocalSurfaceIntegral.
+double RefSurfaceCoefficientIntegral(mfem::ParMesh &pmesh, mfem::Coefficient &f,
+                                     const mfem::Array<int> &marker)
+{
+  double sum = 0.0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    if (!marker[pmesh.GetBdrAttribute(i) - 1])
+    {
+      continue;
+    }
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    const auto &ir = mfem::IntRules.Get(pmesh.GetBdrElementGeometry(i),
+                                        fem::DefaultIntegrationOrder::Get(*T));
+    for (int q = 0; q < ir.GetNPoints(); q++)
+    {
+      const auto &ip = ir.IntPoint(q);
+      T->SetIntPoint(&ip);
+      sum += ip.weight * T->Weight() * f.Eval(*T, ip);
+    }
+  }
+  Mpi::GlobalSum(1, &sum, pmesh.GetComm());
+  return sum;
+}
+
+// Build a 2D mesh with two material regions (attribute 1: y < 0.5, vacuum; attribute
+// 2: y >= 0.5, dielectric) and interior boundary elements (attribute 7) added on the
+// material interface at y = 0.5.
+std::unique_ptr<Mesh> MakeInterfaceMesh2D(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian2D(2, 2, elem_type, false, 1.0, 1.0);
+  for (int e = 0; e < smesh.GetNE(); e++)
+  {
+    mfem::Vector center(2);
+    smesh.GetElementCenter(e, center);
+    smesh.SetAttribute(e, (center(1) < 0.5) ? 1 : 2);
+  }
+  // Add interior boundary elements on the material interface.
+  for (int f = 0; f < smesh.GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh.GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh.GetAttribute(e1) != smesh.GetAttribute(e2))
+    {
+      auto *face_elem = smesh.GetFace(f)->Duplicate(&smesh);
+      face_elem->SetAttribute(7);
+      smesh.AddBdrElement(face_elem);
+    }
+  }
+  smesh.FinalizeTopology();
+  smesh.Finalize();
+  smesh.SetAttributes();
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+class TestBoundaryModePostOperator : public PostOperator<ProblemType::BOUNDARYMODE>
+{
+public:
+  using PostOperator<ProblemType::BOUNDARYMODE>::PostOperator;
+  const Measurement &Cache() const { return measurement_cache; }
+};
+
+// Build a 3D mesh with two material regions (attribute 1: z < 0.5, vacuum; attribute
+// 2: z >= 0.5, dielectric) and interior boundary elements (attribute 7) added on the
+// material interface at z = 0.5.
+std::unique_ptr<Mesh> MakeInterfaceMesh(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
+  for (int e = 0; e < smesh.GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh.GetElementCenter(e, center);
+    smesh.SetAttribute(e, (center(2) < 0.5) ? 1 : 2);
+  }
+  // Add interior boundary elements on the material interface.
+  for (int f = 0; f < smesh.GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh.GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh.GetAttribute(e1) != smesh.GetAttribute(e2))
+    {
+      auto *face_elem = smesh.GetFace(f)->Duplicate(&smesh);
+      face_elem->SetAttribute(7);
+      smesh.AddBdrElement(face_elem);
+    }
+  }
+  smesh.FinalizeTopology();
+  smesh.Finalize();
+  smesh.SetAttributes();
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+// Build a 3D mesh with two material regions and interior boundary elements (attribute
+// 7) on the material interface at z = 0.5, then apply nonconformal refinement to a
+// subset of elements so that marked surfaces (exterior and interior) contain
+// nonconformal (master/slave) faces.
+std::unique_ptr<Mesh> MakeNCInterfaceMesh(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
+  for (int e = 0; e < smesh.GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh.GetElementCenter(e, center);
+    smesh.SetAttribute(e, (center(2) < 0.5) ? 1 : 2);
+  }
+  for (int f = 0; f < smesh.GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh.GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh.GetAttribute(e1) != smesh.GetAttribute(e2))
+    {
+      auto *face_elem = smesh.GetFace(f)->Duplicate(&smesh);
+      face_elem->SetAttribute(7);
+      smesh.AddBdrElement(face_elem);
+    }
+  }
+  smesh.FinalizeTopology();
+  smesh.Finalize();
+  smesh.SetAttributes();
+  smesh.EnsureNodes();
+  smesh.EnsureNCMesh(true);
+
+  // Nonconformally refine the elements in the x < 0.5 half (crosses both the interior
+  // interface and the exterior boundaries), creating master/slave faces on the marked
+  // surfaces.
+  mfem::Array<int> refs;
+  for (int e = 0; e < smesh.GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh.GetElementCenter(e, center);
+    if (center(0) < 0.5)
+    {
+      refs.Append(e);
+    }
+  }
+  smesh.GeneralRefinement(refs, 1);
+
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+}  // namespace
+
+TEST_CASE("DefaultIntegrationOrder Periodic Trace", "[surfacefunctional][Serial]")
+{
+  mfem::Mesh orig_mesh = mfem::Mesh::MakeCartesian3D(3, 3, 3, mfem::Element::HEXAHEDRON);
+  orig_mesh.EnsureNodes();
+  std::vector<mfem::Vector> translations = {mfem::Vector({1.0, 0.0, 0.0}),
+                                            mfem::Vector({0.0, 1.0, 0.0})};
+  mfem::Mesh mesh = mfem::Mesh::MakePeriodic(
+      orig_mesh, orig_mesh.CreatePeriodicVertexMapping(translations));
+
+  REQUIRE(mesh.GetNBE() > 0);
+  REQUIRE(mesh.GetNodes());
+  const auto geom = mesh.GetBdrElementGeometry(0);
+  const auto *fec = mesh.GetNodalFESpace()->FEColl();
+  CHECK(fec->FiniteElementForGeometry(geom) == nullptr);
+  REQUIRE(fec->TraceFiniteElementForGeometry(geom));
+
+  fem::DefaultIntegrationOrder::p_trial = 1;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+  const auto *T = mesh.GetBdrElementTransformation(0);
+  REQUIRE(T);
+  CHECK(fem::DefaultIntegrationOrder::Get(mesh, geom) ==
+        fem::DefaultIntegrationOrder::Get(*T));
+}
+
+TEST_CASE("SurfaceFunctional Area", "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  fem::DefaultIntegrationOrder::p_trial = 1;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+  auto file = GENERATE(std::string("fichera-tet.mesh"), std::string("fichera-hex.mesh"),
+                       std::string("fichera-mixed-p2.mesh"));
+  CAPTURE(file);
+  auto mesh = LoadTestMesh(comm, file);
+  auto &pmesh = mesh->Get();
+
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  SECTION("All boundary attributes")
+  {
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    SurfaceFunctional area(SurfaceFunctional::Kind::AREA, *mesh, marker);
+    CHECK(area.Eval() == Catch::Approx(RefSurfaceArea(pmesh, marker)).epsilon(1.0e-12));
+    if (file != "fichera-mixed-p2.mesh")
+    {
+      // For meshes with straight-sided boundary elements, also cross-check against the
+      // independent implementation in mesh::GetSurfaceArea (exact for any quadrature
+      // order, so quadrature rule differences don't matter).
+      CHECK(area.Eval() ==
+            Catch::Approx(mesh::GetSurfaceArea(pmesh, marker)).epsilon(1.0e-12));
+    }
+  }
+
+  SECTION("Single boundary attribute")
+  {
+    for (auto attr : pmesh.bdr_attributes)
+    {
+      CAPTURE(attr);
+      mfem::Array<int> marker(bdr_attr_max);
+      marker = 0;
+      marker[attr - 1] = 1;
+      SurfaceFunctional area(SurfaceFunctional::Kind::AREA, *mesh, marker);
+      CHECK(area.Eval() == Catch::Approx(RefSurfaceArea(pmesh, marker)).epsilon(1.0e-12));
+    }
+  }
+}
+
+TEST_CASE("SurfaceFunctional HCurl Norm", "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto file = GENERATE(std::string("fichera-tet.mesh"), std::string("fichera-hex.mesh"),
+                       std::string("fichera-mixed-p2.mesh"));
+  auto order = GENERATE(1, 2);
+  CAPTURE(file, order);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+  auto mesh = LoadTestMesh(comm, file);
+  auto &pmesh = mesh->Get();
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+
+  // Project a non-trivial smooth vector field onto the ND space. The reference value is
+  // computed from the same projected grid function, so the comparison is exact up to
+  // quadrature evaluation differences (not projection error).
+  mfem::ParGridFunction E(&nd_fespace.Get());
+  mfem::VectorFunctionCoefficient f(3,
+                                    [](const mfem::Vector &x, mfem::Vector &v)
+                                    {
+                                      v(0) = std::sin(x(1)) + x(2) * x(2);
+                                      v(1) = std::cos(x(2)) + x(0);
+                                      v(2) = x(0) * x(1) + 1.0;
+                                    });
+  E.ProjectCoefficient(f);
+
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  SECTION("All boundary attributes")
+  {
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    SurfaceFunctional norm2(SurfaceFunctional::Kind::HCURL_NORM2, *mesh, marker,
+                            &nd_fespace.Get());
+    const double ref = RefSurfaceHCurlNorm2(pmesh, E, marker);
+    CHECK(norm2.Eval(&E) == Catch::Approx(ref).epsilon(1.0e-10));
+  }
+
+  SECTION("Single boundary attribute")
+  {
+    for (auto attr : pmesh.bdr_attributes)
+    {
+      CAPTURE(attr);
+      mfem::Array<int> marker(bdr_attr_max);
+      marker = 0;
+      marker[attr - 1] = 1;
+      SurfaceFunctional norm2(SurfaceFunctional::Kind::HCURL_NORM2, *mesh, marker,
+                              &nd_fespace.Get());
+      const double ref = RefSurfaceHCurlNorm2(pmesh, E, marker);
+      CHECK(norm2.Eval(&E) == Catch::Approx(ref).epsilon(1.0e-10));
+    }
+  }
+}
+
+TEST_CASE("SurfaceFunctional Interface Dielectric", "[surfacefunctional][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  // Materials: vacuum for attribute 1, dielectric for attribute 2.
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+
+  // Project non-trivial smooth vector fields onto the (complex-valued) ND space.
+  GridFunction E(nd_fespace, complex);
+  mfem::VectorFunctionCoefficient fr(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(x(1)) + x(2) * x(2);
+                                       v(1) = std::cos(x(2)) + x(0);
+                                       v(2) = x(0) * x(1) + 1.0;
+                                     });
+  E.Real().ProjectCoefficient(fr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fi(3,
+                                       [](const mfem::Vector &x, mfem::Vector &v)
+                                       {
+                                         v(0) = x(1) * x(2) - 0.5;
+                                         v(1) = std::sin(x(0)) - x(2);
+                                         v(2) = std::cos(x(1)) + x(0) * x(0);
+                                       });
+    E.Imag().ProjectCoefficient(fi);
+  }
+
+  const double t_i = 2.0e-3, epsilon_i = 10.0;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  auto TestType = [&](InterfaceDielectric type, const mfem::Array<int> &marker)
+  {
+    SurfaceFunctional epr(*mesh, marker, nd_fespace, mat_op, type, t_i, epsilon_i);
+    auto MakeLegacy = [&]() -> std::unique_ptr<mfem::Coefficient>
+    {
+      switch (type)
+      {
+        case InterfaceDielectric::DEFAULT:
+          return std::make_unique<
+              InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>(E, mat_op, t_i,
+                                                                            epsilon_i);
+        case InterfaceDielectric::MA:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::MA>>(
+              E, mat_op, t_i, epsilon_i);
+        case InterfaceDielectric::MS:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::MS>>(
+              E, mat_op, t_i, epsilon_i);
+        case InterfaceDielectric::SA:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::SA>>(
+              E, mat_op, t_i, epsilon_i);
+      }
+      return {};
+    };
+    auto legacy = MakeLegacy();
+    const double ref = RefSurfaceCoefficientIntegral(pmesh, *legacy, marker);
+    const double val = epr.Eval(E);
+    CAPTURE(ref, val);
+    if (std::abs(ref) > 0.0)
+    {
+      CHECK(val == Catch::Approx(ref).epsilon(1.0e-10));
+    }
+    else
+    {
+      CHECK(std::abs(val) < 1.0e-12);
+    }
+  };
+
+  SECTION("Exterior boundary")
+  {
+    // Boundary attribute 1 is an exterior boundary (single-sided evaluation). The
+    // bottom boundary (z = 0) neighbors vacuum, the top (z = 1) neighbors dielectric.
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA,
+                      InterfaceDielectric::MS, InterfaceDielectric::SA})
+    {
+      CAPTURE(static_cast<int>(type));
+      for (int attr : {1, 6})  // z = 0 (vacuum side), z = 1 (dielectric side)
+      {
+        CAPTURE(attr);
+        mfem::Array<int> marker(bdr_attr_max);
+        marker = 0;
+        marker[attr - 1] = 1;
+        TestType(type, marker);
+      }
+    }
+  }
+
+  SECTION("Interior material interface")
+  {
+    // Boundary attribute 7 is the interior vacuum-dielectric interface (two-sided,
+    // side selection by material light speed for MA/MS/SA, averaging for DEFAULT).
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[7 - 1] = 1;
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA,
+                      InterfaceDielectric::MS, InterfaceDielectric::SA})
+    {
+      CAPTURE(static_cast<int>(type));
+      TestType(type, marker);
+    }
+  }
+}
+
+TEST_CASE("SurfaceFunctional Interface Dielectric 2D", "[surfacefunctional][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TRIANGLE, mfem::Element::QUADRILATERAL);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh2D(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  // Materials: vacuum for attribute 1, dielectric for attribute 2. Use diagonal
+  // anisotropy to exercise the 2x2 coefficient unpacking path in the libCEED kernels.
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 3.2;
+  dielectric.epsilon_r.s[2] = 5.1;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+
+  GridFunction E(nd_fespace, complex);
+  mfem::VectorFunctionCoefficient fr(2,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(1.7 * x(1)) + 0.25 * x(0);
+                                       v(1) = std::cos(0.3 + x(0)) + x(1) * x(1);
+                                     });
+  E.Real().ProjectCoefficient(fr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fi(2,
+                                       [](const mfem::Vector &x, mfem::Vector &v)
+                                       {
+                                         v(0) = x(0) * x(1) - 0.2;
+                                         v(1) = std::sin(x(0) + 0.5 * x(1));
+                                       });
+    E.Imag().ProjectCoefficient(fi);
+  }
+
+  const double t_i = 2.0e-3, epsilon_i = 10.0;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  auto TestType = [&](InterfaceDielectric type, const mfem::Array<int> &marker)
+  {
+    SurfaceFunctional epr(*mesh, marker, nd_fespace, mat_op, type, t_i, epsilon_i);
+    REQUIRE(epr.IsValid());
+    auto MakeLegacy = [&]() -> std::unique_ptr<mfem::Coefficient>
+    {
+      switch (type)
+      {
+        case InterfaceDielectric::DEFAULT:
+          return std::make_unique<
+              InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>(E, mat_op, t_i,
+                                                                            epsilon_i);
+        case InterfaceDielectric::MA:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::MA>>(
+              E, mat_op, t_i, epsilon_i);
+        case InterfaceDielectric::MS:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::MS>>(
+              E, mat_op, t_i, epsilon_i);
+        case InterfaceDielectric::SA:
+          return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::SA>>(
+              E, mat_op, t_i, epsilon_i);
+      }
+      return {};
+    };
+    auto legacy = MakeLegacy();
+    const double ref = RefSurfaceCoefficientIntegral(pmesh, *legacy, marker);
+    const double val = epr.Eval(E);
+    CAPTURE(ref, val);
+    if (std::abs(ref) > 0.0)
+    {
+      CHECK(val == Catch::Approx(ref).epsilon(1.0e-10));
+    }
+    else
+    {
+      CHECK(std::abs(val) < 1.0e-12);
+    }
+  };
+
+  SECTION("Exterior boundary")
+  {
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA,
+                      InterfaceDielectric::MS, InterfaceDielectric::SA})
+    {
+      CAPTURE(static_cast<int>(type));
+      for (int attr : {1, 3})  // bottom (vacuum side), top (dielectric side)
+      {
+        CAPTURE(attr);
+        REQUIRE(pmesh.bdr_attributes.Find(attr) >= 0);
+        mfem::Array<int> marker(bdr_attr_max);
+        marker = 0;
+        marker[attr - 1] = 1;
+        TestType(type, marker);
+      }
+    }
+  }
+
+  SECTION("Interior material interface")
+  {
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[7 - 1] = 1;
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA,
+                      InterfaceDielectric::MS, InterfaceDielectric::SA})
+    {
+      CAPTURE(static_cast<int>(type));
+      TestType(type, marker);
+    }
+  }
+}
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator boundary mode 2D interface dielectric matches legacy",
+                 "[postoperator][surfacefunctional][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+  constexpr int order = 2;
+
+  IoData iodata(Units(1.0, 1.0));
+  iodata.problem.type = ProblemType::BOUNDARYMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = false;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0;
+  iodata.model.Lc = 1.0;
+  iodata.solver.order = order;
+  iodata.solver.boundary_mode.freq = 1.0;
+  iodata.solver.boundary_mode.n = 1;
+  iodata.solver.boundary_mode.n_post = 1;
+  iodata.solver.linear.tol = 1.0e-8;
+  iodata.solver.linear.max_it = 50;
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 4.0;
+  dielectric.epsilon_r.s[1] = 6.0;
+  dielectric.epsilon_r.s[2] = 8.0;
+  iodata.domains.materials = {vacuum, dielectric};
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4};
+
+  config::InterfaceDielectricData interface;
+  interface.attributes = {7};
+  interface.type = InterfaceDielectric::SA;
+  interface.t = 2.0e-3;
+  interface.epsilon_r = 10.0;
+  interface.tandelta = 3.0e-4;
+  iodata.boundaries.postpro.dielectric.emplace(1, interface);
+
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(MakeInterfaceMesh2D(comm, mfem::Element::TRIANGLE));
+  auto &pmesh = mesh.front()->Get();
+  MaterialOperator mat_op(iodata, *mesh.front());
+  BoundaryModeOperator fem_op(iodata, mesh, mat_op);
+  TestBoundaryModePostOperator post_op(iodata, fem_op);
+
+  GridFunction E(fem_op.GetNDSpace(), true), En(fem_op.GetH1Space(), true);
+  mfem::VectorFunctionCoefficient etr(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + 0.3 * x(0);
+                                        v(1) = std::cos(x(0)) + x(0) * x(1);
+                                      });
+  mfem::VectorFunctionCoefficient eti(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(0) - 0.2 * x(1);
+                                        v(1) = std::sin(x(0) + x(1));
+                                      });
+  mfem::FunctionCoefficient enr([](const mfem::Vector &x) { return 0.5 + x(0) * x(1); });
+  mfem::FunctionCoefficient eni([](const mfem::Vector &x)
+                                { return std::cos(x(0)) - 0.1 * x(1); });
+  E.Real().ProjectCoefficient(etr);
+  E.Imag().ProjectCoefficient(eti);
+  En.Real().ProjectCoefficient(enr);
+  En.Imag().ProjectCoefficient(eni);
+
+  ComplexVector et(fem_op.GetNDTrueVSize()), en(fem_op.GetH1TrueVSize());
+  E.Real().GetTrueDofs(et.Real());
+  E.Imag().GetTrueDofs(et.Imag());
+  En.Real().GetTrueDofs(en.Real());
+  En.Imag().GetTrueDofs(en.Imag());
+
+  // Public PostOperator entry point under test: BoundaryMode computes its derived B
+  // fields internally, then measures configured interface dielectric participation.
+  const double omega = 2.0;
+  const std::complex<double> kn(0.7, 0.05);
+  post_op.MeasureAndPrintAll(0, et, en, kn, omega, 0.0, 0.0, 1);
+
+  mfem::Array<int> marker(pmesh.bdr_attributes.Max());
+  marker = 0;
+  marker[7 - 1] = 1;
+  InterfaceDielectricCoefficient<InterfaceDielectric::SA> legacy(E, mat_op, interface.t,
+                                                                 interface.epsilon_r);
+  const double interface_energy = RefSurfaceCoefficientIntegral(pmesh, legacy, marker);
+  DomainPostOperator domain_post(iodata.domains.postpro, mat_op, fem_op.GetNDSpace(),
+                                 fem_op.GetCurlSpace());
+  const double domain_energy = domain_post.GetElectricFieldEnergy(E);
+  const double participation = interface_energy / domain_energy;
+
+  const auto &cache = post_op.Cache();
+  REQUIRE(cache.interface_eps_i.size() == 1);
+  const auto &measured = cache.interface_eps_i.front();
+  CHECK(measured.idx == 1);
+  CHECK(measured.energy == Catch::Approx(interface_energy).epsilon(1.0e-10));
+  CHECK(measured.energy_participation == Catch::Approx(participation).epsilon(1.0e-10));
+  CHECK(measured.quality_factor ==
+        Catch::Approx(1.0 / (participation * interface.tandelta)).epsilon(1.0e-10));
+}
+
+TEST_CASE("SurfaceFunctional Surface Flux", "[surfacefunctional][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  mfem::RT_FECollection rt_fec(order - 1, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  // Project non-trivial smooth vector fields onto the (complex-valued) ND and RT
+  // spaces.
+  GridFunction E(nd_fespace, complex), B(rt_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(1) * x(2) - 0.5;
+                                          v(1) = std::sin(x(0)) - x(2);
+                                          v(2) = std::cos(x(1)) + x(0) * x(0);
+                                        });
+    mfem::VectorFunctionCoefficient fbi(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = std::cos(x(2)) - 0.2;
+                                          v(1) = x(0) * x(2) + 0.1;
+                                          v(2) = std::sin(x(1)) - x(0);
+                                        });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  mfem::Vector x0(3);
+  x0(0) = 0.4;
+  x0(1) = 0.6;
+  x0(2) = -0.2;  // Off-center so the orientation sign flip logic is exercised
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  auto TestType = [&](SurfaceFlux type, bool two_sided, const mfem::Array<int> &marker)
+  {
+    const GridFunction *E_use =
+        (type == SurfaceFlux::ELECTRIC || type == SurfaceFlux::POWER) ? &E : nullptr;
+    const GridFunction *B_use =
+        (type == SurfaceFlux::MAGNETIC || type == SurfaceFlux::POWER) ? &B : nullptr;
+    SurfaceFunctional flux(*mesh, marker, E_use ? &nd_fespace.Get() : nullptr,
+                           B_use ? &rt_fespace.Get() : nullptr, mat_op, type, two_sided,
+                           x0);
+
+    // Legacy reference following SurfacePostOperator::GetSurfaceFlux.
+    auto MakeLegacy =
+        [&](const mfem::ParGridFunction *Er,
+            const mfem::ParGridFunction *Br) -> std::unique_ptr<mfem::Coefficient>
+    {
+      switch (type)
+      {
+        case SurfaceFlux::ELECTRIC:
+          return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
+              Er, Br, mat_op, two_sided, x0);
+        case SurfaceFlux::MAGNETIC:
+          return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::MAGNETIC>>(
+              Er, Br, mat_op, two_sided, x0);
+        case SurfaceFlux::POWER:
+          return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>>(
+              Er, Br, mat_op, two_sided, x0);
+      }
+      return {};
+    };
+    auto legacy_re = MakeLegacy(E_use ? &E.Real() : nullptr, B_use ? &B.Real() : nullptr);
+    std::complex<double> ref(RefSurfaceCoefficientIntegral(pmesh, *legacy_re, marker), 0.0);
+    if (complex)
+    {
+      auto legacy_im = MakeLegacy(E_use ? &E.Imag() : nullptr, B_use ? &B.Imag() : nullptr);
+      const double ref_im = RefSurfaceCoefficientIntegral(pmesh, *legacy_im, marker);
+      if (type == SurfaceFlux::POWER)
+      {
+        ref += ref_im;
+      }
+      else
+      {
+        ref.imag(ref_im);
+      }
+    }
+
+    const std::complex<double> val = flux.EvalFlux(E_use, B_use);
+    CAPTURE(ref.real(), ref.imag(), val.real(), val.imag());
+    auto CheckPart = [](double v, double r)
+    {
+      if (std::abs(r) > 1.0e-12)
+      {
+        CHECK(v == Catch::Approx(r).epsilon(1.0e-10));
+      }
+      else
+      {
+        CHECK(std::abs(v) < 1.0e-10);
+      }
+    };
+    CheckPart(val.real(), ref.real());
+    CheckPart(val.imag(), ref.imag());
+  };
+
+  SECTION("Exterior boundary")
+  {
+    for (auto type : {SurfaceFlux::ELECTRIC, SurfaceFlux::MAGNETIC, SurfaceFlux::POWER})
+    {
+      CAPTURE(static_cast<int>(type));
+      for (int attr : {1, 6})  // z = 0 (vacuum side), z = 1 (dielectric side)
+      {
+        CAPTURE(attr);
+        mfem::Array<int> marker(bdr_attr_max);
+        marker = 0;
+        marker[attr - 1] = 1;
+        TestType(type, false, marker);
+      }
+    }
+  }
+
+  SECTION("Interior material interface")
+  {
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[7 - 1] = 1;
+    for (auto type : {SurfaceFlux::ELECTRIC, SurfaceFlux::MAGNETIC, SurfaceFlux::POWER})
+    {
+      CAPTURE(static_cast<int>(type));
+      for (bool two_sided : {false, true})
+      {
+        CAPTURE(two_sided);
+        TestType(type, two_sided, marker);
+      }
+    }
+  }
+}
+
+TEST_CASE("SurfaceFunctional Complex Power", "[surfacefunctional][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  mfem::RT_FECollection rt_fec(order - 1, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, complex), B(rt_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(1) * x(2) - 0.5;
+                                          v(1) = std::sin(x(0)) - x(2);
+                                          v(2) = std::cos(x(1)) + x(0) * x(0);
+                                        });
+    mfem::VectorFunctionCoefficient fbi(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = std::cos(x(2)) - 0.2;
+                                          v(1) = x(0) * x(2) + 0.1;
+                                          v(2) = std::sin(x(1)) - x(0);
+                                        });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  // Legacy reference: replicate LumpedPortData::GetPower exactly (linear form from
+  // BdrSurfaceCurrentVectorCoefficient dotted with the E field expansion).
+  auto LegacyPower = [&](int attr, const mfem::Array<int> &attr_marker)
+  {
+    mfem::Array<int> attr_list(1);
+    attr_list[0] = attr;
+    std::complex<double> dot;
+    {
+      RestrictedVectorCoefficient<BdrSurfaceCurrentVectorCoefficient> fbr_c(
+          attr_list, B.Real(), mat_op);
+      mfem::LinearForm pr(&nd_fespace.Get());
+      pr.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbr_c),
+                               const_cast<mfem::Array<int> &>(attr_marker));
+      pr.UseFastAssembly(false);
+      pr.UseDevice(false);
+      pr.Assemble();
+      pr.UseDevice(true);
+      dot =
+          -(pr * E.Real()) + (complex ? std::complex<double>(0.0, -(pr * E.Imag())) : 0.0);
+    }
+    if (complex)
+    {
+      RestrictedVectorCoefficient<BdrSurfaceCurrentVectorCoefficient> fbi_c(
+          attr_list, B.Imag(), mat_op);
+      mfem::LinearForm pi(&nd_fespace.Get());
+      pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbi_c),
+                               const_cast<mfem::Array<int> &>(attr_marker));
+      pi.UseFastAssembly(false);
+      pi.UseDevice(false);
+      pi.Assemble();
+      pi.UseDevice(true);
+      dot += std::complex<double>(-(pi * E.Imag()), pi * E.Real());
+    }
+    Mpi::GlobalSum(1, &dot, comm);
+    return dot;
+  };
+
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Vector x0(3);
+  x0 = 0.0;
+
+  auto CheckPart = [](double v, double r)
+  {
+    if (std::abs(r) > 1.0e-12)
+    {
+      CHECK(v == Catch::Approx(r).epsilon(1.0e-10));
+    }
+    else
+    {
+      CHECK(std::abs(v) < 1.0e-10);
+    }
+  };
+
+  for (int attr : {1, 6, 7})  // Exterior (vacuum side), exterior (dielectric), interior
+  {
+    CAPTURE(attr);
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[attr - 1] = 1;
+    SurfaceFunctional power(*mesh, marker, &nd_fespace.Get(), &rt_fespace.Get(), mat_op,
+                            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+    const std::complex<double> ref = LegacyPower(attr, marker);
+    const std::complex<double> val = power.EvalComplexPower(E, B);
+    CAPTURE(ref.real(), ref.imag(), val.real(), val.imag());
+    CheckPart(val.real(), ref.real());
+    CheckPart(val.imag(), ref.imag());
+  }
+
+  SECTION("Batched by boundary attribute")
+  {
+    mfem::Array<int> marker(bdr_attr_max), attr_to_bin(bdr_attr_max);
+    marker = 0;
+    attr_to_bin = -1;
+    std::vector<int> attrs = {1, 6, 7};
+    for (std::size_t i = 0; i < attrs.size(); i++)
+    {
+      marker[attrs[i] - 1] = 1;
+      attr_to_bin[attrs[i] - 1] = static_cast<int>(i);
+    }
+    SurfaceFunctional power(*mesh, marker, &nd_fespace.Get(), &rt_fespace.Get(), mat_op,
+                            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+    const auto values = power.EvalComplexPowerByAttribute(E, B, attr_to_bin,
+                                                          static_cast<int>(attrs.size()));
+    REQUIRE(values.size() == attrs.size());
+    for (std::size_t i = 0; i < attrs.size(); i++)
+    {
+      mfem::Array<int> single_marker(bdr_attr_max);
+      single_marker = 0;
+      single_marker[attrs[i] - 1] = 1;
+      const std::complex<double> ref = LegacyPower(attrs[i], single_marker);
+      CAPTURE(attrs[i], ref.real(), ref.imag(), values[i].real(), values[i].imag());
+      CheckPart(values[i].real(), ref.real());
+      CheckPart(values[i].imag(), ref.imag());
+    }
+  }
+}
+
+// Benchmark comparing the legacy mfem::Coefficient-based measurement paths against the
+// libCEED surface functionals. Hidden by default; run explicitly with:
+//   ./palace-unit-tests "[surfacefunctional-bench]" [--device cuda]
+// Mesh size can be controlled with the PALACE_BENCH_N environment variable (default
+// 20, i.e. a 20x20x20 hex mesh).
+TEST_CASE("SurfaceFunctional Benchmark", "[.][surfacefunctional-bench][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  const int order = 2;
+  const int N =
+      std::getenv("PALACE_BENCH_N") ? std::atoi(std::getenv("PALACE_BENCH_N")) : 20;
+  const int n_reps = 10;
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  // Two-material N x N x N hex mesh with an interior interface (attribute 7).
+  auto mesh = [&]()
+  {
+    mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(N, N, N, mfem::Element::HEXAHEDRON);
+    for (int e = 0; e < smesh.GetNE(); e++)
+    {
+      mfem::Vector center(3);
+      smesh.GetElementCenter(e, center);
+      smesh.SetAttribute(e, (center(2) < 0.5) ? 1 : 2);
+    }
+    for (int f = 0; f < smesh.GetNumFaces(); f++)
+    {
+      int e1, e2;
+      smesh.GetFaceElements(f, &e1, &e2);
+      if (e1 >= 0 && e2 >= 0 && smesh.GetAttribute(e1) != smesh.GetAttribute(e2))
+      {
+        auto *face_elem = smesh.GetFace(f)->Duplicate(&smesh);
+        face_elem->SetAttribute(7);
+        smesh.AddBdrElement(face_elem);
+      }
+    }
+    smesh.FinalizeTopology();
+    smesh.Finalize();
+    smesh.SetAttributes();
+    smesh.EnsureNodes();
+    auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+    return std::make_unique<Mesh>(std::move(pmesh));
+  }();
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  mfem::H1_FECollection h1_fec(order, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec),
+      h1_fespace(*mesh, &h1_fec);
+
+  GridFunction E(nd_fespace, true), B(rt_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::cos(x(2)) - 0.2;
+                                        v(1) = x(0) * x(2) + 0.1;
+                                        v(2) = std::sin(x(1)) - x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  const int bdr_attr_max = pmesh.bdr_attributes.Max();
+  mfem::Array<int> marker(bdr_attr_max);
+  marker = 0;
+  marker[7 - 1] = 1;
+  const double t_i = 2.0e-3, epsilon_i = 10.0;
+
+  auto TimeIt = [&](auto &&f, int reps)
+  {
+    // Warm up (also triggers any JIT compilation on GPU backends).
+    f();
+    double t_min = 1.0e30, t_sum = 0.0;
+    for (int r = 0; r < reps; r++)
+    {
+      auto t0 = std::chrono::steady_clock::now();
+      f();
+      auto t1 = std::chrono::steady_clock::now();
+      const double t = std::chrono::duration<double, std::milli>(t1 - t0).count();
+      t_min = std::min(t_min, t);
+      t_sum += t;
+    }
+    return std::make_pair(t_min, t_sum / reps);
+  };
+
+  std::cout << "\n=== SurfaceFunctional benchmark: N = " << N << " (" << pmesh.GetNE()
+            << " elements, " << N * N << " interface boundary elements, ND order " << order
+            << ", " << nd_fespace.GlobalTrueVSize() << " ND dofs) ===\n";
+
+  // 1. Interface dielectric EPR (MA type) over the interior interface.
+  {
+    volatile double sink;
+    auto legacy = [&]()
+    {
+      // Replicates SurfacePostOperator::GetInterfaceElectricFieldEnergy +
+      // GetLocalSurfaceIntegral.
+      InterfaceDielectricCoefficient<InterfaceDielectric::MA> f(E, mat_op, t_i, epsilon_i);
+      mfem::LinearForm s(&h1_fespace.Get());
+      s.AddBoundaryIntegrator(new BoundaryLFIntegrator(f),
+                              const_cast<mfem::Array<int> &>(marker));
+      s.UseFastAssembly(false);
+      s.UseDevice(false);
+      s.Assemble();
+      s.UseDevice(true);
+      double dot = linalg::LocalSum(s);
+      Mpi::GlobalSum(1, &dot, comm);
+      sink = dot;
+    };
+    auto t0 = std::chrono::steady_clock::now();
+    SurfaceFunctional epr(*mesh, marker, nd_fespace, mat_op, InterfaceDielectric::MA, t_i,
+                          epsilon_i);
+    auto t1 = std::chrono::steady_clock::now();
+    const double t_constr = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    auto ceed_path = [&]() { sink = epr.Eval(E); };
+
+    // Verify agreement before timing.
+    InterfaceDielectricCoefficient<InterfaceDielectric::MA> f(E, mat_op, t_i, epsilon_i);
+    const double ref = RefSurfaceCoefficientIntegral(pmesh, f, marker);
+    const double val = epr.Eval(E);
+    REQUIRE(val == Catch::Approx(ref).epsilon(1.0e-10));
+
+    auto [legacy_min, legacy_avg] = TimeIt(legacy, n_reps);
+    auto [ceed_min, ceed_avg] = TimeIt(ceed_path, n_reps);
+    std::cout << "Interface EPR (MA), complex E, per measurement:\n"
+              << "  legacy coefficient path: min " << legacy_min << " ms, avg "
+              << legacy_avg << " ms\n"
+              << "  libCEED functional:      min " << ceed_min << " ms, avg " << ceed_avg
+              << " ms  (construction, once: " << t_constr << " ms)\n"
+              << "  speedup (avg): " << legacy_avg / ceed_avg << "x\n";
+  }
+
+  // 2. Port power over the interior interface (driven solver inner loop quantity).
+  {
+    volatile double sink;
+    mfem::Array<int> attr_list(1);
+    attr_list[0] = 7;
+    auto legacy = [&]()
+    {
+      // Replicates LumpedPortData::GetPower.
+      std::complex<double> dot;
+      {
+        RestrictedVectorCoefficient<BdrSurfaceCurrentVectorCoefficient> fbr_c(
+            attr_list, B.Real(), mat_op);
+        mfem::LinearForm pr(&nd_fespace.Get());
+        pr.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbr_c),
+                                 const_cast<mfem::Array<int> &>(marker));
+        pr.UseFastAssembly(false);
+        pr.UseDevice(false);
+        pr.Assemble();
+        pr.UseDevice(true);
+        dot = std::complex<double>(-(pr * E.Real()), -(pr * E.Imag()));
+      }
+      {
+        RestrictedVectorCoefficient<BdrSurfaceCurrentVectorCoefficient> fbi_c(
+            attr_list, B.Imag(), mat_op);
+        mfem::LinearForm pi(&nd_fespace.Get());
+        pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(fbi_c),
+                                 const_cast<mfem::Array<int> &>(marker));
+        pi.UseFastAssembly(false);
+        pi.UseDevice(false);
+        pi.Assemble();
+        pi.UseDevice(true);
+        dot += std::complex<double>(-(pi * E.Imag()), pi * E.Real());
+      }
+      Mpi::GlobalSum(1, &dot, comm);
+      sink = dot.real();
+    };
+    mfem::Vector x0(3);
+    x0 = 0.0;
+    auto t0 = std::chrono::steady_clock::now();
+    SurfaceFunctional power(*mesh, marker, &nd_fespace.Get(), &rt_fespace.Get(), mat_op,
+                            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+    auto t1 = std::chrono::steady_clock::now();
+    const double t_constr = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    auto ceed_path = [&]() { sink = power.EvalComplexPower(E, B).real(); };
+
+    auto [legacy_min, legacy_avg] = TimeIt(legacy, n_reps);
+    auto [ceed_min, ceed_avg] = TimeIt(ceed_path, n_reps);
+    std::cout << "Port power, complex E and B, per measurement:\n"
+              << "  legacy linear form path: min " << legacy_min << " ms, avg "
+              << legacy_avg << " ms\n"
+              << "  libCEED functional:      min " << ceed_min << " ms, avg " << ceed_avg
+              << " ms  (construction, once: " << t_constr << " ms)\n"
+              << "  speedup (avg): " << legacy_avg / ceed_avg << "x\n";
+  }
+}
+
+TEST_CASE("SurfaceFunctional Nonconformal Mesh", "[surfacefunctional][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  CAPTURE(elem_type, order);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeNCInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+  REQUIRE(pmesh.Nonconforming());
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, true), B(rt_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::cos(x(2)) - 0.2;
+                                        v(1) = x(0) * x(2) + 0.1;
+                                        v(2) = std::sin(x(1)) - x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  const double t_i = 2.0e-3, epsilon_i = 10.0;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Vector x0(3);
+  x0(0) = 0.4;
+  x0(1) = 0.6;
+  x0(2) = -0.2;
+
+  auto CheckPart = [](double v, double r)
+  {
+    if (std::abs(r) > 1.0e-12)
+    {
+      CHECK(v == Catch::Approx(r).epsilon(1.0e-10));
+    }
+    else
+    {
+      CHECK(std::abs(v) < 1.0e-10);
+    }
+  };
+
+  // The exterior boundary attribute 1 (z = 0 in the refined half and beyond) and the
+  // interior interface attribute 7 both contain a mix of conformal and nonconformal
+  // (slave) faces after the partial refinement.
+  for (int attr : {1, 6, 7})
+  {
+    CAPTURE(attr);
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[attr - 1] = 1;
+
+    // Interface dielectric (all variants).
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA,
+                      InterfaceDielectric::MS, InterfaceDielectric::SA})
+    {
+      CAPTURE(static_cast<int>(type));
+      SurfaceFunctional epr(*mesh, marker, nd_fespace, mat_op, type, t_i, epsilon_i);
+      REQUIRE(epr.IsValid());
+      auto MakeLegacy = [&]() -> std::unique_ptr<mfem::Coefficient>
+      {
+        switch (type)
+        {
+          case InterfaceDielectric::DEFAULT:
+            return std::make_unique<
+                InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>(
+                E, mat_op, t_i, epsilon_i);
+          case InterfaceDielectric::MA:
+            return std::make_unique<
+                InterfaceDielectricCoefficient<InterfaceDielectric::MA>>(E, mat_op, t_i,
+                                                                         epsilon_i);
+          case InterfaceDielectric::MS:
+            return std::make_unique<
+                InterfaceDielectricCoefficient<InterfaceDielectric::MS>>(E, mat_op, t_i,
+                                                                         epsilon_i);
+          case InterfaceDielectric::SA:
+            return std::make_unique<
+                InterfaceDielectricCoefficient<InterfaceDielectric::SA>>(E, mat_op, t_i,
+                                                                         epsilon_i);
+        }
+        return {};
+      };
+      auto legacy = MakeLegacy();
+      const double ref = RefSurfaceCoefficientIntegral(pmesh, *legacy, marker);
+      const double val = epr.Eval(E);
+      CAPTURE(ref, val);
+      CheckPart(val, ref);
+    }
+
+    // Surface flux (all types, both two_sided settings).
+    for (auto type : {SurfaceFlux::ELECTRIC, SurfaceFlux::MAGNETIC, SurfaceFlux::POWER})
+    {
+      for (bool two_sided : {false, true})
+      {
+        CAPTURE(static_cast<int>(type), two_sided);
+        const GridFunction *E_use =
+            (type == SurfaceFlux::ELECTRIC || type == SurfaceFlux::POWER) ? &E : nullptr;
+        const GridFunction *B_use =
+            (type == SurfaceFlux::MAGNETIC || type == SurfaceFlux::POWER) ? &B : nullptr;
+        SurfaceFunctional flux(*mesh, marker, E_use ? &nd_fespace.Get() : nullptr,
+                               B_use ? &rt_fespace.Get() : nullptr, mat_op, type, two_sided,
+                               x0);
+        REQUIRE(flux.IsValid());
+        auto MakeLegacy =
+            [&](const mfem::ParGridFunction *Er,
+                const mfem::ParGridFunction *Br) -> std::unique_ptr<mfem::Coefficient>
+        {
+          switch (type)
+          {
+            case SurfaceFlux::ELECTRIC:
+              return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
+                  Er, Br, mat_op, two_sided, x0);
+            case SurfaceFlux::MAGNETIC:
+              return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::MAGNETIC>>(
+                  Er, Br, mat_op, two_sided, x0);
+            case SurfaceFlux::POWER:
+              return std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>>(
+                  Er, Br, mat_op, two_sided, x0);
+          }
+          return {};
+        };
+        auto legacy_re =
+            MakeLegacy(E_use ? &E.Real() : nullptr, B_use ? &B.Real() : nullptr);
+        std::complex<double> ref(RefSurfaceCoefficientIntegral(pmesh, *legacy_re, marker),
+                                 0.0);
+        auto legacy_im =
+            MakeLegacy(E_use ? &E.Imag() : nullptr, B_use ? &B.Imag() : nullptr);
+        const double ref_im = RefSurfaceCoefficientIntegral(pmesh, *legacy_im, marker);
+        if (type == SurfaceFlux::POWER)
+        {
+          ref += ref_im;
+        }
+        else
+        {
+          ref.imag(ref_im);
+        }
+        const std::complex<double> val = flux.EvalFlux(E_use, B_use);
+        CAPTURE(ref.real(), ref.imag(), val.real(), val.imag());
+        CheckPart(val.real(), ref.real());
+        CheckPart(val.imag(), ref.imag());
+      }
+    }
+  }
+}
+
+TEST_CASE("SurfaceFunctional Nonconformal Parallel", "[surfacefunctional][Parallel][GPU]")
+{
+  // On parallel (possibly nonconformal) meshes, two-sided evaluation across process
+  // boundaries uses FaceNbrFieldExchange to pull remote-side physical field values.
+  // This test makes that processor-boundary behavior a committed regression: exterior
+  // and interior interface surfaces must all assemble through libCEED and match the
+  // legacy coefficient oracles.
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  const int order = 2;
+  CAPTURE(elem_type);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeNCInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, true), B(rt_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::cos(x(2)) - 0.2;
+                                        v(1) = x(0) * x(2) + 0.1;
+                                        v(2) = std::sin(x(1)) - x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  // The legacy reference evaluates fields on remote sides of shared faces via face
+  // neighbor data.
+  E.Real().ExchangeFaceNbrData();
+  E.Imag().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+  B.Imag().ExchangeFaceNbrData();
+
+  const double t_i = 2.0e-3, epsilon_i = 10.0;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+
+  for (int attr : {1, 6, 7})
+  {
+    CAPTURE(attr);
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 0;
+    marker[attr - 1] = 1;
+    auto CheckPart = [](double val, double ref)
+    {
+      if (std::abs(ref) > 1.0e-12)
+      {
+        CHECK(val == Catch::Approx(ref).epsilon(1.0e-10));
+      }
+      else
+      {
+        CHECK(std::abs(val) < 1.0e-10);
+      }
+    };
+
+    for (auto type : {InterfaceDielectric::DEFAULT, InterfaceDielectric::MA})
+    {
+      CAPTURE(static_cast<int>(type));
+      SurfaceFunctional epr(*mesh, marker, nd_fespace, mat_op, type, t_i, epsilon_i);
+
+      bool valid = epr.IsValid();
+      bool valid_and = valid, valid_or = valid;
+      Mpi::GlobalAnd(1, &valid_and, comm);
+      Mpi::GlobalOr(1, &valid_or, comm);
+      REQUIRE(valid_and == valid_or);
+      REQUIRE(valid);
+
+      auto MakeLegacy = [&]() -> std::unique_ptr<mfem::Coefficient>
+      {
+        if (type == InterfaceDielectric::DEFAULT)
+        {
+          return std::make_unique<
+              InterfaceDielectricCoefficient<InterfaceDielectric::DEFAULT>>(E, mat_op, t_i,
+                                                                            epsilon_i);
+        }
+        return std::make_unique<InterfaceDielectricCoefficient<InterfaceDielectric::MA>>(
+            E, mat_op, t_i, epsilon_i);
+      };
+      auto legacy = MakeLegacy();
+      const double ref = RefSurfaceCoefficientIntegral(pmesh, *legacy, marker);
+      const double val = epr.Eval(E);
+      CAPTURE(ref, val);
+      CheckPart(val, ref);
+    }
+
+    mfem::Vector x0(3);
+    x0 = 0.0;
+    SurfaceFunctional power(*mesh, marker, &nd_fespace.Get(), &rt_fespace.Get(), mat_op,
+                            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+    bool power_valid = power.IsValid();
+    bool power_valid_and = power_valid, power_valid_or = power_valid;
+    Mpi::GlobalAnd(1, &power_valid_and, comm);
+    Mpi::GlobalOr(1, &power_valid_or, comm);
+    REQUIRE(power_valid_and == power_valid_or);
+    REQUIRE(power_valid);
+
+    auto MakePowerLegacy =
+        [&](const mfem::ParGridFunction &Er, const mfem::ParGridFunction &Br)
+    {
+      auto coeff = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::POWER>>(
+          &Er, &Br, mat_op, /*two_sided*/ true, x0);
+      return RefSurfaceCoefficientIntegral(pmesh, *coeff, marker);
+    };
+    const std::complex<double> ref(
+        MakePowerLegacy(E.Real(), B.Real()) + MakePowerLegacy(E.Imag(), B.Imag()), 0.0);
+    const std::complex<double> val = power.EvalFlux(&E, &B);
+    CAPTURE(ref.real(), val.real(), val.imag());
+    CheckPart(val.real(), ref.real());
+    CheckPart(val.imag(), 0.0);
+  }
+}
+
+TEST_CASE("SurfaceFunctional FarField", "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  CAPTURE(elem_type, order);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};  // Isotropic (far-field requirement)
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, true), B(rt_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::cos(x(2)) - 0.2;
+                                        v(1) = x(0) * x(2) + 0.1;
+                                        v(2) = std::sin(x(1)) - x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  // Observation directions and (complex) frequency.
+  std::vector<std::array<double, 3>> r_naughts;
+  for (auto [theta, phi] : {std::pair{0.3, 0.7}, {1.2, 2.1}, {2.4, 4.5}})
+  {
+    r_naughts.push_back({std::sin(theta) * std::cos(phi), std::sin(theta) * std::sin(phi),
+                         std::cos(theta)});
+  }
+  const double omega_re = 2.7, omega_im = 0.15;
+
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> marker(bdr_attr_max);
+  marker = 0;
+  marker[1 - 1] = 1;  // Exterior boundary (z = 0)
+
+  // Legacy reference following GetFarFieldrE.
+  std::vector<std::array<double, 3>> integrals_r(r_naughts.size()),
+      integrals_i(r_naughts.size());
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    if (!marker[pmesh.GetBdrAttribute(i) - 1])
+    {
+      continue;
+    }
+    auto *T = const_cast<mfem::ParMesh &>(pmesh).GetBdrElementTransformation(i);
+    const auto *fe = nd_fespace.Get().GetBE(i);
+    const auto *ir =
+        &mfem::IntRules.Get(fe->GetGeomType(), fem::DefaultIntegrationOrder::Get(*T));
+    AddStrattonChuIntegrandAtElement(E, B, mat_op, omega_re, omega_im, r_naughts, *T, *ir,
+                                     integrals_r, integrals_i);
+  }
+  Mpi::GlobalSum(3 * r_naughts.size(), integrals_r.data()->data(), comm);
+  Mpi::GlobalSum(3 * r_naughts.size(), integrals_i.data()->data(), comm);
+
+  SurfaceFunctional farfield(*mesh, marker, nd_fespace, rt_fespace, mat_op, r_naughts);
+  REQUIRE(farfield.IsValid());
+  auto result = farfield.EvalFarField(E, B, {omega_re, omega_im});
+  REQUIRE(result.size() == r_naughts.size());
+  for (std::size_t d = 0; d < r_naughts.size(); d++)
+  {
+    const auto &r = r_naughts[d];
+    const auto &Ir = integrals_r[d];
+    const auto &Ii = integrals_i[d];
+    const std::array<double, 3> cr = {r[1] * Ir[2] - r[2] * Ir[1],
+                                      r[2] * Ir[0] - r[0] * Ir[2],
+                                      r[0] * Ir[1] - r[1] * Ir[0]};
+    const std::array<double, 3> ci = {r[1] * Ii[2] - r[2] * Ii[1],
+                                      r[2] * Ii[0] - r[0] * Ii[2],
+                                      r[0] * Ii[1] - r[1] * Ii[0]};
+    for (int c = 0; c < 3; c++)
+    {
+      CAPTURE(d, c, cr[c], ci[c], result[d][c].real(), result[d][c].imag());
+      CHECK(result[d][c].real() == Catch::Approx(cr[c]).epsilon(1.0e-10).margin(1.0e-14));
+      CHECK(result[d][c].imag() == Catch::Approx(ci[c]).epsilon(1.0e-10).margin(1.0e-14));
+    }
+  }
+
+  // Changing the frequency must reassemble and still agree (different result).
+  auto result2 = farfield.EvalFarField(E, B, {2.0 * omega_re, 0.0});
+  CHECK(std::abs(result2[0][0] - result[0][0]) > 0.0);
+}
+
+#if defined(MFEM_USE_GSLIB)
+TEST_CASE("InterpolationOperator Ceed Probes", "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  CAPTURE(elem_type, order);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+  GridFunction E(nd_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+
+  // Probe points (element interiors, in both material regions; points on element
+  // borders are avoided since interpolated values of H(curl) fields are multi-valued
+  // there and the GSLIB reference resolves the donor element rank-dependently).
+  std::map<int, config::ProbeData> probes;
+  const std::array<std::array<double, 3>, 3> pts = {
+      {{0.21, 0.37, 0.23}, {0.74, 0.52, 0.81}, {0.53, 0.48, 0.52}}};
+  for (std::size_t i = 0; i < pts.size(); i++)
+  {
+    config::ProbeData data;
+    data.center = pts[i];
+    probes.emplace(static_cast<int>(i + 1), data);
+  }
+  Units units(1.0, 1.0);
+  InterpolationOperator interp(probes, units, nd_fespace);
+
+  // Reference: GSLIB interpolation at the same points (byVDIM).
+  const int npts = static_cast<int>(pts.size());
+  mfem::Vector xyz(npts * 3), vals_r(npts * 3), vals_i(npts * 3);
+  for (int i = 0; i < npts; i++)
+  {
+    for (int d = 0; d < 3; d++)
+    {
+      xyz(d * npts + i) = pts[i][d];
+    }
+  }
+  fem::InterpolateFunction(xyz, E.Real(), vals_r, mfem::Ordering::byNODES);
+  fem::InterpolateFunction(xyz, E.Imag(), vals_i, mfem::Ordering::byNODES);
+
+  auto vals = interp.ProbeField(E);
+  REQUIRE(static_cast<int>(vals.size()) == npts * 3);
+  for (int i = 0; i < npts; i++)
+  {
+    for (int d = 0; d < 3; d++)
+    {
+      // ProbeField returns byVDIM; the InterpolateFunction reference returns with the
+      // requested (byNODES) ordering.
+      const auto val = vals[3 * i + d];
+      const double ref_r = vals_r(d * npts + i), ref_i = vals_i(d * npts + i);
+      CAPTURE(i, d, ref_r, ref_i);
+      CHECK(val.real() == Catch::Approx(ref_r).epsilon(1.0e-9).margin(1.0e-12));
+      CHECK(val.imag() == Catch::Approx(ref_i).epsilon(1.0e-9).margin(1.0e-12));
+    }
+  }
+}
+#endif
+
+TEST_CASE("FaceNbrFieldExchange", "[surfacefunctional][Serial][Parallel]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal);
+
+  auto mesh = nonconformal ? MakeNCInterfaceMesh(comm, elem_type)
+                           : MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  mfem::RT_FECollection rt_fec(order - 1, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  // Project non-trivial smooth fields. The reference values are computed from the same
+  // projected grid functions through the legacy mfem face neighbor dof exchange, so the
+  // comparison is exact up to roundoff (not projection error).
+  mfem::ParGridFunction E(&nd_fespace.Get()), B(&rt_fespace.Get());
+  mfem::VectorFunctionCoefficient fe(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(x(1)) + x(2) * x(2);
+                                       v(1) = std::cos(x(2)) + x(0);
+                                       v(2) = x(0) * x(1) + 1.0;
+                                     });
+  mfem::VectorFunctionCoefficient fb(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) * x(2) - 0.5;
+                                       v(1) = std::sin(x(0)) - x(2);
+                                       v(2) = std::cos(x(1)) + x(0) * x(0);
+                                     });
+  E.ProjectCoefficient(fe);
+  B.ProjectCoefficient(fb);
+
+  // Request E (slot 0) at a few reference points of every ghost element, and both E
+  // and B (slot 1) for every other ghost element (exercising the value layouts). The
+  // points are valid reference coordinates for both tetrahedra and hexahedra.
+  const int num_ghost = pmesh.GetNFaceNeighborElements();
+  std::vector<FaceNbrFieldExchange::Request> requests;
+  for (int fn = 0; fn < num_ghost; fn++)
+  {
+    auto &req = requests.emplace_back();
+    req.face_nbr_elem = fn;
+    req.source_mask = (fn % 2 == 0) ? 0b01u : 0b11u;
+    req.point_key = {static_cast<long long>(elem_type), static_cast<long long>(order), 4};
+    req.pts.resize(4);
+    req.pts[0].Set3(0.1, 0.2, 0.3);
+    req.pts[1].Set3(0.25, 0.25, 0.25);
+    req.pts[2].Set3(0.05, 0.1, 0.7);
+    req.pts[3].Set3(0.3, 0.05, 0.05);
+  }
+  FaceNbrFieldExchange exchange(
+      *mesh, {&nd_fespace.Get(), &rt_fespace.Get(), nullptr, nullptr}, requests);
+  exchange.Exchange({&E, &B, nullptr, nullptr});
+
+  // Reference: evaluate the ghost elements through the legacy dof exchange.
+  E.ExchangeFaceNbrData();
+  B.ExchangeFaceNbrData();
+  std::vector<double> vals(exchange.Imported().HostRead(),
+                           exchange.Imported().HostRead() + exchange.ImportSize());
+  mfem::Vector ref(3);
+  int num_checked = 0;
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const auto &req = requests[r];
+    for (int s = 0; s < 2; s++)
+    {
+      const int offset = exchange.ImportOffset(static_cast<int>(r), s);
+      if (!(req.source_mask & (1u << s)))
+      {
+        CHECK(offset < 0);
+        continue;
+      }
+      const auto &U = (s == 0) ? E : B;
+      for (std::size_t j = 0; j < req.pts.size(); j++)
+      {
+        U.GetVectorValue(pmesh.GetNE() + req.face_nbr_elem, req.pts[j], ref);
+        for (int c = 0; c < 3; c++)
+        {
+          CAPTURE(r, s, j, c);
+          CHECK(vals[offset + 3 * j + c] == Catch::Approx(ref(c)).margin(1.0e-12));
+          num_checked++;
+        }
+      }
+    }
+  }
+  // With more than one process, the partition must produce at least one ghost element
+  // somewhere (the exchange is the point of the test).
+  int num_global = num_checked;
+  Mpi::GlobalSum(1, &num_global, comm);
+  CHECK((Mpi::Size(comm) == 1 || num_global > 0));
+
+  // The field inputs are re-pointed at the sources on each call: scaling the field
+  // scales the exchanged values.
+  E *= 2.0;
+  exchange.Exchange({&E, &B, nullptr, nullptr});
+  const double *vals2 = exchange.Imported().HostRead();
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const int offset = exchange.ImportOffset(static_cast<int>(r), 0);
+    for (std::size_t j = 0; j < 3 * requests[r].pts.size(); j++)
+    {
+      CHECK(vals2[offset + j] == Catch::Approx(2.0 * vals[offset + j]).margin(1.0e-12));
+    }
+  }
+}
+
+}  // namespace palace

--- a/test/unit/test-waveportimpedance.cpp
+++ b/test/unit/test-waveportimpedance.cpp
@@ -8,7 +8,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include "fem/coefficient.hpp"
 #include "fem/fespace.hpp"
+#include "fem/integrator.hpp"
 #include "fem/mesh.hpp"
 #include "models/materialoperator.hpp"
 #include "models/waveportoperator.hpp"
@@ -21,6 +23,39 @@
 namespace palace
 {
 using namespace Catch::Matchers;
+
+std::complex<double> RefWavePortPower(const MaterialOperator &mat_op,
+                                      const mfem::Array<int> &attr_list, GridFunction &E,
+                                      GridFunction &B)
+{
+  auto &nd_fespace = *E.ParFESpace();
+  const auto &mesh = *nd_fespace.GetParMesh();
+  BdrSurfaceCurrentVectorCoefficient nxHr_func(B.Real(), mat_op);
+  BdrSurfaceCurrentVectorCoefficient nxHi_func(B.Imag(), mat_op);
+  int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+  std::complex<double> dot;
+  {
+    mfem::LinearForm pr(&nd_fespace);
+    pr.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(nxHr_func), attr_marker);
+    pr.UseFastAssembly(false);
+    pr.UseDevice(false);
+    pr.Assemble();
+    pr.UseDevice(true);
+    dot = -(pr * E.Real()) - std::complex<double>(0.0, 1.0) * (pr * E.Imag());
+  }
+  {
+    mfem::LinearForm pi(&nd_fespace);
+    pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(nxHi_func), attr_marker);
+    pi.UseFastAssembly(false);
+    pi.UseDevice(false);
+    pi.Assemble();
+    pi.UseDevice(true);
+    dot += -(pi * E.Imag()) + std::complex<double>(0.0, 1.0) * (pi * E.Real());
+  }
+  Mpi::GlobalSum(1, &dot, nd_fespace.GetComm());
+  return dot;
+}
 
 // Expose private WavePortOperator::Initialize so tests can drive a single port without
 // needing the full simulation harness (and without const_cast around GetPort()).
@@ -147,6 +182,103 @@ TEST_CASE("WavePort TE10 Z_PV", "[waveportimpedance][Serial]")
 // is +y-aligned, so naming y=0 as "signal" (high) and y=a as "ground" (low) gives a
 // (high → low) direction of +y, matching the field, sign = +1. Swapping the two
 // attribute roles flips the expected sign to -1.
+TEST_CASE("WavePort port power", "[waveportimpedance][Serial][GPU]")
+{
+  MPI_Comm comm = Mpi::World();
+
+  const double a_m = 22.86e-3, b_m = 10.16e-3, L_m = 10.0e-3;
+
+  auto serial_mesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(6, 6, 4, mfem::Element::TETRAHEDRON, L_m, a_m, b_m));
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.model.L0 = 1.0;
+  iodata.model.Lc = 1.0;
+
+  auto &material = iodata.domains.materials.emplace_back();
+  material.attributes = {1};
+  material.epsilon_r.s = {2.5, 1.7, 1.3};
+  material.mu_r.s = {1.1, 1.2, 1.4};
+
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4, 6};
+
+  auto &wave = iodata.boundaries.waveport.try_emplace(1).first->second;
+  wave.attributes = {5};
+  wave.mode_idx = 1;
+  wave.excitation = 0;
+  wave.active = true;
+  wave.eig_tol = 1.0e-8;
+  wave.ksp_tol = 1.0e-8;
+  wave.ksp_max_its = 100;
+  wave.max_size = std::max(2 * wave.mode_idx, wave.mode_idx + 15);
+
+  iodata.solver.order = 2;
+  iodata.solver.linear.tol = 1.0e-8;
+  iodata.solver.linear.max_it = 200;
+  iodata.problem.type = ProblemType::DRIVEN;
+
+  iodata.NondimensionalizeInputs(serial_mesh);
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  iodata.CheckConfiguration();
+  Mesh palace_mesh(std::move(par_mesh));
+
+  auto nd_fec =
+      std::make_unique<mfem::ND_FECollection>(iodata.solver.order, palace_mesh.Dimension());
+  auto rt_fec = std::make_unique<mfem::RT_FECollection>(iodata.solver.order - 1,
+                                                        palace_mesh.Dimension());
+  auto h1_fec =
+      std::make_unique<mfem::H1_FECollection>(iodata.solver.order, palace_mesh.Dimension());
+  FiniteElementSpace nd_fespace_palace(palace_mesh, nd_fec.get());
+  FiniteElementSpace rt_fespace_palace(palace_mesh, rt_fec.get());
+  FiniteElementSpace h1_fespace_palace(palace_mesh, h1_fec.get());
+  MaterialOperator mat_op(iodata, palace_mesh);
+
+  WavePortOperator wave_port_op(iodata, mat_op, nd_fespace_palace.Get(),
+                                h1_fespace_palace.Get());
+  wave_port_op.SetSuppressOutput(true);
+
+  GridFunction E(nd_fespace_palace, true), B(rt_fespace_palace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(2.0 * x(1)) + x(2);
+                                        v(1) = std::cos(x(0) + x(2));
+                                        v(2) = x(0) * x(1) + 0.25;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.1;
+                                        v(1) = std::sin(1.5 * x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = 0.2 + x(0) * x(2);
+                                        v(1) = x(0) - std::cos(x(1));
+                                        v(2) = std::sin(x(0) + x(1));
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  auto ref = RefWavePortPower(mat_op, wave_port_op.GetPort(1).GetAttrList(), E, B);
+  auto val = wave_port_op.GetPort(1).GetPower(E, B);
+  CAPTURE(ref, val);
+  CHECK_THAT(val.real(), WithinRel(ref.real(), 1.0e-10));
+  CHECK_THAT(val.imag(), WithinRel(ref.imag(), 1.0e-10));
+}
+
 TEST_CASE("WavePort TE10 mode polarity sign", "[waveportimpedance][Serial]")
 {
   MPI_Comm comm = Mpi::World();


### PR DESCRIPTION
## Summary

This is part one of the GPU postprocessing performance stack. It adds the libCEED-backed postprocessing functional infrastructure used for fast surface and port reductions, while leaving the ParaView/GridFunction field-output routing for the follow-up PR.

This PR introduces the libCEED non-tensor AtPoints CUDA patch required by the stack and wires it through the local Spack package override for libCEED.

## What changed

- Forward `CMAKE_CUDA_HOST_COMPILER` through the superbuild.
- Add the libCEED non-tensor AtPoints CUDA patch.
- Add libCEED-backed surface/output functional infrastructure.
- Add grouped libCEED operator support for postprocessing applies.
- Add 2D and 3D qfunctions for supported surface quantities.
- Add face-neighbor exchange support used by parallel surface/functionals evaluation.
- Route supported surface, lumped-port, wave-port, and mode-overlap reductions through the new libCEED functional path.
- Add focused regression coverage for surface functionals and port semantics.

## What this PR does not do

This PR does not replace the ParaView/GridFunction writer path for visualization fields. That is intentionally left to part two.

Review focus for this PR should be:

- libCEED patch/build wiring,
- CEED vector/operator ownership and lifetime,
- surface functional correctness,
- parallel face-neighbor exchange behavior,
- lumped-port and wave-port postprocessing equivalence.

## Stack relationship

This PR is the base for:

- `hughcars/gpu-postprocessing-paraview-gridfunctions-part-two`

Part two uses the functional/evaluator foundation from this PR to emit supported ParaView/GridFunction fields through libCEED point-field evaluators.

## Testing

Built through Spack on the clean part-one branch:

```bash
source ~/spack-development/spack/share/spack/setup-env.sh
spack env activate .
spack install
```

Additional final-stack validation was run on the equivalent final implementation before history cleanup:

- full non-transmon GPU suite: 35 / 35 passed,
- all 35 configured GPU and libCEED CUDA cases,
- targeted `transmon_amr` run completed with preserved output.
