### PR TITLE
Protect shared Spack buildcache from incompatible writers

### DIFF
--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -47,7 +47,7 @@ spack:
       url: https://binaries.spack.io/develop
     local-buildcache:
       binary: true
-      url: oci://ghcr.io/awslabs/palace
+      url: oci://ghcr.io/awslabs/palace-1.2
       signed: false
       access_pair:
         id_variable: GITHUB_USER

--- a/.github/actions/build-container/spack_env/spack.yaml
+++ b/.github/actions/build-container/spack_env/spack.yaml
@@ -47,7 +47,7 @@ spack:
       url: https://binaries.spack.io/develop
     local-buildcache:
       binary: true
-      url: oci://ghcr.io/awslabs/palace-develop-testing
+      url: oci://ghcr.io/awslabs/palace
       signed: false
       access_pair:
         id_variable: GITHUB_USER

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -201,7 +201,7 @@ runs:
               url: https://binaries.spack.io/develop
             local-buildcache:
               binary: true
-              url: oci://ghcr.io/awslabs/palace-develop-testing
+              url: oci://ghcr.io/awslabs/palace
               signed: false
               access_pair:
                 id_variable: GITHUB_USER
@@ -231,7 +231,11 @@ runs:
       run: |
         source /tmp/timing_functions.sh
         start_timer
-        spack -e . buildcache keys -y --install --trust
+        # The local GHCR buildcache is unsigned and may not exist yet when a new
+        # cache package is bootstrapped. Only install/trust keys from Spack's
+        # public binary mirror; package installs will still use GHCR binaries
+        # opportunistically and fall back to source builds on cache misses.
+        spack -e . buildcache keys -y --install --trust spack
         end_timer "Configure Binary Mirror Keys"
 
     - name: Bootstrap

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -57,18 +57,18 @@ runs:
         source /tmp/timing_functions.sh
         start_timer
 
-        # All jobs consume the same cache, but only the pinned Spack release
-        # may publish to it. A Spack develop job can otherwise repack and
-        # overwrite the same DAG-hash tag in a format the release cannot use.
-        # When changing the pinned release, clear the cache before enabling the
-        # new writer.
-        if [[ "${SPACK_VERSION}" == "releases/v1.2" ]]; then
-          echo "PALACE_BUILD_CACHE_WRITE=true" >> "${GITHUB_ENV}"
-          echo "GHCR buildcache access: read/write"
-        else
-          echo "PALACE_BUILD_CACHE_WRITE=false" >> "${GITHUB_ENV}"
-          echo "GHCR buildcache access: read-only for Spack ${SPACK_VERSION}"
-        fi
+        # Isolate GHCR buildcaches by Spack version. Spack DAG hashes do not
+        # identify the Spack version or buildcache representation that produced
+        # an OCI artifact, so different Spack versions must never write the same
+        # package. They can still each have their own warm cache.
+        CACHE_SUFFIX="${SPACK_VERSION#releases/v}"
+        CACHE_SUFFIX="${CACHE_SUFFIX#v}"
+        CACHE_SUFFIX="$(printf '%s' "${CACHE_SUFFIX}" | tr '[:upper:]/' '[:lower:]-' | tr -c 'a-z0-9._-' '-')"
+        PALACE_BUILD_CACHE_NAME="palace-${CACHE_SUFFIX}"
+        echo "PALACE_BUILD_CACHE_NAME=${PALACE_BUILD_CACHE_NAME}" >> "${GITHUB_ENV}"
+        echo "PALACE_BUILD_CACHE_WRITE=true" >> "${GITHUB_ENV}"
+        echo "GHCR buildcache package: ghcr.io/awslabs/${PALACE_BUILD_CACHE_NAME}"
+        echo "GHCR buildcache access: read/write"
 
         if [[ "${{ inputs.variant }}" == *"+cuda"* ]]; then
           CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
@@ -201,7 +201,7 @@ runs:
               url: https://binaries.spack.io/develop
             local-buildcache:
               binary: true
-              url: oci://ghcr.io/awslabs/palace
+              url: oci://ghcr.io/awslabs/${PALACE_BUILD_CACHE_NAME}
               signed: false
               access_pair:
                 id_variable: GITHUB_USER

--- a/.github/actions/palace-ci/action.yml
+++ b/.github/actions/palace-ci/action.yml
@@ -51,9 +51,25 @@ runs:
 
     - name: Prepare spack.yaml
       shell: bash
+      env:
+        SPACK_VERSION: ${{ inputs.spack-version }}
       run: |
         source /tmp/timing_functions.sh
         start_timer
+
+        # All jobs consume the same cache, but only the pinned Spack release
+        # may publish to it. A Spack develop job can otherwise repack and
+        # overwrite the same DAG-hash tag in a format the release cannot use.
+        # When changing the pinned release, clear the cache before enabling the
+        # new writer.
+        if [[ "${SPACK_VERSION}" == "releases/v1.2" ]]; then
+          echo "PALACE_BUILD_CACHE_WRITE=true" >> "${GITHUB_ENV}"
+          echo "GHCR buildcache access: read/write"
+        else
+          echo "PALACE_BUILD_CACHE_WRITE=false" >> "${GITHUB_ENV}"
+          echo "GHCR buildcache access: read-only for Spack ${SPACK_VERSION}"
+        fi
+
         if [[ "${{ inputs.variant }}" == *"+cuda"* ]]; then
           CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
           CUDA_ARGS="cuda_arch=${CUDA_ARCH}"
@@ -247,7 +263,11 @@ runs:
         # non-redistributable specs (the autopush hook does not, so it is not
         # used); skip --update-index since installs probe OCI tags directly.
         bank_progress() {
-          spack -e . buildcache push --allow-missing --with-build-dependencies --only dependencies --unsigned local-buildcache || true
+          if [[ "${PALACE_BUILD_CACHE_WRITE:-false}" == "true" ]]; then
+            spack -e . buildcache push --allow-missing --with-build-dependencies --only dependencies --unsigned local-buildcache || true
+          else
+            echo "Skipping buildcache publish from non-canonical Spack version."
+          fi
         }
         # No --fail-fast: build (and bank) everything possible; retry to ride
         # out transient source-fetch failures.
@@ -355,8 +375,15 @@ runs:
       run: |
         source /tmp/timing_functions.sh
         start_timer
-        # Push deps only; Palace itself is branch-specific (same reason as the container build).
-        spack -e . buildcache push --force --with-build-dependencies --only dependencies --unsigned --update-index local-buildcache || true
+        # Push deps only; Palace itself is branch-specific (same reason as the
+        # container build). Do not force-overwrite existing spec tags: OCI
+        # installs probe tags directly, and replacing a tag from another build
+        # can invalidate consumers even when the Spack DAG hash is unchanged.
+        if [[ "${PALACE_BUILD_CACHE_WRITE:-false}" == "true" ]]; then
+          spack -e . buildcache push --allow-missing --with-build-dependencies --only dependencies --unsigned local-buildcache || true
+        else
+          echo "Skipping buildcache publish from non-canonical Spack version."
+        fi
         end_timer "Push to GHCR cache"
 
     - name: Run Regression Tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,8 @@ concurrency:
 
 # We need spack so that we can install palace for the tutorials
 env:
-  SPACK_VERSION: develop
-  REGISTRY: ghcr.io/awslabs/palace
+  # Must match the sole buildcache writer configured in palace-ci/action.yml.
+  SPACK_VERSION: releases/v1.2
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -80,7 +80,7 @@ jobs:
           # Pin to the Spack 1.2 release series (matching the self-hosted
           # runners) instead of the moving `develop` branch. spack@1.2 pairs
           # with the spack-packages releases/v2026.06 repo (see repos.yaml).
-          spack_ref: releases/v1.2
+          spack_ref: ${{ env.SPACK_VERSION }}
           packages_ref: releases/v2026.06
           buildcache: true
           color: true
@@ -133,10 +133,10 @@ jobs:
             mirrors:
               spack:
                 binary: true
-                url: https://binaries.spack.io/${SPACK_VERSION}
+                url: https://binaries.spack.io/develop
               local-buildcache:
                 binary: true
-                url: oci://${{ env.REGISTRY }}-${SPACK_VERSION}
+                url: oci://ghcr.io/awslabs/palace-develop-testing
                 signed: false
                 access_pair:
                   id_variable: GITHUB_USER
@@ -251,4 +251,11 @@ jobs:
           needs.filter.outputs.should_build == 'true' &&
           !cancelled() &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        run: spack -e . buildcache push --force --with-build-dependencies --unsigned --update-index local-buildcache || true
+        run: |
+          if [[ "${SPACK_VERSION}" != "releases/v1.2" ]]; then
+            echo "Skipping buildcache publish from non-canonical Spack version."
+            exit 0
+          fi
+          # Palace itself is branch-specific; publish dependencies only and do
+          # not replace an existing DAG-hash tag.
+          spack -e . buildcache push --allow-missing --with-build-dependencies --only dependencies --unsigned local-buildcache || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -136,7 +136,7 @@ jobs:
                 url: https://binaries.spack.io/develop
               local-buildcache:
                 binary: true
-                url: oci://ghcr.io/awslabs/palace
+                url: oci://ghcr.io/awslabs/palace-1.2
                 signed: false
                 access_pair:
                   id_variable: GITHUB_USER

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -136,7 +136,7 @@ jobs:
                 url: https://binaries.spack.io/develop
               local-buildcache:
                 binary: true
-                url: oci://ghcr.io/awslabs/palace-develop-testing
+                url: oci://ghcr.io/awslabs/palace
                 signed: false
                 access_pair:
                   id_variable: GITHUB_USER
@@ -165,7 +165,12 @@ jobs:
 
       - name: Configure Binary Mirror Keys for Spack
         if: needs.filter.outputs.should_build == 'true'
-        run: spack -e . buildcache keys -y --install --trust
+        run: |
+          # The local GHCR buildcache is unsigned and may not exist yet when a
+          # new cache package is bootstrapped. Only install/trust keys from
+          # Spack's public binary mirror; installs will still use GHCR binaries
+          # opportunistically and fall back to source builds on cache misses.
+          spack -e . buildcache keys -y --install --trust spack
 
       - name: Bootstrap Spack
         if: needs.filter.outputs.should_build == 'true'

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,7 +1,7 @@
 # GHCR Buildcache Cleanup
 #
 # The Spack CI (spack.yml) pushes binary packages to an OCI buildcache at
-# ghcr.io/awslabs/palace-develop-testing. Over time, this accumulates stale
+# ghcr.io/awslabs/palace. Over time, this accumulates stale
 # versions as dependencies get rebuilt with new hashes.
 #
 # This workflow periodically prunes old versions, keeping the most recent ones
@@ -27,10 +27,10 @@
 #   1. Install crane: https://github.com/google/go-containerregistry
 #   2. Authenticate: echo $TOKEN | crane auth login ghcr.io -u USER --password-stdin
 #   3. Label any tag:
-#        crane mutate ghcr.io/awslabs/palace-develop-testing:index.spack \
+#        crane mutate ghcr.io/awslabs/palace:index.spack \
 #          --label org.opencontainers.image.source=https://github.com/awslabs/palace
 #   4. Verify the link:
-#        gh api orgs/awslabs/packages/container/palace-develop-testing \
+#        gh api orgs/awslabs/packages/container/palace \
 #          --jq '.repository.full_name'
 #
 # Or as a GitHub Actions step:
@@ -43,7 +43,7 @@
 #   - name: Link GHCR package to repository
 #     run: |
 #       echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
-#       crane mutate ghcr.io/awslabs/palace-develop-testing:index.spack \
+#       crane mutate ghcr.io/awslabs/palace:index.spack \
 #         --label org.opencontainers.image.source=https://github.com/${{ github.repository }}
 name: Cleanup GHCR Buildcache
 
@@ -66,8 +66,8 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
         run: |
-          gh api "/orgs/${REPO_OWNER}/packages/container/palace-develop-testing" \
-            --jq '"palace-develop-testing versions before cleanup: \(.version_count)"'
+          gh api "/orgs/${REPO_OWNER}/packages/container/palace" \
+            --jq '"palace versions before cleanup: \(.version_count)"'
 
       # Each Spack spec is a tagged version in the container package. We keep
       # the most recent 500 versions (roughly 5-10 full build sets) and delete
@@ -77,7 +77,7 @@ jobs:
         continue-on-error: true
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with: &delete-package-versions-inputs
-          package-name: palace-develop-testing
+          package-name: palace
           package-type: container
           owner: awslabs
           min-versions-to-keep: 500
@@ -96,5 +96,5 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
         run: |
-          gh api "/orgs/${REPO_OWNER}/packages/container/palace-develop-testing" \
-            --jq '"palace-develop-testing versions after cleanup: \(.version_count)"'
+          gh api "/orgs/${REPO_OWNER}/packages/container/palace" \
+            --jq '"palace versions after cleanup: \(.version_count)"'

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,11 +1,16 @@
 # GHCR Buildcache Cleanup
 #
-# The Spack CI (spack.yml) pushes binary packages to an OCI buildcache at
-# ghcr.io/awslabs/palace. Over time, this accumulates stale
-# versions as dependencies get rebuilt with new hashes.
+# Palace CI writes Spack binary packages to version-isolated OCI buildcaches:
+#
+#   ghcr.io/awslabs/palace-1.2      Spack releases/v1.2 jobs
+#   ghcr.io/awslabs/palace-develop  Spack develop lookahead jobs
+#
+# Spack DAG hashes do not encode the Spack version/buildcache representation, so
+# each Spack producer line gets its own GHCR package. Over time, each package
+# accumulates stale versions as dependencies get rebuilt with new hashes.
 #
 # This workflow periodically prunes old versions, keeping the most recent ones
-# so that the cache remains useful without growing unboundedly.
+# so that the caches remain useful without growing unboundedly.
 #
 # ## How GHCR package linking works
 #
@@ -21,16 +26,16 @@
 # caused GHCR to auto-link the package to this repo. Once linked, the
 # association persists at the GitHub level regardless of individual tag labels.
 #
-# If the package is ever deleted and recreated (e.g., a full cache rebuild),
+# If a package is ever deleted and recreated (e.g., a full cache rebuild),
 # the link must be re-established. To do this:
 #
 #   1. Install crane: https://github.com/google/go-containerregistry
 #   2. Authenticate: echo $TOKEN | crane auth login ghcr.io -u USER --password-stdin
 #   3. Label any tag:
-#        crane mutate ghcr.io/awslabs/palace:index.spack \
+#        crane mutate ghcr.io/awslabs/palace-1.2:index.spack \
 #          --label org.opencontainers.image.source=https://github.com/awslabs/palace
 #   4. Verify the link:
-#        gh api orgs/awslabs/packages/container/palace \
+#        gh api orgs/awslabs/packages/container/palace-1.2 \
 #          --jq '.repository.full_name'
 #
 # Or as a GitHub Actions step:
@@ -43,7 +48,7 @@
 #   - name: Link GHCR package to repository
 #     run: |
 #       echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
-#       crane mutate ghcr.io/awslabs/palace:index.spack \
+#       crane mutate ghcr.io/awslabs/palace-1.2:index.spack \
 #         --label org.opencontainers.image.source=https://github.com/${{ github.repository }}
 name: Cleanup GHCR Buildcache
 
@@ -58,16 +63,23 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - palace-1.2
+          - palace-develop
     steps:
       - name: Print buildcache version count before cleanup
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ matrix.package }}
         shell: bash
         run: |
-          gh api "/orgs/${REPO_OWNER}/packages/container/palace" \
-            --jq '"palace versions before cleanup: \(.version_count)"'
+          count=$(gh api "/orgs/${REPO_OWNER}/packages/container/${PACKAGE}" --jq '.version_count')
+          echo "${PACKAGE} versions before cleanup: ${count}"
 
       # Each Spack spec is a tagged version in the container package. We keep
       # the most recent 500 versions (roughly 5-10 full build sets) and delete
@@ -77,7 +89,7 @@ jobs:
         continue-on-error: true
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with: &delete-package-versions-inputs
-          package-name: palace
+          package-name: ${{ matrix.package }}
           package-type: container
           owner: awslabs
           min-versions-to-keep: 500
@@ -85,6 +97,7 @@ jobs:
 
       - name: Retry deleting old buildcache versions
         if: steps.cleanup.outcome == 'failure'
+        continue-on-error: true
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         with: *delete-package-versions-inputs
 
@@ -94,7 +107,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ matrix.package }}
         shell: bash
         run: |
-          gh api "/orgs/${REPO_OWNER}/packages/container/palace" \
-            --jq '"palace versions after cleanup: \(.version_count)"'
+          count=$(gh api "/orgs/${REPO_OWNER}/packages/container/${PACKAGE}" --jq '.version_count')
+          echo "${PACKAGE} versions after cleanup: ${count}"

--- a/.github/workflows/lookahead.yml
+++ b/.github/workflows/lookahead.yml
@@ -89,3 +89,21 @@ jobs:
           toolchain: gcc
           run-regression-tests: 'true'
           spack-version: 'develop'
+
+      # This is the only Spack develop writer, so it can refresh its index
+      # directly without racing another writer. Run after Palace CI so the
+      # index includes dependencies banked by this job, even if a later test
+      # failed; readers continue using the previous complete index meanwhile.
+      - name: Refresh Spack develop buildcache index
+        if: |
+          !cancelled() &&
+          hashFiles('spack.yaml') != '' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        shell: bash
+        run: |
+          START_TIME=${SECONDS}
+          spack -e . buildcache update-index local-buildcache
+          echo "Spack develop buildcache index refresh: $((SECONDS - START_TIME))s"

--- a/.github/workflows/lookahead.yml
+++ b/.github/workflows/lookahead.yml
@@ -73,13 +73,15 @@ jobs:
   # Build against the tip of Spack (develop) rather than the pinned 1.2 release
   # series, to catch upstream Spack/spack-packages changes that break Palace.
   # Dependencies stay at their pinned versions so a failure points at Spack.
+  # This job writes only to the isolated palace-develop buildcache, never the
+  # pinned Spack 1.2 cache used by required CI.
   build-test-x64-gcc-spack-develop:
     needs: filter
     if: needs.filter.outputs.test == 'true'
     runs-on: [self-hosted, x64]
     permissions:
       contents: read
-      packages: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/palace-ci

--- a/.github/workflows/lookahead.yml
+++ b/.github/workflows/lookahead.yml
@@ -77,6 +77,9 @@ jobs:
     needs: filter
     if: needs.filter.outputs.test == 'true'
     runs-on: [self-hosted, x64]
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/palace-ci

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -146,6 +146,59 @@ jobs:
           math-libs: armpl-gcc
           additional-test-cases: transmon_coarse
 
+  # Refresh the shared Spack 1.2 buildcache index once all cache writers have
+  # finished. Regression jobs can start as soon as their own build completes,
+  # so this full index rebuild is not on their critical path. The index is
+  # best-effort: binaries pushed concurrently remain available through Spack's
+  # direct OCI-tag fallback and will be included by the next refresh.
+  refresh-buildcache-index:
+    needs:
+      - filter
+      - build-x64-gcc
+      - build-gpu-gcc
+      - build-x64-gcc-openmp
+      - build-x64-gcc-cxx20
+      - build-test-x64-llvm
+      - build-test-x64-intel
+      - build-test-arm64-gcc
+      - build-test-arm64-llvm
+      - build-test-arm64-gcc-armpl
+    if: |
+      !cancelled() &&
+      needs.filter.outputs.test == 'true' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Spack 1.2
+        uses: actions/checkout@v6
+        with:
+          repository: spack/spack
+          path: spack
+          ref: releases/v1.2
+
+      - name: Refresh GHCR buildcache index
+        shell: bash
+        run: |
+          INDEX_ENV="${RUNNER_TEMP}/spack-buildcache-index"
+          mkdir -p "${INDEX_ENV}"
+          cat > "${INDEX_ENV}/spack.yaml" << 'EOF'
+          spack:
+            specs: []
+            mirrors:
+              local-buildcache:
+                binary: true
+                url: oci://ghcr.io/awslabs/palace-1.2
+                signed: false
+                access_pair:
+                  id_variable: GITHUB_USER
+                  secret_variable: GITHUB_TOKEN
+          EOF
+          SPACK_DISABLE_LOCAL_CONFIG=1 spack/bin/spack -e "${INDEX_ENV}" \
+            buildcache update-index local-buildcache
+
   # Test jobs
   test-x64-gcc:
     needs: [filter, build-x64-gcc]


### PR DESCRIPTION
## Summary

Protect Palace CI from incompatible Spack buildcache writers by moving to version-isolated, writable GHCR cache packages.

- Replace the old monolithic `ghcr.io/awslabs/palace-develop-testing` cache.
- Use `ghcr.io/awslabs/palace-1.2` for the canonical pinned Spack release (`releases/v1.2`).
- Use `ghcr.io/awslabs/palace-develop` for the Spack `develop` lookahead job, so lookahead remains warm without being able to corrupt the pinned-release cache.
- Derive the cache package name from `inputs.spack-version` in the shared Palace CI action, so future Spack producer lines get isolated cache packages instead of sharing incompatible artifacts.
- Keep both Spack 1.2 and Spack `develop` caches writable, while stopping force-overwrites of existing DAG-hash tags.
- Rebuild the Spack 1.2 `index.spack` once per main Spack workflow, after all nine cache-writing build jobs finish. Regression jobs remain free to start as soon as their corresponding build completes, so index regeneration is not on their critical path.
- Rebuild the isolated Spack `develop` index at the end of its sole Lookahead job, avoiding any concurrent develop-index writers.
- Move documentation and container dependencies into the canonical Spack 1.2 cache and apply the same publishing rules.
- Keep the GHCR cleanup workflow pointed at both new isolated cache packages.
- Restrict `spack buildcache keys` to Spack's public mirror because the GHCR caches are unsigned.

## Motivation

The Intel CI began failing after a Spack-develop job re-published PETSc `3.25.2` (`/5wheh2s`) under the same OCI tag consumed by Spack 1.2. The same Spack 1.2/PETSc combination had passed immediately before that cache overwrite, and locally rebuilding the dependency from source also passes Palace configuration.

Spack DAG hashes do not identify the Spack version or buildcache representation which produced an OCI artifact. Different Spack versions must therefore not write the same GHCR package. At the same time, the develop lookahead jobs still need a warm cache to avoid becoming prohibitively slow, so this PR gives them their own isolated, writable cache instead of making them uncached.

Separately, the old `palace-develop-testing` GHCR package accumulated hundreds of thousands of versions. GitHub's package-level delete endpoint returns server errors for that package, and per-version cleanup is impractically slow. Rather than continue using a pathological cache, this PR moves CI to fresh versioned packages.

## Cache migration

New cache packages:

```text
ghcr.io/awslabs/palace-1.2      # Spack releases/v1.2 jobs
ghcr.io/awslabs/palace-develop  # Spack develop lookahead jobs
```

The old cache package is intentionally abandoned:

```text
ghcr.io/awslabs/palace-develop-testing
```

After this PR merges, `main` will stop reading from or writing to the old cache. The old package can be left unused or purged later by GitHub support; CI no longer depends on clearing it.

## Index management

The main Spack workflow has one `refresh-buildcache-index` job for `palace-1.2`. It runs with Spack 1.2 after all cache-writing build jobs, including when a build fails after banking some dependencies, and performs a full `spack buildcache update-index`.

The index is best-effort. The first run against a fresh package may probe individual OCI tags before `index.spack` exists. On later runs, readers use the previous complete index while the new one is generated; binaries absent from a slightly stale index remain discoverable through Spack's direct OCI-tag fallback. The isolated `palace-develop` package has its own index, refreshed by its sole Spack `develop` Lookahead job after Palace CI completes, and is never read or written by Spack 1.2 jobs.

## Validation

Validated pre-rebase Spack run (identical patch series): https://github.com/awslabs/palace/actions/runs/29551267711

- All edited GitHub workflow/action YAML parses successfully.
- Cache-name derivation maps `releases/v1.2` to `palace-1.2` and `develop` to `palace-develop`.
- All nine Spack 1.2 build jobs fetched and relocated their complete dependency sets from `palace-1.2` (62–84 cached dependencies per job); dependency installation took 51–95 seconds.
- The x64 default regression job fetched 57 dependencies from the cache; only branch-specific Palace was intentionally rebuilt.
- `refresh-buildcache-index` completed successfully in about 85 seconds. `ghcr.io/awslabs/palace-1.2:index.spack` now returns HTTP 200 and contains 754 indexed specs.
- In post-rebase Lookahead run `29581844622`, the Spack `develop` job fetched and relocated all 83 dependencies from `ghcr.io/awslabs/palace-develop`, emitted no index-fetch warning, and successfully refreshed the develop index in 63 seconds.
- Documentation and container workflows successfully consume `palace-1.2`.
- `buildcache push --force` remains removed.



