### PR TITLE
Check for duplicate SchemaVer entries in changelog

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -75,6 +75,14 @@ jobs:
           git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
           ./scripts/check-schema-version "origin/${GITHUB_BASE_REF}"
 
+  check-changelog-schema-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check changelog schema versions
+        run: ./scripts/check-changelog-schema-versions
+
   check-tests-tags:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-changelog-schema-versions
+++ b/scripts/check-changelog-schema-versions
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+CHANGELOG="${1:-CHANGELOG.md}"
+
+if [[ ! -f "${CHANGELOG}" ]]; then
+    echo "Error: Changelog '${CHANGELOG}' does not exist"
+    exit 1
+fi
+
+DUPLICATES=$(grep -oE 'SchemaVer [0-9]+-[0-9]+-[0-9]+' "${CHANGELOG}" | sort | uniq -d)
+
+if [[ -n "${DUPLICATES}" ]]; then
+    echo "Error: Duplicate schema versions found in ${CHANGELOG}:"
+    echo "${DUPLICATES}"
+    exit 1
+fi
+
+echo "All schema versions in ${CHANGELOG} are unique"
+exit 0


### PR DESCRIPTION
Adds a check to the Style workflow that rejects duplicate `SchemaVer` entries in `CHANGELOG.md`.

Tested locally with both unique and duplicate entries.

Closes #817

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.