### PR TITLE
Use libCEED point fields for ParaView and GridFunction output

### DIFF
--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -39,6 +39,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   SpaceOperator space_op(iodata, mesh);
   auto K = space_op.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
   auto C = space_op.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+  const bool has_C = (C != nullptr);
   auto M = space_op.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
 
   // Check if there are nonlinear terms and, if so, setup interpolation operator.
@@ -76,8 +77,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
   // Configure objects for postprocessing.
   PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
-  ComplexVector E(Curl.Width()), B(Curl.Height());
-  E.UseDevice(true);
+  ComplexVector B(Curl.Height());
   B.UseDevice(true);
 
   // Define and configure the eigensolver to solve the eigenvalue problem:
@@ -403,15 +403,50 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     eigen->SetBMat(*KM);
     eigen->RescaleEigenvectors(num_conv);
   }
+  std::vector<std::complex<double>> eigenvalues(num_conv);
+  std::vector<double> errors_bkwd(num_conv), errors_abs(num_conv);
+  std::vector<ComplexVector> eigenvectors;
+  eigenvectors.reserve(num_conv);
+  for (int i = 0; i < num_conv; i++)
+  {
+    eigenvalues[i] = eigen->GetEigenvalue(i);
+    errors_bkwd[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
+    errors_abs[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
+    auto &E = eigenvectors.emplace_back(Curl.Width());
+    E.UseDevice(true);
+    eigen->GetEigenvector(i, E);
+  }
+
+  // The shifted linear system, eigenvalue solver, and assembled matrices are only needed
+  // through eigenvector extraction. Release their device allocations before error
+  // estimation and field-output postprocessing, where large libCEED visualization
+  // operators may need additional GPU memory on refined meshes.
+  eigen.reset();
+  KM.reset();
+  ksp.reset();
+  P.reset();
+  A.reset();
+  divfree.reset();
+  Kp.reset();
+  Cp.reset();
+  Mp.reset();
+  A2_0.reset();
+  A2_1.reset();
+  A2_2.reset();
+  A2.reset();
+  interp_op.reset();
+  K.reset();
+  C.reset();
+  M.reset();
   Mpi::Print("\n");
 
   for (int i = 0; i < num_conv; i++)
   {
     // Get the eigenvalue and relative error.
-    std::complex<double> omega = eigen->GetEigenvalue(i);
-    double error_bkwd = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
-    double error_abs = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
-    if (!C && !has_A2)
+    std::complex<double> omega = eigenvalues[i];
+    double error_bkwd = errors_bkwd[i];
+    double error_abs = errors_abs[i];
+    if (!has_C && !has_A2)
     {
       // Linear EVP has eigenvalue μ = -λ² = ω².
       omega = std::sqrt(omega);
@@ -424,8 +459,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
     // Compute B = -1/(iω) ∇ x E on the true dofs, and set the internal GridFunctions in
     // PostOperator for all postprocessing operations.
-    eigen->GetEigenvector(i, E);
-
+    auto &E = eigenvectors[i];
     linalg::NormalizePhase(space_op.GetComm(), E);
 
     Curl.Mult(E.Real(), B.Real());

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/bilinearform.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ceed_group_operator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/domain_point_field_evaluator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/facenbrexchange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp
@@ -19,6 +20,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/lumpedelement.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/output_functionals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/point_field_evaluator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/postprocessing_backend.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurlmass.cpp

--- a/palace/fem/ceed_group_operator.cpp
+++ b/palace/fem/ceed_group_operator.cpp
@@ -39,26 +39,46 @@ void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups)
   groups.clear();
 }
 
+void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group)
+{
+  if (group.field_vec_sources.size() == group.field_sources.size())
+  {
+    return;
+  }
+  group.field_vec_sources.clear();
+  group.field_vec_sources.reserve(group.field_sources.size());
+  for (const auto &[name, source] : group.field_sources)
+  {
+    CeedOperatorField field;
+    CeedVector field_vec;
+    PalaceCeedCall(group.ceed, CeedOperatorGetFieldByName(group.op, name.c_str(), &field));
+    PalaceCeedCall(group.ceed, CeedOperatorFieldGetVector(field, &field_vec));
+    group.field_vec_sources.emplace_back(field_vec, source);
+  }
+}
+
 void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
                             const std::array<const Vector *, 4> &srcs, const Vector &out,
                             const Vector *imported)
 {
+  if (groups.empty())
+  {
+    return;
+  }
+
+  CeedMemType out_mem;
+  PalaceCeedCall(groups.front().ceed,
+                 CeedGetPreferredMemType(groups.front().ceed, &out_mem));
+  if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && out_mem == CEED_MEM_DEVICE)
+  {
+    out_mem = CEED_MEM_HOST;
+  }
+  auto *out_data = const_cast<Vector &>(out).ReadWrite(out_mem == CEED_MEM_DEVICE);
+  const CeedSize out_size = out.Size();
+
   for (const auto &group : groups)
   {
-    if (group.field_vec_sources.size() != group.field_sources.size())
-    {
-      group.field_vec_sources.clear();
-      group.field_vec_sources.reserve(group.field_sources.size());
-      for (const auto &[name, source] : group.field_sources)
-      {
-        CeedOperatorField field;
-        CeedVector field_vec;
-        PalaceCeedCall(group.ceed,
-                       CeedOperatorGetFieldByName(group.op, name.c_str(), &field));
-        PalaceCeedCall(group.ceed, CeedOperatorFieldGetVector(field, &field_vec));
-        group.field_vec_sources.emplace_back(field_vec, source);
-      }
-    }
+    CacheGroupOperatorFieldVectors(group);
     for (auto &[field_vec, source] : group.field_vec_sources)
     {
       // Source index 4 selects an optional imported vector, used by surface reductions
@@ -68,14 +88,6 @@ void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
       MFEM_ASSERT(sv, "Missing source vector for libCEED field input!");
       ceed::InitCeedVector(*sv, group.ceed, &field_vec, false);
     }
-    CeedMemType out_mem;
-    PalaceCeedCall(group.ceed, CeedGetPreferredMemType(group.ceed, &out_mem));
-    if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && out_mem == CEED_MEM_DEVICE)
-    {
-      out_mem = CEED_MEM_HOST;
-    }
-    auto *out_data = const_cast<Vector &>(out).ReadWrite(out_mem == CEED_MEM_DEVICE);
-    const CeedSize out_size = out.Size();
     if (!group.out_vec || group.out_size != out_size)
     {
       if (group.out_vec)

--- a/palace/fem/ceed_group_operator.hpp
+++ b/palace/fem/ceed_group_operator.hpp
@@ -38,6 +38,12 @@ struct CeedGroupOperator
   mutable CeedSize out_size = 0;
 };
 
+// Populate cached libCEED vector handles for the named passive fields of a group
+// operator. Calling this right after assembly moves field-name lookup overhead out of
+// the first timed postprocessing apply; ApplyAddGroupOperators also calls it lazily for
+// older call sites or any groups assembled without explicit caching.
+void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group);
+
 // Re-point the passive field inputs of each group operator at the given source vectors
 // and accumulate into the output vector with CeedOperatorApplyAdd. A field source index
 // of 4 (out of the srcs range) selects the optional imported vector instead, used to

--- a/palace/fem/domain_point_field_evaluator.cpp
+++ b/palace/fem/domain_point_field_evaluator.cpp
@@ -1,0 +1,472 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "domain_point_field_evaluator.hpp"
+
+#include <algorithm>
+#include <map>
+#include "fem/coefficient.hpp"
+#include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/coefficient.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/integrator.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/mesh.hpp"
+#include "models/materialoperator.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/22/eval_22_qf.h"
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
+
+namespace palace
+{
+
+namespace
+{
+
+// Holds libCEED object references created during operator assembly for destruction once
+// the assembled operator owns them.
+struct CeedAssemblyScratch
+{
+  Ceed ceed;
+  std::vector<CeedVector> vecs;
+  std::vector<CeedElemRestriction> restrs;
+  std::vector<CeedBasis> bases;
+
+  CeedAssemblyScratch(Ceed ceed) : ceed(ceed) {}
+  CeedAssemblyScratch(const CeedAssemblyScratch &) = delete;
+  CeedAssemblyScratch &operator=(const CeedAssemblyScratch &) = delete;
+
+  ~CeedAssemblyScratch()
+  {
+    for (auto &v : vecs)
+    {
+      PalaceCeedCall(ceed, CeedVectorDestroy(&v));
+    }
+    for (auto &r : restrs)
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&r));
+    }
+    for (auto &b : bases)
+    {
+      PalaceCeedCall(ceed, CeedBasisDestroy(&b));
+    }
+  }
+};
+
+}  // namespace
+
+DomainPointFieldEvaluator::DomainPointFieldEvaluator(
+    Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+    const mfem::ParFiniteElementSpace *nd_fespace,
+    const mfem::ParFiniteElementSpace *rt_fespace,
+    const mfem::ParFiniteElementSpace &target_fespace, double scaling)
+  : kind(kind), nd_fespace(nd_fespace), rt_fespace(rt_fespace)
+{
+  const bool needs_nd = kind == Kind::FIELD_E || kind == Kind::FIELD_H1 ||
+                        kind == Kind::ENERGY_E || kind == Kind::POYNTING ||
+                        kind == Kind::MODE_SN;
+  const bool needs_rt = kind == Kind::FIELD_B || kind == Kind::ENERGY_M ||
+                        kind == Kind::POYNTING || kind == Kind::MODE_SN;
+  MFEM_VERIFY((!needs_nd || nd_fespace) && (!needs_rt || rt_fespace),
+              "Missing finite element space for domain field evaluator!");
+  Assemble(mesh, mat_op, target_fespace, scaling);
+}
+
+DomainPointFieldEvaluator::~DomainPointFieldEvaluator()
+{
+  fem::DestroyGroupOperators(groups);
+  fem::DestroyGroupOperators(buffer_groups);
+}
+
+void DomainPointFieldEvaluator::Assemble(const Mesh &mesh, const MaterialOperator &mat_op,
+                                         const mfem::ParFiniteElementSpace &target_fespace,
+                                         double scaling)
+{
+  const int dim = mesh.Dimension();
+  const int sdim = mesh.SpaceDimension();
+  if (!((dim == 2 && sdim == 2) || (dim == 3 && sdim == 3)))
+  {
+    valid = false;
+    return;
+  }
+  const bool scalar_magnetic_field = (dim == 2);
+  const mfem::ParMesh &pmesh = mesh.Get();
+  const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
+
+  // Point-major buffer layout matching VTK tuple order and MFEM's domain VTU point
+  // order (element order, then refined/nodal points within each element). The output
+  // restriction scatters each point tuple contiguously so CeedParaViewDataCollection can
+  // write the payload without repacking.
+  buffer_num_comp = target_fespace.GetVDim();
+  buffer_bases.assign(pmesh.GetNE(), -1);
+  int buffer_points = 0;
+  const int vtu_lod = target_fespace.GetMaxElementOrder();
+  for (int e = 0; e < pmesh.GetNE(); e++)
+  {
+    const auto *RefG =
+        mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(e), vtu_lod, 1);
+    buffer_bases[e] = buffer_points;
+    buffer_points += RefG->RefPts.GetNPoints();
+  }
+  buffer_size = buffer_points * buffer_num_comp;
+
+  // Group the elements by geometry type.
+  std::map<mfem::Geometry::Type, std::vector<int>> geom_elems;
+  for (int e = 0; e < pmesh.GetNE(); e++)
+  {
+    geom_elems[pmesh.GetElementGeometry(e)].push_back(e);
+  }
+
+  // QFunction context: derived quantities need a scaling factor followed by the material
+  // property table. Plain field probes only need geometry and field values.
+  const bool field_value_kind =
+      (kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1);
+  std::vector<CeedIntScalar> ctx;
+  if (!field_value_kind)
+  {
+    ctx.resize(1);
+    ctx[0].second = scaling;
+    const auto &coeff = (kind == Kind::ENERGY_E)
+                            ? mat_op.GetPermittivityReal()
+                            : ((scalar_magnetic_field || kind == Kind::MODE_SN)
+                                   ? mat_op.GetCurlCurlInvPermeability()
+                                   : mat_op.GetInvPermeability());
+    MaterialPropertyCoefficient coeff_func(mat_op.GetAttributeToMaterial(), coeff);
+    auto mat_ctx = ceed::PopulateCoefficientContext(
+        ((scalar_magnetic_field && kind != Kind::ENERGY_E) || kind == Kind::MODE_SN) ? 1
+                                                                                     : dim,
+        &coeff_func);
+    ctx.insert(ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+
+  field_staging.SetSize(std::max(nd_fespace ? nd_fespace->GetVSize() : 0,
+                                 rt_fespace ? rt_fespace->GetVSize() : 0));
+  field_staging.UseDevice(true);
+  field_staging = 0.0;
+
+  Ceed ceed = ceed::internal::GetCeedObjects()[0];
+  for (const auto &geom_indices : geom_elems)
+  {
+    const mfem::Geometry::Type geom = geom_indices.first;
+    const auto &indices = geom_indices.second;
+    CeedAssemblyScratch scratch(ceed);
+
+    // Evaluation points are the nodal points of the (interpolatory) target space.
+    const mfem::FiniteElement *target_fe =
+        target_fespace.FEColl()->FiniteElementForGeometry(geom);
+    MFEM_VERIFY(target_fe, "Unable to get target finite element for field evaluator!");
+    const mfem::IntegrationRule &nodes_ir = target_fe->GetNodes();
+    const int num_pts = nodes_ir.GetNPoints();
+
+    // Element attributes (libCEED local, for material lookup) and mesh node gradients
+    // (for on the fly geometry evaluation at the points).
+    std::vector<ceed::CeedFunctionalFieldInput> inputs;
+    std::vector<std::pair<std::string, int>> field_sources;
+    if (!field_value_kind)
+    {
+      auto &elem_attr = elem_attrs.emplace_back(indices.size());
+      const auto &loc_attr = mesh.GetCeedAttributes();
+      for (std::size_t k = 0; k < indices.size(); k++)
+      {
+        elem_attr[k] = loc_attr.at(pmesh.GetAttribute(indices[k]));
+      }
+      CeedElemRestriction attr_restr;
+      CeedBasis attr_basis;
+      CeedVector attr_vec;
+      PalaceCeedCall(
+          ceed, CeedElemRestrictionCreateStrided(ceed, indices.size(), 1, 1, indices.size(),
+                                                 CEED_STRIDES_BACKEND, &attr_restr));
+      {
+        // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
+        mfem::Vector Bt(num_pts), Gt(num_pts), qX(num_pts), qW(num_pts);
+        Bt = 1.0;
+        Gt = 0.0;
+        qX = 0.0;
+        qW = 0.0;
+        PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_pts,
+                                               Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                               qW.GetData(), &attr_basis));
+      }
+      ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+      inputs.push_back({"attr", attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      scratch.vecs.push_back(attr_vec);
+      scratch.restrs.push_back(attr_restr);
+      scratch.bases.push_back(attr_basis);
+    }
+    {
+      CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+          mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+      const mfem::FiniteElement *mesh_fe =
+          mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+      CeedBasis mesh_basis;
+      ceed::InitBasisAtPoints(*mesh_fe, nodes_ir, mesh_fespace.GetVDim(), ceed,
+                              &mesh_basis);
+      CeedVector mesh_nodes_vec;
+      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+      inputs.push_back({"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      scratch.vecs.push_back(mesh_nodes_vec);
+      scratch.restrs.push_back(mesh_restr);
+      scratch.bases.push_back(mesh_basis);
+    }
+
+    // Field inputs evaluated at the nodal points.
+    auto AddFieldInput =
+        [&](const std::string &name, int source, const mfem::ParFiniteElementSpace &fespace)
+    {
+      CeedElemRestriction restr;
+      CeedBasis basis;
+      CeedVector vec;
+      ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                            &restr);
+      const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+      ceed::InitBasisAtPoints(*fe, nodes_ir, fespace.GetVDim(), ceed, &basis);
+      ceed::InitCeedVector(field_staging, ceed, &vec);
+      inputs.push_back({name, vec, restr, basis, ceed::EvalMode::Interp});
+      field_sources.emplace_back(name, source);
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+      scratch.bases.push_back(basis);
+    };
+    if (kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E ||
+        kind == Kind::POYNTING || kind == Kind::MODE_SN)
+    {
+      AddFieldInput("u_1", 0, *nd_fespace);
+    }
+    if (kind == Kind::FIELD_B || kind == Kind::ENERGY_M || kind == Kind::POYNTING ||
+        kind == Kind::MODE_SN)
+    {
+      AddFieldInput((kind == Kind::POYNTING || kind == Kind::MODE_SN) ? "u_2" : "u_1", 1,
+                    *rt_fespace);
+    }
+
+    // Output restriction scattering nodal values into the target grid function.
+    CeedElemRestriction out_restr;
+    ceed::InitRestriction(target_fespace, indices, false, /*is_interp*/ true, false, ceed,
+                          &out_restr);
+    scratch.restrs.push_back(out_restr);
+
+    ceed::CeedQFunctionInfo info;
+    switch (kind)
+    {
+      case Kind::FIELD_E:
+        info.apply_qf = (dim == 2) ? f_eval_probe_hcurl_22 : f_eval_probe_hcurl_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_hcurl_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+        break;
+      case Kind::FIELD_B:
+        info.apply_qf = scalar_magnetic_field ? f_eval_probe_l2_22 : f_eval_probe_hdiv_33;
+        info.apply_qf_path = scalar_magnetic_field
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_l2_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+        break;
+      case Kind::FIELD_H1:
+        info.apply_qf = (dim == 2) ? f_eval_probe_l2_22 : f_eval_probe_l2_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_l2_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_l2_33_loc);
+        break;
+      case Kind::ENERGY_E:
+        info.apply_qf = (dim == 2) ? f_eval_energy_e_22 : f_eval_energy_e_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_energy_e_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_energy_e_33_loc);
+        break;
+      case Kind::ENERGY_M:
+        info.apply_qf = (dim == 2) ? f_eval_energy_m_22 : f_eval_energy_m_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_energy_m_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_energy_m_33_loc);
+        break;
+      case Kind::POYNTING:
+        info.apply_qf = (dim == 2) ? f_eval_poynting_22 : f_eval_poynting_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_poynting_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_poynting_33_loc);
+        break;
+      case Kind::MODE_SN:
+        MFEM_VERIFY(dim == 2, "Boundary-mode Sn output requires a 2D mesh!");
+        info.apply_qf = f_eval_mode_sn_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_mode_sn_22_loc);
+        break;
+    }
+
+    CeedOperator op;
+    ceed::AssembleCeedPointEvaluator(info, ctx.empty() ? nullptr : ctx.data(),
+                                     ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+                                     target_fespace.GetVDim(), out_restr, &op);
+    groups.push_back({ceed, op, std::move(field_sources)});
+    fem::CacheGroupOperatorFieldVectors(groups.back());
+
+    // Assemble a second operator for the direct VTU point-buffer path. This evaluates at
+    // MFEM's refined VTU points (not necessarily the same order as the target L2 nodes)
+    // and scatters into point-major tuples consumed by CeedParaViewDataCollection.
+    const mfem::IntegrationRule &vtu_ir =
+        mfem::GlobGeometryRefiner.Refine(geom, vtu_lod, 1)->RefPts;
+    const int num_vtu_pts = vtu_ir.GetNPoints();
+    std::vector<ceed::CeedFunctionalFieldInput> buffer_inputs;
+    std::vector<std::pair<std::string, int>> buffer_field_sources;
+    if (!field_value_kind)
+    {
+      auto &elem_attr = elem_attrs.emplace_back(indices.size());
+      const auto &loc_attr = mesh.GetCeedAttributes();
+      for (std::size_t k = 0; k < indices.size(); k++)
+      {
+        elem_attr[k] = loc_attr.at(pmesh.GetAttribute(indices[k]));
+      }
+      CeedElemRestriction attr_restr;
+      CeedBasis attr_basis;
+      CeedVector attr_vec;
+      PalaceCeedCall(
+          ceed, CeedElemRestrictionCreateStrided(ceed, indices.size(), 1, 1, indices.size(),
+                                                 CEED_STRIDES_BACKEND, &attr_restr));
+      {
+        mfem::Vector Bt(num_vtu_pts), Gt(num_vtu_pts), qX(num_vtu_pts), qW(num_vtu_pts);
+        Bt = 1.0;
+        Gt = 0.0;
+        qX = 0.0;
+        qW = 0.0;
+        PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_vtu_pts,
+                                               Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                               qW.GetData(), &attr_basis));
+      }
+      ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+      buffer_inputs.push_back(
+          {"attr", attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      scratch.vecs.push_back(attr_vec);
+      scratch.restrs.push_back(attr_restr);
+      scratch.bases.push_back(attr_basis);
+    }
+    {
+      CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+          mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+      const mfem::FiniteElement *mesh_fe =
+          mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+      CeedBasis mesh_basis;
+      ceed::InitBasisAtPoints(*mesh_fe, vtu_ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+      CeedVector mesh_nodes_vec;
+      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+      buffer_inputs.push_back(
+          {"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      scratch.vecs.push_back(mesh_nodes_vec);
+      scratch.restrs.push_back(mesh_restr);
+      scratch.bases.push_back(mesh_basis);
+    }
+    auto AddBufferFieldInput =
+        [&](const std::string &name, int source, const mfem::ParFiniteElementSpace &fespace)
+    {
+      CeedElemRestriction restr;
+      CeedBasis basis;
+      CeedVector vec;
+      ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                            &restr);
+      const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+      ceed::InitBasisAtPoints(*fe, vtu_ir, fespace.GetVDim(), ceed, &basis);
+      ceed::InitCeedVector(field_staging, ceed, &vec);
+      buffer_inputs.push_back({name, vec, restr, basis, ceed::EvalMode::Interp});
+      buffer_field_sources.emplace_back(name, source);
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+      scratch.bases.push_back(basis);
+    };
+    if (kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E ||
+        kind == Kind::POYNTING || kind == Kind::MODE_SN)
+    {
+      AddBufferFieldInput("u_1", 0, *nd_fespace);
+    }
+    if (kind == Kind::FIELD_B || kind == Kind::ENERGY_M || kind == Kind::POYNTING ||
+        kind == Kind::MODE_SN)
+    {
+      AddBufferFieldInput((kind == Kind::POYNTING || kind == Kind::MODE_SN) ? "u_2" : "u_1",
+                          1, *rt_fespace);
+    }
+    CeedElemRestriction buffer_out_restr;
+    {
+      std::vector<CeedInt> offsets(indices.size() * num_vtu_pts);
+      for (std::size_t e = 0; e < indices.size(); e++)
+      {
+        const int point_base = buffer_bases[indices[e]];
+        for (int j = 0; j < num_vtu_pts; j++)
+        {
+          offsets[e * num_vtu_pts + j] = (point_base + j) * buffer_num_comp;
+        }
+      }
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(indices.size()), num_vtu_pts,
+                               buffer_num_comp, 1, (CeedSize)buffer_size, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &buffer_out_restr));
+    }
+    scratch.restrs.push_back(buffer_out_restr);
+    CeedOperator buffer_op;
+    ceed::AssembleCeedPointEvaluator(
+        info, ctx.empty() ? nullptr : ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed,
+        buffer_inputs, buffer_num_comp, buffer_out_restr, &buffer_op);
+    buffer_groups.push_back({ceed, buffer_op, std::move(buffer_field_sources)});
+    fem::CacheGroupOperatorFieldVectors(buffer_groups.back());
+  }
+}
+
+void DomainPointFieldEvaluator::Eval(const GridFunction *E, const GridFunction *B,
+                                     Vector &out) const
+{
+  MFEM_VERIFY(valid, "Eval called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(
+      (E || kind == Kind::FIELD_B || kind == Kind::ENERGY_M) &&
+          (B || kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E),
+      "Missing field grid function for domain field evaluator!");
+  out = 0.0;
+  fem::ApplyAddGroupOperators(groups, {E ? &E->Real() : nullptr, B ? &B->Real() : nullptr},
+                              out);
+  if (E ? E->HasImag() : B->HasImag())
+  {
+    fem::ApplyAddGroupOperators(groups,
+                                {E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr}, out);
+  }
+}
+
+void DomainPointFieldEvaluator::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(valid,
+              "EvalBuffer called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1,
+              "Vector EvalBuffer is only valid for linear field evaluators!");
+  MFEM_ASSERT(buffer.Size() == buffer_size,
+              "Invalid buffer size for DomainPointFieldEvaluator::EvalBuffer!");
+  buffer = 0.0;
+  fem::ApplyAddGroupOperators(
+      buffer_groups,
+      {(kind == Kind::FIELD_E || kind == Kind::FIELD_H1) ? &u : nullptr,
+       kind == Kind::FIELD_B ? &u : nullptr, nullptr, nullptr},
+      buffer);
+}
+
+void DomainPointFieldEvaluator::EvalBuffer(const GridFunction *E, const GridFunction *B,
+                                           Vector &buffer) const
+{
+  MFEM_VERIFY(valid,
+              "EvalBuffer called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(
+      (E || kind == Kind::FIELD_B || kind == Kind::ENERGY_M) &&
+          (B || kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E),
+      "Missing field grid function for domain field evaluator!");
+  MFEM_ASSERT(buffer.Size() == buffer_size,
+              "Invalid buffer size for DomainPointFieldEvaluator::EvalBuffer!");
+  buffer = 0.0;
+  fem::ApplyAddGroupOperators(buffer_groups,
+                              {E ? &E->Real() : nullptr, B ? &B->Real() : nullptr}, buffer);
+  if (E ? E->HasImag() : B->HasImag())
+  {
+    fem::ApplyAddGroupOperators(
+        buffer_groups, {E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr}, buffer);
+  }
+}
+
+}  // namespace palace

--- a/palace/fem/domain_point_field_evaluator.hpp
+++ b/palace/fem/domain_point_field_evaluator.hpp
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP
+#define PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP
+
+#include <deque>
+#include <vector>
+#include <mfem.hpp>
+#include "fem/ceed_group_operator.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+class GridFunction;
+class MaterialOperator;
+class Mesh;
+
+//
+// Class to evaluate derived field quantities (energy densities, Poynting vector) at the
+// nodal points of an interpolatory output space using libCEED, filling a grid function
+// for visualization output without per-point host coefficient evaluation. Follows the
+// conventions of EnergyDensityCoefficient and PoyntingVectorCoefficient.
+//
+class DomainPointFieldEvaluator
+{
+public:
+  enum class Kind
+  {
+    FIELD_E,   // H(curl) vector field value
+    FIELD_B,   // Magnetic flux value, scalar in 2D and vector in 3D
+    FIELD_H1,  // H1 scalar field value
+    ENERGY_E,  // 1/2 (ε E)ᴴ E, scalar output
+    ENERGY_M,  // 1/2 (μ⁻¹ B)ᴴ B, scalar output
+    POYNTING,  // Re{E x (μ⁻¹ B)⥁}, vector output
+    MODE_SN    // Boundary-mode Re{Eₜ x (μ⁻¹Bₜ)⋆} ⋅ z, scalar output
+  };
+
+private:
+  Kind kind;
+
+  // Source field finite element spaces (not owned): nd_fespace for H(curl), rt_fespace
+  // for H(div)/L2 B; either may be nullptr depending on the kind.
+  const mfem::ParFiniteElementSpace *nd_fespace;
+  const mfem::ParFiniteElementSpace *rt_fespace;
+
+  // Whether the evaluator could be assembled.
+  bool valid = true;
+
+  // Per-geometry assembled libCEED operators, evaluating at the target space nodal
+  // points and scattering directly into the output grid function or into a point-major
+  // ParaView point buffer. The element attribute vectors are operator inputs and must
+  // outlive the operators.
+  std::vector<fem::CeedGroupOperator> groups, buffer_groups;
+  std::deque<Vector> elem_attrs;
+
+  // Point-major buffer layout for domain visualization fields. Buffer bases are point
+  // offsets in the same element/refined-point order used by MFEM's VTU writer.
+  int buffer_size = 0, buffer_num_comp = 0;
+  std::vector<int> buffer_bases;
+
+  // Staging vector used to initialize the field input CeedVectors at construction.
+  mutable Vector field_staging;
+
+  void Assemble(const Mesh &mesh, const MaterialOperator &mat_op,
+                const mfem::ParFiniteElementSpace &target_fespace, double scaling);
+
+public:
+  // Construct an evaluator filling grid functions on target_fespace (an interpolatory
+  // L2 space). The scaling multiplies the output as for the legacy coefficients.
+  DomainPointFieldEvaluator(Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+                            const mfem::ParFiniteElementSpace *nd_fespace,
+                            const mfem::ParFiniteElementSpace *rt_fespace,
+                            const mfem::ParFiniteElementSpace &target_fespace,
+                            double scaling);
+  ~DomainPointFieldEvaluator();
+
+  DomainPointFieldEvaluator(const DomainPointFieldEvaluator &) = delete;
+  DomainPointFieldEvaluator &operator=(const DomainPointFieldEvaluator &) = delete;
+
+  // Whether the evaluator was successfully assembled.
+  bool IsValid() const { return valid; }
+
+  // Total buffer size (all elements, lattice points, components), number of components,
+  // and per-element point-base offsets for the domain visualization field. Vector
+  // buffers are point-major: xyzxyz... in VTK tuple order.
+  int BufferSize() const { return buffer_size; }
+  int BufferNumComp() const { return buffer_num_comp; }
+  const std::vector<int> &BufferBases() const { return buffer_bases; }
+
+  // Fill the output vector (L-vector of the target space, e.g. a GridFunction) with
+  // the pointwise quantity. Real and imaginary field contributions add. Local
+  // operation (no MPI communication).
+  void Eval(const GridFunction *E, const GridFunction *B, Vector &out) const;
+
+  // Fill the point-major domain visualization point buffer for a single linear field.
+  // Local operation (no MPI communication).
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+
+  // Fill the point-major domain visualization point buffer. Real and imaginary field
+  // contributions add. Local operation (no MPI communication).
+  void EvalBuffer(const GridFunction *E, const GridFunction *B, Vector &buffer) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP

--- a/palace/fem/facenbrexchange.cpp
+++ b/palace/fem/facenbrexchange.cpp
@@ -76,19 +76,49 @@ bool CeedSupportsNonTensorAtPoints(Ceed ceed)
          std::strstr(resource, "/gpu/cuda/magma");
 }
 
-int TetNumModes(int degree)
+int SimplexNumModes(mfem::Geometry::Type geom, int degree)
 {
-  return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+  switch (geom)
+  {
+    case mfem::Geometry::TRIANGLE:
+      return (degree + 1) * (degree + 2) / 2;
+    case mfem::Geometry::TETRAHEDRON:
+      return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+    default:
+      MFEM_ABORT("FaceNbrFieldExchange AtPoints export only supports simplex volume "
+                 "elements!");
+      return 0;
+  }
 }
 
-mfem::IntegrationRule MakeTetLatticeRule(int degree)
+mfem::IntegrationRule MakeSimplexLatticeRule(mfem::Geometry::Type geom, int degree)
 {
-  mfem::IntegrationRule ir(TetNumModes(degree));
+  mfem::IntegrationRule ir(SimplexNumModes(geom, degree));
   int q = 0;
   if (degree == 0)
   {
-    ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    if (geom == mfem::Geometry::TRIANGLE)
+    {
+      ir.IntPoint(q).Set2(1.0 / 3.0, 1.0 / 3.0);
+    }
+    else
+    {
+      ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    }
     ir.IntPoint(q++).weight = 1.0;
+  }
+  else if (geom == mfem::Geometry::TRIANGLE)
+  {
+    for (int total = 0; total <= degree; total++)
+    {
+      for (int i = 0; i <= total; i++)
+      {
+        const int j = total - i;
+        ir.IntPoint(q).Set2(static_cast<double>(i) / degree,
+                            static_cast<double>(j) / degree);
+        ir.IntPoint(q++).weight = 1.0;
+      }
+    }
   }
   else
   {
@@ -110,21 +140,40 @@ mfem::IntegrationRule MakeTetLatticeRule(int degree)
   return ir;
 }
 
-void InitTetBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
-                             CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+void InitSimplexBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
+                                 CeedInt num_comp, Ceed ceed, CeedBasis *basis)
 {
-  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
-              "FaceNbrFieldExchange AtPoints export currently supports tetrahedral "
-              "volume elements only!");
+  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TRIANGLE ||
+                  fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
+              "FaceNbrFieldExchange AtPoints export only supports simplex volume "
+              "elements!");
   // MAGMA's hardened non-tensor AtPoints basis construction (libCEED
   // cuda-nontensor-atpoints branch) requires tabulation points that overdetermine the
   // complete polynomial space for non-H1 spaces; square tabulations are rejected. Bump the
-  // lattice by one degree, matching the InitTetBasisForAtPoints copy in
-  // output_functionals.cpp, since this exchange builds bases for the same ND/RT field
-  // spaces.
+  // lattice by one degree, matching the simplex AtPoints helper in output_functionals.cpp,
+  // since this exchange builds bases for the same ND/RT field spaces.
   const int degree = std::max(0, fe.GetOrder() - (grad_only ? 1 : 0) + 1);
-  const mfem::IntegrationRule ir = MakeTetLatticeRule(degree);
+  const mfem::IntegrationRule ir = MakeSimplexLatticeRule(fe.GetGeomType(), degree);
   ceed::InitBasisAtPoints(fe, ir, num_comp, ceed, basis);
+}
+
+int FieldValueDim(const mfem::ParFiniteElementSpace &fespace, int space_dim)
+{
+  const auto map_type = fespace.FEColl()->GetMapType(fespace.GetParMesh()->Dimension());
+  if (map_type == mfem::FiniteElement::H_CURL || map_type == mfem::FiniteElement::H_DIV)
+  {
+    return space_dim;
+  }
+  if (map_type == mfem::FiniteElement::VALUE || map_type == mfem::FiniteElement::INTEGRAL)
+  {
+    MFEM_VERIFY(fespace.GetVDim() == 1,
+                "FaceNbrFieldExchange scalar source spaces must have one component!");
+    return 1;
+  }
+  MFEM_ABORT("FaceNbrFieldExchange requires H(curl), H(div), or scalar VALUE/INTEGRAL "
+             "source spaces (map type = "
+             << map_type << ")!");
+  return 0;
 }
 
 void CreateSequentialPointRestriction(Ceed ceed, std::size_t num_elem, int nq, int num_comp,
@@ -155,9 +204,17 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
 {
   const mfem::ParMesh &pmesh = mesh.Get();
   const int num_nbr = pmesh.GetNFaceNeighbors();
-  const int value_dim = pmesh.SpaceDimension();
-  MFEM_VERIFY(value_dim == 2 || value_dim == 3,
+  const int space_dim = pmesh.SpaceDimension();
+  MFEM_VERIFY(space_dim == 2 || space_dim == 3,
               "FaceNbrFieldExchange requires 2D or 3D physical-space fields!");
+  source_num_comp.fill(0);
+  for (int s = 0; s < MaxSources; s++)
+  {
+    if (fespaces[s])
+    {
+      source_num_comp[s] = FieldValueDim(*fespaces[s], space_dim);
+    }
+  }
   MFEM_VERIFY(requests.empty() || num_nbr > 0,
               "FaceNbrFieldExchange requires face neighbor data "
               "(ParMesh::ExchangeFaceNbrData)!");
@@ -229,7 +286,7 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
           MFEM_VERIFY(fespaces[s],
                       "Missing finite element space for requested source slot!");
           import_offsets[r][s] = import_size;
-          import_size += value_dim * nq;
+          import_size += source_num_comp[s] * nq;
         }
       }
     }
@@ -329,7 +386,9 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
         {
           MFEM_VERIFY(fespaces[s],
                       "Missing finite element space for received source slot!");
-          const bool at_points_group = use_at_points && geom == mfem::Geometry::TETRAHEDRON;
+          const bool at_points_group =
+              use_at_points &&
+              (geom == mfem::Geometry::TRIANGLE || geom == mfem::Geometry::TETRAHEDRON);
           PointConfigKey key;
           key.reserve(5 + point_key.size());
           key.push_back(s);
@@ -359,7 +418,7 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
           }
           group.elems.push_back(elem);
           group.bases.push_back(export_size);
-          export_size += value_dim * nq;
+          export_size += source_num_comp[s] * nq;
         }
       }
     }
@@ -380,9 +439,9 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
     return;
   }
 
-  // Assemble a libCEED point evaluator for each export group, writing the
-  // physical-space field values (space-dimension components per point, point-major)
-  // into the exported vector at the assigned offsets.
+  // Assemble a libCEED point evaluator for each export group, writing point-major
+  // values into the exported vector at the assigned offsets. H(curl)/H(div) sources are
+  // physical-space vectors; VALUE sources are scalar fields.
   int max_vsize = 0;
   for (const auto *fespace : fespaces)
   {
@@ -397,6 +456,7 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
     const int s = static_cast<int>(key[0]);
     const auto geom = static_cast<mfem::Geometry::Type>(key[1]);
     const int nq = static_cast<int>(key[2]);
+    const int value_dim = source_num_comp[s];
     const std::size_t num_elem = group.elems.size();
     const auto &fespace = *fespaces[s];
     MFEM_VERIFY(!group.at_points ||
@@ -435,8 +495,8 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
     CeedBasis mesh_basis;
     if (group.at_points)
     {
-      InitTetBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(), ceed,
-                              &mesh_basis);
+      InitSimplexBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(),
+                                  ceed, &mesh_basis);
     }
     else
     {
@@ -453,8 +513,8 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
     CeedBasis field_basis;
     if (group.at_points)
     {
-      InitTetBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
-                              &field_basis);
+      InitSimplexBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
+                                  &field_basis);
     }
     else
     {
@@ -481,17 +541,27 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
                                                    CEED_MEM_HOST, CEED_COPY_VALUES,
                                                    offsets.data(), &out_restr));
 
-    // The reply contains physical-space field values: the Piola transformation
-    // (H(curl) or H(div) depending on the source space) is applied here so the
-    // requester needs no neighbor element geometry.
+    // The reply contains physical-space field values for Piola-mapped spaces, and scalar
+    // values for H1/L2 spaces. The requester needs no neighbor element geometry.
     const auto map_type = fespace.FEColl()->GetMapType(pmesh.Dimension());
-    MFEM_VERIFY(map_type == mfem::FiniteElement::H_CURL ||
-                    map_type == mfem::FiniteElement::H_DIV,
-                "FaceNbrFieldExchange requires H(curl) or H(div) source spaces!");
     ceed::CeedQFunctionInfo info;
-    if (map_type == mfem::FiniteElement::H_CURL)
+    if (map_type == mfem::FiniteElement::VALUE || map_type == mfem::FiniteElement::INTEGRAL)
     {
-      if (value_dim == 2)
+      MFEM_VERIFY(value_dim == 1, "Scalar face neighbor fields must have one component!");
+      if (space_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_l2_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_l2_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_l2_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_l2_33_loc);
+      }
+    }
+    else if (map_type == mfem::FiniteElement::H_CURL)
+    {
+      if (space_dim == 2)
       {
         info.apply_qf = f_eval_probe_hcurl_22;
         info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_22_loc);
@@ -502,9 +572,9 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
         info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
       }
     }
-    else
+    else if (map_type == mfem::FiniteElement::H_DIV)
     {
-      if (value_dim == 2)
+      if (space_dim == 2)
       {
         info.apply_qf = f_eval_probe_hdiv_22;
         info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_22_loc);
@@ -514,6 +584,10 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
         info.apply_qf = f_eval_probe_hdiv_33;
         info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
       }
+    }
+    else
+    {
+      MFEM_ABORT("Unsupported face neighbor field map type!");
     }
     CeedOperator op;
     if (group.at_points)
@@ -527,6 +601,7 @@ FaceNbrFieldExchange::FaceNbrFieldExchange(
                                        &op);
     }
     export_groups.push_back({ceed, op, std::move(field_sources)});
+    fem::CacheGroupOperatorFieldVectors(export_groups.back());
 
     // Cleanup (the assembled operator holds its own references).
     if (points_vec)

--- a/palace/fem/facenbrexchange.hpp
+++ b/palace/fem/facenbrexchange.hpp
@@ -29,9 +29,10 @@ class Mesh;
 // ParMesh::ExchangeFaceNbrData relies on, valid for conformal and nonconforming
 // meshes). At evaluation, the owning process evaluates the requested fields at the
 // points with libCEED point evaluators (on the device) and replies with physical-space
-// field values (Piola transformations applied by the evaluating process, so the
-// requester needs no neighbor element geometry; material properties are applied by the
-// requester using the ghost element attributes).
+// field values (Piola transformations applied by the evaluating process for H(curl) and
+// H(div) sources, scalar VALUE/INTEGRAL sources copied directly), so the requester needs
+// no neighbor element geometry; material properties are applied by the requester using
+// the ghost element attributes).
 //
 class FaceNbrFieldExchange
 {
@@ -79,9 +80,13 @@ private:
   };
   std::vector<Message> recv_msgs, send_msgs;
 
+  // Number of imported components for each source slot. H(curl)/H(div) fields use the
+  // mesh space dimension; scalar VALUE/INTEGRAL fields use one component.
+  std::array<int, MaxSources> source_num_comp;
+
   // For request r (construction order), base offset of the values for source slot s in
-  // the imported vector (-1 when not requested). Values are space-dimension components
-  // per point, point-major: [x0 y0 (z0) x1 y1 (z1) ...].
+  // the imported vector (-1 when not requested). Values are point-major with
+  // source_num_comp[s] components per point.
   std::vector<std::array<int, MaxSources>> import_offsets;
 
   // Assembled libCEED point evaluators serving the requests of neighboring processes,
@@ -114,9 +119,12 @@ public:
   // Size of the imported values vector.
   int ImportSize() const { return imported.Size(); }
 
+  // Number of point-major components imported for source slot s.
+  int ImportNumComp(int s) const { return source_num_comp[s]; }
+
   // Base offset in the imported vector of the values of source slot s for request r
   // (construction order), or -1 when source s was not requested. Layout per request
-  // and source: space-dimension components per point, point-major.
+  // and source: ImportNumComp(s) components per point, point-major.
   int ImportOffset(int r, int s) const { return import_offsets[r][s]; }
 
   // The imported values vector (filled by Exchange()).

--- a/palace/fem/interpolator.cpp
+++ b/palace/fem/interpolator.cpp
@@ -159,6 +159,7 @@ public:
         ceed::AssembleCeedPointEvaluator(info, nullptr, 0, ceed, inputs, 3, out_restr,
                                          &point_op);
         groups.push_back({ceed, point_op, std::move(field_sources)});
+        fem::CacheGroupOperatorFieldVectors(groups.back());
 
         PalaceCeedCall(ceed, CeedVectorDestroy(&mesh_nodes_vec));
         PalaceCeedCall(ceed, CeedVectorDestroy(&field_vec));

--- a/palace/fem/output_functionals.cpp
+++ b/palace/fem/output_functionals.cpp
@@ -4,7 +4,6 @@
 #include "output_functionals.hpp"
 
 #include <algorithm>
-#include <atomic>
 #include <cmath>
 #include <cstring>
 #include <map>
@@ -55,25 +54,23 @@ using FaceConfigKey = std::vector<long long>;
 // application lifetime: mfem::FiniteElement::GetDofToQuad caches tabulations keyed by
 // the IntegrationRule pointer inside the (global, shared) FiniteElement objects, so
 // destroying an IntegrationRule which was used for tabulation would leave a dangling
-// cache entry.
+// cache entry. Each SurfaceFunctional face group registers its representative mapped
+// rule explicitly; grouping itself is driven by MFEM/NCMesh structural face data, not by
+// quantized reference-coordinate point matching.
 const mfem::IntegrationRule *
-GetRegisteredMappedIr(const FaceConfigKey &key,
-                      const std::vector<mfem::IntegrationPoint> &pts)
+RegisterMappedIr(const std::vector<mfem::IntegrationPoint> &pts)
 {
-  static std::map<FaceConfigKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::vector<std::unique_ptr<mfem::IntegrationRule>> registry;
   static std::mutex registry_mutex;
-  std::lock_guard<std::mutex> lock(registry_mutex);
-  auto it = registry.find(key);
-  if (it == registry.end())
+  auto ir = std::make_unique<mfem::IntegrationRule>(static_cast<int>(pts.size()));
+  for (std::size_t q = 0; q < pts.size(); q++)
   {
-    auto ir = std::make_unique<mfem::IntegrationRule>(static_cast<int>(pts.size()));
-    for (std::size_t q = 0; q < pts.size(); q++)
-    {
-      ir->IntPoint(static_cast<int>(q)) = pts[q];
-    }
-    it = registry.emplace(key, std::move(ir)).first;
+    ir->IntPoint(static_cast<int>(q)) = pts[q];
   }
-  return it->second.get();
+  const mfem::IntegrationRule *ptr = ir.get();
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  registry.push_back(std::move(ir));
+  return ptr;
 }
 
 // Evaluation plan for a single marked boundary element: which volume element(s) the
@@ -133,37 +130,6 @@ struct FaceGroup
   std::vector<double> normal_scales;
 };
 
-long long EncodeReferenceCoordinate(double x)
-{
-  // Most NC trace maps have exact dyadic reference coordinates, but conforming/curved or
-  // generated boundary-mode examples can arrive here with ordinary floating-point
-  // reference coordinates from MFEM transformations. Quantize finely enough to keep the
-  // topology key deterministic; VerifyMappedRuleMatches below remains the safety net
-  // against accidentally reusing one mapped integration rule for different points.
-  constexpr long long denom = 1LL << 40;
-  MFEM_VERIFY(std::isfinite(x), "Invalid reference coordinate in trace-map key!");
-  return std::llround(denom * x);
-}
-
-void AppendDenseMatrixTopologyKey(const mfem::DenseMatrix *pm, FaceConfigKey &key)
-{
-  if (!pm)
-  {
-    key.push_back(0);  // No NC point matrix.
-    return;
-  }
-  key.push_back(1);
-  key.push_back(pm->Height());
-  key.push_back(pm->Width());
-  for (int j = 0; j < pm->Width(); j++)
-  {
-    for (int i = 0; i < pm->Height(); i++)
-    {
-      key.push_back(EncodeReferenceCoordinate((*pm)(i, j)));
-    }
-  }
-}
-
 int FaceInformationSide(const mfem::Mesh::FaceInformation &face, int elem, bool ghost,
                         int face_nbr)
 {
@@ -194,15 +160,13 @@ std::vector<long long> MakeTraceMapTopologyKey(const mfem::Mesh::FaceInformation
                                                int bdr_to_face_orientation,
                                                mfem::IntegrationPointTransformation &loc)
 {
-  // The primary identity is MFEM/NCMesh topology: face tag, side role, local face id,
-  // orientation, element conformity, and the finite NC point-matrix class. The encoded
-  // reference-vertex image is not a fuzzy point-cloud key; it is an exact dyadic guard
-  // for the reference trace map that catches omitted orientation/subface bits.
+  // The identity is MFEM/NCMesh topology: face tag, side role, local face id,
+  // orientation, element conformity, and the NC face id. Do not key on transformed
+  // floating-point coordinates here; MFEM already provides the deterministic trace map
+  // for each face/side, and VerifyMappedRuleMatches remains a debug guard if this
+  // structural key is ever too coarse within one assembly.
   FaceConfigKey key;
-  const mfem::IntegrationRule *verts = mfem::Geometries.GetVertices(face_geom);
-  key.reserve(
-      24 + 3 * verts->GetNPoints() +
-      (face.point_matrix ? face.point_matrix->Height() * face.point_matrix->Width() : 0));
+  key.reserve(24);
   key.push_back(static_cast<long long>(vol_geom));
   key.push_back(static_cast<long long>(face_geom));
   key.push_back(static_cast<long long>(face_ir.GetOrder()));
@@ -215,18 +179,9 @@ std::vector<long long> MakeTraceMapTopologyKey(const mfem::Mesh::FaceInformation
   key.push_back(static_cast<long long>(face.element[side].conformity));
   key.push_back(static_cast<long long>(face.element[side].local_face_id));
   key.push_back(static_cast<long long>(face.element[side].orientation));
-  key.push_back(face.ncface >= 0 ? 1 : 0);
-  AppendDenseMatrixTopologyKey(face.point_matrix, key);
-  for (int i = 0; i < verts->GetNPoints(); i++)
-  {
-    mfem::IntegrationPoint fip = mfem::Mesh::TransformBdrElementToFace(
-        face_geom, bdr_to_face_orientation, verts->IntPoint(i));
-    mfem::IntegrationPoint ip;
-    loc.Transform(fip, ip);
-    key.push_back(EncodeReferenceCoordinate(ip.x));
-    key.push_back(EncodeReferenceCoordinate(ip.y));
-    key.push_back(EncodeReferenceCoordinate(ip.z));
-  }
+  key.push_back(static_cast<long long>(face.ncface));
+  key.push_back(face.point_matrix ? face.point_matrix->Height() : 0);
+  key.push_back(face.point_matrix ? face.point_matrix->Width() : 0);
   return key;
 }
 
@@ -274,19 +229,48 @@ bool CeedSupportsNonTensorAtPoints(Ceed ceed)
          std::strstr(resource, "/gpu/cuda/magma");
 }
 
-int TetNumModes(int degree)
+int SimplexNumModes(mfem::Geometry::Type geom, int degree)
 {
-  return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+  switch (geom)
+  {
+    case mfem::Geometry::TRIANGLE:
+      return (degree + 1) * (degree + 2) / 2;
+    case mfem::Geometry::TETRAHEDRON:
+      return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+    default:
+      MFEM_ABORT("AtPoints surface output only supports simplex volume elements!");
+      return 0;
+  }
 }
 
-mfem::IntegrationRule MakeTetLatticeRule(int degree)
+mfem::IntegrationRule MakeSimplexLatticeRule(mfem::Geometry::Type geom, int degree)
 {
-  mfem::IntegrationRule ir(TetNumModes(degree));
+  mfem::IntegrationRule ir(SimplexNumModes(geom, degree));
   int q = 0;
   if (degree == 0)
   {
-    ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    if (geom == mfem::Geometry::TRIANGLE)
+    {
+      ir.IntPoint(q).Set2(1.0 / 3.0, 1.0 / 3.0);
+    }
+    else
+    {
+      ir.IntPoint(q).Set3(0.25, 0.25, 0.25);
+    }
     ir.IntPoint(q++).weight = 1.0;
+  }
+  else if (geom == mfem::Geometry::TRIANGLE)
+  {
+    for (int total = 0; total <= degree; total++)
+    {
+      for (int i = 0; i <= total; i++)
+      {
+        const int j = total - i;
+        ir.IntPoint(q).Set2(static_cast<double>(i) / degree,
+                            static_cast<double>(j) / degree);
+        ir.IntPoint(q++).weight = 1.0;
+      }
+    }
   }
   else
   {
@@ -308,17 +292,17 @@ mfem::IntegrationRule MakeTetLatticeRule(int degree)
   return ir;
 }
 
-void InitTetBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
-                             CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+void InitSimplexBasisForAtPoints(const mfem::FiniteElement &fe, bool grad_only,
+                                 CeedInt num_comp, Ceed ceed, CeedBasis *basis)
 {
-  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
-              "AtPoints surface output proof currently supports tetrahedral volume "
-              "elements only!");
+  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TRIANGLE ||
+                  fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
+              "AtPoints surface output only supports simplex volume elements!");
   // MAGMA's non-tensor AtPoints basis construction requires tabulation points that
   // overdetermine the complete polynomial space. Use one extra lattice degree to provide
   // a small, deterministic overdetermined reconstruction while keeping AtPoints grouping.
   const int degree = std::max(0, fe.GetOrder() - (grad_only ? 1 : 0) + 1);
-  const mfem::IntegrationRule ir = MakeTetLatticeRule(degree);
+  const mfem::IntegrationRule ir = MakeSimplexLatticeRule(fe.GetGeomType(), degree);
   ceed::InitBasisAtPoints(fe, ir, num_comp, ceed, basis);
 }
 
@@ -398,6 +382,8 @@ SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(PointFieldKind kin
       return KernelKind::BDR_FIELD_E;
     case PointFieldKind::FIELD_B:
       return KernelKind::BDR_FIELD_B;
+    case PointFieldKind::FIELD_H1:
+      return KernelKind::BDR_FIELD_H1;
     case PointFieldKind::FLUX_Q:
       return KernelKind::BDR_FLUX_Q;
     case PointFieldKind::CURRENT_J:
@@ -408,6 +394,8 @@ SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(PointFieldKind kin
       return KernelKind::BDR_ENERGY_M;
     case PointFieldKind::POYNTING:
       return KernelKind::BDR_POYNTING;
+    case PointFieldKind::MODE_SN:
+      MFEM_ABORT("Boundary-mode Sn is a domain point field, not a boundary field!");
   }
   MFEM_ABORT("Unknown point field kind!");
 }
@@ -432,6 +420,8 @@ const char *SurfaceFunctional::KindName(KernelKind kind)
       return "BDR_FIELD_E";
     case KernelKind::BDR_FIELD_B:
       return "BDR_FIELD_B";
+    case KernelKind::BDR_FIELD_H1:
+      return "BDR_FIELD_H1";
     case KernelKind::BDR_FLUX_Q:
       return "BDR_FLUX_Q";
     case KernelKind::BDR_CURRENT_J:
@@ -464,13 +454,17 @@ SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
                                      const mfem::Array<int> &bdr_attr_marker,
                                      const mfem::ParFiniteElementSpace &fespace, int lod)
   : kind(ToKernelKind(kind)),
-    nd_fespace(kind == PointFieldKind::FIELD_E ? &fespace : nullptr),
+    nd_fespace((kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_H1)
+                   ? &fespace
+                   : nullptr),
     rt_fespace(kind == PointFieldKind::FIELD_B ? &fespace : nullptr), mat_op(nullptr),
     comm(mesh.GetComm()), viz_lod(lod)
 {
-  MFEM_VERIFY(kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_B,
+  MFEM_VERIFY(kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_B ||
+                  kind == PointFieldKind::FIELD_H1,
               "Invalid SurfaceFunctional point-field backend constructor!");
   Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
 }
 
 SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
@@ -491,6 +485,7 @@ SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
                   kind == PointFieldKind::ENERGY_E || kind == PointFieldKind::ENERGY_M,
               "Invalid SurfaceFunctional point-field backend constructor!");
   Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
 }
 
 SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
@@ -505,6 +500,7 @@ SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
   MFEM_VERIFY(kind == PointFieldKind::POYNTING,
               "Invalid SurfaceFunctional point-field backend constructor!");
   Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
 }
 
 SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
@@ -589,13 +585,13 @@ void SurfaceFunctional::Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_a
   // The validity decision must be globally consistent: a rank may locally encounter an
   // unsupported configuration while others do not. All ranks must agree on whether the
   // libCEED path is valid so that collective evaluation calls match; model-level callers
-  // decide whether invalid means an explicit unsupported-case legacy path or an error for
-  // a supported path.
+  // then report the unsupported configuration directly instead of hiding it behind an
+  // alternate writer.
   bool global_valid = valid;
   Mpi::GlobalAnd(1, &global_valid, comm);
   if (!global_valid && valid)
   {
-    // Discard locally assembled state; the legacy path will be used.
+    // Discard locally assembled state; callers will observe IsValid() == false.
     fem::DestroyGroupOperators(groups);
     face_nbr_exchange.reset();
     elem_attrs.clear();
@@ -620,12 +616,13 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     valid = false;
     return;
   }
-  if (is_2d && kind != KernelKind::AREA && kind != KernelKind::HCURL_NORM2 &&
-      kind != KernelKind::INTERFACE_EPR)
+  if (IsBufferKind(kind))
   {
-    // Initial 2D support covers line integrals needed by interface dielectric
-    // postprocessing. Other boundary-output, surface-flux, and mode-overlap kinds still
-    // use the legacy paths until their 2D scalar/vector conventions are implemented.
+    buffer_num_comp = BufferNumComp(kind, sdim);
+  }
+  if (is_2d && kind != KernelKind::AREA && kind != KernelKind::HCURL_NORM2 &&
+      kind != KernelKind::INTERFACE_EPR && !IsBufferKind(kind))
+  {
     valid = false;
     return;
   }
@@ -634,57 +631,13 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
   const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
   const bool need_field = (kind != KernelKind::AREA);
   Ceed ceed = ceed::internal::GetCeedObjects()[0];
-  const bool use_at_points = is_3d && CeedSupportsNonTensorAtPoints(ceed);
-
-  if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
-  {
-    // Continuous trace fields live on the MFEM boundary/face DOFs. Keep the VTU geometry
-    // on the existing boundary elements (including NC slave/leaf faces), but do not map
-    // visualization points into attached volume elements or assemble two-sided/ghost
-    // operators. EvalTraceFieldBuffer samples those boundary DOFs directly.
-    buffer_bases.resize(pmesh.GetNBE(), -1);
-    trace_bdr_indices.clear();
-    trace_bdr_indices.reserve(pmesh.GetNBE());
-    int num_marked = 0;
-    for (int i = 0; i < pmesh.GetNBE(); i++)
-    {
-      const int attr = pmesh.GetBdrAttribute(i);
-      if (!bdr_attr_marker[attr - 1])
-      {
-        continue;
-      }
-      int face_id, face_orientation;
-      pmesh.GetBdrElementFace(i, &face_id, &face_orientation);
-      MFEM_VERIFY(face_id >= 0,
-                  "Boundary trace field output requires a valid MFEM face id!");
-      const auto bdr_geom = pmesh.GetBdrElementGeometry(i);
-      const mfem::IntegrationRule &face_ir =
-          mfem::GlobGeometryRefiner.Refine(bdr_geom, viz_lod, 1)->RefPts;
-      trace_bdr_indices.push_back(i);
-      buffer_bases[i] = buffer_size / BufferNumComp(kind);
-      buffer_size += face_ir.GetNPoints() * BufferNumComp(kind);
-      num_marked++;
-    }
-    if (std::getenv("PALACE_SURFACE_PROFILE") != nullptr)
-    {
-      long long profile_counts[2] = {static_cast<long long>(num_marked), 0};
-      Mpi::GlobalSum(2, profile_counts, comm);
-      Mpi::Print(comm,
-                 "SurfaceFunctional profile kind={} groups=0 elems={} "
-                 "at_points_groups=0 at_points_elems=0 mapped_groups=0 mapped_elems=0 "
-                 "two_sided_groups=0 ghost_groups=0 max_group_elems=0 trace_elems={}\n",
-                 KindName(kind), profile_counts[0], profile_counts[0]);
-    }
-    return;
-  }
+  const bool use_at_points = CeedSupportsNonTensorAtPoints(ceed);
 
   // Plan the evaluation for each marked boundary element and group the elements by
   // their face configuration. AtPoints groups share tabulated bases and carry mapped
   // reference points as runtime data. Non-AtPoints groups use a finite trace-map key
   // derived from MFEM/NCMesh face topology instead of creating one operator per boundary
   // element.
-  static std::atomic<long long> next_mapped_assembly_id{0};
-  const long long mapped_assembly_id = next_mapped_assembly_id++;
   std::map<FaceConfigKey, FaceGroup> face_groups;
   int num_marked = 0;
   {
@@ -709,8 +662,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       const bool has_elem2 = (FET.Elem2 != nullptr);
       const bool elem2_local = has_elem2 && (FET.Elem2No < pmesh.GetNE());
 
-      // Decide which side(s) the field is evaluated from following the conventions of
-      // the legacy coefficients (see InterfaceDielectricCoefficient and
+      // Decide which side(s) the field is evaluated from following the established
+      // coefficient semantics (see InterfaceDielectricCoefficient and
       // BdrSurfaceFluxCoefficient).
       ElemPlan plan;
       plan.bdr_elem = i;
@@ -727,8 +680,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       {
         if (has_elem2)
         {
-          // Far-field computations are only supported on external boundaries (the
-          // legacy path errors in this case as well).
+          // Far-field computations are only supported on external boundaries.
           valid = false;
           return;
         }
@@ -857,6 +809,11 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         plan.point_key_b = MakeTraceMapTopologyKey(face_info, side, vol_geom_b, bdr_geom,
                                                    face_ir, o, FET.Loc2);
       }
+      auto IsAtPointsSimplex = [&](mfem::Geometry::Type geom)
+      {
+        return (is_3d && geom == mfem::Geometry::TETRAHEDRON) ||
+               (is_2d && geom == mfem::Geometry::TRIANGLE);
+      };
       const bool can_surface_flux_at_points_a =
           use_at_points && kind == KernelKind::SURFACE_FLUX && plan.elem_a >= 0 &&
           !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
@@ -865,7 +822,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           !plan.ghost_b && vol_geom_b == mfem::Geometry::TETRAHEDRON;
       const bool can_epr_at_points = use_at_points && kind == KernelKind::INTERFACE_EPR &&
                                      plan.elem_a >= 0 && plan.elem_b < 0 && !plan.ghost_a &&
-                                     vol_geom_a == mfem::Geometry::TETRAHEDRON;
+                                     IsAtPointsSimplex(vol_geom_a);
       const bool can_farfield_at_points =
           use_at_points && kind == KernelKind::FARFIELD && plan.elem_a >= 0 &&
           plan.elem_b < 0 && !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
@@ -889,7 +846,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         {
           buffer_bases.resize(pmesh.GetNBE(), -1);
         }
-        const int nc = BufferNumComp(kind);
+        const int nc = buffer_num_comp;
         out_slot = buffer_size / nc;
         buffer_bases[i] = out_slot;
         buffer_size += nq * nc;
@@ -910,8 +867,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
                           double side_scale, double normal_scale)
       {
         FaceConfigKey key;
-        key.reserve(12);
-        key.push_back(mapped_assembly_id);
+        key.reserve(11);
         key.push_back(static_cast<long long>(bdr_geom));
         key.push_back(static_cast<long long>(geom_a));
         key.push_back(static_cast<long long>(geom_b));
@@ -968,15 +924,11 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           group.normal_scale = normal_scale;
           if (!at_points_group && elem_a >= 0)
           {
-            FaceConfigKey key_a = key;
-            key_a.push_back(0);  // Side tag
-            group.mapped_ir_a = GetRegisteredMappedIr(key_a, pts_a);
+            group.mapped_ir_a = RegisterMappedIr(pts_a);
           }
           if (!at_points_group && elem_b >= 0)
           {
-            FaceConfigKey key_b = key;
-            key_b.push_back(1);  // Side tag
-            group.mapped_ir_b = GetRegisteredMappedIr(key_b, pts_b);
+            group.mapped_ir_b = RegisterMappedIr(pts_b);
           }
           it = face_groups.emplace(key, std::move(group)).first;
         }
@@ -1058,8 +1010,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         // mapped-point specialization.
         const bool average_quantity =
             kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
-            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
-            kind == KernelKind::BDR_POYNTING;
+            kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_ENERGY_E ||
+            kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
         const double side_weight = average_quantity ? 0.5 : 1.0;
         AddGroup(plan.elem_a, false, vol_geom_a, plan.pts_a, plan.point_key_a, -1, false,
                  mfem::Geometry::INVALID, {}, {}, true, side_weight, 1.0);
@@ -1075,8 +1027,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         // only the ghost contribution uses the finite mapped trace key.
         const bool average_quantity =
             kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
-            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
-            kind == KernelKind::BDR_POYNTING;
+            kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_ENERGY_E ||
+            kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
         const double side_weight = average_quantity ? 0.5 : 1.0;
         AddGroup(plan.elem_a, plan.ghost_a, vol_geom_a, plan.pts_a, plan.point_key_a, -1,
                  false, mfem::Geometry::INVALID, {}, {}, can_at_points_a, side_weight, 1.0);
@@ -1179,11 +1131,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     base_ctx.resize(2);
     base_ctx[0].second = 1.0;  // Normal sign, set per group
     base_ctx[1].second = viz_scaling;
+    const bool magnetic = (kind == KernelKind::BDR_CURRENT_J);
     MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
-                                           (kind == KernelKind::BDR_FLUX_Q)
-                                               ? mat_op->GetPermittivityReal()
-                                               : mat_op->GetInvPermeability());
-    auto mat_ctx = ceed::PopulateCoefficientContext(3, &coeff_func);
+                                           magnetic ? mat_op->GetCurlCurlInvPermeability()
+                                                    : mat_op->GetPermittivityReal());
+    auto mat_ctx =
+        ceed::PopulateCoefficientContext(magnetic && is_2d ? 1 : dim, &coeff_func);
     base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
   }
   else if (kind == KernelKind::BDR_POYNTING)
@@ -1193,8 +1146,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     base_ctx.resize(1);
     base_ctx[0].second = viz_scaling;
     MaterialPropertyCoefficient invmu_func(mat_op->GetAttributeToMaterial(),
-                                           mat_op->GetInvPermeability());
-    auto mat_ctx = ceed::PopulateCoefficientContext(3, &invmu_func);
+                                           mat_op->GetCurlCurlInvPermeability());
+    auto mat_ctx = ceed::PopulateCoefficientContext(is_2d ? 1 : dim, &invmu_func);
     base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
   }
   else if (kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M)
@@ -1204,11 +1157,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     base_ctx.resize(2);
     base_ctx[0].first = (kind == KernelKind::BDR_ENERGY_M) ? 1 : 0;
     base_ctx[1].second = viz_scaling;
+    const bool magnetic = (kind == KernelKind::BDR_ENERGY_M);
     MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
-                                           (kind == KernelKind::BDR_ENERGY_E)
-                                               ? mat_op->GetPermittivityReal()
-                                               : mat_op->GetInvPermeability());
-    auto mat_ctx = ceed::PopulateCoefficientContext(3, &coeff_func);
+                                           magnetic ? mat_op->GetCurlCurlInvPermeability()
+                                                    : mat_op->GetPermittivityReal());
+    auto mat_ctx =
+        ceed::PopulateCoefficientContext(magnetic && is_2d ? 1 : dim, &coeff_func);
     base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
   }
   else if (kind == KernelKind::MODE_OVERLAP)
@@ -1250,7 +1204,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     base_ctx[1].second = 1.0;
     if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
     {
-      // Shared field kernel: [0].first = piola (0 = ND/E, 1 = RT/B),
+      // Shared vector field kernel: [0].first = piola (0 = ND/E, 1 = RT/B),
       // [1].second = output scale (used when split AtPoints sides accumulate).
       base_ctx[0].first = (kind == KernelKind::BDR_FIELD_B) ? 1 : 0;
     }
@@ -1467,8 +1421,9 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       }
       AddSequentialPointInput("grad_x_f", face_geom, 6);
     };
-    const bool field_value_kind =
-        kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B;
+    const bool field_value_kind = kind == KernelKind::BDR_FIELD_E ||
+                                  kind == KernelKind::BDR_FIELD_B ||
+                                  kind == KernelKind::BDR_FIELD_H1;
     const bool needs_face_geom = !field_value_kind && kind != KernelKind::BDR_ENERGY_E &&
                                  kind != KernelKind::BDR_ENERGY_M &&
                                  kind != KernelKind::BDR_POYNTING;
@@ -1526,8 +1481,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         const mfem::FiniteElement *mesh_fe =
             mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
         CeedBasis mesh_basis;
-        InitTetBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(), ceed,
-                                &mesh_basis);
+        InitSimplexBasisForAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(),
+                                    ceed, &mesh_basis);
         CeedVector mesh_nodes_vec;
         ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
         inputs.push_back(
@@ -1745,7 +1700,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       MFEM_VERIFY(fe, "Unable to get field finite element for surface functional!");
       if (group.at_points)
       {
-        InitTetBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed, &basis);
+        InitSimplexBasisForAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
+                                    &basis);
       }
       else
       {
@@ -1768,18 +1724,19 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         [&](const std::string &name, int slot, const mfem::IntegrationRule &ir)
     {
       const int nq = ir.GetNPoints();
+      const int num_comp = face_nbr_exchange->ImportNumComp(slot);
       std::vector<CeedInt> offsets(num_elem * nq);
       for (std::size_t e = 0; e < num_elem; e++)
       {
         const int base = face_nbr_exchange->ImportOffset(group.req_idx[e], slot);
         for (int i = 0; i < nq; i++)
         {
-          offsets[e * nq + i] = base + sdim * i;
+          offsets[e * nq + i] = base + num_comp * i;
         }
       }
       CeedElemRestriction restr;
       PalaceCeedCall(ceed, CeedElemRestrictionCreate(
-                               ceed, static_cast<CeedInt>(num_elem), nq, sdim, 1,
+                               ceed, static_cast<CeedInt>(num_elem), nq, num_comp, 1,
                                (CeedSize)face_nbr_exchange->ImportSize(), CEED_MEM_HOST,
                                CEED_COPY_VALUES, offsets.data(), &restr));
       CeedVector vec;
@@ -1898,7 +1855,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     if (buffer_kind)
     {
       const int nq = face_ir.GetNPoints();
-      const int nc = BufferNumComp(kind);
+      const int nc = buffer_num_comp;
       const int component_stride = buffer_size / nc;
       std::vector<CeedInt> offsets(num_elem * nq);
       for (std::size_t e = 0; e < num_elem; e++)
@@ -1972,37 +1929,70 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         break;
       case KernelKind::BDR_FIELD_E:
       case KernelKind::BDR_FIELD_B:
-        // Shared kernel; the ND/RT Piola is set in base_ctx[0].first.
+        // Shared vector field kernel; the ND/RT Piola is set in base_ctx[0].first.
         ctx[1].second *= group.side_scale;
-        info.apply_qf = has_b ? f_eval_bdr_field_2_32 : f_eval_bdr_field_1_32;
-        info.apply_qf_path = PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_32_loc
-                                                               : f_eval_bdr_field_1_32_loc);
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_field_2_21 : f_eval_bdr_field_1_21)
+                              : (has_b ? f_eval_bdr_field_2_32 : f_eval_bdr_field_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_21_loc
+                                                      : f_eval_bdr_field_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_32_loc
+                                                      : f_eval_bdr_field_1_32_loc);
+        break;
+      case KernelKind::BDR_FIELD_H1:
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = is_2d
+                            ? (has_b ? f_eval_bdr_field_h1_2_21 : f_eval_bdr_field_h1_1_21)
+                            : (has_b ? f_eval_bdr_field_h1_2_32 : f_eval_bdr_field_h1_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_h1_2_21_loc
+                                                      : f_eval_bdr_field_h1_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_h1_2_32_loc
+                                                      : f_eval_bdr_field_h1_1_32_loc);
         break;
       case KernelKind::BDR_FLUX_Q:
         ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
-        info.apply_qf = has_b ? f_eval_bdr_flux_q_2_32 : f_eval_bdr_flux_q_1_32;
-        info.apply_qf_path = PalaceQFunctionRelativePath(
-            has_b ? f_eval_bdr_flux_q_2_32_loc : f_eval_bdr_flux_q_1_32_loc);
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_flux_q_2_21 : f_eval_bdr_flux_q_1_21)
+                              : (has_b ? f_eval_bdr_flux_q_2_32 : f_eval_bdr_flux_q_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_flux_q_2_21_loc
+                                                      : f_eval_bdr_flux_q_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_flux_q_2_32_loc
+                                                      : f_eval_bdr_flux_q_1_32_loc);
         break;
       case KernelKind::BDR_CURRENT_J:
         ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
-        info.apply_qf = has_b ? f_eval_bdr_current_j_2_32 : f_eval_bdr_current_j_1_32;
-        info.apply_qf_path = PalaceQFunctionRelativePath(
-            has_b ? f_eval_bdr_current_j_2_32_loc : f_eval_bdr_current_j_1_32_loc);
+        info.apply_qf =
+            is_2d ? (has_b ? f_eval_bdr_current_j_2_21 : f_eval_bdr_current_j_1_21)
+                  : (has_b ? f_eval_bdr_current_j_2_32 : f_eval_bdr_current_j_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_current_j_2_21_loc
+                                                      : f_eval_bdr_current_j_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_current_j_2_32_loc
+                                                      : f_eval_bdr_current_j_1_32_loc);
         break;
       case KernelKind::BDR_ENERGY_E:
       case KernelKind::BDR_ENERGY_M:
         // Shared kernel; the ND/RT Piola is set in base_ctx[0].first.
         ctx[1].second *= group.side_scale;
-        info.apply_qf = has_b ? f_eval_bdr_energy_2_32 : f_eval_bdr_energy_1_32;
-        info.apply_qf_path = PalaceQFunctionRelativePath(
-            has_b ? f_eval_bdr_energy_2_32_loc : f_eval_bdr_energy_1_32_loc);
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_energy_2_21 : f_eval_bdr_energy_1_21)
+                              : (has_b ? f_eval_bdr_energy_2_32 : f_eval_bdr_energy_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_energy_2_21_loc
+                                                      : f_eval_bdr_energy_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_energy_2_32_loc
+                                                      : f_eval_bdr_energy_1_32_loc);
         break;
       case KernelKind::BDR_POYNTING:
         ctx[0].second *= group.side_scale;
-        info.apply_qf = has_b ? f_eval_bdr_poynting_2_32 : f_eval_bdr_poynting_1_32;
-        info.apply_qf_path = PalaceQFunctionRelativePath(
-            has_b ? f_eval_bdr_poynting_2_32_loc : f_eval_bdr_poynting_1_32_loc);
+        info.apply_qf = is_2d
+                            ? (has_b ? f_eval_bdr_poynting_2_21 : f_eval_bdr_poynting_1_21)
+                            : (has_b ? f_eval_bdr_poynting_2_32 : f_eval_bdr_poynting_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_poynting_2_21_loc
+                                                      : f_eval_bdr_poynting_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_poynting_2_32_loc
+                                                      : f_eval_bdr_poynting_1_32_loc);
         break;
       case KernelKind::FARFIELD:
         ctx[0].second = group.flip_normal ? -1.0 : 1.0;
@@ -2066,13 +2056,13 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       {
         ceed::AssembleCeedPointEvaluatorAtPoints(
             info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
-            points_restr, points_vec, BufferNumComp(kind), out_restr, &op);
+            points_restr, points_vec, buffer_num_comp, out_restr, &op);
       }
       else
       {
         ceed::AssembleCeedPointEvaluator(info, ctx.data(),
                                          ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
-                                         BufferNumComp(kind), out_restr, &op);
+                                         buffer_num_comp, out_restr, &op);
       }
     }
     else if (group.at_points)
@@ -2089,6 +2079,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           out_restr, &op, (kind == KernelKind::FARFIELD) ? &op_ctx : nullptr);
     }
     groups.push_back({ceed, op, std::move(field_sources), op_ctx});
+    fem::CacheGroupOperatorFieldVectors(groups.back());
   }
   if (profile)
   {
@@ -2133,6 +2124,29 @@ double SurfaceFunctional::EvalLocal(const std::array<const Vector *, 4> &srcs) c
   }
   ApplyAdd(srcs);
   return (local_out.Size() > 0) ? linalg::LocalSum(local_out) : 0.0;
+}
+
+void SurfaceFunctional::BinLocalOutByAttribute(const mfem::Array<int> &attr_to_bin,
+                                               int num_bins, std::vector<double> &bins,
+                                               double scale) const
+{
+  if (local_out.Size() == 0)
+  {
+    return;
+  }
+  MFEM_VERIFY(local_out_attrs.size() == static_cast<std::size_t>(local_out.Size()),
+              "SurfaceFunctional attribute bins require one output slot per element!");
+  const double *vals = local_out.HostRead();
+  for (int i = 0; i < local_out.Size(); i++)
+  {
+    const int attr = local_out_attrs[i];
+    const int bin = (attr > 0 && attr <= attr_to_bin.Size()) ? attr_to_bin[attr - 1] : -1;
+    if (bin >= 0)
+    {
+      MFEM_VERIFY(bin < num_bins, "SurfaceFunctional attribute bin out of range!");
+      bins[bin] += scale * vals[i];
+    }
+  }
 }
 
 double SurfaceFunctional::Eval(const Vector *u) const
@@ -2186,6 +2200,86 @@ std::complex<double> SurfaceFunctional::EvalModeOverlap(const GridFunction &E) c
   return dot;
 }
 
+std::vector<std::complex<double>> SurfaceFunctional::EvalModeOverlapByAttribute(
+    const GridFunction &E, const mfem::Array<int> &attr_to_bin, int num_bins) const
+{
+  MFEM_VERIFY(kind == KernelKind::MODE_OVERLAP,
+              "SurfaceFunctional::EvalModeOverlapByAttribute is only valid for "
+              "mode-overlap functionals!");
+  MFEM_VERIFY(num_bins >= 0, "Invalid number of output bins!");
+  auto AccumulateBins = [&](const Vector &u, std::vector<double> &bins)
+  {
+    if (local_out.Size() > 0)
+    {
+      local_out = 0.0;
+    }
+    // Keep the apply collective even on ranks with no local marked elements, matching
+    // the per-port EvalModeOverlap path and the binned power evaluator.
+    ApplyAdd({&u, nullptr});
+    BinLocalOutByAttribute(attr_to_bin, num_bins, bins, 1.0);
+  };
+
+  std::vector<double> real(num_bins, 0.0), imag(num_bins, 0.0);
+  AccumulateBins(E.Real(), real);
+  if (E.HasImag())
+  {
+    AccumulateBins(E.Imag(), imag);
+  }
+
+  std::vector<double> packed(2 * num_bins, 0.0);
+  for (int i = 0; i < num_bins; i++)
+  {
+    packed[2 * i + 0] = real[i];
+    packed[2 * i + 1] = imag[i];
+  }
+  Mpi::GlobalSum(static_cast<int>(packed.size()), packed.data(), comm);
+
+  std::vector<std::complex<double>> result(num_bins);
+  for (int i = 0; i < num_bins; i++)
+  {
+    result[i] = {packed[2 * i + 0], packed[2 * i + 1]};
+  }
+  return result;
+}
+
+void SurfaceFunctional::WarmUpBufferOperators() const
+{
+  if (!valid || !IsBufferKind(kind) || groups.empty() || buffer_size <= 0)
+  {
+    return;
+  }
+  // Force libCEED/CUDA lazy initialization for boundary point-field operators while the
+  // output backend is being configured instead of during the first VTU payload write.
+  // This does not remove any output fields or payload bytes; secondary timers track the
+  // shifted setup cost in the full application run.
+  Vector buffer(buffer_size);
+  buffer.UseDevice(true);
+  buffer = 0.0;
+  if (kind == KernelKind::BDR_POYNTING)
+  {
+    if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&field_staging, &field_staging});
+      fem::ApplyAddGroupOperators(groups, {&field_staging, &field_staging}, buffer,
+                                  &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&field_staging, &field_staging}, buffer);
+    }
+  }
+  else if (face_nbr_exchange)
+  {
+    face_nbr_exchange->Exchange({&field_staging});
+    fem::ApplyAddGroupOperators(groups, {&field_staging}, buffer,
+                                &face_nbr_exchange->Imported());
+  }
+  else
+  {
+    fem::ApplyAddGroupOperators(groups, {&field_staging}, buffer);
+  }
+}
+
 std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
                                                  const GridFunction *B) const
 {
@@ -2219,101 +2313,6 @@ std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
   return dot;
 }
 
-void SurfaceFunctional::EvalTraceFieldBuffer(const Vector &u, Vector &buffer) const
-{
-  MFEM_VERIFY(kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B,
-              "Trace-field buffer evaluation is only valid for boundary E/B fields!");
-  const mfem::ParFiniteElementSpace *fespace =
-      (kind == KernelKind::BDR_FIELD_E) ? nd_fespace : rt_fespace;
-  MFEM_VERIFY(fespace, "Missing finite element space for boundary trace field output!");
-  const mfem::ParMesh &pmesh = *fespace->GetParMesh();
-  const int nc = BufferNumComp(kind);
-  MFEM_VERIFY(nc == 3, "Boundary trace field output expects ambient 3-vector buffers!");
-  MFEM_VERIFY(buffer.Size() == buffer_size && buffer_size % nc == 0,
-              "Invalid boundary trace field buffer size!");
-  const int component_stride = buffer_size / nc;
-  double *out = buffer.HostReadWrite();
-
-  mfem::Array<int> vdofs;
-  mfem::DofTransformation dof_trans;
-  mfem::Vector loc_data, shape, val, normal;
-  mfem::DenseMatrix vshape;
-  mfem::IsoparametricTransformation T;
-  for (const int i : trace_bdr_indices)
-  {
-    const int base = buffer_bases[i];
-    MFEM_VERIFY(base >= 0, "Boundary trace field output has an invalid buffer base!");
-    const mfem::FiniteElement *fe = fespace->GetBE(i);
-    MFEM_VERIFY(fe, "Unable to get boundary trace finite element for E_t/B_n output!");
-    const mfem::IntegrationRule &face_ir =
-        mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), viz_lod, 1)
-            ->RefPts;
-    MFEM_VERIFY(base + face_ir.GetNPoints() <= component_stride,
-                "Boundary trace field buffer base is out of range!");
-
-    fespace->GetBdrElementVDofs(i, vdofs, dof_trans);
-    u.GetSubVector(vdofs, loc_data);
-    dof_trans.InvTransformPrimal(loc_data);
-    pmesh.GetBdrElementTransformation(i, &T);
-
-    if (kind == KernelKind::BDR_FIELD_B)
-    {
-      // RT trace elements are scalar H^{-1/2} normal flux densities on the boundary
-      // element. Output the signed normal trace as an ambient normal vector to preserve
-      // the existing three-component ParaView field shape while avoiding any attached
-      // volume-element evaluation.
-      MFEM_VERIFY(fe->GetRangeType() == mfem::FiniteElement::SCALAR,
-                  "Expected scalar RT trace finite element for B_n output!");
-      shape.SetSize(fe->GetDof());
-      normal.SetSize(3);
-      for (int q = 0; q < face_ir.GetNPoints(); q++)
-      {
-        const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
-        T.SetIntPoint(&ip);
-        if (fe->GetMapType() == mfem::FiniteElement::VALUE)
-        {
-          fe->CalcShape(ip, shape);
-        }
-        else
-        {
-          fe->CalcPhysShape(T, shape);
-        }
-        const double bn = shape * loc_data;
-        mfem::CalcOrtho(T.Jacobian(), normal);
-        const double normal_norm = normal.Norml2();
-        MFEM_VERIFY(normal_norm > 0.0, "Invalid boundary normal for B_n output!");
-        normal /= normal_norm;
-        for (int c = 0; c < 3; c++)
-        {
-          out[base + q + c * component_stride] += bn * normal(c);
-        }
-      }
-    }
-    else
-    {
-      // ND trace elements evaluate the tangential trace as an ambient vector on the
-      // boundary element. NC slave/leaf face constraints are already represented in the
-      // boundary DOF restriction, so no Elem2/master-side mapping is needed.
-      MFEM_VERIFY(fe->GetRangeType() == mfem::FiniteElement::VECTOR,
-                  "Expected vector ND trace finite element for E_t output!");
-      const int vdim = std::max(pmesh.SpaceDimension(), fe->GetRangeDim());
-      vshape.SetSize(fe->GetDof(), vdim);
-      val.SetSize(vdim);
-      for (int q = 0; q < face_ir.GetNPoints(); q++)
-      {
-        const mfem::IntegrationPoint &ip = face_ir.IntPoint(q);
-        T.SetIntPoint(&ip);
-        fe->CalcVShape(T, vshape);
-        vshape.MultTranspose(loc_data, val);
-        for (int c = 0; c < 3; c++)
-        {
-          out[base + q + c * component_stride] += (c < val.Size()) ? val(c) : 0.0;
-        }
-      }
-    }
-  }
-}
-
 void SurfaceFunctional::EvalBuffer(const Vector &u, Vector &buffer) const
 {
   MFEM_VERIFY(
@@ -2321,11 +2320,6 @@ void SurfaceFunctional::EvalBuffer(const Vector &u, Vector &buffer) const
       "EvalBuffer requires a valid single-field boundary visualization functional!");
   MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
   buffer = 0.0;
-  if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
-  {
-    EvalTraceFieldBuffer(u, buffer);
-    return;
-  }
   if (face_nbr_exchange)
   {
     face_nbr_exchange->Exchange({&u});
@@ -2346,11 +2340,7 @@ void SurfaceFunctional::EvalBuffer(const GridFunction &u, Vector &buffer) const
   buffer = 0.0;
   auto Apply = [&](const Vector &v)
   {
-    if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
-    {
-      EvalTraceFieldBuffer(v, buffer);
-    }
-    else if (face_nbr_exchange)
+    if (face_nbr_exchange)
     {
       face_nbr_exchange->Exchange({&v});
       fem::ApplyAddGroupOperators(groups, {&v}, buffer, &face_nbr_exchange->Imported());
@@ -2507,9 +2497,6 @@ SurfaceFunctional::EvalComplexPowerByAttribute(const GridFunction &E, const Grid
               "Mismatch between real- and complex-valued E and B fields in batched "
               "port power calculation!");
   MFEM_VERIFY(num_bins >= 0, "Invalid number of output bins!");
-  MFEM_VERIFY(local_out_attrs.size() == static_cast<std::size_t>(local_out.Size()),
-              "SurfaceFunctional attribute bins require one output slot per element!");
-
   auto AccumulateBins = [&](const std::array<const Vector *, 4> &srcs,
                             std::vector<double> &bins, double scale)
   {
@@ -2521,21 +2508,7 @@ SurfaceFunctional::EvalComplexPowerByAttribute(const GridFunction &E, const Grid
     // face-neighbor exchange may need this rank to export field data for another rank's
     // processor-boundary side.
     ApplyAdd(srcs);
-    if (local_out.Size() == 0)
-    {
-      return;
-    }
-    const double *vals = local_out.HostRead();
-    for (int i = 0; i < local_out.Size(); i++)
-    {
-      const int attr = local_out_attrs[i];
-      const int bin = (attr > 0 && attr <= attr_to_bin.Size()) ? attr_to_bin[attr - 1] : -1;
-      if (bin >= 0)
-      {
-        MFEM_VERIFY(bin < num_bins, "SurfaceFunctional attribute bin out of range!");
-        bins[bin] += scale * vals[i];
-      }
-    }
+    BinLocalOutByAttribute(attr_to_bin, num_bins, bins, scale);
   };
 
   std::vector<double> real(num_bins, 0.0), imag(num_bins, 0.0);

--- a/palace/fem/output_functionals.hpp
+++ b/palace/fem/output_functionals.hpp
@@ -24,21 +24,6 @@ class Mesh;
 class PointFieldEvaluator;
 class FaceNbrFieldExchange;
 
-// Non-reducing boundary point field kinds. These are private SurfaceFunctional backend
-// hooks used by the ParaView/GridFunction follow-up; the output-functional PR keeps the
-// enum here so the reducing functional implementation is self-contained without pulling
-// in the point-field evaluator API.
-enum class PointFieldKind : char
-{
-  FIELD_E,    // H(curl) E field values
-  FIELD_B,    // H(div) B field values
-  FLUX_Q,     // Surface charge (eps E) . n
-  CURRENT_J,  // Surface current n x (mu^-1 B)
-  ENERGY_E,   // Electric energy density
-  ENERGY_M,   // Magnetic energy density
-  POYNTING    // Poynting vector E x (mu^-1 B)
-};
-
 // Description of a real vector-valued mode coefficient on a marked boundary surface.
 // UNIFORM represents scale * direction. COAXIAL represents scale * (x - origin) /
 // |x - origin|^2, matching CoaxialElementData::GetModeCoefficient.
@@ -64,13 +49,13 @@ struct SurfaceModeCoefficient
 // visualization point fields are exposed through PointFieldEvaluator, which uses private
 // boundary point-field assembly hooks here. This enables postprocessing measurements
 // (interface dielectric energy participation, surface fluxes, port powers, etc.) to
-// execute on the device, in contrast to the legacy mfem::Coefficient-based paths which
-// are host-only.
+// execute on the device instead of using host-only mfem::Coefficient evaluation for
+// supported paths.
 //
 // The key construction: for each boundary element, the field is evaluated from an
 // attached volume element (or both, with averaging or differencing, for interior
 // boundaries, following the conventions of BdrGridFunctionCoefficient and its derived
-// legacy coefficients). AtPoints-capable groups keep mapped reference points as runtime
+// coefficient semantics). AtPoints-capable groups keep mapped reference points as runtime
 // data; mapped-integration-rule groups use per-assembly integer identities rather than
 // rounded coordinate keys. Processor-boundary ghost values are requested through
 // FaceNbrFieldExchange with integer/topological reference-face orientation keys so point
@@ -104,6 +89,7 @@ private:
     MODE_OVERLAP,
     BDR_FIELD_E,
     BDR_FIELD_B,
+    BDR_FIELD_H1,
     BDR_FLUX_Q,
     BDR_CURRENT_J,
     BDR_ENERGY_E,
@@ -120,24 +106,25 @@ private:
   static bool IsBufferKind(KernelKind kind)
   {
     return kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
-           kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_CURRENT_J ||
-           kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M ||
-           kind == KernelKind::BDR_POYNTING;
+           kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_FLUX_Q ||
+           kind == KernelKind::BDR_CURRENT_J || kind == KernelKind::BDR_ENERGY_E ||
+           kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
   }
 
   // Number of components per visualization point for buffer kinds.
-  static int BufferNumComp(KernelKind kind)
+  static int BufferNumComp(KernelKind kind, int sdim)
   {
-    return (kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_ENERGY_E ||
-            kind == KernelKind::BDR_ENERGY_M)
+    return (kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_FLUX_Q ||
+            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M)
                ? 1
-               : 3;
+               : sdim;
   }
 
   // Total buffer size (all boundary elements, lattice points, components) and
   // per-element point-base offsets for the boundary visualization field kinds. Vector
-  // buffers are component-major: x[points], y[points], z[points].
+  // buffers are component-major: x[points], y[points], (z[points] in 3D).
   int BufferSize() const { return buffer_size; }
+  int BufferNumComp() const { return buffer_num_comp; }
   const std::vector<int> &BufferBases() const { return buffer_bases; }
 
   // Computation kind and integrand parameters.
@@ -157,21 +144,20 @@ private:
   int viz_lod = 0;
   double viz_scaling = 1.0;
   int buffer_size = 0;
+  int buffer_num_comp = 0;
   std::vector<int> buffer_bases;
-  std::vector<int> trace_bdr_indices;
 
-  // Field finite element spaces (not owned): nd_fespace for H(curl) fields (source index
-  // 0), rt_fespace for H(div) fields (source index 1). Either may be nullptr depending
-  // on the functional kind. Material operator (not owned) for material property lookups
-  // and side selection.
+  // Field finite element spaces (not owned): nd_fespace for H(curl)/H1 fields (source
+  // index 0), rt_fespace for H(div) fields (source index 1). Either may be nullptr
+  // depending on the functional kind. Material operator (not owned) for material property
+  // lookups and side selection.
   const mfem::ParFiniteElementSpace *nd_fespace;
   const mfem::ParFiniteElementSpace *rt_fespace;
   const MaterialOperator *mat_op;
 
   // Whether the functional could be assembled. False means the configuration is outside
-  // the current support matrix; model-level callers may explicitly use legacy code for
-  // those cases, but supported cases should treat invalid assembly as an error rather
-  // than silently falling back.
+  // the current support matrix; supported model-level paths treat invalid assembly as an
+  // error rather than silently selecting a different implementation.
   bool valid = true;
 
   // MPI communicator from the mesh.
@@ -202,6 +188,7 @@ private:
 
   void Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
   void AssembleLocal(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
+  void WarmUpBufferOperators() const;
 
   // Apply all group operators with the field inputs pointed at the given source
   // vectors, accumulating into the local output vector.
@@ -209,6 +196,10 @@ private:
 
   // Zero the local output vector, apply, and return the local sum (no MPI reduction).
   double EvalLocal(const std::array<const Vector *, 4> &srcs) const;
+
+  // Add the current local_out element slots into per-attribute bins.
+  void BinLocalOutByAttribute(const mfem::Array<int> &attr_to_bin, int num_bins,
+                              std::vector<double> &bins, double scale) const;
 
   // Construct boundary point-field evaluators. These are intentionally private to keep
   // SurfaceFunctional reduction-oriented at call sites; PointFieldEvaluator owns the
@@ -227,17 +218,13 @@ private:
                     const MaterialOperator &mat_op, int lod, double scaling);
 
   // Fill boundary visualization buffers. Friend-only; non-reducing callers use
-  // PointFieldEvaluator. Continuous trace fields (E_t/B_n) use boundary/face DOFs
-  // directly on the MFEM boundary-element tessellation.
-  void EvalTraceFieldBuffer(const Vector &u, Vector &buffer) const;
+  // PointFieldEvaluator.
   void EvalBuffer(const Vector &u, Vector &buffer) const;
   void EvalBuffer(const GridFunction &u, Vector &buffer) const;
   void EvalBuffer(const GridFunction &E, const GridFunction &B, Vector &buffer) const;
 
 public:
-  // Returns false when libCEED surface functionals have been globally disabled via the
-  // PALACE_LEGACY_SURFACE_POSTPRO environment variable (legacy mfem::Coefficient paths
-  // are used instead, for debugging and benchmarking).
+  // Returns whether libCEED-backed surface functionals are available.
   static bool Enabled();
 
   // Construct a functional over the boundary elements with marked attributes (marker
@@ -282,9 +269,8 @@ public:
   SurfaceFunctional &operator=(const SurfaceFunctional &) = delete;
 
   // Whether the functional was successfully assembled. When false, evaluation is not
-  // possible. Supported model-level paths should error rather than silently falling back;
-  // explicit legacy/oracle paths remain available for unsupported configurations and
-  // validation.
+  // possible; supported model-level paths should error rather than silently selecting a
+  // different implementation.
   bool IsValid() const { return valid; }
 
   // Evaluate the functional for the given field (L-vector, e.g. the local vector of a
@@ -326,6 +312,13 @@ public:
   // Evaluate the linear mode-overlap functional, returning the complex integral when the
   // supplied field has real and imaginary parts.
   std::complex<double> EvalModeOverlap(const GridFunction &E) const;
+
+  // Same mode-overlap convention as EvalModeOverlap, but return one result per
+  // boundary-attribute bin. attr_to_bin is indexed by boundary attribute - 1 and uses -1
+  // for attributes not assigned to an output bin. Collective on the mesh communicator.
+  std::vector<std::complex<double>>
+  EvalModeOverlapByAttribute(const GridFunction &E, const mfem::Array<int> &attr_to_bin,
+                             int num_bins) const;
 };
 
 }  // namespace palace

--- a/palace/fem/point_field_evaluator.cpp
+++ b/palace/fem/point_field_evaluator.cpp
@@ -1,0 +1,178 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fem/point_field_evaluator.hpp"
+
+#include "fem/domain_point_field_evaluator.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/output_functionals.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+DomainPointFieldEvaluator::Kind ToDomainKind(PointFieldEvaluator::Kind kind)
+{
+  switch (kind)
+  {
+    case PointFieldEvaluator::Kind::FIELD_E:
+      return DomainPointFieldEvaluator::Kind::FIELD_E;
+    case PointFieldEvaluator::Kind::FIELD_B:
+      return DomainPointFieldEvaluator::Kind::FIELD_B;
+    case PointFieldEvaluator::Kind::FIELD_H1:
+      return DomainPointFieldEvaluator::Kind::FIELD_H1;
+    case PointFieldEvaluator::Kind::ENERGY_E:
+      return DomainPointFieldEvaluator::Kind::ENERGY_E;
+    case PointFieldEvaluator::Kind::ENERGY_M:
+      return DomainPointFieldEvaluator::Kind::ENERGY_M;
+    case PointFieldEvaluator::Kind::POYNTING:
+      return DomainPointFieldEvaluator::Kind::POYNTING;
+    case PointFieldEvaluator::Kind::MODE_SN:
+      return DomainPointFieldEvaluator::Kind::MODE_SN;
+    default:
+      MFEM_ABORT("Unsupported domain point field kind!");
+  }
+}
+
+}  // namespace
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const MaterialOperator &mat_op,
+                                         const mfem::ParFiniteElementSpace *nd_fespace,
+                                         const mfem::ParFiniteElementSpace *rt_fespace,
+                                         const mfem::ParFiniteElementSpace &target_fespace,
+                                         double scaling)
+  : location(MeshEntityType::Domain), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1 ||
+                  kind == Kind::ENERGY_E || kind == Kind::ENERGY_M ||
+                  kind == Kind::POYNTING || kind == Kind::MODE_SN,
+              "Unsupported domain point field kind!");
+  domain_eval = std::make_unique<DomainPointFieldEvaluator>(
+      ToDomainKind(kind), mesh, mat_op, nd_fespace, rt_fespace, target_fespace, scaling);
+  valid = domain_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &fespace,
+                                         int lod)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1,
+              "Unsupported boundary field point kind!");
+  boundary_eval.reset(new SurfaceFunctional(kind, mesh, bdr_attr_marker, fespace, lod));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &fespace,
+                                         const MaterialOperator &mat_op, int lod,
+                                         double scaling)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FLUX_Q || kind == Kind::CURRENT_J || kind == Kind::ENERGY_E ||
+                  kind == Kind::ENERGY_M,
+              "Unsupported boundary material point field kind!");
+  boundary_eval.reset(
+      new SurfaceFunctional(kind, mesh, bdr_attr_marker, fespace, mat_op, lod, scaling));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &nd_fespace,
+                                         const mfem::ParFiniteElementSpace &rt_fespace,
+                                         const MaterialOperator &mat_op, int lod,
+                                         double scaling)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::POYNTING, "Unsupported two-field boundary point kind!");
+  boundary_eval.reset(new SurfaceFunctional(kind, mesh, bdr_attr_marker, nd_fespace,
+                                            rt_fespace, mat_op, lod, scaling));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::~PointFieldEvaluator() = default;
+
+bool PointFieldEvaluator::IsValid() const
+{
+  return valid;
+}
+
+int PointFieldEvaluator::BufferSize() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferSize()
+                                            : boundary_eval->BufferSize();
+}
+
+int PointFieldEvaluator::BufferNumComp() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferNumComp()
+                                            : boundary_eval->BufferNumComp();
+}
+
+const std::vector<int> &PointFieldEvaluator::BufferBases() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferBases()
+                                            : boundary_eval->BufferBases();
+}
+
+void PointFieldEvaluator::Eval(const GridFunction *E, const GridFunction *B,
+                               Vector &out) const
+{
+  MFEM_VERIFY(location == MeshEntityType::Domain && domain_eval,
+              "GridFunction output is only supported for domain point fields!");
+  domain_eval->Eval(E, B, out);
+}
+
+void PointFieldEvaluator::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid() && kind != Kind::POYNTING,
+              "Vector EvalBuffer is only valid for single-field point fields!");
+  if (location == MeshEntityType::Domain)
+  {
+    domain_eval->EvalBuffer(u, buffer);
+  }
+  else
+  {
+    boundary_eval->EvalBuffer(u, buffer);
+  }
+}
+
+void PointFieldEvaluator::EvalBuffer(const GridFunction &u, Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid() && location == MeshEntityType::Boundary && kind != Kind::POYNTING,
+              "GridFunction EvalBuffer is only valid for single-field boundary point "
+              "fields!");
+  boundary_eval->EvalBuffer(u, buffer);
+}
+
+void PointFieldEvaluator::EvalBuffer(const GridFunction *E, const GridFunction *B,
+                                     Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid(), "EvalBuffer called on an invalid point field evaluator!");
+  if (location == MeshEntityType::Domain)
+  {
+    domain_eval->EvalBuffer(E, B, buffer);
+    return;
+  }
+
+  MFEM_VERIFY(boundary_eval, "Missing boundary point field evaluator!");
+  if (kind == Kind::POYNTING)
+  {
+    MFEM_VERIFY(E && B, "Boundary Poynting point field requires E and B fields!");
+    boundary_eval->EvalBuffer(*E, *B, buffer);
+  }
+  else
+  {
+    const GridFunction *u = E ? E : B;
+    MFEM_VERIFY(u, "Boundary point field requires a source field!");
+    boundary_eval->EvalBuffer(*u, buffer);
+  }
+}
+
+}  // namespace palace

--- a/palace/fem/point_field_evaluator.hpp
+++ b/palace/fem/point_field_evaluator.hpp
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_POINT_FIELD_EVALUATOR_HPP
+#define PALACE_FEM_POINT_FIELD_EVALUATOR_HPP
+
+#include <memory>
+#include <vector>
+#include <mfem.hpp>
+#include "linalg/vector.hpp"
+#include "utils/labels.hpp"
+
+namespace palace
+{
+
+class DomainPointFieldEvaluator;
+class GridFunction;
+class MaterialOperator;
+class Mesh;
+class SurfaceFunctional;
+
+// Non-reducing libCEED evaluator for visualization point fields. Unlike reduction
+// functionals, this produces one value per local visualization point and is intended to
+// feed ParaView point data. Domain direct-VTU buffers are point-major; boundary buffers
+// use the existing component-major writer path. The mesh entity location selects domain
+// elements or boundary elements; the operation remains pointwise, not an MPI-reduced
+// functional.
+class PointFieldEvaluator
+{
+public:
+  using Kind = PointFieldKind;
+
+private:
+  MeshEntityType location;
+  Kind kind;
+  bool valid = false;
+  std::unique_ptr<DomainPointFieldEvaluator> domain_eval;
+  std::unique_ptr<SurfaceFunctional> boundary_eval;
+
+public:
+  // Domain pointwise evaluator for U_e, U_m, or S at VTU visualization points. The
+  // target space is retained only to preserve the existing GridFunction export path.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+                      const mfem::ParFiniteElementSpace *nd_fespace,
+                      const mfem::ParFiniteElementSpace *rt_fespace,
+                      const mfem::ParFiniteElementSpace &target_fespace, double scaling);
+
+  // Boundary field evaluator for E or B at boundary VTU visualization points.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &fespace, int lod);
+
+  // Boundary material-dependent evaluator for Q_s, J_s, U_e, or U_m.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &fespace,
+                      const MaterialOperator &mat_op, int lod, double scaling);
+
+  // Boundary Poynting vector evaluator.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &nd_fespace,
+                      const mfem::ParFiniteElementSpace &rt_fespace,
+                      const MaterialOperator &mat_op, int lod, double scaling);
+  ~PointFieldEvaluator();
+
+  PointFieldEvaluator(const PointFieldEvaluator &) = delete;
+  PointFieldEvaluator &operator=(const PointFieldEvaluator &) = delete;
+
+  bool IsValid() const;
+  MeshEntityType Location() const { return location; }
+  Kind GetKind() const { return kind; }
+
+  int BufferSize() const;
+  int BufferNumComp() const;
+  const std::vector<int> &BufferBases() const;
+
+  // Domain-only compatibility path for grid-function output.
+  void Eval(const GridFunction *E, const GridFunction *B, Vector &out) const;
+
+  // Fill the visualization buffer. Domain buffers are point-major for direct VTU output;
+  // boundary buffers are component-major. The Vector overload is for already split
+  // real/imaginary fields; the GridFunction overload accumulates real and imaginary
+  // contributions for quadratic single-field quantities. For POYNTING pass E and B to
+  // the two-field overload.
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction *E, const GridFunction *B, Vector &buffer) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_POINT_FIELD_EVALUATOR_HPP

--- a/palace/fem/postprocessing_backend.hpp
+++ b/palace/fem/postprocessing_backend.hpp
@@ -11,8 +11,9 @@ namespace fem
 {
 
 // Central query for libCEED-backed postprocessing availability. Supported production
-// postprocessing paths use the libCEED backend directly; coefficient implementations are
-// retained only as reference semantics in tests and for explicitly unsupported features.
+// visualization/postprocessing paths use the libCEED backend directly; coefficient
+// implementations are retained only as reference semantics in tests and for explicitly
+// unsupported features.
 bool LibceedPostprocessingEnabled();
 
 }  // namespace fem

--- a/palace/fem/qfunctions/21/surf_21_qf.h
+++ b/palace/fem/qfunctions/21/surf_21_qf.h
@@ -5,6 +5,7 @@
 #define PALACE_LIBCEED_SURF_21_QF_H
 
 #include "../22/utils_22_qf.h"
+#include "../coeff/coeff_1_qf.h"
 #include "../coeff/coeff_2_qf.h"
 #include "utils_21_qf.h"
 
@@ -47,6 +48,96 @@ SurfHcurlField2Avg21(CeedInt i, CeedInt Q, const CeedScalar *J_v1, const CeedSca
   SurfHcurlField21(i, Q, J_v2, u_2, E_2);
   E[0] = 0.5 * (E[0] + E_2[0]);
   E[1] = 0.5 * (E[1] + E_2[1]);
+}
+
+// Runtime-selected 2D field value for boundary visualization. H(curl) fields are full
+// in-plane physical vectors. The H(div) branch is not used for Palace's scalar 2D B
+// boundary output, but keeps the shared enum path well-defined.
+CEED_QFUNCTION_HELPER void SurfField21(CeedInt piola, CeedInt i, CeedInt Q,
+                                       const CeedScalar *J_v, const CeedScalar *u,
+                                       CeedScalar V[2])
+{
+  if (piola)
+  {
+    V[0] = u[i];
+    V[1] = 0.0;
+  }
+  else
+  {
+    SurfHcurlField21(i, Q, J_v, u, V);
+  }
+}
+
+// Pointwise boundary vector field values (no quadrature weighting; for visualization
+// output at the boundary element lattice points), following BdrFieldVectorCoefficient:
+// the full field from the attached volume element, averaged over both sides for interior
+// boundaries. Inputs match the 3D field kernels. Output: 2 components per point.
+CEED_QFUNCTION(f_eval_bdr_field_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[2];
+    SurfField21(ctx[0].first, i, Q, J_v, u, V);
+    v[i + Q * 0] = ctx[1].second * V[0];
+    v[i + Q * 1] = ctx[1].second * V[1];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v1 = in[0], *J_v2 = in[1], *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[2], V_2[2];
+    SurfField21(ctx[0].first, i, Q, J_v1, u_1, V);
+    SurfField21(ctx[0].first, i, Q, J_v2, u_2, V_2);
+    v[i + Q * 0] = ctx[1].second * 0.5 * (V[0] + V_2[0]);
+    v[i + Q * 1] = ctx[1].second * 0.5 * (V[1] + V_2[1]);
+  }
+  return 0;
+}
+
+// Pointwise scalar H1 boundary field values. Inputs: grad_x_1, u_1; or grad_x_1,
+// grad_x_2, u_1, u_2. The geometry inputs keep the operator shape shared with other
+// boundary field kernels; the scalar VALUE basis already evaluates the physical value.
+CEED_QFUNCTION(f_eval_bdr_field_h1_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * u[i];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_h1_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * 0.5 * (u_1[i] + u_2[i]);
+  }
+  return 0;
 }
 
 // Line measure: v = qw * |J_f|. Inputs: qw, grad_x_f.
@@ -166,6 +257,203 @@ CEED_QFUNCTION(f_integ_surf_epr_2_21)(void *__restrict__ ctx_, CeedInt Q,
     const CeedScalar wdetJ = qw[i] * SurfMeasure21(J_f_loc, n);
     SurfHcurlField2Avg21(i, Q, J_v1, J_v2, u_1, u_2, E);
     v[i] = wdetJ * SurfEpr21(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+// Pointwise boundary surface charge, surface current, energy density, and Poynting
+// values at visualization lattice points for 2D line boundaries. These mirror the 3D
+// boundary visualization kernels in surf_32_qf.h using Palace's 2D field convention:
+// E is an in-plane H(curl) vector and B is the scalar out-of-plane magnetic flux B_z.
+// Vector outputs have two in-plane components to preserve MFEM's 2D ParaView field
+// shape. Context layouts match the 3D kernels, except material tables for magnetic
+// quantities use the scalar 1x1 out-of-plane inverse permeability.
+CEED_QFUNCTION(f_eval_bdr_flux_q_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2], eps[4], D[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    SurfHcurlField21(i, Q, J_v, u, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr[i], eps);
+    MultBx22(eps, E, D);
+    v[i] = ctx[0].second * ctx[1].second * (D[0] * n[0] + D[1] * n[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_flux_q_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2], eps[4], D[2], D_2[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    SurfHcurlField21(i, Q, J_v1, u_1, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr_1[i], eps);
+    MultBx22(eps, E, D);
+    SurfHcurlField21(i, Q, J_v2, u_2, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr_2[i], eps);
+    MultBx22(eps, E, D_2);
+    // Two-sided: contributions from opposite sides add with opposite normals.
+    v[i] =
+        ctx[0].second * ctx[1].second * ((D[0] - D_2[0]) * n[0] + (D[1] - D_2[1]) * n[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    const CeedScalar Hz = CoeffUnpack1(ctx + 2, (CeedInt)attr[i]) * u[i];
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * Hz * n[1];
+    v[i + Q * 1] = -s * Hz * n[0];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *attr_2 = in[3], *u_1 = in[5],
+                   *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    const CeedScalar Hz_1 = CoeffUnpack1(ctx + 2, (CeedInt)attr_1[i]) * u_1[i];
+    const CeedScalar Hz_2 = CoeffUnpack1(ctx + 2, (CeedInt)attr_2[i]) * u_2[i];
+    const CeedScalar Hz = Hz_1 - Hz_2;
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * Hz * n[1];
+    v[i + Q * 1] = -s * Hz * n[0];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION_HELPER void SurfPoynting21(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                          CeedInt attr, const CeedScalar *J_v,
+                                          const CeedScalar *u_e, const CeedScalar *u_b,
+                                          CeedScalar S[2])
+{
+  CeedScalar E[2];
+  SurfHcurlField21(i, Q, J_v, u_e, E);
+  const CeedScalar Hz = CoeffUnpack1(ctx + 1, attr) * u_b[i];
+  S[0] = E[1] * Hz;
+  S[1] = -E[0] * Hz;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[2];
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr[i], J_v, u_e, u_b, S);
+    const CeedScalar s = ctx[0].second;
+    v[i + Q * 0] = s * S[0];
+    v[i + Q * 1] = s * S[1];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_e_1 = in[4], *u_b_1 = in[5], *u_e_2 = in[6], *u_b_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[2], S_2[2];
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_e_1, u_b_1, S);
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_e_2, u_b_2, S_2);
+    const CeedScalar s = 0.5 * ctx[0].second;
+    v[i + Q * 0] = s * (S[0] + S_2[0]);
+    v[i + Q * 1] = s * (S[1] + S_2[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEnergy21(const CeedIntScalar *ctx, CeedInt i,
+                                              CeedInt Q, CeedInt attr,
+                                              const CeedScalar *J_v, const CeedScalar *u)
+{
+  if (ctx[0].first)
+  {
+    const CeedScalar Bz = u[i];
+    return CoeffUnpack1(ctx + 2, attr) * Bz * Bz;
+  }
+  CeedScalar E[2], eps[4], D[2];
+  SurfHcurlField21(i, Q, J_v, u, E);
+  CoeffUnpack2(ctx + 2, attr, eps);
+  MultBx22(eps, E, D);
+  return D[0] * E[0] + D[1] * E[1];
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = 0.5 * ctx[1].second * SurfEnergy21(ctx, i, Q, (CeedInt)attr[i], J_v, u);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_1 = in[4], *u_2 = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar U_1 = SurfEnergy21(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_1);
+    const CeedScalar U_2 = SurfEnergy21(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_2);
+    v[i] = 0.25 * ctx[1].second * (U_1 + U_2);
   }
   return 0;
 }

--- a/palace/fem/qfunctions/22/eval_22_qf.h
+++ b/palace/fem/qfunctions/22/eval_22_qf.h
@@ -74,6 +74,33 @@ CEED_QFUNCTION(f_eval_poynting_22)(void *__restrict__ ctx_, CeedInt Q,
   return 0;
 }
 
+// Boundary-mode normal Poynting density on a 2D cross-section, matching
+// ModeSnCoefficient's sign convention: v = scale * Re{-Ex Hy* + Ey Hx*}, with
+// Ht = mu^{-1}_{zz} Bt. This qfunction is applied separately to real and imaginary
+// parts and accumulated.
+CEED_QFUNCTION(f_eval_mode_sn_22)(void *__restrict__ ctx_, CeedInt Q,
+                                  const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[2] = {u_e[i + Q * 0], u_e[i + Q * 1]};
+    const CeedScalar ub_loc[2] = {u_b[i + Q * 0], u_b[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2], B[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, ue_loc, E);
+    MultBx22(adjJt_loc, ub_loc, B);
+    const CeedScalar invmu = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]);
+    const CeedScalar s = ctx[0].second * invmu / (detJ * detJ);
+    v[i] = s * (-E[0] * B[1] + E[1] * B[0]);
+  }
+  return 0;
+}
+
 // Pointwise H(curl) field value: v = adj(J)^T/detJ u. Inputs: grad_x, u.
 CEED_QFUNCTION(f_eval_probe_hcurl_22)(void *, CeedInt Q, const CeedScalar *const *in,
                                       CeedScalar *const *out)
@@ -90,6 +117,21 @@ CEED_QFUNCTION(f_eval_probe_hcurl_22)(void *, CeedInt Q, const CeedScalar *const
     MultBx22(adjJt_loc, u_loc, E);
     v[i + Q * 0] = E[0] / detJ;
     v[i + Q * 1] = E[1] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise scalar L2 field value. Inputs: grad_x, u. The geometry input is unused but
+// kept so this probe has the same field list as the vector-valued domain probes.
+CEED_QFUNCTION(f_eval_probe_l2_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                   CeedScalar *const *out)
+{
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = u[i];
   }
   return 0;
 }

--- a/palace/fem/qfunctions/32/surf_32_qf.h
+++ b/palace/fem/qfunctions/32/surf_32_qf.h
@@ -622,6 +622,39 @@ CEED_QFUNCTION(f_eval_bdr_field_2_32)(void *__restrict__ ctx_, CeedInt Q,
   return 0;
 }
 
+// Pointwise scalar H1 boundary field values. Inputs: grad_x_1, u_1; or grad_x_1,
+// grad_x_2, u_1, u_2. The geometry inputs keep the operator shape shared with other
+// boundary field kernels; the scalar VALUE basis already evaluates the physical value.
+CEED_QFUNCTION(f_eval_bdr_field_h1_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * u[i];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_h1_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * 0.5 * (u_1[i] + u_2[i]);
+  }
+  return 0;
+}
+
 // Pointwise boundary surface charge, surface current, and energy density values at the
 // visualization lattice points, following BdrSurfaceFluxCoefficient<ELECTRIC>
 // (two-sided), BdrSurfaceCurrentVectorCoefficient, and EnergyDensityCoefficient

--- a/palace/fem/qfunctions/33/eval_33_qf.h
+++ b/palace/fem/qfunctions/33/eval_33_qf.h
@@ -113,6 +113,21 @@ CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const
   return 0;
 }
 
+// Pointwise scalar H1/L2 field value. Inputs: grad_x, u. The geometry input is unused
+// but kept so this probe has the same field list as the vector-valued probes.
+CEED_QFUNCTION(f_eval_probe_l2_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                   CeedScalar *const *out)
+{
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = u[i];
+  }
+  return 0;
+}
+
 // Pointwise H(div) field value: v = J/detJ u. Inputs: grad_x, u.
 CEED_QFUNCTION(f_eval_probe_hdiv_33)(void *, CeedInt Q, const CeedScalar *const *in,
                                      CeedScalar *const *out)

--- a/palace/linalg/slepc.cpp
+++ b/palace/linalg/slepc.cpp
@@ -119,8 +119,7 @@ inline PetscErrorCode ConfigurePetscDevice()
                                    mfem::Device::GetGPUAwareMPI() ? "1" : "0"));
     PetscCall(PetscOptionsSetValue(NULL, "-device_select_cuda",
                                    std::to_string(mfem::Device::GetId()).c_str()));
-    // PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
-    // PetscCall(PetscOptionsSetValue(NULL, "-vec_type", "cuda"));
+    PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
   }
   if (mfem::Device::Allows(mfem::Backend::HIP_MASK))
   {
@@ -128,8 +127,7 @@ inline PetscErrorCode ConfigurePetscDevice()
                                    mfem::Device::GetGPUAwareMPI() ? "1" : "0"));
     PetscCall(PetscOptionsSetValue(NULL, "-device_select_hip",
                                    std::to_string(mfem::Device::GetId()).c_str()));
-    // PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
-    // PetscCall(PetscOptionsSetValue(NULL, "-vec_type", "hip"));
+    PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
   }
   return PETSC_SUCCESS;
 }

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -357,18 +357,6 @@ std::complex<double> LumpedPortData::GetPowerLegacy(GridFunction &E, GridFunctio
   }
 }
 
-std::complex<double> LumpedPortData::GetSParameter(GridFunction &E) const
-{
-  // The S-parameter mode coefficient is the voltage coefficient scaled by 1/sqrt(R):
-  // H_inc = 1 / sqrt((R W/L n) W L n) = 1 / (W n sqrt(R)). Reuse the device-backed
-  // voltage overlap and preserve the legacy zero result for ports without resistance.
-  if (std::abs(R) == 0.0)
-  {
-    return 0.0;
-  }
-  return GetVoltage(E) / std::sqrt(R);
-}
-
 std::complex<double> LumpedPortData::GetVoltage(GridFunction &E) const
 {
   // Compute the average voltage across the port using the same mode-overlap machinery as
@@ -583,19 +571,19 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
   // SurfaceFunctional still accumulates per-boundary-element slots;
   // EvalComplexPowerByAttribute bins those slots back to the port indices, so no
   // processor-boundary or ghost-side behavior is weakened relative to the per-port path.
-  if (!batched_power_unavailable && SurfaceFunctional::Enabled())
+  if (!batched_power_bins.unavailable && SurfaceFunctional::Enabled())
   {
     if (!batched_power_func)
     {
       auto &nd_fespace = *E.ParFESpace();
       const auto &mesh = *nd_fespace.GetParMesh();
       const int bdr_attr_max = mesh::GetMaxBdrAttribute(mesh);
-      batched_power_attr_to_port.SetSize(bdr_attr_max);
-      for (int i = 0; i < batched_power_attr_to_port.Size(); i++)
+      batched_power_bins.attr_to_port.SetSize(bdr_attr_max);
+      for (int i = 0; i < batched_power_bins.attr_to_port.Size(); i++)
       {
-        batched_power_attr_to_port[i] = -1;
+        batched_power_bins.attr_to_port[i] = -1;
       }
-      batched_power_port_indices.clear();
+      batched_power_bins.port_indices.clear();
 
       mfem::Array<int> attr_list;
       std::set<int> seen_attrs;
@@ -603,7 +591,7 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
       int bin = 0;
       for (const auto &[idx, data] : ports)
       {
-        batched_power_port_indices.push_back(idx);
+        batched_power_bins.port_indices.push_back(idx);
         for (const auto &elem : data.elems)
         {
           for (int attr : elem->GetAttrList())
@@ -614,7 +602,7 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
               break;
             }
             attr_list.Append(attr);
-            batched_power_attr_to_port[attr - 1] = bin;
+            batched_power_bins.attr_to_port[attr - 1] = bin;
           }
           if (!can_batch)
           {
@@ -643,18 +631,18 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
       }
       else
       {
-        batched_power_unavailable = true;
+        batched_power_bins.unavailable = true;
       }
     }
 
     if (batched_power_func && batched_power_func->IsValid())
     {
       auto values = batched_power_func->EvalComplexPowerByAttribute(
-          E, B, batched_power_attr_to_port,
-          static_cast<int>(batched_power_port_indices.size()));
-      for (std::size_t i = 0; i < batched_power_port_indices.size(); i++)
+          E, B, batched_power_bins.attr_to_port,
+          static_cast<int>(batched_power_bins.port_indices.size()));
+      for (std::size_t i = 0; i < batched_power_bins.port_indices.size(); i++)
       {
-        powers.emplace(batched_power_port_indices[i], values[i]);
+        powers.emplace(batched_power_bins.port_indices[i], values[i]);
       }
       return powers;
     }
@@ -667,7 +655,7 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
                     "libCEED batched lumped-port power postprocessing could not assemble "
                     "for supported 3D port surfaces!");
       }
-      batched_power_unavailable = true;
+      batched_power_bins.unavailable = true;
     }
   }
 
@@ -676,6 +664,108 @@ std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &
     powers.emplace(idx, data.GetPower(E, B));
   }
   return powers;
+}
+
+std::map<int, std::complex<double>> LumpedPortOperator::GetVoltages(GridFunction &E) const
+{
+  std::map<int, std::complex<double>> voltages;
+  if (ports.empty())
+  {
+    return voltages;
+  }
+  // Assemble one union-surface mode-overlap functional for all disjoint lumped ports.
+  // EvalModeOverlapByAttribute bins per-boundary-element slots back to port indices,
+  // avoiding one separate mode-overlap apply per port while preserving per-port values.
+  if (!batched_voltage_bins.unavailable && SurfaceFunctional::Enabled())
+  {
+    if (!batched_voltage_func)
+    {
+      auto &nd_fespace = *E.ParFESpace();
+      const auto &mesh = *nd_fespace.GetParMesh();
+      const int bdr_attr_max = mesh::GetMaxBdrAttribute(mesh);
+      batched_voltage_bins.attr_to_port.SetSize(bdr_attr_max);
+      for (int i = 0; i < batched_voltage_bins.attr_to_port.Size(); i++)
+      {
+        batched_voltage_bins.attr_to_port[i] = -1;
+      }
+      batched_voltage_bins.port_indices.clear();
+
+      std::vector<SurfaceModeCoefficient> modes;
+      std::set<int> seen_attrs;
+      bool can_batch = true;
+      int bin = 0;
+      for (const auto &[idx, data] : ports)
+      {
+        batched_voltage_bins.port_indices.push_back(idx);
+        for (const auto &elem : data.elems)
+        {
+          SurfaceModeCoefficient mode = data.GetModeCoefficient(
+              *elem, 1.0 / (elem->GetGeometryWidth() * data.elems.size()));
+          for (int attr : mode.attr_list)
+          {
+            if (attr <= 0 || attr > bdr_attr_max || !seen_attrs.insert(attr).second)
+            {
+              can_batch = false;
+              break;
+            }
+            batched_voltage_bins.attr_to_port[attr - 1] = bin;
+          }
+          if (!can_batch)
+          {
+            break;
+          }
+          modes.push_back(std::move(mode));
+        }
+        if (!can_batch)
+        {
+          break;
+        }
+        bin++;
+      }
+
+      Mpi::GlobalAnd(1, &can_batch, nd_fespace.GetComm());
+
+      if (can_batch && !modes.empty())
+      {
+        const auto &data0 = ports.begin()->second;
+        batched_voltage_func =
+            std::make_unique<SurfaceFunctional>(data0.mat_op.GetMesh(), nd_fespace, modes);
+      }
+      else
+      {
+        batched_voltage_bins.unavailable = true;
+      }
+    }
+
+    if (batched_voltage_func && batched_voltage_func->IsValid())
+    {
+      auto values = batched_voltage_func->EvalModeOverlapByAttribute(
+          E, batched_voltage_bins.attr_to_port,
+          static_cast<int>(batched_voltage_bins.port_indices.size()));
+      for (std::size_t i = 0; i < batched_voltage_bins.port_indices.size(); i++)
+      {
+        voltages.emplace(batched_voltage_bins.port_indices[i], values[i]);
+      }
+      return voltages;
+    }
+    if (batched_voltage_func)
+    {
+      if (E.ParFESpace()->GetParMesh()->Dimension() == 3 &&
+          E.ParFESpace()->GetParMesh()->SpaceDimension() == 3)
+      {
+        MFEM_VERIFY(batched_voltage_func->IsValid(),
+                    "libCEED batched lumped-port voltage postprocessing could not "
+                    "assemble for supported 3D port surfaces!");
+      }
+      batched_voltage_bins.unavailable = true;
+    }
+  }
+
+  for (const auto &[idx, data] : ports)
+  {
+    voltages.emplace(idx, data.GetVoltage(E));
+  }
+  return voltages;
 }
 
 mfem::Array<int> LumpedPortOperator::GetAttrList() const

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -34,6 +34,8 @@ struct LumpedPortData;
 //
 class LumpedPortData
 {
+  friend class LumpedPortOperator;
+
 public:
   // Reference to material property data (not owned).
   const MaterialOperator &mat_op;
@@ -48,17 +50,21 @@ public:
   bool active;
   bool include_in_synthesis;
 
-protected:
+private:
   // Linear forms for postprocessing integrated quantities on the port.
   mutable std::unique_ptr<mfem::LinearForm> s, v;
 
-  // libCEED surface functionals for port power, voltage, and S-parameter computation,
-  // replacing host boundary LinearForm paths when supported.
+  // Per-port libCEED evaluators for port power and voltage.
   mutable std::unique_ptr<SurfaceFunctional> power_func, v_func;
 
   void InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespace) const;
   SurfaceModeCoefficient GetModeCoefficient(const LumpedElementData &elem,
                                             double coeff) const;
+  // Per-port evaluation used by LumpedPortOperator when a batched functional is not
+  // available for the requested port set.
+  std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetPowerLegacy(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetVoltage(GridFunction &E) const;
 
 public:
   LumpedPortData(const config::LumpedPortData &data, const MaterialOperator &mat_op,
@@ -110,11 +116,6 @@ public:
 
   double GetExcitationPower() const;
   double GetExcitationVoltage() const;
-
-  std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
-  std::complex<double> GetPowerLegacy(GridFunction &E, GridFunction &B) const;
-  std::complex<double> GetSParameter(GridFunction &E) const;
-  std::complex<double> GetVoltage(GridFunction &E) const;
 };
 
 //
@@ -128,13 +129,19 @@ private:
   // ports.
   std::map<int, LumpedPortData> ports;
 
-  // Batched libCEED surface functional for lumped-port power. The per-port
-  // LumpedPortData fallback remains authoritative when batching is unavailable (for
-  // example, overlapping boundary attributes or unsupported surface-functional cases).
+  struct PortAttributeBins
+  {
+    mfem::Array<int> attr_to_port;
+    std::vector<int> port_indices;
+    bool unavailable = false;
+  };
+
+  // Batched libCEED surface functionals for lumped-port power and voltage. Individual
+  // LumpedPortData evaluation remains available for port sets that cannot be batched.
   mutable std::unique_ptr<SurfaceFunctional> batched_power_func;
-  mutable mfem::Array<int> batched_power_attr_to_port;
-  mutable std::vector<int> batched_power_port_indices;
-  mutable bool batched_power_unavailable = false;
+  mutable PortAttributeBins batched_power_bins;
+  mutable std::unique_ptr<SurfaceFunctional> batched_voltage_func;
+  mutable PortAttributeBins batched_voltage_bins;
 
   void SetUpBoundaryProperties(const std::map<int, config::LumpedPortData> &lumpedport,
                                const MaterialOperator &mat_op, const mfem::ParMesh &mesh);
@@ -158,6 +165,10 @@ public:
   // Compute port powers, batching disjoint libCEED surface-functional evaluations when
   // possible while preserving per-port scalar outputs.
   std::map<int, std::complex<double>> GetPowers(GridFunction &E, GridFunction &B) const;
+
+  // Compute port voltages, batching disjoint libCEED mode-overlap evaluations when
+  // possible while preserving per-port scalar outputs.
+  std::map<int, std::complex<double>> GetVoltages(GridFunction &E) const;
 
   // Returns array of lumped port attributes.
   mfem::Array<int> GetAttrList() const;

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -5,12 +5,18 @@
 
 #include <algorithm>
 #include <complex>
+#include <cstdlib>
+#include <map>
+#include <memory>
 #include <set>
 #include <string>
+#include <tuple>
+#include <vector>
 #include "drivers/boundarymodesolver.hpp"
 #include "fem/coefficient.hpp"
 #include "fem/errorindicator.hpp"
 #include "fem/interpolator.hpp"
+#include "fem/postprocessing_backend.hpp"
 #include "linalg/operator.hpp"
 #include "models/curlcurloperator.hpp"
 #include "models/floquetportoperator.hpp"
@@ -26,6 +32,11 @@
 #include "utils/tablecsv.hpp"
 #include "utils/timer.hpp"
 
+#include <mfem/config/config.hpp>
+#if defined(MFEM_USE_CUDA)
+#include <cuda_profiler_api.h>
+#endif
+
 namespace palace
 {
 
@@ -33,6 +44,59 @@ using namespace std::complex_literals;
 
 namespace
 {
+
+bool IsSupportedDomainOutputDimension(const mfem::ParMesh &mesh)
+{
+  return (mesh.Dimension() == 2 && mesh.SpaceDimension() == 2) ||
+         (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3);
+}
+
+bool IsSupportedBoundaryOutputDimension(const mfem::ParMesh &mesh)
+{
+  return IsSupportedDomainOutputDimension(mesh);
+}
+
+bool UseCeedDomainParaviewPointFields(const mfem::ParMesh &mesh)
+{
+  return IsSupportedDomainOutputDimension(mesh);
+}
+
+bool UseCeedBoundaryParaviewPointFields(const mfem::ParMesh &mesh)
+{
+  return IsSupportedBoundaryOutputDimension(mesh);
+}
+
+void RequireCeedPointFieldEvaluator(const PointFieldEvaluator *eval,
+                                    const std::string &what)
+{
+  MFEM_VERIFY(eval && eval->IsValid(), "libCEED postprocessing was expected for " + what +
+                                           ", but PointFieldEvaluator could not assemble!");
+}
+
+bool UseCudaProfilerParaviewRange()
+{
+  return std::getenv("PALACE_PROFILE_PARAVIEW_RANGE") != nullptr;
+}
+
+void StartCudaProfilerParaviewRange()
+{
+#if defined(MFEM_USE_CUDA)
+  if (UseCudaProfilerParaviewRange())
+  {
+    cudaProfilerStart();
+  }
+#endif
+}
+
+void StopCudaProfilerParaviewRange()
+{
+#if defined(MFEM_USE_CUDA)
+  if (UseCudaProfilerParaviewRange())
+  {
+    cudaProfilerStop();
+  }
+#endif
+}
 
 std::string OutputFolderName(const ProblemType solver_t)
 {
@@ -246,6 +310,11 @@ PostOperator<solver_t>::PostOperator(const config::ProblemData &problem,
   Mpi::Barrier(fem_op->GetComm());
   gridfunction_output_dir = (gridfunction_root / OutputFolderName(solver_t)).string();
 
+  // Initialize field output helpers and ParaView collections before any timed write.
+  // This matches the direct libCEED point-field output design: operator construction and
+  // any backend setup/JIT happen during model setup, while the ParaView timer measures
+  // dimensionalization, point-field evaluation, and VTU writing rather than lazy backend
+  // construction on the first Save().
   SetupFieldCoefficients();
   InitializeParaviewDataCollection();
 
@@ -284,16 +353,202 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
   {
     return;
   }
+  MFEM_VERIFY(!field_coefficients_initialized,
+              "Field coefficients should only be initialized once!");
+  field_coefficients_initialized = true;
 
-  // Set-up grid-functions for the paraview output / measurement.
+  // Initialize the (interpolatory L2) output spaces for the libCEED-evaluated
+  // visualization fields. The order matches the ParaView output sampling lattice
+  // (SetLevelsOfDetail below), preserving the existing VTU point layout.
+  // TODO: Revisit the output order choice: order p smooths the (degree 2p) energy
+  // densities slightly relative to the legacy exact-at-lattice sampling (U_e showed
+  // ~2e-3 relative on the CPW example, visualization only). Order 2p reproduces the
+  // legacy values exactly on affine elements at ~3.5x the field storage, which may be
+  // immaterial next to the solver memory high water mark.
+  auto InitializeVizSpaces = [&](mfem::ParFiniteElementSpace &src_fespace)
+  {
+    if (viz_fec)
+    {
+      return;
+    }
+    auto *pmesh = src_fespace.GetParMesh();
+    viz_fec = std::make_unique<mfem::L2_FECollection>(src_fespace.GetMaxElementOrder(),
+                                                      pmesh->Dimension());
+    viz_scalar_fespace =
+        std::make_unique<mfem::ParFiniteElementSpace>(pmesh, viz_fec.get());
+    viz_vector_fespace = std::make_unique<mfem::ParFiniteElementSpace>(
+        pmesh, viz_fec.get(), pmesh->SpaceDimension());
+  };
+  const auto &output_mesh = fem_op->GetNDSpace().GetParMesh();
+  const int paraview_refine_order = [&]()
+  {
+    if constexpr (HasEGridFunction<solver_t>())
+    {
+      return E->ParFESpace()->GetMaxElementOrder();
+    }
+    else if constexpr (HasBGridFunction<solver_t>())
+    {
+      return B->ParFESpace()->GetMaxElementOrder();
+    }
+    else if constexpr (HasVGridFunction<solver_t>())
+    {
+      return V->ParFESpace()->GetMaxElementOrder();
+    }
+    else
+    {
+      return A->ParFESpace()->GetMaxElementOrder();
+    }
+  }();
+  const bool use_ceed_domain_paraview_fields =
+      ShouldWriteParaviewFields() && UseCeedDomainParaviewPointFields(output_mesh);
+  const bool use_ceed_domain_fields =
+      fem::LibceedPostprocessingEnabled() &&
+      (ShouldWriteGridFunctionFields() || use_ceed_domain_paraview_fields);
+  const bool use_ceed_boundary_fields = fem::LibceedPostprocessingEnabled() &&
+                                        ShouldWriteParaviewFields() &&
+                                        UseCeedBoundaryParaviewPointFields(output_mesh);
+
+  auto MakeFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                mfem::ParFiniteElementSpace *e_fespace,
+                                mfem::ParFiniteElementSpace *b_fespace, double scaling,
+                                std::unique_ptr<PointFieldEvaluator> &eval,
+                                std::unique_ptr<mfem::ParGridFunction> &gf)
+  {
+    InitializeVizSpaces(e_fespace ? *e_fespace : *b_fespace);
+    auto &target = (kind == PointFieldEvaluator::Kind::POYNTING) ? *viz_vector_fespace
+                                                                 : *viz_scalar_fespace;
+    eval = std::make_unique<PointFieldEvaluator>(kind, fem_op->GetMaterialOp().GetMesh(),
+                                                 fem_op->GetMaterialOp(), e_fespace,
+                                                 b_fespace, target, scaling);
+    if (eval->IsValid())
+    {
+      if (ShouldWriteGridFunctionFields())
+      {
+        gf = std::make_unique<mfem::ParGridFunction>(&target);
+        gf->UseDevice(true);
+      }
+    }
+    else
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "domain field visualization");
+    }
+  };
+  auto MakeBaseDomainFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                          mfem::ParFiniteElementSpace &fespace,
+                                          std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    if (!use_ceed_domain_paraview_fields)
+    {
+      return;
+    }
+    InitializeVizSpaces(fespace);
+    const bool scalar_b_field = kind == PointFieldEvaluator::Kind::FIELD_B &&
+                                fespace.GetParMesh()->Dimension() == 2;
+    auto &target = (kind == PointFieldEvaluator::Kind::FIELD_H1 || scalar_b_field)
+                       ? *viz_scalar_fespace
+                       : *viz_vector_fespace;
+    eval = std::make_unique<PointFieldEvaluator>(
+        kind, fem_op->GetMaterialOp().GetMesh(), fem_op->GetMaterialOp(),
+        (kind == PointFieldEvaluator::Kind::FIELD_E ||
+         kind == PointFieldEvaluator::Kind::FIELD_H1)
+            ? &fespace
+            : nullptr,
+        kind == PointFieldEvaluator::Kind::FIELD_B ? &fespace : nullptr, target, 1.0);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "base domain field visualization");
+    }
+  };
+  auto MakeBdrFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                   mfem::ParFiniteElementSpace &fespace,
+                                   std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(kind, mesh, marker, fespace,
+                                                 paraview_refine_order);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary field visualization");
+    }
+  };
+  auto MakeBdrCoeffEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                   mfem::ParFiniteElementSpace &fespace, double scaling,
+                                   std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(kind, mesh, marker, fespace,
+                                                 fem_op->GetMaterialOp(),
+                                                 paraview_refine_order, scaling);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary coefficient visualization");
+    }
+  };
+  auto MakeBdrPoyntingEvaluator =
+      [&](mfem::ParFiniteElementSpace &e_fespace, mfem::ParFiniteElementSpace &b_fespace,
+          double scaling, std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(
+        PointFieldEvaluator::Kind::POYNTING, mesh, marker, e_fespace, b_fespace,
+        fem_op->GetMaterialOp(), paraview_refine_order, scaling);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary Poynting visualization");
+    }
+  };
+
+  // Set-up evaluators for the paraview output / measurement.
+  if (En)
+  {
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *En->ParFESpace(),
+                                 En_domain_eval);
+  }
+
+  if (Bt_inplane)
+  {
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E,
+                                 *Bt_inplane->ParFESpace(), Bt_domain_eval);
+  }
+
+  if (E && Bt_inplane && use_ceed_domain_fields)
+  {
+    MakeFieldEvaluator(PointFieldEvaluator::Kind::MODE_SN, E->ParFESpace(),
+                       Bt_inplane->ParFESpace(), 1.0, Sn_eval, Sn_gf);
+  }
+
   if constexpr (HasVGridFunction<solver_t>())
   {
-    V_s = std::make_unique<BdrFieldCoefficient>(V->Real());
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *V->ParFESpace(),
+                                 V_domain_eval);
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *V->ParFESpace(),
+                            V_bdr_eval);
+    }
   }
 
   if constexpr (HasAGridFunction<solver_t>())
   {
-    A_s = std::make_unique<BdrFieldVectorCoefficient>(A->Real());
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *A->ParFESpace(),
+                                 A_domain_eval);
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *A->ParFESpace(),
+                            A_bdr_eval);
+    }
   }
 
   if constexpr (HasEGridFunction<solver_t>())
@@ -311,17 +566,30 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
     // U_e = 1/2 Dᴴ E = 1/2 ε_0 Eᴴ E.
     U_e = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(
         *E, fem_op->GetMaterialOp(), scaling);
+    if (use_ceed_domain_fields)
+    {
+      MakeFieldEvaluator(PointFieldEvaluator::Kind::ENERGY_E, E->ParFESpace(), nullptr,
+                         scaling, U_e_eval, U_e_gf);
+    }
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::ENERGY_E, *E->ParFESpace(), scaling,
+                            Ue_bdr_eval);
+    }
 
     // Electric Boundary Field & Surface Charge.
-    E_sr = std::make_unique<BdrFieldVectorCoefficient>(E->Real());
-    // Q_s = D ⋅ n = ε_0 E ⋅ n.
-    Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
-        &E->Real(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector(), scaling);
-    if constexpr (HasComplexGridFunction<solver_t>())
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *E->ParFESpace(),
+                                 E_domain_eval);
+    if (use_ceed_boundary_fields)
     {
-      E_si = std::make_unique<BdrFieldVectorCoefficient>(E->Imag());
-      Q_si = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
-          &E->Imag(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector(), scaling);
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *E->ParFESpace(),
+                            E_bdr_eval);
+    }
+    // Q_s = D ⋅ n = ε_0 E ⋅ n.
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::FLUX_Q, *E->ParFESpace(), scaling,
+                            Q_bdr_eval);
     }
   }
 
@@ -340,24 +608,33 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
     // U_m = 1/2 Hᴴ B = 1/2 μ⁻¹ Bᴴ B.
     U_m = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(
         *B, fem_op->GetMaterialOp(), scaling);
-
-    // Magnetic Boundary Field & Surface Current.
-    // In 2D, B is scalar (L2), so boundary vector coefficients are not applicable.
-    if (B->Real().VectorDim() > 1)
+    if (use_ceed_domain_fields)
     {
-      B_sr = std::make_unique<BdrFieldVectorCoefficient>(B->Real());
-      // J_s = n x H = n x μ⁻¹ B.
-      J_sr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(
-          B->Real(), fem_op->GetMaterialOp(), scaling);
+      MakeFieldEvaluator(PointFieldEvaluator::Kind::ENERGY_M, nullptr, B->ParFESpace(),
+                         scaling, U_m_eval, U_m_gf);
+    }
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::ENERGY_M, *B->ParFESpace(), scaling,
+                            Um_bdr_eval);
     }
 
-    if constexpr (HasComplexGridFunction<solver_t>())
+    // Magnetic Field, Boundary Field & Surface Current. In 2D, B is scalar (L2), so the
+    // domain field is scalar while boundary vector B and J_s outputs are not applicable.
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_B, *B->ParFESpace(),
+                                 B_domain_eval);
+    if (B->Real().VectorDim() > 1)
     {
-      if (B->Imag().VectorDim() > 1)
+      if (use_ceed_boundary_fields)
       {
-        B_si = std::make_unique<BdrFieldVectorCoefficient>(B->Imag());
-        J_si = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(
-            B->Imag(), fem_op->GetMaterialOp(), scaling);
+        MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_B, *B->ParFESpace(),
+                              B_bdr_eval);
+      }
+      // J_s = n x H = n x μ⁻¹ B.
+      if (use_ceed_boundary_fields)
+      {
+        MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::CURRENT_J, *B->ParFESpace(),
+                              scaling, J_bdr_eval);
       }
     }
   }
@@ -375,9 +652,37 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
                              units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
       S = std::make_unique<PoyntingVectorCoefficient>(*E, *B, fem_op->GetMaterialOp(),
                                                       scaling);
+      if (use_ceed_domain_fields)
+      {
+        MakeFieldEvaluator(PointFieldEvaluator::Kind::POYNTING, E->ParFESpace(),
+                           B->ParFESpace(), scaling, S_eval, S_gf);
+      }
+      if (use_ceed_boundary_fields)
+      {
+        MakeBdrPoyntingEvaluator(*E->ParFESpace(), *B->ParFESpace(), scaling, S_bdr_eval);
+      }
     }
-    // For boundary mode, Sn = Re{Et · (ẑ × Ht*)} is computed after Bt_inplane is
-    // available (in MeasureAndPrintAll), as it requires the in-plane B field.
+    // For boundary mode, Sn = Re{Et · (ẑ × Ht*)} uses the in-plane B field and is
+    // registered below through a domain point evaluator.
+  }
+}
+
+template <ProblemType solver_t>
+void PostOperator<solver_t>::EnsureFieldCoefficientsSetup()
+{
+  if (!field_coefficients_initialized)
+  {
+    SetupFieldCoefficients();
+  }
+}
+
+template <ProblemType solver_t>
+void PostOperator<solver_t>::EnsureParaviewDataCollection()
+{
+  EnsureFieldCoefficientsSetup();
+  if (ShouldWriteParaviewFields() && !paraview)
+  {
+    InitializeParaviewDataCollection();
   }
 }
 
@@ -385,6 +690,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::InitializeParaviewDataCollection(
     const fs::path &sub_folder_name)
 {
+  EnsureFieldCoefficientsSetup();
   if (!ShouldWriteParaviewFields())
   {
     return;
@@ -417,29 +723,91 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
   paraview_bdr = {paraview_dir_b, &fem_op->GetNDSpace().GetParMesh()};
 
   const mfem::VTKFormat format = mfem::VTKFormat::BINARY32;
-#if defined(MFEM_USE_ZLIB)
-  const int compress = -1;  // Default compression level
-#else
-  const int compress = 0;
-#endif
   const bool use_ho = true;
   const int refine_ho = HasEGridFunction<solver_t>()
                             ? E->ParFESpace()->GetMaxElementOrder()
                             : B->ParFESpace()->GetMaxElementOrder();
+  const bool use_ceed_domain_paraview =
+      UseCeedDomainParaviewPointFields(fem_op->GetNDSpace().GetParMesh());
+  const bool use_ceed_boundary_paraview =
+      UseCeedBoundaryParaviewPointFields(fem_op->GetNDSpace().GetParMesh());
 
   // Output mesh coordinate units same as input.
   paraview->SetCycle(-1);
   paraview->SetDataFormat(format);
-  paraview->SetCompressionLevel(compress);
+  MFEM_VERIFY(use_ceed_domain_paraview,
+              "ParaView domain output requires the libCEED point-field path!");
+  // Direct point fields use appended raw VTU arrays so their payload can be written
+  // without an extra full-field base64 staging buffer.
+  paraview->SetCompressionLevel(0);
   paraview->SetHighOrderOutput(use_ho);
   paraview->SetLevelsOfDetail(refine_ho);
 
   paraview_bdr->SetBoundaryOutput(true);
   paraview_bdr->SetCycle(-1);
   paraview_bdr->SetDataFormat(format);
-  paraview_bdr->SetCompressionLevel(compress);
+  MFEM_VERIFY(use_ceed_boundary_paraview,
+              "ParaView boundary output requires the libCEED point-field path!");
+  paraview_bdr->SetCompressionLevel(0);
   paraview_bdr->SetHighOrderOutput(use_ho);
   paraview_bdr->SetLevelsOfDetail(refine_ho);
+  paraview->PrecacheMeshVTU();
+  paraview_bdr->PrecacheMeshVTU();
+
+  // Register libCEED domain and boundary visualization fields lazily: ParaView Save()
+  // evaluates one field at a time into a reusable device-capable buffer and then writes
+  // that buffer to the VTU file. Domain direct-VTU buffers are point-major to match VTK
+  // tuple order; boundary buffers keep the existing component-major packing path. This
+  // keeps peak memory proportional to one output field instead of the sum of all derived
+  // fields, while still doing the sampling/transforms in libCEED. Nonconforming AMR
+  // meshes use the same point-field path; the static mesh/header caches above avoid
+  // repeating VTU setup across mode saves.
+  auto RegisterDomainEvalField =
+      [&](const std::string &name, const std::unique_ptr<PointFieldEvaluator> &eval,
+          const GridFunction *E_field, const GridFunction *B_field)
+  {
+    const auto *eval_ptr = eval.get();
+    const auto *E_ptr = E_field;
+    const auto *B_ptr = B_field;
+    paraview->RegisterDomainPointEvaluator(
+        name, [eval_ptr, E_ptr, B_ptr](Vector &buffer)
+        { eval_ptr->EvalBuffer(E_ptr, B_ptr, buffer); }, eval_ptr->BufferBases(),
+        eval_ptr->BufferNumComp(), eval_ptr->BufferSize(), true);
+  };
+  auto RegisterDomainBaseEvalField = [&](const std::string &name,
+                                         const std::unique_ptr<PointFieldEvaluator> &eval,
+                                         const mfem::ParGridFunction &field)
+  {
+    RequireCeedPointFieldEvaluator(eval.get(),
+                                   fmt::format("domain {} visualization", name));
+    const auto *eval_ptr = eval.get();
+    const auto *field_ptr = &field;
+    paraview->RegisterDomainPointEvaluator(
+        name,
+        [eval_ptr, field_ptr](Vector &buffer) { eval_ptr->EvalBuffer(*field_ptr, buffer); },
+        eval_ptr->BufferBases(), eval_ptr->BufferNumComp(), eval_ptr->BufferSize(), true);
+  };
+  auto RegisterBdrEvalField = [&](const std::string &name,
+                                  const std::unique_ptr<PointFieldEvaluator> &eval,
+                                  const auto &field)
+  {
+    const auto *eval_ptr = eval.get();
+    const auto *field_ptr = &field;
+    paraview_bdr->RegisterBoundaryPointEvaluator(
+        name,
+        [eval_ptr, field_ptr](Vector &buffer) { eval_ptr->EvalBuffer(*field_ptr, buffer); },
+        eval_ptr->BufferBases(), eval_ptr->BufferNumComp(), eval_ptr->BufferSize());
+  };
+  auto RegisterBdrPoyntingField = [&](const std::string &name)
+  {
+    const auto *eval_ptr = S_bdr_eval.get();
+    const auto *E_ptr = E.get();
+    const auto *B_ptr = B.get();
+    paraview_bdr->RegisterBoundaryPointEvaluator(
+        name, [eval_ptr, E_ptr, B_ptr](Vector &buffer)
+        { eval_ptr->EvalBuffer(E_ptr, B_ptr, buffer); }, eval_ptr->BufferBases(),
+        eval_ptr->BufferNumComp(), eval_ptr->BufferSize());
+  };
 
   // Output fields @ phase = 0 and π/2 for frequency domain (rather than, for example,
   // peak phasors or magnitude = sqrt(2) * RMS). Also output fields evaluated on mesh
@@ -450,114 +818,139 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("E_real", &E->Real());
-      paraview->RegisterField("E_imag", &E->Imag());
-      paraview_bdr->RegisterVCoeffField("E_real", E_sr.get());
-      paraview_bdr->RegisterVCoeffField("E_imag", E_si.get());
+      RegisterDomainBaseEvalField("E_real", E_domain_eval, E->Real());
+      RegisterDomainBaseEvalField("E_imag", E_domain_eval, E->Imag());
+      RequireCeedPointFieldEvaluator(E_bdr_eval.get(), "boundary E visualization");
+      RegisterBdrEvalField("E_real", E_bdr_eval, E->Real());
+      RegisterBdrEvalField("E_imag", E_bdr_eval, E->Imag());
     }
     else
     {
-      paraview->RegisterField("E", &E->Real());
-      paraview_bdr->RegisterVCoeffField("E", E_sr.get());
+      RegisterDomainBaseEvalField("E", E_domain_eval, E->Real());
+      RequireCeedPointFieldEvaluator(E_bdr_eval.get(), "boundary E visualization");
+      RegisterBdrEvalField("E", E_bdr_eval, E->Real());
     }
   }
   if (En)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("En_real", &En->Real());
-      paraview->RegisterField("En_imag", &En->Imag());
+      RegisterDomainBaseEvalField("En_real", En_domain_eval, En->Real());
+      RegisterDomainBaseEvalField("En_imag", En_domain_eval, En->Imag());
     }
     else
     {
-      paraview->RegisterField("En", &En->Real());
+      RegisterDomainBaseEvalField("En", En_domain_eval, En->Real());
     }
   }
   if (B)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("B_real", &B->Real());
-      paraview->RegisterField("B_imag", &B->Imag());
-      if (B_sr)
+      RegisterDomainBaseEvalField("B_real", B_domain_eval, B->Real());
+      RegisterDomainBaseEvalField("B_imag", B_domain_eval, B->Imag());
+      if (B_bdr_eval)
       {
-        paraview_bdr->RegisterVCoeffField("B_real", B_sr.get());
-      }
-      if (B_si)
-      {
-        paraview_bdr->RegisterVCoeffField("B_imag", B_si.get());
+        RegisterBdrEvalField("B_real", B_bdr_eval, B->Real());
+        RegisterBdrEvalField("B_imag", B_bdr_eval, B->Imag());
       }
     }
     else
     {
-      paraview->RegisterField("B", &B->Real());
-      if (B_sr)
+      RegisterDomainBaseEvalField("B", B_domain_eval, B->Real());
+      if (B_bdr_eval)
       {
-        paraview_bdr->RegisterVCoeffField("B", B_sr.get());
+        RegisterBdrEvalField("B", B_bdr_eval, B->Real());
       }
     }
   }
   // In-plane B field for mode analysis (2D vector on ND space).
   if (Bt_inplane)
   {
-    paraview->RegisterField("Bt_real", &Bt_inplane->Real());
-    paraview->RegisterField("Bt_imag", &Bt_inplane->Imag());
+    RegisterDomainBaseEvalField("Bt_real", Bt_domain_eval, Bt_inplane->Real());
+    RegisterDomainBaseEvalField("Bt_imag", Bt_domain_eval, Bt_inplane->Imag());
   }
   if (V)
   {
-    paraview->RegisterField("V", &V->Real());
-    paraview_bdr->RegisterCoeffField("V", V_s.get());
+    RegisterDomainBaseEvalField("V", V_domain_eval, V->Real());
+    RequireCeedPointFieldEvaluator(V_bdr_eval.get(), "boundary V visualization");
+    RegisterBdrEvalField("V", V_bdr_eval, V->Real());
   }
   if (A)
   {
-    paraview->RegisterField("A", &A->Real());
-    paraview_bdr->RegisterVCoeffField("A", A_s.get());
+    RegisterDomainBaseEvalField("A", A_domain_eval, A->Real());
+    RequireCeedPointFieldEvaluator(A_bdr_eval.get(), "boundary A visualization");
+    RegisterBdrEvalField("A", A_bdr_eval, A->Real());
   }
 
   // Extract energy density field for electric field energy 1/2 Dᴴ E or magnetic field
   // energy 1/2 Hᴴ B. Also Poynting vector S = E x H⋆.
   if (U_e)
   {
-    paraview->RegisterCoeffField("U_e", U_e.get());
-    paraview_bdr->RegisterCoeffField("U_e", U_e.get());
+    RequireCeedPointFieldEvaluator(U_e_eval.get(), "domain electric energy visualization");
+    RegisterDomainEvalField("U_e", U_e_eval, E.get(), nullptr);
+    RequireCeedPointFieldEvaluator(Ue_bdr_eval.get(),
+                                   "boundary electric energy visualization");
+    RegisterBdrEvalField("U_e", Ue_bdr_eval, *E);
   }
   if (U_m)
   {
-    paraview->RegisterCoeffField("U_m", U_m.get());
-    paraview_bdr->RegisterCoeffField("U_m", U_m.get());
+    RequireCeedPointFieldEvaluator(U_m_eval.get(), "domain magnetic energy visualization");
+    RegisterDomainEvalField("U_m", U_m_eval, nullptr, B.get());
+    RequireCeedPointFieldEvaluator(Um_bdr_eval.get(),
+                                   "boundary magnetic energy visualization");
+    RegisterBdrEvalField("U_m", Um_bdr_eval, *B);
   }
   if (S)
   {
-    paraview->RegisterVCoeffField("S", S.get());
-    paraview_bdr->RegisterVCoeffField("S", S.get());
+    RequireCeedPointFieldEvaluator(S_eval.get(), "domain Poynting visualization");
+    RegisterDomainEvalField("S", S_eval, E.get(), B.get());
+    RequireCeedPointFieldEvaluator(S_bdr_eval.get(), "boundary Poynting visualization");
+    RegisterBdrPoyntingField("S");
   }
 
   // Extract surface charge from normally discontinuous ND E-field. Also extract surface
   // currents from tangentially discontinuous RT B-field The surface charge and surface
   // currents are single-valued at internal boundaries.
-  if (Q_sr)
+  if (Q_bdr_eval)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview_bdr->RegisterCoeffField("Q_s_real", Q_sr.get());
-      paraview_bdr->RegisterCoeffField("Q_s_imag", Q_si.get());
+      RegisterBdrEvalField("Q_s_real", Q_bdr_eval, E->Real());
+      RegisterBdrEvalField("Q_s_imag", Q_bdr_eval, E->Imag());
     }
     else
     {
-      paraview_bdr->RegisterCoeffField("Q_s", Q_sr.get());
+      RegisterBdrEvalField("Q_s", Q_bdr_eval, E->Real());
     }
   }
-  if (J_sr)
+  else if (Q_sr)
+  {
+    MFEM_ABORT(
+        "Boundary surface-charge ParaView output requires a libCEED point evaluator!");
+  }
+  if (J_bdr_eval)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview_bdr->RegisterVCoeffField("J_s_real", J_sr.get());
-      paraview_bdr->RegisterVCoeffField("J_s_imag", J_si.get());
+      RegisterBdrEvalField("J_s_real", J_bdr_eval, B->Real());
+      RegisterBdrEvalField("J_s_imag", J_bdr_eval, B->Imag());
     }
     else
     {
-      paraview_bdr->RegisterVCoeffField("J_s", J_sr.get());
+      RegisterBdrEvalField("J_s", J_bdr_eval, B->Real());
     }
+  }
+  else if (J_sr)
+  {
+    MFEM_ABORT(
+        "Boundary surface-current ParaView output requires a libCEED point evaluator!");
+  }
+
+  if (Sn_eval)
+  {
+    RequireCeedPointFieldEvaluator(Sn_eval.get(), "boundary-mode Sn visualization");
+    RegisterDomainEvalField("Sn", Sn_eval, E.get(), Bt_inplane.get());
   }
 
   // Add wave port boundary mode postprocessing when available.
@@ -661,6 +1054,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
 {
   BlockTimer bt(Timer::POSTPRO_PARAVIEW);
+  EnsureParaviewDataCollection();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 
@@ -686,12 +1080,9 @@ void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
     Bt_inplane->Imag().FaceNbrData() *= mesh_Lc0;
     units.DimensionalizeInPlace<Units::ValueType::FIELD_B>(*Bt_inplane);
   }
-  // Register Sn on first write (created lazily after Bt_inplane is available).
-  if (Sn && !sn_registered)
-  {
-    paraview->RegisterCoeffField("Sn", Sn.get());
-    sn_registered = true;
-  }
+  // libCEED-evaluated derived domain fields are registered as lazy point evaluators;
+  // Save() evaluates them now, after dimensionalization, without materializing
+  // GridFunctions.
   double paraview_time = time;
   if constexpr (solver_t == ProblemType::DRIVEN)
   {
@@ -701,8 +1092,10 @@ void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
   paraview->SetTime(paraview_time);
   paraview_bdr->SetCycle(step);
   paraview_bdr->SetTime(paraview_time);
+  StartCudaProfilerParaviewRange();
   paraview->Save();
   paraview_bdr->Save();
+  StopCudaProfilerParaviewRange();
   mesh::NondimensionalizeMesh(mesh, mesh_Lc0);
   ScaleGridFunctions(1.0 / mesh_Lc0, mesh.Dimension(), E, B, V, A);
   NondimensionalizeGridFunctions(units, E, B, V, A);
@@ -725,6 +1118,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteParaviewFieldsFinal(const ErrorIndicator *indicator)
 {
   BlockTimer bt(Timer::POSTPRO_PARAVIEW);
+  EnsureParaviewDataCollection();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 
@@ -760,30 +1154,28 @@ void PostOperator<solver_t>::WriteParaviewFieldsFinal(const ErrorIndicator *indi
   {
     paraview->DeregisterVCoeffField(name);
   }
-  mfem::L2_FECollection pwconst_fec(0, mesh.Dimension());
-  mfem::FiniteElementSpace pwconst_fespace(&mesh, &pwconst_fec);
-  std::unique_ptr<mfem::GridFunction> rank, eta;
-  {
-    rank = std::make_unique<mfem::GridFunction>(&pwconst_fespace);
-    *rank = mesh.GetMyRank() + 1;
-    paraview->RegisterField("Rank", rank.get());
-  }
+  Vector rank(mesh.GetNE());
+  rank = mesh.GetMyRank() + 1;
+  paraview->RegisterDomainCellField("Rank", rank);
   if (indicator)
   {
-    eta = std::make_unique<mfem::GridFunction>(&pwconst_fespace);
-    MFEM_VERIFY(eta->Size() == indicator->Local().Size(),
+    MFEM_VERIFY(mesh.GetNE() == indicator->Local().Size(),
                 "Size mismatch for provided ErrorIndicator for postprocessing!");
-    *eta = indicator->Local();
-    paraview->RegisterField("Indicator", eta.get());
+    paraview->RegisterDomainCellField("Indicator", indicator->Local());
   }
+  for (const char *name :
+       {"E", "E_real", "E_imag", "B", "B_real", "B_imag", "En", "En_real", "En_imag",
+        "Bt_real", "Bt_imag", "V", "A", "U_e", "U_m", "S", "Sn"})
+  {
+    paraview->DeregisterDomainPointField(name);
+  }
+  StartCudaProfilerParaviewRange();
   paraview->Save();
-  if (rank)
+  StopCudaProfilerParaviewRange();
+  paraview->DeregisterDomainCellField("Rank");
+  if (indicator)
   {
-    paraview->DeregisterField("Rank");
-  }
-  if (eta)
-  {
-    paraview->DeregisterField("Indicator");
+    paraview->DeregisterDomainCellField("Indicator");
   }
   for (const auto &[name, gf] : field_map)
   {
@@ -805,6 +1197,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteMFEMGridFunctions(double time, int step)
 {
   BlockTimer bt(Timer::POSTPRO_GRIDFUNCTION);
+  EnsureFieldCoefficientsSetup();
 
   // Create output directory if it doesn't exist.
   if (Mpi::Root(fem_op->GetComm()))
@@ -925,29 +1318,54 @@ void PostOperator<solver_t>::WriteMFEMGridFunctions(double time, int step)
 
   if (U_e)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*U_e.get());
-    write_grid_function(gridfunc_scalar, "U_e");
+    if (U_e_eval)
+    {
+      // Device-evaluated (libCEED) energy density into the interpolatory L2 output
+      // space, reusing the ParaView evaluator instead of a host coefficient projection.
+      U_e_eval->Eval(E.get(), nullptr, *U_e_gf);
+      write_grid_function(*U_e_gf, "U_e");
+    }
+    else
+    {
+      gridfunc_scalar = 0.0;
+      gridfunc_scalar.ProjectCoefficient(*U_e.get());
+      write_grid_function(gridfunc_scalar, "U_e");
+    }
   }
 
   if (U_m)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*U_m.get());
-    write_grid_function(gridfunc_scalar, "U_m");
+    if (U_m_eval)
+    {
+      U_m_eval->Eval(nullptr, B.get(), *U_m_gf);
+      write_grid_function(*U_m_gf, "U_m");
+    }
+    else
+    {
+      gridfunc_scalar = 0.0;
+      gridfunc_scalar.ProjectCoefficient(*U_m.get());
+      write_grid_function(gridfunc_scalar, "U_m");
+    }
   }
 
   if (S)
   {
-    gridfunc_vector = 0.0;
-    gridfunc_vector.ProjectCoefficient(*S.get());
-    write_grid_function(gridfunc_vector, "S");
+    if (S_eval)
+    {
+      S_eval->Eval(E.get(), B.get(), *S_gf);
+      write_grid_function(*S_gf, "S");
+    }
+    else
+    {
+      gridfunc_vector = 0.0;
+      gridfunc_vector.ProjectCoefficient(*S.get());
+      write_grid_function(gridfunc_vector, "S");
+    }
   }
-  if (Sn)
+  if (Sn_eval)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*Sn.get());
-    write_grid_function(gridfunc_scalar, "Sn");
+    Sn_eval->Eval(E.get(), Bt_inplane.get(), *Sn_gf);
+    write_grid_function(*Sn_gf, "Sn");
   }
 
   mesh::NondimensionalizeMesh(mesh, mesh_Lc0);
@@ -972,6 +1390,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteMFEMGridFunctionsFinal(const ErrorIndicator *indicator)
 {
   BlockTimer bt(Timer::POSTPRO_GRIDFUNCTION);
+  EnsureFieldCoefficientsSetup();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 
@@ -1119,11 +1538,12 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
                 solver_t == ProblemType::TRANSIENT)
   {
     const auto port_powers = fem_op->GetLumpedPortOp().GetPowers(*E, *B);
+    const auto port_voltages = fem_op->GetLumpedPortOp().GetVoltages(*E);
     for (const auto &[idx, data] : fem_op->GetLumpedPortOp())
     {
       auto &vi = measurement_cache.lumped_port_vi[idx];
       vi.P = port_powers.at(idx);
-      vi.V = data.GetVoltage(*E);
+      vi.V = port_voltages.at(idx);
       if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN)
       {
         // Compute current from the port impedance, separate contributions for R, L, C
@@ -1149,7 +1569,8 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
                 : 0.0;
         vi.I = std::accumulate(vi.I_RLC.begin(), vi.I_RLC.end(),
                                std::complex<double>{0.0, 0.0});
-        vi.S = data.GetSParameter(*E);
+        // S-parameter mode coefficient is the port voltage scaled by 1/sqrt(R).
+        vi.S = (std::abs(data.R) > 0.0) ? vi.V / std::sqrt(data.R) : 0.0;
 
         // Add contribution due to all inductive lumped boundaries in the model:
         //                      E_ind = ∑_j 1/2 L_j I_mj².
@@ -1246,10 +1667,13 @@ void PostOperator<solver_t>::MeasureWavePorts() const
       MFEM_VERIFY(freq_re > 0.0,
                   "Frequency domain wave port postprocessing requires nonzero frequency!");
       auto &vi = measurement_cache.wave_port_vi[idx];
-      vi.P = data.GetPower(*E, *B);
       vi.S = data.GetSParameter(*E);
-      vi.V = data.GetVoltage(*E);
-      vi.Z_PV = data.GetCharacteristicImpedance();
+      if (data.HasVoltageCoords())
+      {
+        vi.P = data.GetPower(*E, *B);
+        vi.V = data.GetVoltage(*E);
+        vi.Z_PV = data.GetCharacteristicImpedance();
+      }
     }
   }
 }
@@ -1835,14 +2259,6 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     Bt_inplane->Imag().ExchangeFaceNbrData();
   }
 
-  // Create Sn coefficient for boundary mode Poynting visualization.
-  // Sn = Re{Ex Hy* - Ey Hx*}: z-directed power density on the cross-section.
-  if (Bt_inplane && !Sn)
-  {
-    Sn = std::make_unique<ModeSnCoefficient>(E->Real(), E->Imag(), Bt_inplane->Real(),
-                                             Bt_inplane->Imag(), fem_op->GetMaterialOp());
-  }
-
   measurement_cache = {};
   measurement_cache.error_abs = error_abs;
   measurement_cache.error_bkwd = error_bkwd;
@@ -1852,11 +2268,60 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
   measurement_cache.mode_data.kn = kn;
   measurement_cache.mode_data.n_eff = n_eff;
 
-  // Helper: compute voltage V = ∫ E · dl via coordinate path or boundary attributes.
-  auto ComputeVoltage = [this](const std::vector<mfem::Vector> &path, bool has_coords,
-                               mfem::Array<int> marker, int quad_order,
-                               const GridFunction &field) -> std::complex<double>
+  struct LineIntegralKey
   {
+    bool has_coords = false;
+    int quad_order = 0;
+    std::vector<double> path_data;
+    std::vector<int> marker_data;
+
+    bool operator<(const LineIntegralKey &other) const
+    {
+      return std::tie(has_coords, quad_order, path_data, marker_data) <
+             std::tie(other.has_coords, other.quad_order, other.path_data,
+                      other.marker_data);
+    }
+  };
+  auto MakeLineIntegralKey = [](const std::vector<mfem::Vector> &path, bool has_coords,
+                                const mfem::Array<int> &marker, int quad_order)
+  {
+    LineIntegralKey key;
+    key.has_coords = has_coords;
+    key.quad_order = quad_order;
+    if (has_coords)
+    {
+      for (const auto &pt : path)
+      {
+        for (int d = 0; d < pt.Size(); d++)
+        {
+          key.path_data.push_back(pt(d));
+        }
+      }
+    }
+    else
+    {
+      key.marker_data.reserve(marker.Size());
+      for (int i = 0; i < marker.Size(); i++)
+      {
+        key.marker_data.push_back(marker[i]);
+      }
+    }
+    return key;
+  };
+  std::map<LineIntegralKey, std::complex<double>> voltage_cache, current_cache;
+
+  // Helper: compute voltage V = ∫ E · dl via coordinate path or boundary attributes.
+  auto ComputeVoltage = [this, &MakeLineIntegralKey, &voltage_cache](
+                            const std::vector<mfem::Vector> &path, bool has_coords,
+                            mfem::Array<int> marker, int quad_order,
+                            const GridFunction &field) -> std::complex<double>
+  {
+    auto key = MakeLineIntegralKey(path, has_coords, marker, quad_order);
+    if (auto it = voltage_cache.find(key); it != voltage_cache.end())
+    {
+      return it->second;
+    }
+
     std::complex<double> V(0.0, 0.0);
     if (has_coords)
     {
@@ -1885,14 +2350,22 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
       V.real(linalg::Dot(nd_fespace.GetComm(), v_lf_tdof, fr));
       V.imag(linalg::Dot(nd_fespace.GetComm(), v_lf_tdof, fi));
     }
+    voltage_cache.emplace(std::move(key), V);
     return V;
   };
 
   // Helper: compute current I = ∮ H · t dl via coordinate path or boundary attributes.
-  auto ComputeCurrent = [this](const std::vector<mfem::Vector> &path, bool has_path,
-                               mfem::Array<int> marker, int quad_order,
-                               const GridFunction &field) -> std::complex<double>
+  auto ComputeCurrent = [this, &MakeLineIntegralKey, &current_cache](
+                            const std::vector<mfem::Vector> &path, bool has_path,
+                            mfem::Array<int> marker, int quad_order,
+                            const GridFunction &field) -> std::complex<double>
   {
+    auto key = MakeLineIntegralKey(path, has_path, marker, quad_order);
+    if (auto it = current_cache.find(key); it != current_cache.end())
+    {
+      return it->second;
+    }
+
     std::complex<double> I(0.0, 0.0);
     if (has_path)
     {
@@ -1921,8 +2394,57 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
       I.real(linalg::Dot(nd_fespace.GetComm(), i_lf_tdof, fr));
       I.imag(linalg::Dot(nd_fespace.GetComm(), i_lf_tdof, fi));
     }
+    current_cache.emplace(std::move(key), I);
     return I;
   };
+
+  auto SameMarker = [](const mfem::Array<int> &a, const mfem::Array<int> &b)
+  {
+    if (a.Size() != b.Size())
+    {
+      return false;
+    }
+    for (int i = 0; i < a.Size(); i++)
+    {
+      if (a[i] != b[i])
+      {
+        return false;
+      }
+    }
+    return true;
+  };
+  auto SamePath = [](const std::vector<mfem::Vector> &a, const std::vector<mfem::Vector> &b)
+  {
+    if (a.size() != b.size())
+    {
+      return false;
+    }
+    for (std::size_t i = 0; i < a.size(); i++)
+    {
+      if (a[i].Size() != b[i].Size())
+      {
+        return false;
+      }
+      for (int d = 0; d < a[i].Size(); d++)
+      {
+        if (a[i](d) != b[i](d))
+        {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+  auto SameVoltageConfig =
+      [&](const ImpedancePostproConfig &imp, const VoltagePostproConfig &vol)
+  {
+    return imp.n_samples == vol.n_samples &&
+           imp.has_voltage_coordinates == vol.has_coordinates &&
+           (imp.has_voltage_coordinates
+                ? SamePath(imp.voltage_path, vol.voltage_path)
+                : SameMarker(imp.voltage_marker, vol.voltage_marker));
+  };
+  std::set<int> filled_voltage_postpro;
 
   // Compute impedance for each configured entry. P is the Poynting power of the
   // power-normalized mode (|P| ≈ 1), computed by the caller on the mode eigensolver.
@@ -1931,6 +2453,12 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     auto V = ComputeVoltage(cfg.voltage_path, cfg.has_voltage_coordinates,
                             cfg.voltage_marker, cfg.n_samples, *E);
     auto &result = measurement_cache.mode_data.impedance[idx];
+    if (auto vol_it = voltage_postpro.find(idx);
+        vol_it != voltage_postpro.end() && SameVoltageConfig(cfg, vol_it->second))
+    {
+      measurement_cache.mode_data.voltage[idx] = {V};
+      filled_voltage_postpro.insert(idx);
+    }
 
     // Power-voltage impedance: Z_PV = |V|^2 / (2P).
     if (std::abs(P) > 1e-30)
@@ -1941,18 +2469,25 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     }
 
     // V/I impedance: Z_VI = |V| / |I|.
-    auto I = ComputeCurrent(cfg.current_path, cfg.has_current_path, cfg.current_marker,
-                            cfg.n_samples, *Bt_inplane);
-    if (std::abs(I) > 1e-30)
+    if (cfg.has_current)
     {
-      result.Z_VI = std::abs(V) / std::abs(I);
-      result.has_vi_impedance = true;
+      auto I = ComputeCurrent(cfg.current_path, cfg.has_current_path, cfg.current_marker,
+                              cfg.n_samples, *Bt_inplane);
+      if (std::abs(I) > 1e-30)
+      {
+        result.Z_VI = std::abs(V) / std::abs(I);
+        result.has_vi_impedance = true;
+      }
     }
   }
 
   // Compute voltage for each configured voltage-only entry.
   for (const auto &[idx, cfg] : voltage_postpro)
   {
+    if (filled_voltage_postpro.count(idx))
+    {
+      continue;
+    }
     auto V = ComputeVoltage(cfg.voltage_path, cfg.has_coordinates, cfg.voltage_marker,
                             cfg.n_samples, *E);
     measurement_cache.mode_data.voltage[idx] = {V};

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -14,12 +14,14 @@
 #include <mfem.hpp>
 #include "fem/gridfunction.hpp"
 #include "fem/interpolator.hpp"
+#include "fem/point_field_evaluator.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
 #include "models/domainpostoperator.hpp"
 #include "models/lumpedportoperator.hpp"
 #include "models/postoperatorcsv.hpp"
 #include "models/surfacepostoperator.hpp"
+#include "utils/ceedparaviewdatacollection.hpp"
 #include "utils/configfile.hpp"
 #include "utils/filesystem.hpp"
 #include "utils/units.hpp"
@@ -130,6 +132,7 @@ protected:
   // Field output format control flags.
   bool enable_paraview_output = false;
   bool enable_gridfunction_output = false;
+  bool field_coefficients_initialized = false;
 
   // How many / which fields to output.
   int output_delta_post = 0;                          // printing rate (TRANSIENT)
@@ -180,7 +183,8 @@ protected:
   // ParaView data collection: writing fields to disk for visualization.
   // This is an optional, since ParaViewDataCollection has no default (empty) ctor,
   // and we only want initialize it if ShouldWriteParaviewFields() returns true.
-  std::optional<mfem::ParaViewDataCollection> paraview, paraview_bdr;
+  std::optional<CeedParaViewDataCollection> paraview;
+  std::optional<CeedParaViewDataCollection> paraview_bdr;
 
   // MFEM grid function output details.
   std::string gridfunction_output_dir;
@@ -188,16 +192,29 @@ protected:
 
   // Measurements of field solution for ParaView files (full domain or surfaces).
 
-  // Poynting Coefficient (vector for 3D, scalar Sn for boundary mode), Electric Boundary
-  // Field (re+im), Magnetic Boundary Field (re+im), Vector Potential Boundary Field,
-  // Surface Current (re+im).
-  std::unique_ptr<mfem::VectorCoefficient> S, E_sr, E_si, B_sr, B_si, A_s, J_sr, J_si;
-  std::unique_ptr<mfem::Coefficient> Sn;
-  bool sn_registered = false;
+  // Poynting Coefficient (vector for 3D), Electric Boundary Field (re+im), Magnetic
+  // Boundary Field (re+im), Surface Current (re+im).
+  std::unique_ptr<mfem::VectorCoefficient> S, E_sr, E_si, B_sr, B_si, J_sr, J_si;
 
-  // Electric Energy Density, Magnetic Energy Density, Scalar Potential Boundary Field,
-  // Surface Charge (re+im).
-  std::unique_ptr<mfem::Coefficient> U_e, U_m, V_s, Q_sr, Q_si;
+  // Electric Energy Density, Magnetic Energy Density, Surface Charge (re+im).
+  std::unique_ptr<mfem::Coefficient> U_e, U_m, Q_sr, Q_si;
+
+  // libCEED evaluators and optional output grid functions for the domain coefficient
+  // fields (U_e, U_m, S), replacing per-point host coefficient evaluation at ParaView
+  // save time when supported. ParaView output uses lazy component-major point buffers;
+  // gridfunction output still uses the GridFunction path when requested.
+  std::unique_ptr<mfem::L2_FECollection> viz_fec;
+  std::unique_ptr<mfem::ParFiniteElementSpace> viz_scalar_fespace, viz_vector_fespace;
+  std::unique_ptr<mfem::ParGridFunction> U_e_gf, U_m_gf, S_gf, Sn_gf;
+  std::unique_ptr<PointFieldEvaluator> E_domain_eval, B_domain_eval, En_domain_eval,
+      Bt_domain_eval, V_domain_eval, A_domain_eval, U_e_eval, U_m_eval, S_eval, Sn_eval;
+
+  // libCEED evaluators for boundary collection fields (E_s, B_s, Q_s, J_s, U_e, U_m,
+  // S). CeedParaViewDataCollection evaluates these lazily into one temporary buffer per
+  // field in the same integer boundary-element/refined-point order used for writing,
+  // avoiding coefficient adapters or floating-point point lookup at save time.
+  std::unique_ptr<PointFieldEvaluator> E_bdr_eval, B_bdr_eval, V_bdr_eval, A_bdr_eval,
+      Q_bdr_eval, J_bdr_eval, Ue_bdr_eval, Um_bdr_eval, S_bdr_eval;
 
   // Wave port boundary mode field postprocessing.
   struct WavePortFieldData
@@ -206,11 +223,15 @@ protected:
   };
   std::map<int, WavePortFieldData> port_E0;
 
-  // Setup coefficients for field postprocessing.
+  // Setup coefficients/evaluators for field output. These can be large libCEED objects on
+  // GPU, so initialize them lazily at write time instead of keeping them alive during the
+  // solve/preconditioner phase.
   void SetupFieldCoefficients();
+  void EnsureFieldCoefficientsSetup();
 
   // Initialize Paraview, register all fields to write.
   void InitializeParaviewDataCollection(const fs::path &sub_folder_name = "");
+  void EnsureParaviewDataCollection();
 
 public:
   // Public overload for the driven solver only, that takes in an excitation index and

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -106,20 +106,6 @@ void GetEssentialTrueDofs(mfem::ParGridFunction &E0t, mfem::ParGridFunction &E0n
   }
 }
 
-void GetInitialSpace(const mfem::ParFiniteElementSpace &nd_fespace,
-                     const mfem::ParFiniteElementSpace &h1_fespace,
-                     const mfem::Array<int> &dbc_tdof_list, ComplexVector &v)
-{
-  // Initial space which satisfies Dirichlet BCs.
-  const int nd_size = nd_fespace.GetTrueVSize(), h1_size = h1_fespace.GetTrueVSize();
-  v.SetSize(nd_size + h1_size);
-  v.UseDevice(true);
-  v = std::complex<double>(1.0, 0.0);
-  // linalg::SetRandomReal(nd_fespace.GetComm(), v);
-  linalg::SetSubVector(v, nd_size, nd_size + h1_size, 0.0);
-  linalg::SetSubVector(v, dbc_tdof_list, 0.0);
-}
-
 void Normalize(const GridFunction &S0t, GridFunction &E0t, GridFunction &E0n,
                mfem::LinearForm &sr, mfem::LinearForm &si)
 {
@@ -502,8 +488,7 @@ WavePortData::WavePortData(const config::WavePortData &data,
     }
   }
 
-  // Create vector for initial space for eigenvalue solves and eigenmode solution.
-  GetInitialSpace(*port_nd_fespace, *port_h1_fespace, port_dbc_tdof_list, v0);
+  // Create vector for the eigenmode solution.
   e0.SetSize(port_nd_fespace->GetTrueVSize() + port_h1_fespace->GetTrueVSize());
   e0.UseDevice(true);
 
@@ -653,7 +638,7 @@ void WavePortData::Initialize(double omega)
   std::complex<double> lambda;
   {
     const bool has_solver = (port_comm != MPI_COMM_NULL);
-    auto result = mode_solver->Solve(omega, sigma, has_solver ? &v0 : nullptr);
+    auto result = mode_solver->Solve(omega, sigma, nullptr);
     if (has_solver)
     {
       MFEM_VERIFY(result.num_converged >= mode_idx,

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -92,7 +92,7 @@ private:
 
   // Boundary mode eigenvalue problem solver.
   std::unique_ptr<ModeEigenSolver> mode_solver;
-  ComplexVector v0, e0;
+  ComplexVector e0;
 
   // Communicator for processes which have elements for this port.
   MPI_Comm port_comm = MPI_COMM_NULL;

--- a/palace/utils/CMakeLists.txt
+++ b/palace/utils/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 target_sources(${LIB_TARGET_NAME}
   PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/ceedparaviewdatacollection.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/configfile.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/dorfler.cpp

--- a/palace/utils/ceedparaviewdatacollection.cpp
+++ b/palace/utils/ceedparaviewdatacollection.cpp
@@ -1,0 +1,817 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "utils/ceedparaviewdatacollection.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include <mfem/mesh/vtk.hpp>
+
+namespace palace
+{
+
+namespace
+{
+
+void WriteAll(std::ostream &os, const void *data, std::size_t bytes)
+{
+  const char *ptr = static_cast<const char *>(data);
+  constexpr std::size_t max_write = std::size_t{1} << 30;
+  while (bytes > 0)
+  {
+    const std::size_t chunk = std::min(bytes, max_write);
+    os.write(ptr, static_cast<std::streamsize>(chunk));
+    MFEM_VERIFY(os.good(), "Failed while writing contiguous ParaView point data payload!");
+    ptr += chunk;
+    bytes -= chunk;
+  }
+}
+
+}  // namespace
+
+std::map<std::string, CeedParaViewDataCollection::PointField> &
+CeedParaViewDataCollection::PointFields(MeshEntityType location)
+{
+  switch (location)
+  {
+    case MeshEntityType::Domain:
+      return domain_point_fields;
+    case MeshEntityType::Boundary:
+      return boundary_point_fields;
+  }
+  MFEM_ABORT("Unknown point field location!");
+}
+
+const std::map<std::string, CeedParaViewDataCollection::PointField> &
+CeedParaViewDataCollection::PointFields(MeshEntityType location) const
+{
+  switch (location)
+  {
+    case MeshEntityType::Domain:
+      return domain_point_fields;
+    case MeshEntityType::Boundary:
+      return boundary_point_fields;
+  }
+  MFEM_ABORT("Unknown point field location!");
+}
+
+int CeedParaViewDataCollection::NumPointFieldEntities(MeshEntityType location) const
+{
+  return location == MeshEntityType::Domain ? mesh->GetNE() : mesh->GetNBE();
+}
+
+mfem::Geometry::Type
+CeedParaViewDataCollection::PointFieldBaseGeometry(MeshEntityType location, int i) const
+{
+  return location == MeshEntityType::Domain ? mesh->GetElementBaseGeometry(i)
+                                            : mesh->GetBdrElementBaseGeometry(i);
+}
+
+const char *CeedParaViewDataCollection::PointFieldLocationName(MeshEntityType location)
+{
+  return location == MeshEntityType::Domain ? "Domain" : "Boundary";
+}
+
+const char *CeedParaViewDataCollection::PointFieldEntityName(MeshEntityType location)
+{
+  return location == MeshEntityType::Domain ? "element" : "boundary element";
+}
+
+bool CeedParaViewDataCollection::LocationMatchesOutput(MeshEntityType location) const
+{
+  return location == MeshEntityType::Domain ? !bdr_output : bdr_output;
+}
+
+void CeedParaViewDataCollection::RegisterPointField(MeshEntityType location,
+                                                    const std::string &field_name,
+                                                    const Vector &values,
+                                                    const std::vector<int> &bases,
+                                                    int num_comp)
+{
+  MFEM_VERIFY(num_comp > 0, PointFieldLocationName(location)
+                                << " point field must have at least one component!");
+  cached_point_headers_vtu.clear();
+  PointFields(location)[field_name] =
+      PointField{&values, {}, &bases, num_comp, values.Size(), false};
+}
+
+void CeedParaViewDataCollection::RegisterPointEvaluator(
+    MeshEntityType location, const std::string &field_name,
+    std::function<void(Vector &)> evaluator, const std::vector<int> &bases, int num_comp,
+    int buffer_size, bool point_major)
+{
+  MFEM_VERIFY(evaluator, PointFieldLocationName(location)
+                             << " point evaluator must be callable!");
+  MFEM_VERIFY(num_comp > 0, PointFieldLocationName(location)
+                                << " point field must have at least one component!");
+  MFEM_VERIFY(buffer_size >= 0, PointFieldLocationName(location)
+                                    << " point evaluator buffer size is invalid!");
+  cached_point_headers_vtu.clear();
+  PointFields(location)[field_name] =
+      PointField{nullptr, std::move(evaluator), &bases, num_comp, buffer_size, point_major};
+}
+
+void CeedParaViewDataCollection::DeregisterPointField(MeshEntityType location,
+                                                      const std::string &field_name)
+{
+  cached_point_headers_vtu.clear();
+  PointFields(location).erase(field_name);
+}
+
+void CeedParaViewDataCollection::WriteCellFieldVTU(std::ostream &os,
+                                                   const std::string &name,
+                                                   const CellField &field) const
+{
+  MFEM_VERIFY(!bdr_output, "Domain cell fields require domain ParaView output!");
+  MFEM_VERIFY(field.values && field.num_comp > 0,
+              "Invalid domain cell field registration!");
+  MFEM_VERIFY(field.values->Size() == mesh->GetNE() * field.num_comp,
+              "Domain cell field size does not match the mesh cell count!");
+
+  os << "<DataArray type=\"" << GetDataTypeString() << "\" Name=\"" << name
+     << "\" NumberOfComponents=\"" << field.num_comp << "\" "
+     << mfem::VTKComponentLabels(field.num_comp) << " "
+     << "format=\"" << GetDataFormatString() << "\" >" << '\n';
+
+  std::vector<char> buf;
+  const double *data = field.values->HostRead();
+  for (int i = 0; i < mesh->GetNE(); i++)
+  {
+    for (int c = 0; c < field.num_comp; c++)
+    {
+      mfem::WriteBinaryOrASCII(os, buf, data[i * field.num_comp + c], " ", pv_data_format);
+    }
+    if (pv_data_format == mfem::VTKFormat::ASCII)
+    {
+      os << '\n';
+    }
+  }
+  if (pv_data_format != mfem::VTKFormat::ASCII)
+  {
+    mfem::WriteBase64WithSizeAndClear(os, buf, GetCompressionLevel());
+  }
+  os << "</DataArray>" << std::endl;
+}
+
+void CeedParaViewDataCollection::RegisterBoundaryPointField(const std::string &field_name,
+                                                            const Vector &values,
+                                                            const std::vector<int> &bases,
+                                                            int num_comp)
+{
+  RegisterPointField(MeshEntityType::Boundary, field_name, values, bases, num_comp);
+}
+
+void CeedParaViewDataCollection::RegisterBoundaryPointEvaluator(
+    const std::string &field_name, std::function<void(Vector &)> evaluator,
+    const std::vector<int> &bases, int num_comp, int buffer_size)
+{
+  RegisterPointEvaluator(MeshEntityType::Boundary, field_name, std::move(evaluator), bases,
+                         num_comp, buffer_size);
+}
+
+void CeedParaViewDataCollection::RegisterDomainPointEvaluator(
+    const std::string &field_name, std::function<void(Vector &)> evaluator,
+    const std::vector<int> &bases, int num_comp, int buffer_size, bool point_major)
+{
+  RegisterPointEvaluator(MeshEntityType::Domain, field_name, std::move(evaluator), bases,
+                         num_comp, buffer_size, point_major);
+}
+
+void CeedParaViewDataCollection::DeregisterBoundaryPointField(const std::string &field_name)
+{
+  DeregisterPointField(MeshEntityType::Boundary, field_name);
+}
+
+void CeedParaViewDataCollection::PrecacheMeshVTU()
+{
+  if (!domain_cell_fields.empty())
+  {
+    return;
+  }
+  std::ostringstream mesh_os;
+  mesh_os.precision(precision);
+  mesh->PrintVTU(mesh_os, levels_of_detail, pv_data_format, high_order_output,
+                 GetCompressionLevel(), bdr_output);
+  cached_mesh_vtu = mesh_os.str();
+  cached_mesh_vtu_ref = levels_of_detail;
+  cached_mesh_vtu_bdr_output = bdr_output;
+}
+
+void CeedParaViewDataCollection::RegisterDomainCellField(const std::string &field_name,
+                                                         const Vector &values, int num_comp)
+{
+  MFEM_VERIFY(num_comp > 0, "Domain cell field must have at least one component!");
+  MFEM_VERIFY(values.Size() == mesh->GetNE() * num_comp,
+              "Domain cell field size does not match the mesh cell count!");
+  cached_point_headers_vtu.clear();
+  domain_cell_fields[field_name] = CellField{&values, num_comp};
+}
+
+void CeedParaViewDataCollection::DeregisterDomainPointField(const std::string &field_name)
+{
+  DeregisterPointField(MeshEntityType::Domain, field_name);
+}
+
+void CeedParaViewDataCollection::DeregisterDomainCellField(const std::string &field_name)
+{
+  cached_point_headers_vtu.clear();
+  domain_cell_fields.erase(field_name);
+}
+
+bool CeedParaViewDataCollection::UseAppendedPointFields(MeshEntityType location) const
+{
+  const auto &fields = PointFields(location);
+  return LocationMatchesOutput(location) && !fields.empty() &&
+         pv_data_format != mfem::VTKFormat::ASCII && GetCompressionLevel() == 0;
+}
+
+int CeedParaViewDataCollection::MaxPointFieldBufferSize(
+    const std::map<std::string, PointField> &fields) const
+{
+  int size = 0;
+  for (const auto &[name, field] : fields)
+  {
+    size = std::max(size, field.buffer_size);
+  }
+  return size;
+}
+
+std::uint64_t
+CeedParaViewDataCollection::PointFieldPayloadSize(MeshEntityType location,
+                                                  const PointField &field) const
+{
+  MFEM_VERIFY((field.values || field.evaluator) && field.bases && field.num_comp > 0,
+              "Invalid " << PointFieldLocationName(location)
+                         << " point field registration!");
+  MFEM_VERIFY(static_cast<int>(field.bases->size()) == NumPointFieldEntities(location),
+              PointFieldLocationName(location)
+                  << " point field base offsets do not match the mesh!");
+  MFEM_VERIFY(field.buffer_size >= 0, PointFieldLocationName(location)
+                                          << " point field buffer size is invalid!");
+
+  const std::uint64_t scalar_size =
+      pv_data_format == mfem::VTKFormat::BINARY32 ? sizeof(float) : sizeof(double);
+  return static_cast<std::uint64_t>(field.buffer_size) * scalar_size;
+}
+
+void CeedParaViewDataCollection::WritePointFieldValues(MeshEntityType location,
+                                                       std::ostream &os, int ref,
+                                                       const std::string &name,
+                                                       const PointField &field,
+                                                       const Vector &values) const
+{
+  MFEM_VERIFY(values.Size() % field.num_comp == 0,
+              PointFieldLocationName(location)
+                  << " point field buffer size is not divisible by its component count!");
+  const int component_stride = values.Size() / field.num_comp;
+  const double *data = values.HostRead();
+
+  const std::uint64_t payload_size = PointFieldPayloadSize(location, field);
+  const bool binary32 = pv_data_format == mfem::VTKFormat::BINARY32;
+  const std::size_t scalar_size = binary32 ? sizeof(float) : sizeof(double);
+  MFEM_VERIFY(payload_size % scalar_size == 0,
+              "Point field payload size is not divisible by scalar size!");
+  const std::size_t payload_count = static_cast<std::size_t>(payload_size / scalar_size);
+
+  if (field.point_major)
+  {
+    MFEM_VERIFY(static_cast<std::size_t>(values.Size()) == payload_count,
+                PointFieldLocationName(location)
+                    << " point-major field buffer has an invalid size!");
+    if (binary32)
+    {
+      auto payload = std::make_unique<float[]>(payload_count);
+      for (std::size_t i = 0; i < payload_count; i++)
+      {
+        payload[i] = static_cast<float>(data[i]);
+      }
+      WriteAll(os, payload.get(), payload_count * sizeof(float));
+    }
+    else
+    {
+      WriteAll(os, data, payload_count * sizeof(double));
+    }
+    return;
+  }
+
+  auto PackPayload = [&](auto *payload_data)
+  {
+    using scalar_t = std::remove_pointer_t<decltype(payload_data)>;
+    std::size_t out = 0;
+    for (int i = 0; i < NumPointFieldEntities(location); i++)
+    {
+      const auto *RefG =
+          mfem::GlobGeometryRefiner.Refine(PointFieldBaseGeometry(location, i), ref, 1);
+      const int base = (*field.bases)[i];
+      const int npts = RefG->RefPts.GetNPoints();
+      MFEM_VERIFY(base >= 0 && base + npts <= component_stride,
+                  PointFieldLocationName(location)
+                      << " point field '" << name << "' buffer is missing data for "
+                      << PointFieldEntityName(location) << " " << i << "!");
+      for (int j = 0; j < npts; j++)
+      {
+        for (int c = 0; c < field.num_comp; c++)
+        {
+          payload_data[out++] =
+              static_cast<scalar_t>(data[base + j + c * component_stride]);
+        }
+      }
+    }
+    MFEM_VERIFY(out == payload_count, "Packed point field payload has an invalid size!");
+  };
+
+  if (binary32)
+  {
+    std::vector<float> payload(payload_count);
+    PackPayload(payload.data());
+    WriteAll(os, payload.data(), payload.size() * sizeof(float));
+  }
+  else
+  {
+    std::vector<double> payload(payload_count);
+    PackPayload(payload.data());
+    WriteAll(os, payload.data(), payload.size() * sizeof(double));
+  }
+}
+
+void CeedParaViewDataCollection::SavePointFieldVTU(MeshEntityType location,
+                                                   std::ostream &os, int ref,
+                                                   const std::string &name,
+                                                   const PointField &field, Vector *scratch)
+{
+  MFEM_VERIFY(LocationMatchesOutput(location),
+              PointFieldLocationName(location)
+                  << " point fields require matching ParaView output!");
+  MFEM_VERIFY((field.values || field.evaluator) && field.bases && field.num_comp > 0,
+              "Invalid " << PointFieldLocationName(location)
+                         << " point field registration!");
+  MFEM_VERIFY(static_cast<int>(field.bases->size()) == NumPointFieldEntities(location),
+              PointFieldLocationName(location)
+                  << " point field base offsets do not match the mesh!");
+
+  os << "<DataArray type=\"" << GetDataTypeString() << "\" Name=\"" << name
+     << "\" NumberOfComponents=\"" << field.num_comp << "\" "
+     << mfem::VTKComponentLabels(field.num_comp) << " "
+     << "format=\"" << GetDataFormatString() << "\" >" << '\n';
+
+  Vector values;
+  const Vector *value_ptr = field.values;
+  if (field.evaluator)
+  {
+    MFEM_VERIFY(scratch && scratch->Size() >= field.buffer_size,
+                PointFieldLocationName(location)
+                    << " point evaluator scratch buffer is too small!");
+    values.MakeRef(*scratch, 0, field.buffer_size);
+    field.evaluator(values);
+    value_ptr = &values;
+  }
+  MFEM_VERIFY(value_ptr, PointFieldLocationName(location)
+                             << " point field has no values to write!");
+
+  MFEM_VERIFY(value_ptr->Size() % field.num_comp == 0,
+              PointFieldLocationName(location)
+                  << " point field buffer size is not divisible by its component count!");
+  const int component_stride = value_ptr->Size() / field.num_comp;
+  std::vector<char> buf;
+  const double *data = value_ptr->HostRead();
+  for (int i = 0; i < NumPointFieldEntities(location); i++)
+  {
+    const auto *RefG =
+        mfem::GlobGeometryRefiner.Refine(PointFieldBaseGeometry(location, i), ref, 1);
+    const int base = (*field.bases)[i];
+    const int npts = RefG->RefPts.GetNPoints();
+    MFEM_VERIFY(base >= 0 && base + npts <= component_stride,
+                PointFieldLocationName(location)
+                    << " point field buffer is missing data for "
+                    << PointFieldEntityName(location) << " " << i << "!");
+    for (int j = 0; j < npts; j++)
+    {
+      for (int c = 0; c < field.num_comp; c++)
+      {
+        mfem::WriteBinaryOrASCII(os, buf, data[base + j + c * component_stride], " ",
+                                 pv_data_format);
+      }
+      if (pv_data_format == mfem::VTKFormat::ASCII)
+      {
+        os << '\n';
+      }
+    }
+  }
+  if (pv_data_format != mfem::VTKFormat::ASCII)
+  {
+    mfem::WriteBase64WithSizeAndClear(os, buf, GetCompressionLevel());
+  }
+  os << "</DataArray>" << std::endl;
+}
+
+void CeedParaViewDataCollection::SavePointFieldVTUAppendedHeader(MeshEntityType location,
+                                                                 std::ostream &os, int ref,
+                                                                 const std::string &name,
+                                                                 const PointField &field,
+                                                                 std::uint64_t offset)
+{
+  MFEM_VERIFY(LocationMatchesOutput(location),
+              PointFieldLocationName(location)
+                  << " point fields require matching ParaView output!");
+  const std::uint64_t payload_size = PointFieldPayloadSize(location, field);
+  MFEM_VERIFY(payload_size <= std::numeric_limits<std::uint32_t>::max(),
+              PointFieldLocationName(location)
+                  << " point field is too large for the current appended VTU writer!");
+  os << "<DataArray type=\"" << GetDataTypeString() << "\" Name=\"" << name
+     << "\" NumberOfComponents=\"" << field.num_comp << "\" "
+     << mfem::VTKComponentLabels(field.num_comp) << " "
+     << "format=\"appended\" offset=\"" << offset << "\" />" << '\n';
+}
+
+void CeedParaViewDataCollection::SavePointFieldVTUAppendedPayload(MeshEntityType location,
+                                                                  std::ostream &os, int ref,
+                                                                  const std::string &name,
+                                                                  const PointField &field,
+                                                                  Vector *scratch)
+{
+  const std::uint64_t payload_size64 = PointFieldPayloadSize(location, field);
+  MFEM_VERIFY(payload_size64 <= std::numeric_limits<std::uint32_t>::max(),
+              PointFieldLocationName(location)
+                  << " point field is too large for the current appended VTU writer!");
+  const std::uint32_t payload_size = static_cast<std::uint32_t>(payload_size64);
+  os.write(reinterpret_cast<const char *>(&payload_size), sizeof(payload_size));
+
+  Vector values;
+  const Vector *value_ptr = field.values;
+  if (field.evaluator)
+  {
+    MFEM_VERIFY(scratch && scratch->Size() >= field.buffer_size,
+                PointFieldLocationName(location)
+                    << " point evaluator scratch buffer is too small!");
+    values.MakeRef(*scratch, 0, field.buffer_size);
+    field.evaluator(values);
+    value_ptr = &values;
+  }
+  MFEM_VERIFY(value_ptr, PointFieldLocationName(location)
+                             << " point field has no values to write!");
+  WritePointFieldValues(location, os, ref, name, field, *value_ptr);
+}
+
+void CeedParaViewDataCollection::SaveDataVTU(std::ostream &os, int ref)
+{
+  os << "<VTKFile type=\"UnstructuredGrid\"";
+  if (GetCompressionLevel() != 0)
+  {
+    os << " compressor=\"vtkZLibDataCompressor\"";
+  }
+  os << " version=\"2.2\" byte_order=\"" << mfem::VTKByteOrder() << "\">\n";
+  os << "<UnstructuredGrid>\n";
+  if (domain_cell_fields.empty())
+  {
+    if (cached_mesh_vtu.empty() || cached_mesh_vtu_ref != ref ||
+        cached_mesh_vtu_bdr_output != bdr_output)
+    {
+      std::ostringstream mesh_os;
+      mesh_os.precision(os.precision());
+      mesh->PrintVTU(mesh_os, ref, pv_data_format, high_order_output, GetCompressionLevel(),
+                     bdr_output);
+      cached_mesh_vtu = mesh_os.str();
+      cached_mesh_vtu_ref = ref;
+      cached_mesh_vtu_bdr_output = bdr_output;
+    }
+    os.write(cached_mesh_vtu.data(), static_cast<std::streamsize>(cached_mesh_vtu.size()));
+  }
+  else
+  {
+    // MFEM owns mesh/attribute VTU emission and closes the <CellData> block before
+    // returning. For lightweight element fields (rank, AMR indicator), splice our arrays
+    // into that existing CellData section instead of routing them through a piecewise
+    // constant GridFunction, which would expand one cell value to every refined point.
+    std::ostringstream mesh_os;
+    mesh_os.precision(os.precision());
+    mesh->PrintVTU(mesh_os, ref, pv_data_format, high_order_output, GetCompressionLevel(),
+                   bdr_output);
+    const std::string mesh_vtu = mesh_os.str();
+    const std::string cell_data_end = "</CellData>";
+    const auto pos = mesh_vtu.find(cell_data_end);
+    MFEM_VERIFY(pos != std::string::npos,
+                "Unable to locate CellData block in MFEM VTU mesh output!");
+    os.write(mesh_vtu.data(), static_cast<std::streamsize>(pos));
+    for (const auto &kv : domain_cell_fields)
+    {
+      WriteCellFieldVTU(os, kv.first, kv.second);
+    }
+    os.write(mesh_vtu.data() + pos, static_cast<std::streamsize>(mesh_vtu.size() - pos));
+  }
+
+  os << "<PointData >\n";
+  for (FieldMapIterator it = field_map.begin(); it != field_map.end(); ++it)
+  {
+    MFEM_VERIFY(!bdr_output,
+                "GridFunction output is not supported for ParaViewDataCollection on "
+                "domain boundary!");
+    SaveGFieldVTU(os, ref, it);
+  }
+  for (const auto &kv : GetCoeffFieldMap())
+  {
+    SaveCoeffFieldVTU(os, ref, kv.first, *kv.second);
+  }
+  for (const auto &kv : GetVCoeffFieldMap())
+  {
+    SaveVCoeffFieldVTU(os, ref, kv.first, *kv.second);
+  }
+  const bool appended_boundary_fields = UseAppendedPointFields(MeshEntityType::Boundary);
+  const bool appended_domain_fields = UseAppendedPointFields(MeshEntityType::Domain);
+  Vector boundary_point_scratch, domain_point_scratch;
+  if (!boundary_point_fields.empty())
+  {
+    boundary_point_scratch.SetSize(MaxPointFieldBufferSize(boundary_point_fields));
+    boundary_point_scratch.UseDevice(true);
+  }
+  if (!domain_point_fields.empty())
+  {
+    domain_point_scratch.SetSize(MaxPointFieldBufferSize(domain_point_fields));
+    domain_point_scratch.UseDevice(true);
+  }
+  const bool cache_appended_headers =
+      (appended_boundary_fields || appended_domain_fields) &&
+      (boundary_point_fields.empty() || appended_boundary_fields) &&
+      (domain_point_fields.empty() || appended_domain_fields);
+  auto WriteAppendedPointHeaders = [&](std::ostream &header_os)
+  {
+    std::uint64_t appended_offset = 0;
+    for (const auto &kv : boundary_point_fields)
+    {
+      SavePointFieldVTUAppendedHeader(MeshEntityType::Boundary, header_os, ref, kv.first,
+                                      kv.second, appended_offset);
+      appended_offset += sizeof(std::uint32_t) +
+                         PointFieldPayloadSize(MeshEntityType::Boundary, kv.second);
+    }
+    for (const auto &kv : domain_point_fields)
+    {
+      SavePointFieldVTUAppendedHeader(MeshEntityType::Domain, header_os, ref, kv.first,
+                                      kv.second, appended_offset);
+      appended_offset +=
+          sizeof(std::uint32_t) + PointFieldPayloadSize(MeshEntityType::Domain, kv.second);
+    }
+  };
+  if (cache_appended_headers)
+  {
+    if (cached_point_headers_vtu.empty() || cached_point_headers_vtu_ref != ref ||
+        cached_point_headers_vtu_bdr_output != bdr_output)
+    {
+      std::ostringstream header_os;
+      WriteAppendedPointHeaders(header_os);
+      cached_point_headers_vtu = header_os.str();
+      cached_point_headers_vtu_ref = ref;
+      cached_point_headers_vtu_bdr_output = bdr_output;
+    }
+    os.write(cached_point_headers_vtu.data(),
+             static_cast<std::streamsize>(cached_point_headers_vtu.size()));
+  }
+  else
+  {
+    std::uint64_t appended_offset = 0;
+    for (const auto &kv : boundary_point_fields)
+    {
+      if (appended_boundary_fields)
+      {
+        SavePointFieldVTUAppendedHeader(MeshEntityType::Boundary, os, ref, kv.first,
+                                        kv.second, appended_offset);
+        appended_offset += sizeof(std::uint32_t) +
+                           PointFieldPayloadSize(MeshEntityType::Boundary, kv.second);
+      }
+      else
+      {
+        SavePointFieldVTU(MeshEntityType::Boundary, os, ref, kv.first, kv.second,
+                          &boundary_point_scratch);
+      }
+    }
+    for (const auto &kv : domain_point_fields)
+    {
+      if (appended_domain_fields)
+      {
+        SavePointFieldVTUAppendedHeader(MeshEntityType::Domain, os, ref, kv.first,
+                                        kv.second, appended_offset);
+        appended_offset += sizeof(std::uint32_t) +
+                           PointFieldPayloadSize(MeshEntityType::Domain, kv.second);
+      }
+      else
+      {
+        SavePointFieldVTU(MeshEntityType::Domain, os, ref, kv.first, kv.second,
+                          &domain_point_scratch);
+      }
+    }
+  }
+  os << "</PointData>\n";
+  os << "</Piece>\n";
+  os << "</UnstructuredGrid>\n";
+  if (appended_boundary_fields || appended_domain_fields)
+  {
+    os << "<AppendedData encoding=\"raw\">\n_";
+    for (const auto &kv : boundary_point_fields)
+    {
+      SavePointFieldVTUAppendedPayload(MeshEntityType::Boundary, os, ref, kv.first,
+                                       kv.second, &boundary_point_scratch);
+    }
+    for (const auto &kv : domain_point_fields)
+    {
+      SavePointFieldVTUAppendedPayload(MeshEntityType::Domain, os, ref, kv.first, kv.second,
+                                       &domain_point_scratch);
+    }
+    os << "\n</AppendedData>\n";
+  }
+  os << "</VTKFile>" << std::endl;
+}
+
+void CeedParaViewDataCollection::Save()
+{
+  const std::string col_path = GenerateCollectionPath();
+  {
+    const std::string path = col_path + "/" + GenerateVTUPath();
+    const int error_code = create_directory(path, mesh, myid);
+    if (error_code)
+    {
+      error = WRITE_ERROR;
+      MFEM_WARNING("Error creating directory: " << path);
+      return;
+    }
+  }
+
+  if (myid == 0 && !pvd_stream.is_open())
+  {
+    const std::string pvdname = col_path + "/" + GeneratePVDFileName();
+
+    bool write_header = true;
+    std::ifstream pvd_in;
+    if (restart_mode && (pvd_in.open(pvdname, std::ios::binary), pvd_in.good()))
+    {
+      std::fstream::pos_type pos_begin = pvd_in.tellg();
+      std::fstream::pos_type pos_end = pos_begin;
+
+      std::regex regexp("timestep=\"([^[:space:]]+)\".*file=\"Cycle(\\d+)");
+      std::smatch match;
+
+      std::string line;
+      while (getline(pvd_in, line))
+      {
+        if (regex_search(line, match, regexp))
+        {
+          MFEM_ASSERT(match.size() == 3, "Unable to parse DataSet");
+          const double tvalue = std::stod(match[1]);
+          if (tvalue >= GetTime())
+          {
+            break;
+          }
+          const int cvalue = std::stoi(match[2]);
+          MFEM_VERIFY(cvalue < GetCycle(), "Cycle " << GetCycle()
+                                                    << " is too small for restart mode: "
+                                                       "trying to overwrite existing "
+                                                       "data.");
+          pos_end = pvd_in.tellg();
+        }
+      }
+
+      const size_t count = pos_end - pos_begin;
+      if (count != 0)
+      {
+        write_header = false;
+        std::vector<char> buf(count);
+        pvd_in.clear();
+        pvd_in.seekg(pos_begin);
+        pvd_in.read(buf.data(), count);
+        pvd_in.close();
+        pvd_stream.open(pvdname, std::ios::out | std::ios::trunc | std::ios::binary);
+        pvd_stream.write(buf.data(), count);
+        pvd_stream.close();
+        pvd_stream.open(pvdname, std::ios::in | std::ios::out | std::ios::ate);
+      }
+    }
+    if (write_header)
+    {
+      pvd_stream.open(pvdname, std::ios::out | std::ios::trunc);
+      pvd_stream << "<?xml version=\"1.0\"?>\n";
+      pvd_stream << "<VTKFile type=\"Collection\" version=\"2.2\"";
+      pvd_stream << " byte_order=\"" << mfem::VTKByteOrder() << "\">\n";
+      pvd_stream << "<Collection>" << std::endl;
+    }
+  }
+
+  const std::string vtu_prefix = col_path + "/" + GenerateVTUPath() + "/";
+  {
+    const std::string os_str = vtu_prefix + GenerateVTUFileName("proc", myid);
+    std::ofstream os(os_str, std::ios::binary);
+    MFEM_VERIFY(os.is_open(), "Failed to open ofstream " << os_str);
+    os.precision(precision);
+    SaveDataVTU(os, levels_of_detail);
+  }
+
+  for (const auto &qfield : q_field_map)
+  {
+    MFEM_VERIFY(!bdr_output,
+                "QuadratureFunction output is not supported for ParaViewDataCollection "
+                "on domain boundary!");
+    const std::string &field_name = qfield.first;
+    const std::string os_str = vtu_prefix + GenerateVTUFileName(field_name, myid);
+    std::ofstream os(os_str);
+    MFEM_VERIFY(os.is_open(), "Failed to open ofstream " << os_str);
+    qfield.second->SaveVTU(os, pv_data_format, GetCompressionLevel(), field_name);
+  }
+
+  if (myid == 0)
+  {
+    {
+      const std::string os_str = vtu_prefix + GeneratePVTUFileName("data");
+      std::ofstream pvtu_out(os_str);
+      MFEM_VERIFY(pvtu_out.is_open(), "Failed to open ofstream " << os_str);
+      WritePVTUHeader(pvtu_out);
+
+      pvtu_out << "<PPointData>\n";
+      for (auto &field_it : field_map)
+      {
+        const int vec_dim = field_it.second->VectorDim();
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                 << mfem::VTKComponentLabels(vec_dim) << " "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      for (const auto &field_it : GetCoeffFieldMap())
+      {
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"1\" "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      for (const auto &field_it : GetVCoeffFieldMap())
+      {
+        const int vec_dim = field_it.second->GetVDim();
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      for (const auto &field_it : boundary_point_fields)
+      {
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"" << field_it.second.num_comp
+                 << "\" " << mfem::VTKComponentLabels(field_it.second.num_comp) << " "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      for (const auto &field_it : domain_point_fields)
+      {
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"" << field_it.second.num_comp
+                 << "\" " << mfem::VTKComponentLabels(field_it.second.num_comp) << " "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      pvtu_out << "</PPointData>\n";
+
+      pvtu_out << "<PCellData>\n";
+      pvtu_out << "\t<PDataArray type=\"Int32\" Name=\"attribute\" "
+                  "NumberOfComponents=\"1\""
+               << " format=\"" << GetDataFormatString() << "\"/>\n";
+      for (const auto &field_it : domain_cell_fields)
+      {
+        pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+                 << field_it.first << "\" NumberOfComponents=\"" << field_it.second.num_comp
+                 << "\" " << mfem::VTKComponentLabels(field_it.second.num_comp) << " "
+                 << "format=\"" << GetDataFormatString() << "\" />\n";
+      }
+      pvtu_out << "</PCellData>\n";
+
+      WritePVTUFooter(pvtu_out, "proc");
+    }
+
+    pvd_stream << "<DataSet timestep=\"" << GetTime() << "\" group=\"\" part=\"" << 0
+               << "\" file=\"" << GeneratePVTUPath() + "/" + GeneratePVTUFileName("data")
+               << "\" name=\"mesh\"/>\n";
+
+    for (auto &q_field : q_field_map)
+    {
+      const std::string &q_field_name = q_field.first;
+      const std::string q_fname =
+          GeneratePVTUPath() + "/" + GeneratePVTUFileName(q_field_name);
+      const std::string os_str = col_path + "/" + q_fname;
+      std::ofstream pvtu_out(os_str);
+      MFEM_VERIFY(pvtu_out.is_open(), "Failed to open ofstream " << os_str);
+      WritePVTUHeader(pvtu_out);
+      const int vec_dim = q_field.second->GetVDim();
+      pvtu_out << "<PPointData>\n";
+      pvtu_out << "<PDataArray type=\"" << GetDataTypeString() << "\" Name=\""
+               << q_field_name << "\" NumberOfComponents=\"" << vec_dim << "\" "
+               << mfem::VTKComponentLabels(vec_dim) << " "
+               << "format=\"" << GetDataFormatString() << "\" />\n";
+      pvtu_out << "</PPointData>\n";
+      WritePVTUFooter(pvtu_out, q_field_name);
+
+      pvd_stream << "<DataSet timestep=\"" << GetTime() << "\" group=\"\" part=\"" << 0
+                 << "\" file=\"" << q_fname << "\" name=\"" << q_field_name << "\"/>\n";
+    }
+    pvd_stream.flush();
+    const std::fstream::pos_type pos = pvd_stream.tellp();
+    pvd_stream << "</Collection>\n";
+    pvd_stream << "</VTKFile>" << std::endl;
+    pvd_stream.seekp(pos);
+  }
+}
+
+}  // namespace palace

--- a/palace/utils/ceedparaviewdatacollection.hpp
+++ b/palace/utils/ceedparaviewdatacollection.hpp
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_UTILS_CEED_PARAVIEW_DATA_COLLECTION_HPP
+#define PALACE_UTILS_CEED_PARAVIEW_DATA_COLLECTION_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+#include <mfem.hpp>
+#include "linalg/vector.hpp"
+#include "utils/labels.hpp"
+
+namespace palace
+{
+
+// ParaView data collection with extra registration paths for point data ordered exactly
+// as MFEM's VTU writer emits refined points. The data can be precomputed or evaluated
+// lazily during Save(). This avoids pretending libCEED output is an mfem::Coefficient
+// and, more importantly, avoids recovering point identity from floating-point reference
+// coordinates during Save().
+class CeedParaViewDataCollection : public mfem::ParaViewDataCollection
+{
+private:
+  struct PointField
+  {
+    const Vector *values = nullptr;
+    std::function<void(Vector &)> evaluator;
+    const std::vector<int> *bases = nullptr;
+    int num_comp = 0;
+    int buffer_size = 0;
+    bool point_major = false;
+  };
+  struct CellField
+  {
+    const Vector *values = nullptr;
+    int num_comp = 0;
+  };
+
+  std::fstream pvd_stream;
+  std::map<std::string, PointField> boundary_point_fields;
+  std::map<std::string, PointField> domain_point_fields;
+  std::map<std::string, CellField> domain_cell_fields;
+  std::string cached_mesh_vtu, cached_point_headers_vtu;
+  int cached_mesh_vtu_ref = -1, cached_point_headers_vtu_ref = -1;
+  bool cached_mesh_vtu_bdr_output = false;
+  bool cached_point_headers_vtu_bdr_output = false;
+
+  std::map<std::string, PointField> &PointFields(MeshEntityType location);
+  const std::map<std::string, PointField> &PointFields(MeshEntityType location) const;
+  int NumPointFieldEntities(MeshEntityType location) const;
+  mfem::Geometry::Type PointFieldBaseGeometry(MeshEntityType location, int i) const;
+  static const char *PointFieldLocationName(MeshEntityType location);
+  static const char *PointFieldEntityName(MeshEntityType location);
+  bool LocationMatchesOutput(MeshEntityType location) const;
+
+  void RegisterPointField(MeshEntityType location, const std::string &field_name,
+                          const Vector &values, const std::vector<int> &bases,
+                          int num_comp);
+  void RegisterPointEvaluator(MeshEntityType location, const std::string &field_name,
+                              std::function<void(Vector &)> evaluator,
+                              const std::vector<int> &bases, int num_comp, int buffer_size,
+                              bool point_major = false);
+  void DeregisterPointField(MeshEntityType location, const std::string &field_name);
+  void WriteCellFieldVTU(std::ostream &os, const std::string &name,
+                         const CellField &field) const;
+
+  bool UseAppendedPointFields(MeshEntityType location) const;
+  int MaxPointFieldBufferSize(const std::map<std::string, PointField> &fields) const;
+  std::uint64_t PointFieldPayloadSize(MeshEntityType location,
+                                      const PointField &field) const;
+  void WritePointFieldValues(MeshEntityType location, std::ostream &os, int ref,
+                             const std::string &name, const PointField &field,
+                             const Vector &values) const;
+
+  void SaveDataVTU(std::ostream &os, int ref);
+  void SavePointFieldVTU(MeshEntityType location, std::ostream &os, int ref,
+                         const std::string &name, const PointField &field, Vector *scratch);
+  void SavePointFieldVTUAppendedHeader(MeshEntityType location, std::ostream &os, int ref,
+                                       const std::string &name, const PointField &field,
+                                       std::uint64_t offset);
+  void SavePointFieldVTUAppendedPayload(MeshEntityType location, std::ostream &os, int ref,
+                                        const std::string &name, const PointField &field,
+                                        Vector *scratch);
+
+public:
+  using mfem::ParaViewDataCollection::ParaViewDataCollection;
+
+  void RegisterBoundaryPointField(const std::string &field_name, const Vector &values,
+                                  const std::vector<int> &bases, int num_comp);
+  void RegisterBoundaryPointEvaluator(const std::string &field_name,
+                                      std::function<void(Vector &)> evaluator,
+                                      const std::vector<int> &bases, int num_comp,
+                                      int buffer_size);
+  void RegisterDomainPointEvaluator(const std::string &field_name,
+                                    std::function<void(Vector &)> evaluator,
+                                    const std::vector<int> &bases, int num_comp,
+                                    int buffer_size, bool point_major = false);
+  void RegisterDomainCellField(const std::string &field_name, const Vector &values,
+                               int num_comp = 1);
+  void PrecacheMeshVTU();
+  void DeregisterBoundaryPointField(const std::string &field_name);
+  void DeregisterDomainPointField(const std::string &field_name);
+  void DeregisterDomainCellField(const std::string &field_name);
+
+  void Save() override;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_UTILS_CEED_PARAVIEW_DATA_COLLECTION_HPP

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -560,7 +560,14 @@ WavePortData::WavePortData(const json &port)
   // Resolve subspace sentinel: fed directly into ModeEigenSolver → SLEPc/ARPACK.
   if (max_size <= 0)
   {
-    max_size = DefaultEigenSubspaceSize(mode_idx);
+    // Wave-port boundary mode solves target a small, fixed number of propagating modes
+    // (typically Mode 1-3) and are re-solved many times over a frequency sweep, unlike the
+    // general 3D eigenmode driver, which may target dozens of eigenvalues and benefits
+    // from a generously oversized subspace for robust convergence. Use a smaller default
+    // subspace tuned for the wave-port case while preserving the same requested
+    // eigenmodes and tolerances; users needing more headroom (e.g. densely clustered
+    // modes near cutoff) can still override via "MaxSize".
+    max_size = std::max(2 * mode_idx, mode_idx + 5);
   }
 }
 

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -62,6 +62,28 @@ enum class InterfaceDielectric : char
   SA
 };
 
+// Mesh entity location: domain/volume elements or boundary/surface elements.
+enum class MeshEntityType : char
+{
+  Domain,
+  Boundary
+};
+
+// Non-reducing point field outputs for visualization. These produce one value per
+// sampled mesh point rather than a globally reduced scalar/array.
+enum class PointFieldKind : char
+{
+  FIELD_E,    // H(curl) vector field values
+  FIELD_B,    // H(div)/L2 magnetic flux values
+  FIELD_H1,   // H1 scalar field values
+  FLUX_Q,     // Surface charge (eps E) . n
+  CURRENT_J,  // Surface current n x (mu^-1 B)
+  ENERGY_E,   // Electric energy density
+  ENERGY_M,   // Magnetic energy density
+  POYNTING,   // Poynting vector E x (mu^-1 B)
+  MODE_SN     // Boundary-mode z-directed Poynting density
+};
+
 // Frequency sampling schemes.
 enum class FrequencySampling : char
 {

--- a/scripts/schema/config-schema.json
+++ b/scripts/schema/config-schema.json
@@ -1306,7 +1306,7 @@
         },
         "MaxSize": {
           "type": "integer",
-          "description": "Maximum subspace dimension for the eigenvalue solver. If omitted, Palace uses `max(2 \u00d7 Mode, Mode + 15)`.",
+          "description": "Maximum subspace dimension for the eigenvalue solver. If omitted, Palace uses `max(2 \u00d7 Mode, Mode + 5)`, smaller than the general eigenmode solver's default since wave-port boundary mode problems target only a handful of propagating modes.",
           "exclusiveMinimum": 0,
           "x-palace-advanced": true
         },

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacefunctional.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-postoperator-boundary-viz.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp
@@ -73,6 +74,13 @@ target_link_libraries(unit-tests
           $<$<BOOL:${PALACE_BUILD_WITH_SANITIZERS}>:sanitizer_flags>
           $<IF:$<BOOL:${PALACE_BUILD_WITH_COVERAGE}>,$<LINK_LIBRARY:WHOLE_ARCHIVE,${LIB_TARGET_NAME}>,${LIB_TARGET_NAME}>
           )
+
+# The PostOperator boundary-viz regression decodes MFEM's compressed binary VTU output
+# when MFEM is built with zlib support.
+find_package(ZLIB QUIET)
+if(ZLIB_FOUND)
+  target_link_libraries(unit-tests PRIVATE ZLIB::ZLIB)
+endif()
 
 # Handle device source code
 set(TARGET_SOURCES_DEVICE
@@ -108,7 +116,7 @@ endif()
 # Add JIT source file path definition for libCEED
 set_property(
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-  APPEND PROPERTY COMPILE_DEFINITIONS "PALACE_LIBCEED_JIT_SOURCE_DIR=\"${CMAKE_INSTALL_PREFIX}/include/palace/\""
+  APPEND PROPERTY COMPILE_DEFINITIONS "PALACE_LIBCEED_JIT_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}/fem/\""
 )
 
 # Add path for test data files.

--- a/test/unit/test-postoperator-boundary-viz.cpp
+++ b/test/unit/test-postoperator-boundary-viz.cpp
@@ -1,0 +1,856 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+#include <mfem.hpp>
+#include <mfem/general/binaryio.hpp>
+#ifdef MFEM_USE_ZLIB
+#include <zlib.h>
+#endif
+#include <catch2/catch_test_macros.hpp>
+#include "fem/coefficient.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
+#include "fem/mesh.hpp"
+#include "fixtures.hpp"
+#include "linalg/vector.hpp"
+#include "models/postoperator.hpp"
+#include "models/spaceoperator.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/geodata.hpp"
+#include "utils/iodata.hpp"
+#include "utils/labels.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+std::unique_ptr<mfem::Mesh> MakeSmallTetInterfaceSerialMesh()
+{
+  // 2 x 2 x 2 cubes split into tetrahedra: small enough for a unit test, but it has
+  // exterior boundaries, an interior material interface, and enough face orientations to
+  // exercise boundary-normal conventions through PostOperator's boundary ParaView output.
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON));
+  for (int e = 0; e < smesh->GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh->GetElementCenter(e, center);
+    smesh->SetAttribute(e, (center(2) < 0.5) ? 1 : 2);
+  }
+
+  // Add boundary elements on the interior material interface z = 0.5. The public
+  // PostOperator output path should preserve the legacy one-sided exterior and two-sided
+  // interior boundary semantics when its internals are replaced by libCEED kernels.
+  for (int f = 0; f < smesh->GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh->GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh->GetAttribute(e1) != smesh->GetAttribute(e2))
+    {
+      auto *face_elem = smesh->GetFace(f)->Duplicate(smesh.get());
+      face_elem->SetAttribute(7);
+      smesh->AddBdrElement(face_elem);
+    }
+  }
+  smesh->FinalizeTopology();
+  smesh->Finalize();
+  smesh->SetAttributes();
+  smesh->EnsureNodes();
+  return smesh;
+}
+
+std::unique_ptr<mfem::Mesh> MakeSmallTriInterfaceSerialMesh()
+{
+  // 2D companion to MakeSmallTetInterfaceSerialMesh. It has exterior boundaries and an
+  // interior material interface so boundary point fields exercise line-boundary kernels,
+  // scalar out-of-plane B, and two-sided averaging through the public PostOperator path.
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian2D(3, 2, mfem::Element::TRIANGLE, false, 1.0, 1.0));
+  for (int e = 0; e < smesh->GetNE(); e++)
+  {
+    mfem::Vector center(2);
+    smesh->GetElementCenter(e, center);
+    smesh->SetAttribute(e, (center(1) < 0.5) ? 1 : 2);
+  }
+
+  for (int f = 0; f < smesh->GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh->GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh->GetAttribute(e1) != smesh->GetAttribute(e2))
+    {
+      auto *face_elem = smesh->GetFace(f)->Duplicate(smesh.get());
+      face_elem->SetAttribute(7);
+      smesh->AddBdrElement(face_elem);
+    }
+  }
+  smesh->FinalizeTopology();
+  smesh->Finalize();
+  smesh->SetAttributes();
+  smesh->EnsureNodes();
+  return smesh;
+}
+
+std::vector<config::MaterialData> MakeTwoMaterials()
+{
+  config::MaterialData lower, upper;
+  lower.attributes = {1};
+  upper.attributes = {2};
+
+  // Diagonal anisotropy and different values on each side exercise component ordering and
+  // material lookup, not just identity/isotropic paths.
+  lower.epsilon_r.s = {1.1, 1.2, 1.3};
+  lower.mu_r.s = {0.9, 1.0, 1.1};
+  upper.epsilon_r.s = {11.7, 3.1, 2.4};
+  upper.mu_r.s = {1.4, 1.8, 2.2};
+
+  return {lower, upper};
+}
+
+void ProjectTestFields3D(GridFunction &E, GridFunction &B)
+{
+  mfem::VectorFunctionCoefficient er(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(1.3 * x(1)) + x(2) * x(2) + 0.2;
+                                       v(1) = std::cos(0.7 * x(2)) + 0.4 * x(0);
+                                       v(2) = x(0) * x(1) - 0.3 * x(2) + 1.0;
+                                     });
+  mfem::VectorFunctionCoefficient ei(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) * x(2) - 0.5;
+                                       v(1) = std::sin(x(0)) - 0.25 * x(2);
+                                       v(2) = std::cos(1.1 * x(1)) + x(0) * x(0);
+                                     });
+  mfem::VectorFunctionCoefficient br(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) - 0.3 * x(2) + 0.4;
+                                       v(1) = std::sin(0.9 * x(2)) + 0.5;
+                                       v(2) = std::cos(x(0)) - x(1) * x(2);
+                                     });
+  mfem::VectorFunctionCoefficient bi(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::cos(x(2)) - 0.2;
+                                       v(1) = x(0) * x(2) + 0.1;
+                                       v(2) = std::sin(x(1)) - 0.4 * x(0);
+                                     });
+
+  E.Real().ProjectCoefficient(er);
+  E.Imag().ProjectCoefficient(ei);
+  B.Real().ProjectCoefficient(br);
+  B.Imag().ProjectCoefficient(bi);
+
+  E.Real().ExchangeFaceNbrData();
+  E.Imag().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+  B.Imag().ExchangeFaceNbrData();
+}
+
+void ProjectTestFields2D(GridFunction &E, GridFunction &B)
+{
+  mfem::VectorFunctionCoefficient er(2,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(1.7 * x(1)) + 0.25 * x(0) + 0.1;
+                                       v(1) = std::cos(0.8 * x(0)) - 0.35 * x(1) + 0.2;
+                                     });
+  mfem::VectorFunctionCoefficient ei(2,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(0) * x(1) - 0.15;
+                                       v(1) = std::sin(0.9 * x(0)) + 0.4 * x(1);
+                                     });
+  mfem::FunctionCoefficient br([](const mfem::Vector &x)
+                               { return std::cos(1.1 * x(0)) + 0.3 * x(1) + 0.5; });
+  mfem::FunctionCoefficient bi([](const mfem::Vector &x)
+                               { return std::sin(1.4 * x(1)) - 0.2 * x(0) + 0.25; });
+
+  E.Real().ProjectCoefficient(er);
+  E.Imag().ProjectCoefficient(ei);
+  B.Real().ProjectCoefficient(br);
+  B.Imag().ProjectCoefficient(bi);
+
+  E.Real().ExchangeFaceNbrData();
+  E.Imag().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+  B.Imag().ExchangeFaceNbrData();
+}
+
+void GetTrueDofs(const GridFunction &gf, ComplexVector &x)
+{
+  gf.Real().GetTrueDofs(x.Real());
+  gf.Imag().GetTrueDofs(x.Imag());
+}
+
+void DimensionalizeForPostOperatorOutput(const Units &units, GridFunction &E,
+                                         GridFunction &B)
+{
+  // This test sets L0 == Lc, so PostOperator's mesh redimensionalization and Piola
+  // compensation scale are both unity. The remaining output scaling is the public
+  // dimensional field scaling applied inside PostOperator::MeasureAndPrintAll before
+  // ParaViewDataCollection::Save().
+  E *= units.GetScaleFactor<Units::ValueType::FIELD_E>();
+  E.Real().FaceNbrData() *= units.GetScaleFactor<Units::ValueType::FIELD_E>();
+  E.Imag().FaceNbrData() *= units.GetScaleFactor<Units::ValueType::FIELD_E>();
+  B *= units.GetScaleFactor<Units::ValueType::FIELD_B>();
+  B.Real().FaceNbrData() *= units.GetScaleFactor<Units::ValueType::FIELD_B>();
+  B.Imag().FaceNbrData() *= units.GetScaleFactor<Units::ValueType::FIELD_B>();
+}
+
+struct ErrorStats
+{
+  long long count = 0;
+  double max_abs = 0.0;
+  double max_scaled = 0.0;
+  double sum_sq = 0.0;
+
+  void Add(double val, double ref, double rtol, double atol)
+  {
+    const double err = std::abs(val - ref);
+    const double denom = atol + rtol * std::max({1.0, std::abs(val), std::abs(ref)});
+    max_abs = std::max(max_abs, err);
+    max_scaled = std::max(max_scaled, err / denom);
+    sum_sq += err * err;
+    count++;
+  }
+
+  double Rms() const
+  {
+    return count ? std::sqrt(sum_sq / static_cast<double>(count)) : 0.0;
+  }
+};
+
+void CheckStats(const std::string &name, const ErrorStats &stats)
+{
+  INFO("field = " << name);
+  INFO("count = " << stats.count);
+  INFO("max_abs = " << stats.max_abs);
+  INFO("max_scaled = " << stats.max_scaled);
+  INFO("rms = " << stats.Rms());
+  CHECK(stats.count > 0);
+  CHECK(stats.max_scaled <= 1.0);
+}
+
+std::string ReadFile(const fs::path &path)
+{
+  std::ifstream in(path, std::ios::binary);
+  REQUIRE(in.good());
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+std::string RemoveWhitespace(std::string_view text)
+{
+  std::string out;
+  out.reserve(text.size());
+  for (char c : text)
+  {
+    if (!std::isspace(static_cast<unsigned char>(c)))
+    {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+std::vector<char> DecodeBase64(std::string_view encoded)
+{
+  std::vector<char> decoded;
+  const auto clean = RemoveWhitespace(encoded);
+  mfem::bin_io::DecodeBase64(clean.c_str(), clean.size(), decoded);
+  return decoded;
+}
+
+template <typename T>
+T ReadLittleEndian(const char *bytes)
+{
+  T value;
+  std::memcpy(&value, bytes, sizeof(T));
+  return value;
+}
+
+std::vector<char> DecodeVtkBinaryPayload(std::string_view encoded, bool compressed)
+{
+  const auto clean = RemoveWhitespace(encoded);
+  if (!compressed)
+  {
+    const auto decoded = DecodeBase64(clean);
+    REQUIRE(decoded.size() >= sizeof(std::uint32_t));
+    const auto nbytes = ReadLittleEndian<std::uint32_t>(decoded.data());
+    REQUIRE(decoded.size() >= sizeof(std::uint32_t) + nbytes);
+    return {decoded.begin() + sizeof(std::uint32_t),
+            decoded.begin() + sizeof(std::uint32_t) + nbytes};
+  }
+
+  // MFEM writes one compressed VTK block with a 4 * uint32 header encoded separately
+  // from the zlib payload: [num_blocks=1, uncompressed_size, partial_size=0,
+  // compressed_size]. Decode the two base64 chunks independently because the header chunk
+  // carries its own padding.
+  constexpr std::size_t header_bytes = 4 * sizeof(std::uint32_t);
+  const auto header_chars = mfem::bin_io::NumBase64Chars(header_bytes);
+  REQUIRE(clean.size() >= header_chars);
+  const auto header = DecodeBase64(std::string_view(clean).substr(0, header_chars));
+  REQUIRE(header.size() == header_bytes);
+  const auto num_blocks = ReadLittleEndian<std::uint32_t>(header.data());
+  const auto uncompressed_size = ReadLittleEndian<std::uint32_t>(header.data() + 4);
+  const auto partial_size = ReadLittleEndian<std::uint32_t>(header.data() + 8);
+  const auto compressed_size = ReadLittleEndian<std::uint32_t>(header.data() + 12);
+  REQUIRE(num_blocks == 1);
+  REQUIRE(partial_size == 0);
+
+  const auto compressed_payload =
+      DecodeBase64(std::string_view(clean).substr(header_chars));
+  REQUIRE(compressed_payload.size() >= compressed_size);
+  std::vector<char> uncompressed(uncompressed_size);
+#ifdef MFEM_USE_ZLIB
+  uLongf dest_len = uncompressed_size;
+  const int zret = uncompress(reinterpret_cast<Bytef *>(uncompressed.data()), &dest_len,
+                              reinterpret_cast<const Bytef *>(compressed_payload.data()),
+                              compressed_size);
+  REQUIRE(zret == Z_OK);
+  REQUIRE(dest_len == uncompressed_size);
+#else
+  MFEM_ABORT("Cannot decode compressed VTK output without zlib support!");
+#endif
+  return uncompressed;
+}
+
+std::string_view ExtractDataArrayTag(std::string_view xml, const std::string &name)
+{
+  const std::string needle = "Name=\"" + name + "\"";
+  const auto name_pos = xml.find(needle);
+  REQUIRE(name_pos != std::string_view::npos);
+  const auto tag_begin = xml.rfind("<DataArray", name_pos);
+  REQUIRE(tag_begin != std::string_view::npos);
+  const auto tag_end = xml.find('>', name_pos);
+  REQUIRE(tag_end != std::string_view::npos);
+  return xml.substr(tag_begin, tag_end - tag_begin + 1);
+}
+
+std::string_view ExtractDataArrayPayload(std::string_view xml, const std::string &name)
+{
+  const std::string needle = "Name=\"" + name + "\"";
+  const auto name_pos = xml.find(needle);
+  REQUIRE(name_pos != std::string_view::npos);
+  const auto tag_end = xml.find('>', name_pos);
+  REQUIRE(tag_end != std::string_view::npos);
+  const auto close = xml.find("</DataArray>", tag_end);
+  REQUIRE(close != std::string_view::npos);
+  return xml.substr(tag_end + 1, close - tag_end - 1);
+}
+
+std::uint64_t ExtractUnsignedAttribute(std::string_view tag, std::string_view attr)
+{
+  const std::string needle = std::string(attr) + "=\"";
+  const auto begin = tag.find(needle);
+  REQUIRE(begin != std::string_view::npos);
+  const auto value_begin = begin + needle.size();
+  const auto value_end = tag.find('"', value_begin);
+  REQUIRE(value_end != std::string_view::npos);
+  return std::stoull(std::string(tag.substr(value_begin, value_end - value_begin)));
+}
+
+std::vector<char> ExtractAppendedDataArrayPayload(std::string_view xml,
+                                                  std::string_view tag)
+{
+  REQUIRE(tag.find("format=\"appended\"") != std::string_view::npos);
+  const auto offset = ExtractUnsignedAttribute(tag, "offset");
+  const auto appended_begin = xml.find("<AppendedData");
+  REQUIRE(appended_begin != std::string_view::npos);
+  const auto underscore = xml.find('_', appended_begin);
+  REQUIRE(underscore != std::string_view::npos);
+  const auto data_begin = underscore + 1 + offset;
+  REQUIRE(data_begin + sizeof(std::uint32_t) <= xml.size());
+  const auto nbytes = ReadLittleEndian<std::uint32_t>(xml.data() + data_begin);
+  const auto payload_begin = data_begin + sizeof(std::uint32_t);
+  REQUIRE(payload_begin + nbytes <= xml.size());
+  return {xml.begin() + static_cast<std::ptrdiff_t>(payload_begin),
+          xml.begin() + static_cast<std::ptrdiff_t>(payload_begin + nbytes)};
+}
+
+bool VtuUsesCompression(std::string_view xml)
+{
+  return xml.find("compressor=\"vtkZLibDataCompressor\"") != std::string_view::npos;
+}
+
+std::vector<char> ReadDataArrayBytes(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  if (tag.find("format=\"appended\"") != std::string_view::npos)
+  {
+    return ExtractAppendedDataArrayPayload(xml, tag);
+  }
+  return DecodeVtkBinaryPayload(ExtractDataArrayPayload(xml, name),
+                                VtuUsesCompression(xml));
+}
+
+std::vector<double> ReadFloatDataArray(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  const auto bytes = ReadDataArrayBytes(xml, name);
+
+  std::vector<double> values;
+  if (tag.find("type=\"Float32\"") != std::string_view::npos)
+  {
+    REQUIRE(bytes.size() % sizeof(float) == 0);
+    values.resize(bytes.size() / sizeof(float));
+    for (std::size_t i = 0; i < values.size(); i++)
+    {
+      values[i] = ReadLittleEndian<float>(bytes.data() + i * sizeof(float));
+    }
+  }
+  else
+  {
+    REQUIRE(tag.find("type=\"Float64\"") != std::string_view::npos);
+    REQUIRE(bytes.size() % sizeof(double) == 0);
+    values.resize(bytes.size() / sizeof(double));
+    for (std::size_t i = 0; i < values.size(); i++)
+    {
+      values[i] = ReadLittleEndian<double>(bytes.data() + i * sizeof(double));
+    }
+  }
+  return values;
+}
+
+std::vector<int> ReadIntDataArray(std::string_view xml, const std::string &name)
+{
+  const auto bytes = ReadDataArrayBytes(xml, name);
+  REQUIRE(bytes.size() % sizeof(std::int32_t) == 0);
+  std::vector<int> values(bytes.size() / sizeof(std::int32_t));
+  for (std::size_t i = 0; i < values.size(); i++)
+  {
+    values[i] = ReadLittleEndian<std::int32_t>(bytes.data() + i * sizeof(std::int32_t));
+  }
+  return values;
+}
+
+int CountBoundaryVisualizationPoints(const mfem::ParMesh &pmesh, int lod)
+{
+  int count = 0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    count += RefG.RefPts.GetNPoints();
+  }
+  return count;
+}
+
+int CountDomainVisualizationPoints(const mfem::ParMesh &pmesh, int lod)
+{
+  int count = 0;
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    count += RefG.RefPts.GetNPoints();
+  }
+  return count;
+}
+
+ErrorStats CompareScalarField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                              int lod, mfem::Coefficient &legacy, double rtol, double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++, idx++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      stats.Add(values[idx], legacy.Eval(*T, ip), rtol, atol);
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+ErrorStats CompareScalarDomainField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                                    int lod, mfem::Coefficient &legacy, double rtol,
+                                    double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++, idx++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      stats.Add(values[idx], legacy.Eval(*T, ip), rtol, atol);
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+ErrorStats CompareVectorField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                              int lod, mfem::VectorCoefficient &legacy, double rtol,
+                              double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  mfem::Vector ref(legacy.GetVDim());
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      legacy.Eval(ref, *T, ip);
+      for (int c = 0; c < legacy.GetVDim(); c++, idx++)
+      {
+        stats.Add(values[idx], ref(c), rtol, atol);
+      }
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+void RequireInteriorBoundaryWasWritten(std::string_view xml, const mfem::ParMesh &pmesh)
+{
+  const auto attributes = ReadIntDataArray(xml, "attribute");
+  REQUIRE(attributes.size() == static_cast<std::size_t>(pmesh.GetNBE()));
+  CHECK(std::find(attributes.begin(), attributes.end(), 7) != attributes.end());
+}
+
+ErrorStats CompareVectorDomainField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                                    int lod, mfem::VectorCoefficient &legacy, double rtol,
+                                    double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  mfem::Vector ref(legacy.GetVDim());
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      legacy.Eval(ref, *T, ip);
+      for (int c = 0; c < legacy.GetVDim(); c++, idx++)
+      {
+        stats.Add(values[idx], ref(c), rtol, atol);
+      }
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+void RequirePointFieldUsesAppendedData(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  CHECK(tag.find("format=\"appended\"") != std::string_view::npos);
+  CHECK(xml.find("<AppendedData encoding=\"raw\">") != std::string_view::npos);
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator boundary ParaView fields match legacy coefficients",
+                 "[postoperator][boundary-viz][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+
+  constexpr int order = 2;
+  // PostOperator intentionally writes ParaView files as Float32, so tolerate single
+  // precision roundoff in the file representation while still catching semantic errors.
+  constexpr double rtol = 5.0e-5;
+  constexpr double atol = 5.0e-7;
+
+  auto serial_mesh = MakeSmallTetInterfaceSerialMesh();
+  REQUIRE(serial_mesh->bdr_attributes.Find(7) >= 0);
+
+  IoData iodata(Units(1.0e-4, 1.0e-4));
+  iodata.problem.type = ProblemType::EIGENMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = true;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0e-4;
+  iodata.model.Lc = mesh::ComputeReferenceLength(serial_mesh, comm);
+  iodata.domains.materials = MakeTwoMaterials();
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4, 5, 6};
+  iodata.solver.order = order;
+  iodata.solver.eigenmode.n_post = 1;
+  iodata.CheckConfiguration();
+  iodata.NondimensionalizeInputs(serial_mesh);
+
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(std::move(par_mesh)));
+  auto &pmesh = mesh.front()->Get();
+  REQUIRE(pmesh.bdr_attributes.Find(7) >= 0);
+
+  SpaceOperator space_op(iodata, mesh);
+  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
+
+  GridFunction E(space_op.GetNDSpace(), true), B(space_op.GetCurlSpace(), true);
+  ProjectTestFields3D(E, B);
+  ComplexVector e_true(space_op.GetNDSpace().GetTrueVSize());
+  ComplexVector b_true(space_op.GetRTSpace().GetTrueVSize());
+  GetTrueDofs(E, e_true);
+  GetTrueDofs(B, b_true);
+
+  // Public API under test: this is the same PostOperator entry point used by the solver.
+  // On origin/main it writes boundary ParaView fields by evaluating legacy coefficients;
+  // this branch replaces selected internals with libCEED buffers while preserving the API
+  // and output contract.
+  post_op.MeasureAndPrintAll(0, e_true, b_true, {1.0, 0.1}, 0.0, 0.0, 1);
+
+  DimensionalizeForPostOperatorOutput(iodata.units, E, B);
+
+  const auto domain_vtu = ReadFile(fs::path(iodata.problem.output) / "paraview" /
+                                   "eigenmode" / "Cycle000001" / "proc000000.vtu");
+  const auto boundary_vtu =
+      ReadFile(fs::path(iodata.problem.output) / "paraview" / "eigenmode_boundary" /
+               "Cycle000001" / "proc000000.vtu");
+  RequireInteriorBoundaryWasWritten(boundary_vtu, pmesh);
+  RequirePointFieldUsesAppendedData(boundary_vtu, "E_real");
+  RequirePointFieldUsesAppendedData(domain_vtu, "U_e");
+
+  const int lod = order;
+  const int n_bdr_pts = CountBoundaryVisualizationPoints(pmesh, lod);
+  const int n_domain_pts = CountDomainVisualizationPoints(pmesh, lod);
+  auto ReadBoundaryChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(boundary_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_bdr_pts * components));
+    return values;
+  };
+  auto ReadDomainChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(domain_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_domain_pts * components));
+    return values;
+  };
+
+  const auto &mat_op = space_op.GetMaterialOp();
+  const double eps_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_D>(1.0) /
+                             iodata.units.Dimensionalize<Units::ValueType::FIELD_E>(1.0);
+  const double invmu_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_H>(1.0) /
+                               iodata.units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
+
+  BdrFieldVectorCoefficient E_real_legacy(E.Real()), E_imag_legacy(E.Imag());
+  BdrFieldVectorCoefficient B_real_legacy(B.Real()), B_imag_legacy(B.Imag());
+  CheckStats("E_real", CompareVectorField(ReadBoundaryChecked("E_real", 3), pmesh, lod,
+                                          E_real_legacy, rtol, atol));
+  CheckStats("E_imag", CompareVectorField(ReadBoundaryChecked("E_imag", 3), pmesh, lod,
+                                          E_imag_legacy, rtol, atol));
+  CheckStats("B_real", CompareVectorField(ReadBoundaryChecked("B_real", 3), pmesh, lod,
+                                          B_real_legacy, rtol, atol));
+  CheckStats("B_imag", CompareVectorField(ReadBoundaryChecked("B_imag", 3), pmesh, lod,
+                                          B_imag_legacy, rtol, atol));
+
+  mfem::Vector unused_x0;
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_real_legacy(
+      &E.Real(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_imag_legacy(
+      &E.Imag(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceCurrentVectorCoefficient J_real_legacy(B.Real(), mat_op, invmu_scaling);
+  BdrSurfaceCurrentVectorCoefficient J_imag_legacy(B.Imag(), mat_op, invmu_scaling);
+  CheckStats("Q_s_real", CompareScalarField(ReadBoundaryChecked("Q_s_real", 1), pmesh, lod,
+                                            Q_real_legacy, rtol, atol));
+  CheckStats("Q_s_imag", CompareScalarField(ReadBoundaryChecked("Q_s_imag", 1), pmesh, lod,
+                                            Q_imag_legacy, rtol, atol));
+  CheckStats("J_s_real", CompareVectorField(ReadBoundaryChecked("J_s_real", 3), pmesh, lod,
+                                            J_real_legacy, rtol, atol));
+  CheckStats("J_s_imag", CompareVectorField(ReadBoundaryChecked("J_s_imag", 3), pmesh, lod,
+                                            J_imag_legacy, rtol, atol));
+
+  EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> Ue_legacy(E, mat_op, eps_scaling);
+  EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> Um_legacy(B, mat_op, invmu_scaling);
+  PoyntingVectorCoefficient S_legacy(E, B, mat_op, invmu_scaling);
+  CheckStats("U_e boundary", CompareScalarField(ReadBoundaryChecked("U_e", 1), pmesh, lod,
+                                                Ue_legacy, rtol, atol));
+  CheckStats("U_m boundary", CompareScalarField(ReadBoundaryChecked("U_m", 1), pmesh, lod,
+                                                Um_legacy, rtol, atol));
+  CheckStats("S boundary", CompareVectorField(ReadBoundaryChecked("S", 3), pmesh, lod,
+                                              S_legacy, rtol, atol));
+  CheckStats("U_e domain", CompareScalarDomainField(ReadDomainChecked("U_e", 1), pmesh, lod,
+                                                    Ue_legacy, rtol, atol));
+  CheckStats("U_m domain", CompareScalarDomainField(ReadDomainChecked("U_m", 1), pmesh, lod,
+                                                    Um_legacy, rtol, atol));
+  CheckStats("S domain", CompareVectorDomainField(ReadDomainChecked("S", 3), pmesh, lod,
+                                                  S_legacy, rtol, atol));
+}
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator 2D boundary ParaView fields match legacy coefficients",
+                 "[postoperator][boundary-viz][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+
+  constexpr int order = 2;
+  constexpr double rtol = 5.0e-5;
+  constexpr double atol = 5.0e-7;
+
+  auto serial_mesh = MakeSmallTriInterfaceSerialMesh();
+  REQUIRE(serial_mesh->Dimension() == 2);
+  REQUIRE(serial_mesh->SpaceDimension() == 2);
+  REQUIRE(serial_mesh->bdr_attributes.Find(7) >= 0);
+
+  IoData iodata(Units(1.0e-4, 1.0e-4));
+  iodata.problem.type = ProblemType::EIGENMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = true;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0e-4;
+  iodata.model.Lc = mesh::ComputeReferenceLength(serial_mesh, comm);
+  iodata.domains.materials = MakeTwoMaterials();
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4};
+  iodata.solver.order = order;
+  iodata.solver.eigenmode.n_post = 1;
+  iodata.CheckConfiguration();
+  iodata.NondimensionalizeInputs(serial_mesh);
+
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(std::move(par_mesh)));
+  auto &pmesh = mesh.front()->Get();
+  REQUIRE(pmesh.bdr_attributes.Find(7) >= 0);
+
+  SpaceOperator space_op(iodata, mesh);
+  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
+
+  GridFunction E(space_op.GetNDSpace(), true), B(space_op.GetCurlSpace(), true);
+  REQUIRE(E.VectorDim() == 2);
+  REQUIRE(B.VectorDim() == 1);
+  ProjectTestFields2D(E, B);
+  ComplexVector e_true(space_op.GetNDSpace().GetTrueVSize());
+  ComplexVector b_true(space_op.GetCurlSpace().GetTrueVSize());
+  GetTrueDofs(E, e_true);
+  GetTrueDofs(B, b_true);
+
+  post_op.MeasureAndPrintAll(0, e_true, b_true, {1.0, 0.1}, 0.0, 0.0, 1);
+
+  DimensionalizeForPostOperatorOutput(iodata.units, E, B);
+
+  const auto domain_vtu = ReadFile(fs::path(iodata.problem.output) / "paraview" /
+                                   "eigenmode" / "Cycle000001" / "proc000000.vtu");
+  const auto boundary_vtu =
+      ReadFile(fs::path(iodata.problem.output) / "paraview" / "eigenmode_boundary" /
+               "Cycle000001" / "proc000000.vtu");
+  RequireInteriorBoundaryWasWritten(boundary_vtu, pmesh);
+  RequirePointFieldUsesAppendedData(boundary_vtu, "E_real");
+  RequirePointFieldUsesAppendedData(boundary_vtu, "U_m");
+  RequirePointFieldUsesAppendedData(domain_vtu, "B_real");
+
+  const int lod = order;
+  const int n_bdr_pts = CountBoundaryVisualizationPoints(pmesh, lod);
+  const int n_domain_pts = CountDomainVisualizationPoints(pmesh, lod);
+  auto ReadBoundaryChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(boundary_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_bdr_pts * components));
+    return values;
+  };
+  auto ReadDomainChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(domain_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_domain_pts * components));
+    return values;
+  };
+
+  const auto &mat_op = space_op.GetMaterialOp();
+  const double eps_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_D>(1.0) /
+                             iodata.units.Dimensionalize<Units::ValueType::FIELD_E>(1.0);
+  const double invmu_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_H>(1.0) /
+                               iodata.units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
+
+  BdrFieldVectorCoefficient E_real_legacy(E.Real()), E_imag_legacy(E.Imag());
+  CheckStats("E_real boundary 2D",
+             CompareVectorField(ReadBoundaryChecked("E_real", 2), pmesh, lod, E_real_legacy,
+                                rtol, atol));
+  CheckStats("E_imag boundary 2D",
+             CompareVectorField(ReadBoundaryChecked("E_imag", 2), pmesh, lod, E_imag_legacy,
+                                rtol, atol));
+
+  mfem::Vector unused_x0;
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_real_legacy(
+      &E.Real(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_imag_legacy(
+      &E.Imag(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  CheckStats("Q_s_real boundary 2D",
+             CompareScalarField(ReadBoundaryChecked("Q_s_real", 1), pmesh, lod,
+                                Q_real_legacy, rtol, atol));
+  CheckStats("Q_s_imag boundary 2D",
+             CompareScalarField(ReadBoundaryChecked("Q_s_imag", 1), pmesh, lod,
+                                Q_imag_legacy, rtol, atol));
+
+  EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> Ue_legacy(E, mat_op, eps_scaling);
+  EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> Um_legacy(B, mat_op, invmu_scaling);
+  PoyntingVectorCoefficient S_legacy(E, B, mat_op, invmu_scaling);
+  CheckStats("U_e boundary 2D", CompareScalarField(ReadBoundaryChecked("U_e", 1), pmesh,
+                                                   lod, Ue_legacy, rtol, atol));
+  CheckStats("U_m boundary 2D", CompareScalarField(ReadBoundaryChecked("U_m", 1), pmesh,
+                                                   lod, Um_legacy, rtol, atol));
+  CheckStats("S boundary 2D", CompareVectorField(ReadBoundaryChecked("S", 2), pmesh, lod,
+                                                 S_legacy, rtol, atol));
+
+  mfem::VectorGridFunctionCoefficient E_real_domain(&E.Real());
+  mfem::VectorGridFunctionCoefficient E_imag_domain(&E.Imag());
+  mfem::GridFunctionCoefficient B_real_domain(&B.Real());
+  mfem::GridFunctionCoefficient B_imag_domain(&B.Imag());
+  CheckStats("E_real domain 2D",
+             CompareVectorDomainField(ReadDomainChecked("E_real", 2), pmesh, lod,
+                                      E_real_domain, rtol, atol));
+  CheckStats("E_imag domain 2D",
+             CompareVectorDomainField(ReadDomainChecked("E_imag", 2), pmesh, lod,
+                                      E_imag_domain, rtol, atol));
+  CheckStats("B_real domain 2D",
+             CompareScalarDomainField(ReadDomainChecked("B_real", 1), pmesh, lod,
+                                      B_real_domain, rtol, atol));
+  CheckStats("B_imag domain 2D",
+             CompareScalarDomainField(ReadDomainChecked("B_imag", 1), pmesh, lod,
+                                      B_imag_domain, rtol, atol));
+  CheckStats("U_e domain 2D", CompareScalarDomainField(ReadDomainChecked("U_e", 1), pmesh,
+                                                       lod, Ue_legacy, rtol, atol));
+  CheckStats("U_m domain 2D", CompareScalarDomainField(ReadDomainChecked("U_m", 1), pmesh,
+                                                       lod, Um_legacy, rtol, atol));
+  CheckStats("S domain 2D", CompareVectorDomainField(ReadDomainChecked("S", 2), pmesh, lod,
+                                                     S_legacy, rtol, atol));
+}
+
+}  // namespace palace

--- a/test/unit/test-surfacefunctional.cpp
+++ b/test/unit/test-surfacefunctional.cpp
@@ -18,6 +18,7 @@
 #include "fem/interpolator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/output_functionals.hpp"
+#include "fem/point_field_evaluator.hpp"
 #include "fixtures.hpp"
 #include "models/boundarymodeoperator.hpp"
 #include "models/domainpostoperator.hpp"
@@ -1631,6 +1632,251 @@ TEST_CASE("SurfaceFunctional Nonconformal Parallel", "[surfacefunctional][Parall
   }
 }
 
+TEST_CASE("PointFieldEvaluator Domain Fields", "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = nonconformal ? MakeNCInterfaceMesh(comm, elem_type)
+                           : MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, complex), B(rt_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(1) * x(2) - 0.5;
+                                          v(1) = std::sin(x(0)) - x(2);
+                                          v(2) = std::cos(x(1)) + x(0) * x(0);
+                                        });
+    mfem::VectorFunctionCoefficient fbi(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = std::cos(x(2)) - 0.2;
+                                          v(1) = x(0) * x(2) + 0.1;
+                                          v(2) = std::sin(x(1)) - x(0);
+                                        });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  // Interpolatory L2 output spaces (legacy ProjectCoefficient on these spaces evaluates
+  // the coefficient at the nodal points, which is exactly the libCEED evaluator
+  // semantics, at any order).
+  mfem::L2_FECollection viz_fec(order, 3);
+  mfem::ParFiniteElementSpace viz_scalar(&pmesh, &viz_fec), viz_vector(&pmesh, &viz_fec, 3);
+
+  const double scaling = 2.5;
+  auto CheckField = [](const mfem::ParGridFunction &val, const mfem::ParGridFunction &ref)
+  {
+    // HostRead to sync from device (the evaluator fills on device).
+    const double *v = val.HostRead();
+    const double *r = ref.HostRead();
+    double max_diff = 0.0, max_ref = 0.0;
+    for (int i = 0; i < ref.Size(); i++)
+    {
+      max_diff = std::max(max_diff, std::abs(v[i] - r[i]));
+      max_ref = std::max(max_ref, std::abs(r[i]));
+    }
+    CAPTURE(max_diff, max_ref);
+    CHECK(max_diff <= 1.0e-11 * std::max(max_ref, 1.0));
+  };
+
+  SECTION("Electric energy density")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_E, *mesh, mat_op,
+                             E.ParFESpace(), nullptr, viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(&E, nullptr, val);
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> legacy(E, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Magnetic energy density")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_M, *mesh, mat_op, nullptr,
+                             B.ParFESpace(), viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(nullptr, &B, val);
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> legacy(B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Poynting vector")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::POYNTING, *mesh, mat_op,
+                             E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
+    eval.Eval(&E, &B, val);
+    PoyntingVectorCoefficient legacy(E, B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+}
+
+TEST_CASE("PointFieldEvaluator Domain Fields 2D",
+          "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TRIANGLE, mfem::Element::QUADRILATERAL);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian2D(3, 2, elem_type, false, 1.2, 0.7));
+  smesh->EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh->GetNE());
+  auto pmesh_ptr = std::make_unique<mfem::ParMesh>(comm, *smesh);
+  Mesh mesh(std::move(pmesh_ptr));
+  auto &pmesh = mesh.Get();
+
+  config::MaterialData material;
+  material.attributes = {1};
+  material.epsilon_r.s[0] = 2.0;
+  material.epsilon_r.s[1] = 3.0;
+  material.epsilon_r.s[2] = 4.0;
+  material.mu_r.s[0] = 1.0;
+  material.mu_r.s[1] = 1.5;
+  material.mu_r.s[2] = 2.0;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({material}, periodic, ProblemType::DRIVEN, mesh);
+
+  mfem::ND_FECollection nd_fec(order, 2);
+  mfem::L2_FECollection l2_fec(order, 2);
+  FiniteElementSpace nd_fespace(mesh, &nd_fec), l2_fespace(mesh, &l2_fec);
+
+  GridFunction E(nd_fespace, complex), B(l2_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + 0.2 * x(0);
+                                        v(1) = std::cos(x(0)) + x(1) * x(1);
+                                      });
+  mfem::FunctionCoefficient fbr([](const mfem::Vector &x)
+                                { return 0.3 + x(0) - 0.7 * x(1); });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(2,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(0) * x(1) - 0.1;
+                                          v(1) = std::sin(x(0) + x(1));
+                                        });
+    mfem::FunctionCoefficient fbi([](const mfem::Vector &x)
+                                  { return std::cos(x(0)) + 0.4 * x(1); });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  mfem::L2_FECollection viz_fec(order, 2);
+  mfem::ParFiniteElementSpace viz_scalar(&pmesh, &viz_fec), viz_vector(&pmesh, &viz_fec, 2);
+
+  const double scaling = 1.7;
+  auto CheckField = [](const mfem::ParGridFunction &val, const mfem::ParGridFunction &ref)
+  {
+    const double *v = val.HostRead();
+    const double *r = ref.HostRead();
+    double max_diff = 0.0, max_ref = 0.0;
+    for (int i = 0; i < ref.Size(); i++)
+    {
+      max_diff = std::max(max_diff, std::abs(v[i] - r[i]));
+      max_ref = std::max(max_ref, std::abs(r[i]));
+    }
+    CAPTURE(max_diff, max_ref);
+    CHECK(max_diff <= 1.0e-11 * std::max(max_ref, 1.0));
+  };
+
+  SECTION("Electric energy density")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_E, mesh, mat_op,
+                             E.ParFESpace(), nullptr, viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(&E, nullptr, val);
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> legacy(E, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Magnetic energy density")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_M, mesh, mat_op, nullptr,
+                             B.ParFESpace(), viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(nullptr, &B, val);
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> legacy(B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Poynting vector")
+  {
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::POYNTING, mesh, mat_op,
+                             E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
+    eval.Eval(&E, &B, val);
+    PoyntingVectorCoefficient legacy(E, B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+}
+
 TEST_CASE("SurfaceFunctional FarField", "[surfacefunctional][Serial][Parallel][GPU]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
@@ -1830,6 +2076,191 @@ TEST_CASE("InterpolationOperator Ceed Probes", "[surfacefunctional][Serial][Para
   }
 }
 #endif
+
+TEST_CASE("PointFieldEvaluator Boundary Viz Fields",
+          "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = nonconformal ? MakeNCInterfaceMesh(comm, elem_type)
+                           : MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, false), B(rt_fespace, false);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  E.Real().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+
+  const int lod = order;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> marker(bdr_attr_max);
+  marker = 1;
+
+  auto TestKind = [&](PointFieldEvaluator::Kind kind,
+                      const mfem::ParFiniteElementSpace &fes,
+                      const mfem::ParGridFunction &U)
+  {
+    PointFieldEvaluator viz(kind, *mesh, marker, fes, lod);
+
+    // The validity decision must be identical on all ranks; interior surfaces split
+    // across processes fall back (consistently).
+    bool valid = viz.IsValid();
+    bool valid_and = valid, valid_or = valid;
+    Mpi::GlobalAnd(1, &valid_and, comm);
+    Mpi::GlobalOr(1, &valid_or, comm);
+    REQUIRE(valid_and == valid_or);
+    if (!valid)
+    {
+      return;
+    }
+
+    Vector buffer(viz.BufferSize());
+    buffer.UseDevice(true);
+    viz.EvalBuffer(U, buffer);
+    const double *buf = buffer.HostRead();
+    const auto &bases = viz.BufferBases();
+    const int component_stride = viz.BufferSize() / 3;
+
+    BdrFieldVectorCoefficient legacy(U);
+    mfem::Vector V(3);
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const auto &RefG =
+          *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), lod, 1);
+      auto *T = pmesh.GetBdrElementTransformation(i);
+      for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+      {
+        const auto &ip = RefG.RefPts.IntPoint(j);
+        T->SetIntPoint(&ip);
+        legacy.Eval(V, *T, ip);
+        for (int c = 0; c < 3; c++)
+        {
+          const double val = buf[bases[i] + j + c * component_stride];
+          CAPTURE(i, j, c, V(c), val);
+          CHECK(val == Catch::Approx(V(c)).epsilon(1.0e-10).margin(1.0e-13));
+        }
+      }
+    }
+  };
+
+  TestKind(PointFieldEvaluator::Kind::FIELD_E, nd_fespace, E.Real());
+  TestKind(PointFieldEvaluator::Kind::FIELD_B, rt_fespace, B.Real());
+
+  // Material-dependent boundary visualization kinds (surface charge, surface current,
+  // boundary energy densities) against the corresponding legacy coefficients.
+  const double scaling = 1.7;
+  auto TestKindCoeff = [&](PointFieldEvaluator::Kind kind,
+                           const mfem::ParFiniteElementSpace &fes,
+                           mfem::Coefficient *legacy_s, mfem::VectorCoefficient *legacy_v)
+  {
+    PointFieldEvaluator viz(kind, *mesh, marker, fes, mat_op, lod, scaling);
+    const int nc = viz.BufferNumComp();
+    bool valid = viz.IsValid();
+    bool valid_and = valid, valid_or = valid;
+    Mpi::GlobalAnd(1, &valid_and, comm);
+    Mpi::GlobalOr(1, &valid_or, comm);
+    REQUIRE(valid_and == valid_or);
+    if (!valid)
+    {
+      return;
+    }
+    Vector buffer(viz.BufferSize());
+    buffer.UseDevice(true);
+    viz.EvalBuffer(kind == PointFieldEvaluator::Kind::CURRENT_J ||
+                           kind == PointFieldEvaluator::Kind::ENERGY_M
+                       ? B.Real()
+                       : E.Real(),
+                   buffer);
+    const double *buf = buffer.HostRead();
+    const auto &bases = viz.BufferBases();
+    const int component_stride = viz.BufferSize() / nc;
+    mfem::Vector V(3);
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const auto &RefG =
+          *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), lod, 1);
+      auto *T = pmesh.GetBdrElementTransformation(i);
+      for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+      {
+        const auto &ip = RefG.RefPts.IntPoint(j);
+        T->SetIntPoint(&ip);
+        if (nc == 1)
+        {
+          const double ref = legacy_s->Eval(*T, ip);
+          const double val = buf[bases[i] + j];
+          CAPTURE(i, j, ref, val);
+          CHECK(val == Catch::Approx(ref).epsilon(1.0e-10).margin(1.0e-13));
+        }
+        else
+        {
+          legacy_v->Eval(V, *T, ip);
+          for (int c = 0; c < 3; c++)
+          {
+            const double val = buf[bases[i] + j + c * component_stride];
+            CAPTURE(i, j, c, V(c), val);
+            CHECK(val == Catch::Approx(V(c)).epsilon(1.0e-10).margin(1.0e-13));
+          }
+        }
+      }
+    }
+  };
+  {
+    BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> q_legacy(
+        &E.Real(), nullptr, mat_op, true, mfem::Vector(), scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::FLUX_Q, nd_fespace, &q_legacy, nullptr);
+  }
+  {
+    BdrSurfaceCurrentVectorCoefficient j_legacy(B.Real(), mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::CURRENT_J, rt_fespace, nullptr, &j_legacy);
+  }
+  {
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> ue_legacy(E, mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::ENERGY_E, nd_fespace, &ue_legacy, nullptr);
+  }
+  {
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> um_legacy(B, mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::ENERGY_M, rt_fespace, &um_legacy, nullptr);
+  }
+}
 
 TEST_CASE("FaceNbrFieldExchange", "[surfacefunctional][Serial][Parallel]")
 {


### PR DESCRIPTION
## Summary

This is part two of the GPU postprocessing performance stack. It builds on the libCEED output-functional infrastructure from part one and changes supported ParaView/GridFunction field materialization to use libCEED point-field evaluators.

The goal is to preserve the `origin/main` field-output contract while avoiding the dominant host-side coefficient/GridFunction materialization cost in output-heavy GPU runs.

## What changed

- Add `CeedParaViewDataCollection` point-field payload support.
- Add domain and boundary point-field evaluators.
- Route supported `origin/main` output fields through libCEED point evaluators:
  - `E`
  - `B`
  - `Q_s`
  - `J_s`
  - `U_e`
  - `U_m`
  - `S`
  - `V`
  - `A`
  - `En`
  - `Bt`
  - `Sn`
- Preserve the existing `E0_<idx>_{real,imag}` wave-port mode-profile fields on their existing coefficient path.
- Add scalar H1 point-field support for `V` and `En`.
- Add vector H(curl) point-field support for `A` and `Bt`.
- Add dedicated BoundaryMode `Sn` point-field qfunction support.
- Treat 2D as a supported point-field path, not a legacy/special-case path.
- Support scalar 2D `B` and vector 3D `B` with the expected component counts.
- Use the direct point-field path for nonconforming-AMR output by default.
- Use structural NC trace keys and mapped integration rules rather than coordinate quantization.
- Cache static VTU mesh/header state and prewarm point-field operators.
- Add focused 2D/3D boundary visualization regression coverage.

## Field-output contract

The field-name audit on the equivalent pre-cleanup implementation found no added or removed ParaView field names relative to the base/`origin/main` contract:

```text
worktree-only []
base-only []
```

The preserved field set includes:

```text
A
B, B_real, B_imag
Bt_real, Bt_imag
E, E_real, E_imag
E0_<idx>_real, E0_<idx>_imag
En, En_real, En_imag
Indicator
J_s, J_s_real, J_s_imag
Q_s, Q_s_real, Q_s_imag
Rank
S
Sn
U_e
U_m
V
```

## Historical performance results

The following P4 measurement used the equivalent final implementation before history cleanup. It is the final AMR stage of `examples/transmon/transmon_amr.json`, run with scratch output enabling both GridFunction and ParaView output.

| Timer | origin/main | final stack | Change |
|---|---:|---:|---:|
| Total | 978.325 s | 599.639 s | -38.7% |
| ParaView | 198.085 s | 4.416 s | -97.8% |
| Grid function | 165.532 s | 8.055 s | -95.1% |
| Output-related subtotal | 364.419 s | 20.783 s | -94.3% |

That transmon AMR run preserved output integrity:

- 574 files,
- 2.2 GB output tree.

These are workload-specific historical measurements, not a current branch-wide performance claim. Later one-shot profiling found regressions in short-dipole far-field setup and CPW ParaView output; those remain under investigation.

## GPU transfer behavior

Nsight Systems captures of the equivalent pre-cleanup implementation showed output-payload-scale transfer behavior:

- host-to-device traffic in the ParaView range was effectively zero,
- device-to-host traffic was proportional to output size,
- no unified-memory migration summaries appeared.

Covered profile cases included:

- 3D Driven,
- 3D Eigenmode,
- 3D Electrostatic,
- 3D Magnetostatic,
- 3D Transient,
- 2D Driven,
- 2D Eigenmode,
- 2D Electrostatic,
- 2D Magnetostatic,
- 2D Transient,
- 2D BoundaryMode.

## Stack relationship

This PR is stacked on #814:

- `hughcars/gpu-postprocessing-output-functionals-part-one`

Please review the diff against that branch, not against `main`.

Review focus for this PR should be:

- field-name preservation,
- point-field routing,
- VTU payload sizing and offsets,
- 2D/3D component counts,
- nonconforming-AMR mapped-rule handling,
- explicit evaluator/assembly failure behavior.

## Testing

The clean part-two stack was previously built through Spack and smoke-tested on the P4 CUDA system. Additional validation on the equivalent implementation before history cleanup included:

- full non-transmon GPU suite: 35 / 35 passed,
- all 35 configured GPU and libCEED CUDA cases,
- targeted `transmon_amr` with ParaView + GridFunction output passed,
- final transmon AMR output tree: 574 files, 2.2 GB.

For this latest rebase:

- part one was rebased onto current `origin/main`,
- part two was rebased as one commit directly on part one,
- `git diff --check` passed,
- the C++ formatting dry run passed.

Known validation limitations and open issues:

- The latest rebased part-two head has not yet completed a fresh Spack build and serial/MPI test pass.
- The 2D `cavity2d` point-field path currently has an unresolved `component_stride` buffer-packing assertion.
- One-shot far-field and CPW ParaView performance regressions remain under investigation.
- HIP/AMD runtime validation was not run on the NVIDIA CUDA machine.
