### PR TITLE
Improve ports documentation in reference.md

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -367,7 +367,12 @@ For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
 
 To Do:
 
-  - Fix dembedding sign and normal sign convention (outward vs inward normal)
+  - Fix dembedding sign and normal sign convention (outward vs inward normal):
+    In the boundarymode-2d branch, the normal sign convention: ``+\hat{\bm{n}}`` is the outward mesh normal.
+    The mode eigenvalue gives ``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the
+    ``+\hat{\bm{n}}`` direction. De-embedding
+    ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift the
+    reference plane toward the device (removing waveguide), consistent with [[8]](#References).
   - Update with 1/2 factors if we move to average power definition
   - link to impedance post-processing docs section once available.
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -259,7 +259,7 @@ respectively. If ``Z`` is a combination of LRC responses, these add in parallel
 Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
 
 In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
-``Ls``, ``Rs``, ``Cs`` corresponding to ``Z_s``. For a single-element port, these will just be
+``L_s``, ``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
 converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
 to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
 Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
@@ -270,9 +270,6 @@ Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
 ```
 
 Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
-
-An excited lumped port must be purely resistive, with nonzero ``R`` or ``Rs`` and zero inductance
-and capacitance.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
 tangential component of the incident field at an excited port boundary by
@@ -323,8 +320,8 @@ For more information on the implementation of numeric wave ports, see [[3]](#Ref
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
 determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
-form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. A 3D
-wave port uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
+form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. The
+wave port configuration uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
 ``V`` and mode polarity, while
 [boundary-mode impedance postprocessing](config/reference.md#config-boundaries-postprocessing-impedance)
 can additionally define a current path for ``I``.
@@ -356,9 +353,7 @@ magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode field
 
 where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
 constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
-field component on the port. The current path is a postprocessing convention and does not set the
-3D wave-port polarity. The current postprocessor currently integrates ``\bm{B}_t`` directly, so
-``Z_{VI}`` follows this ``\bm{H}_t`` definition when ``\mu_r = 1`` along the contour.
+field component on the port.
 
 **Impedance.** The *power-voltage* characteristic impedance is defined as
 
@@ -369,7 +364,7 @@ Z_{PV} = \frac{|V|^2}{P}
 where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
 peak-phasor power flux through the port cross-section, equal to twice the time-averaged power. For
 TEM modes with a voltage path between the two conductors, ``Z_{PV}`` reduces to the conventional TEM
-characteristic impedance. For 3D wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
+characteristic impedance. For wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
 specified.
 
 As a diagnostic, boundary-mode impedance postprocessing also reports the *voltage-current*

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -17,8 +17,8 @@ SPDX-License-Identifier: Apache-2.0
   - Boundary mode: guided modes on a waveguide cross section.
 
 Here, we will summarize the mathematics of each, provide a description of boundary conditions, and
-specify convention choices. This should be read in conjunction with the "User Guide" and
-"Configuration File" documentation.
+specify convention choices. This should be read in conjunction with the [User
+Guide](guide/guide.md) and [Configuration File](config/config.md) documentation.
 
 ## Mathematical background
 
@@ -302,8 +302,9 @@ The incident field ``\bm{E}^{inc}(\bm{x},t)`` is
 ```
 
 where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the frequency domain
-formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options include a
-sinusoidal, Gaussian, modulated Gaussian, or step excitation.
+formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options for
+[`config["Solver"]["Transient"]["Excitation"]`](config/reference.md#config-solver-transient-excitation)
+include a sinusoidal, Gaussian, modulated Gaussian, or step excitation.
 
 For AC simulations, a surface-current source and a resistive lumped port with the same geometry
 produce right-hand-side source terms with the same spatial form, up to an overall normalization. A

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,6 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
+*Palace* calculate solutions of Maxwell's equation for five different "Problem Types":
+
+  - Electrostatics: time-independent voltage sources,
+  - Magnetostatics: time-independent current sources,
+  - Driven: monochromatic excitations ``\bm{U}^{inc}(f)``,
+  - Eigenmode: resonances of the system,
+  - Transient: time-dependant excitations ``\bm{U}^{inc}(t)``.
+
+Here, we will summarize the mathematics of each, provide a description of boundary conditions, and
+specify convention choices. This should be read in conjunction with the "User Guide" and
+"Configuration File" documentation.
+
 ## Mathematical background
 
 The solver computes a finite element approximation to the three-dimensional, time-harmonic
@@ -170,40 +182,96 @@ The eigenmodes are normalized such that they have unit norm and their mean phase
 
 ## Lumped ports and wave ports
 
-For lumped port boundaries, the surface impedance can be related to an equivalent circuit
-impedance, ``Z``. There are two common cases:
+Ports have two effects. First, they impose a boundary condition that relates the electric and
+magnetic fields on the surface. Second, for the driven and transient solver, they can excite the
+system with an incident field.
 
- 1. *Rectangular ports*: ``Z = Z_s l / w``, where ``l`` and ``w`` are the length and width
-    of the port, respectively (length here is defined as the distance between the two
-    conductors).
+For lumped ports, the boundary condition is an impedance condition as described above — tangential
+fields satisfy ``\bm{E}_t = Z_s \bm{H}_t \times \bm{n}``. Here ``Z_s`` is the physical surface
+impedance (per unit area) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
+analytically specified.
 
- 2. *Coaxial ports*: ``Z = Z_s \ln(b/a) / 2\pi``, where ``a`` and ``b`` denote the inner and
-    outer radii of the port, respectively.
+For wave ports, a solver performs eigenmode simulations on the boundary to find supported modes of a
+transmission line with the wave-port cross section. The boundary modes will be used to relate
+``\bm{E}`` and ``\bm{H}``, which will only be impedance-like for TEM, TE or TM modes. Additionally,
+users can choose which of the found modes to excite.
 
-A lumped parallel RLC circuit boundary has a circuit impedance
+We normalize port fields so the total power flow is ``\vert P^{inc} \vert = 1~\mathrm{W}``, where
 
-```math
-\frac{1}{Z} = \frac{1}{R}+\frac{1}{i\omega L}+i\omega C \,.
-```
-
-Thus, the relationships between the circuit and surface element parameters for the user to
-specify are given by ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``, where
-``\alpha = w/l`` for a rectangular port or ``\alpha = 2\pi / \ln(b/a)`` for a coaxial
-port.
-
-For multielement lumped ports, the effective circuit impedance is given by
+[TODO: Right now this is peak power, not the average. This is the Palace convention, but needs
+adjusting].
 
 ```math
-\frac{1}{Z} = \sum_k \frac{1}{Z_k} \,.
+P^{inc} = V^{inc} [I^{inc}]^*  = \sum_e \int_{\Gamma_e} dS_e \,  \bm{n}_e \cdot (\bm{E}_e^{inc} \times [\bm{H}_e^{inc}]^*).
 ```
 
-That is, the circuit impedances of each port contributing to the multielement port add in
-parallel. For the specific case of a two element multielement port with two identical
-lumped elements, we have ``Z = (1/Z_1 + 1/Z_2)^{-1} = Z_k / 2``, where ``Z_k`` is the
-circuit impedance of a single port element.
+Here we have allowed for the possibility that a port can be made of disjoint surface elements ``e``,
+which separately contribute to the Poynting vector.
+
+There is an additional normalization related to voltages and currents. For AC simulations of
+microwave networks, circuit ``V`` and ``I`` are not generally well defined and have to be fixed by
+convention [11,12]. This is tantamount to relating the circuit characteristic impedance
+
+```math
+Z = \frac{V^{inc}}{I^{inc}} = \frac{\vert V^{inc} \vert^2}{[P^{inc}]^*},
+```
+
+to the physical surface (wave) impedance ``Z_s``. We discuss this for each port type below.
+
+### Lumped Ports
+
+Lumped ports in *Palace* can be composed of two types of elements:
+
+ 1. *Rectangular*: The incident field is ``\bm{E}^{inc} = E_0 \, \hat{\bm{l}}``. Here ``E_0`` is a
+    normalization constant and ``\hat{\bm{l}}`` is the user-defined polarization direction, which
+    should point between two conductors. We denote the length of the port along the polarization as
+    ``l`` and the perpendicular width as ``w``.
+
+ 2. *Coaxial*: ``\bm{E}^{inc} = {E_0 r_0} \hat{\bm{r}} / {r}``, where ``E_0 r_0`` is a
+    normalization constant, ``r`` is the distance from the port center, and ``\hat{\bm{r}}`` is the
+    unit radial vector. We denote the inner and outer radii as ``a`` and ``b``.
+
+We define the voltage across each element as averages over the area, rather than line integrals. For
+an electric field ``\bm{E}``, the voltage across element ``e`` is:
+
+ 1. *Rectangular*: ``V_{e} = \int_{\Gamma_e}dS\, \bm{E} \cdot\hat{\bm{l}}_e / w_e``,
+
+ 2. *Coaxial*: ``V_{e} = \int_{\Gamma_e}dS\, \bm{E} \cdot\hat{\bm{r}}_e / (2 \pi r)``.
+
+This is a convention choice. For electrostatics or for TEM and TM transmission lines, the voltage in
+the port plane is path-independent between different conductors; in general, it is not.
+
+The power normalization and voltage convention now fix the coefficients ``E_0, r_0`` in the port
+definition and relate the physical surface impedance to the circuit impedance. For each element:
+
+ 1. *Rectangular*: ``Z = Z_s l / w``,
+
+ 2. *Coaxial*: ``Z = Z_s \ln(b/a) / (2\pi)``,
+
+which we also write as ``Z = Z_s / \alpha``  where ``\alpha = w/l`` or ``\alpha = 2\pi / \ln(b/a)``
+respectively. If ``Z`` is a combination of LRC responses, these add in parallel
+
+```math
+\frac{1}{Z} = \frac{1}{R}+\frac{1}{i\omega L}+i\omega C.
+```
+
+Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
+
+In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
+``L_s`` ,``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
+converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
+to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
+Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
+surface impedance depending on their shape ``\alpha_e``:
+
+```math
+Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
+```
+
+Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
-incident field at an excited port boundary by
+tangential component of the incident field at an excited port boundary by
 
 ```math
 \bm{U}^{inc} = -2\gamma_{exc}(\bm{n}\times\bm{E}^{inc})\times\bm{n} \,, \qquad
@@ -216,19 +284,10 @@ excited port: the port resistance ``R`` when ``R > 0``, or the impedance of free
 ``Z_0`` for a purely reactive port with ``R = 0`` (see the discussion of reactive port
 excitation below). The excitation coefficient ``\gamma_{exc}`` is in general distinct from
 the termination coefficient ``\gamma = i\omega/Z_s`` appearing in the Robin boundary
-condition, and the two coincide for a purely resistive port. The incident fields for lumped
-ports depend on the port shape:
+condition, and the two coincide for a purely resistive port. The excitation amplitude is
+fixed at the unit-power mode normalization described above, ``1~\mathrm{W}``.
 
- 1. *Rectangular ports*: ``\bm{E}^{inc} = E_0 \, \hat{\bm{l}}``, where ``E_0`` is a uniform
-    constant field strength and ``\hat{\bm{l}}`` a unit vector defining the direction of
-    polarization on the port (typically should be the direction between the two conductors).
-
- 2. *Coaxial ports*: ``\bm{E}^{inc} = \frac{E_0 r_0}{r} \, \hat{\bm{r}}``, where ``E_0`` is
-    again a uniform constant field strength, ``r_0`` is a characteristic length for the
-    port, ``r`` is the distance from the port center, and ``\hat{\bm{r}}`` a unit vector
-    specifying the port radial direction.
-
-In the time domain formulation, the source term ``\bm{U}^{inc}`` appears as
+In the time-domain formulation, the source term ``\bm{U}^{inc}`` appears as
 
 ```math
 \bm{U}^{inc} = -2 R_{ref}^{-1}\left(\bm{n}\times\frac{\partial\bm{E}^{inc}}{\partial t}\right)
@@ -241,9 +300,28 @@ The incident field ``\bm{E}^{inc}(\bm{x},t)`` is
 \bm{E}^{inc}(\bm{x},t) = p(t)\bm{E}^{inc}(\bm{x})
 ```
 
-where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the frequency
-domain formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible
-options include a sinusoidal, Gaussian, modulated Gaussian, or step excitation.
+where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the frequency domain
+formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options include a
+sinusoidal, Gaussian, modulated Gaussian, or step excitation.
+
+### Wave ports
+
+Numeric wave ports assume a field with known normal-direction dependence
+``\bm{E}(\bm{x}) = \bm{e}(\bm{x}_t)e^{ik_n x_n}`` where ``k_n`` is the propagation constant. For each operating
+frequency ``\omega``, a two-dimensional eigenvalue problem is solved on the port yielding the mode
+shapes ``\bm{e}_m`` and associated propagation constants ``k_{n,m}``. These are used in the full 3D
+model where the Robin port boundary condition has coefficient
+``\gamma = i\text{Re}\{k_{n,m}\}/\mu_r`` and the computed mode is used to compute the incident field in the
+source term ``\bm{U}^{inc}`` at excited ports.
+
+For more information on the implementation of numeric wave ports, see [[3]](#References).
+
+To Do:
+
+  - Discuss V / I / Z convention choice here.
+  - Fix dembedding sign and normal sign convention (outward vs inward normal)
+
+### Scattering Parameters
 
 In the frequency domain, the scattering parameters can be postprocessed from the computed
 electric field for each lumped port with boundary ``\Gamma_i`` as
@@ -293,23 +371,12 @@ waves (an ``R = 0`` port supports no incident traveling wave).
 In the time domain, the time histories of the port voltages can be Fourier-transformed to
 get their frequency domain representation for scattering parameter calculation.
 
-Numeric wave ports assume a field with known normal-direction dependence
-``\bm{E}(\bm{x}) = \bm{e}(\bm{x}_t)e^{ik_n x_n}`` where ``k_n`` is the propagation constant.
-For each operating frequency ``\omega``, a two-dimensional eigenvalue problem is solved on
-the port yielding the mode shapes ``\bm{e}_m`` and associated propagation constants
-``k_{n,m}``. These are used in the full 3D model where the Robin port boundary condition has
-coefficient ``\gamma = i\text{Re}\{k_{n,m}\}/\mu_r`` and the computed mode is used to
-compute the incident field in the source term ``\bm{U}^{inc}`` at excited ports. Scattering
-parameter postprocessing takes the same form as the lumped port counterpart using the
-computed modal solutions. Since the propagation constants are known for each wave port,
-scattering parameter de-embedding can be performed by specifying an offset distance ``d``
-for each port:
+For wave ports, since the propagation constants are known, we allow additional de-embedding by
+specifying an offset distance ``d`` for each wave port:
 
 ```math
 \tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j} \,.
 ```
-
-For more information on the implementation of numeric wave ports, see [[3]](#References).
 
 ## Adaptive driven solver and reduced-order modeling
 
@@ -588,7 +655,7 @@ quality factor for interface ``j`` is given by
 where ``\bm{E}_n`` denotes the normal field to the interface and
 ``\bm{E}_t = \bm{E}-\bm{E}_n`` denotes the tangential field.
 
-## Lumped parameter extraction
+## Electrostatic Simulations
 
 For electrostatic simulations, the Maxwell capacitance matrix is computed in the following
 manner. First, the Laplace equation subject to Dirichlet boundary conditions is solved for
@@ -615,6 +682,8 @@ capacitance matrix, ``\bm{C}``, are given by
 ```math
 \bm{C}_{ij} = \mathcal{E}(V_i+V_j)-\frac{1}{2}(\bm{C}_{ii}+\bm{C}_{jj}) \,.
 ```
+
+## Magnetostatic Simulations
 
 Magnetostatic problems for inductance matrix extraction are based on the magnetic vector
 potential formulation:
@@ -761,18 +830,17 @@ previous section and implemented in *Palace*.
 
 ## References
 
-[1] J.-M. Jin, _The Finite Element Method in Electromagnetics_, Wiley-IEEE Press, Hoboken,
+[1] J.-M. Jin, *The Finite Element Method in Electromagnetics*, Wiley-IEEE Press, Hoboken,
 NJ, Third edition, 2014.\
-[2] P. Monk, _Finite Element Methods for Maxwell's Equations_, Oxford University Press,
+[2] P. Monk, *Finite Element Methods for Maxwell's Equations*, Oxford University Press,
 Oxford, 2003.\
 [3] L. Vardapetyan and L. Demkowicz, Full-wave analysis of dielectric waveguides at a given
-frequency, _Mathematics of Computation_ 72 (2003) 105-129.\
+frequency, *Mathematics of Computation* 72 (2003) 105-129.\
 [4] J. Wenner, R. Barends, R. C. Bialczak, et al., Surface loss of superconducting coplanar
-waveguide resonators, _Applied Physics Letters_ 99, 113513 (2011).\
-[5] S. Nicaise, On Zienkiewicz-Zhu error estimators for Maxwell’s equations, _Comptes Rendus
-Mathematique_ 340 (2005) 697-702.\
+waveguide resonators, *Applied Physics Letters* 99, 113513 (2011).\
+[5] S. Nicaise, On Zienkiewicz-Zhu error estimators for Maxwell’s equations, *Comptes Rendus Mathematique* 340 (2005) 697-702.\
 [6] J. A, Stratton and L. J. Chu, Diffraction theory of Electromagnetic
-Waves, _Physical Review_, 56, 1, (1939), 99-107.\
+Waves, *Physical Review*, 56, 1, (1939), 99-107.\
 [7] P. Benner, D. C. Sorensen, and V. Mehrmann, Eds., _Dimension Reduction of
 Large-Scale Systems_, Lecture Notes in Computational Science and Engineering,
 vol. 45, Springer, 2005. doi: [10.1007/3-540-27909-1](https://doi.org/10.1007/3-540-27909-1).\
@@ -784,4 +852,6 @@ sampling, _Advances in Computational Mathematics_ 49, 92 (2023). doi:
 [10] D. Pradovera, Interpolatory rational model order reduction of parametric
 problems lacking uniform inf-sup stability, _SIAM Journal on Numerical
 Analysis_ 58 (2020) 2265-2293. doi:
-[10.1137/19M1269695](https://doi.org/10.1137/19M1269695).
+[10.1137/19M1269695](https://doi.org/10.1137/19M1269695).\
+[11] R. B. Marks and D. F. Williams, A general waveguide circuit theory, *J. Res. Natl. Inst. Stan.* 97, 533 (1992).\
+[12] D. M. Pozar, *Microwave engineering*, Fourth edition. John Wiley & Sons, Hoboken, NJ, 2012.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -305,6 +305,16 @@ where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the fre
 formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options include a
 sinusoidal, Gaussian, modulated Gaussian, or step excitation.
 
+For AC simulations, a surface-current source and a resistive lumped port with the same geometry
+produce right-hand-side source terms with the same spatial form, up to an overall normalization. A
+surface-current source is normalized to unit current and only drives the right-hand side: it
+prescribes no boundary condition and provides no termination or dissipation. A lumped port is
+normalized to the unit incident power described above and also imposes its impedance (Robin)
+boundary condition, so a nonzero resistance allows energy to leave the model through the port. Thus,
+use a surface current for an ideal nondissipative drive and a lumped port when a terminating
+impedance is part of the physical model. Without any other loss, the driven system can become
+ill-conditioned near an eigenfrequency.
+
 ### Wave ports
 
 Numeric wave ports assume a field with known normal-direction dependence

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -311,9 +311,8 @@ surface-current source is normalized to unit current and only drives the right-h
 prescribes no boundary condition and provides no termination or dissipation. A lumped port is
 normalized to the unit incident power described above and also imposes its impedance (Robin)
 boundary condition, so a nonzero resistance allows energy to leave the model through the port. Thus,
-use a surface current for an ideal nondissipative drive and a lumped port when a terminating
-impedance is part of the physical model. Without any other loss, the driven system can become
-ill-conditioned near an eigenfrequency.
+surface current should be used for an ideal nondissipative drive and a lumped port when a terminating
+impedance is part of the physical model.
 
 ### Wave ports
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
-*Palace* calculate solutions of Maxwell's equation for five different "Problem Types":
+*Palace* calculates solutions of Maxwell's equation for five different "Problem Types":
 
   - Electrostatics: time-independent voltage sources,
   - Magnetostatics: time-independent current sources,
@@ -316,10 +316,67 @@ source term ``\bm{U}^{inc}`` at excited ports.
 
 For more information on the implementation of numeric wave ports, see [[3]](#References).
 
+For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
+determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
+to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
+form, wave port ``V`` and ``I`` are obtained from path integrals along user-specified paths on the
+port cross-section.
+
+**Voltage.** The mode voltage is defined as a path integral of the electric field:
+
+```math
+V = \int_\mathcal{C} \bm{E} \cdot d\bm{l}
+```
+
+where ``\mathcal{C}`` is a user-specified path between two conductors on the port cross-section. For
+TEM and TM modes, this integral depends only on the endpoints and not on the path between them; for
+TE and hybrid modes, it is path-dependent [[11]](#References).
+
+**Current.** The mode current is defined as a closed-loop path integral of the in-plane magnetic
+field:
+
+```math
+I = \oint_\mathcal{L} \bm{H}_t \cdot d\bm{l}
+```
+
+where ``\mathcal{L}`` is a user-specified closed contour encircling one conductor. The in-plane
+magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode fields via
+
+```math
+\bm{B}_t = -\frac{k_n}{\omega}(\hat{\bm{n}}\times\bm{E}_t)
+    + \frac{1}{i\omega}(\nabla_t E_n \times\hat{\bm{n}})
+```
+
+where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
+constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
+field component on the port.
+
+**Impedance.** Two impedance quantities are reported. The *power-voltage* characteristic impedance
+is defined as
+
+```math
+Z_{PV} = \frac{|V|^2}{P}
+```
+
+where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
+time-averaged power flux through the port cross-section. For TEM modes with a voltage path between the
+two conductors, ``Z_{PV}`` reduces to the conventional TEM characteristic impedance.
+
+As a diagnostic, the *voltage-current* impedance magnitude is also reported:
+
+```math
+Z_{VI} = |V| / |I|
+```
+
+where ``V`` and ``I`` are computed independently from different paths. Note that independently
+specifying both voltage and current does not in general define a valid characteristic impedance [[11]](#References).
+For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
+
 To Do:
 
-  - Discuss V / I / Z convention choice here.
   - Fix dembedding sign and normal sign convention (outward vs inward normal)
+  - Update with 1/2 factors if we move to average power definition
+  - link to impedance post-processing docs section once available.
 
 ### Scattering Parameters
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,13 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
-*Palace* calculates solutions of Maxwell's equation for five different "Problem Types":
+*Palace* calculates solutions of Maxwell's equation for six different "Problem Types":
 
   - Electrostatics: time-independent voltage sources,
   - Magnetostatics: time-independent current sources,
   - Driven: monochromatic excitations ``\bm{U}^{inc}(f)``,
   - Eigenmode: resonances of the system,
-  - Transient: time-dependant excitations ``\bm{U}^{inc}(t)``.
+  - Transient: time-dependent excitations ``\bm{U}^{inc}(t)``,
+  - Boundary mode: guided modes on a waveguide cross section.
 
 Here, we will summarize the mathematics of each, provide a description of boundary conditions, and
 specify convention choices. This should be read in conjunction with the "User Guide" and
@@ -188,7 +189,7 @@ system with an incident field.
 
 For lumped ports, the boundary condition is an impedance condition as described above — tangential
 fields satisfy ``\bm{E}_t = Z_s \bm{H}_t \times \bm{n}``. Here ``Z_s`` is the physical surface
-impedance (per unit area) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
+impedance (per square) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
 analytically specified.
 
 For wave ports, a solver performs eigenmode simulations on the boundary to find supported modes of a
@@ -198,8 +199,8 @@ users can choose which of the found modes to excite.
 
 We normalize port fields so the total power flow is ``\vert P^{inc} \vert = 1~\mathrm{W}``, where
 
-[TODO: Right now this is peak power, not the average. This is the Palace convention, but needs
-adjusting].
+*Palace* uses peak phasors for this convention, so ``P^{inc}`` is twice the time-averaged power for
+a propagating mode.
 
 ```math
 P^{inc} = V^{inc} [I^{inc}]^*  = \sum_e \int_{\Gamma_e} dS_e \,  \bm{n}_e \cdot (\bm{E}_e^{inc} \times [\bm{H}_e^{inc}]^*).
@@ -258,7 +259,7 @@ respectively. If ``Z`` is a combination of LRC responses, these add in parallel
 Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
 
 In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
-``L_s`` ,``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
+``Ls``, ``Rs``, ``Cs`` corresponding to ``Z_s``. For a single-element port, these will just be
 converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
 to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
 Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
@@ -269,6 +270,9 @@ Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
 ```
 
 Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
+
+An excited lumped port must be purely resistive, with nonzero ``R`` or ``Rs`` and zero inductance
+and capacitance.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
 tangential component of the incident field at an excited port boundary by
@@ -319,8 +323,11 @@ For more information on the implementation of numeric wave ports, see [[3]](#Ref
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
 determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
-form, wave port ``V`` and ``I`` are obtained from path integrals along user-specified paths on the
-port cross-section.
+form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. A 3D
+wave port uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
+``V`` and mode polarity, while
+[boundary-mode impedance postprocessing](config/reference.md#config-boundaries-postprocessing-impedance)
+can additionally define a current path for ``I``.
 
 **Voltage.** The mode voltage is defined as a path integral of the electric field:
 
@@ -349,20 +356,24 @@ magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode field
 
 where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
 constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
-field component on the port.
+field component on the port. The current path is a postprocessing convention and does not set the
+3D wave-port polarity. The current postprocessor currently integrates ``\bm{B}_t`` directly, so
+``Z_{VI}`` follows this ``\bm{H}_t`` definition when ``\mu_r = 1`` along the contour.
 
-**Impedance.** Two impedance quantities are reported. The *power-voltage* characteristic impedance
-is defined as
+**Impedance.** The *power-voltage* characteristic impedance is defined as
 
 ```math
 Z_{PV} = \frac{|V|^2}{P}
 ```
 
 where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
-time-averaged power flux through the port cross-section. For TEM modes with a voltage path between the
-two conductors, ``Z_{PV}`` reduces to the conventional TEM characteristic impedance.
+peak-phasor power flux through the port cross-section, equal to twice the time-averaged power. For
+TEM modes with a voltage path between the two conductors, ``Z_{PV}`` reduces to the conventional TEM
+characteristic impedance. For 3D wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
+specified.
 
-As a diagnostic, the *voltage-current* impedance magnitude is also reported:
+As a diagnostic, boundary-mode impedance postprocessing also reports the *voltage-current*
+impedance magnitude when a current path is specified:
 
 ```math
 Z_{VI} = |V| / |I|
@@ -372,16 +383,10 @@ where ``V`` and ``I`` are computed independently from different paths. Note that
 specifying both voltage and current does not in general define a valid characteristic impedance [[11]](#References).
 For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
 
-To Do:
-
-  - Fix dembedding sign and normal sign convention (outward vs inward normal):
-    In the boundarymode-2d branch, the normal sign convention: ``+\hat{\bm{n}}`` is the outward mesh normal.
-    The mode eigenvalue gives ``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the
-    ``+\hat{\bm{n}}`` direction. De-embedding
-    ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift the
-    reference plane toward the device (removing waveguide), consistent with [[8]](#References).
-  - Update with 1/2 factors if we move to average power definition
-  - link to impedance post-processing docs section once available.
+The normal convention ``+\hat{\bm{n}}`` is the outward mesh normal. The mode eigenvalue gives
+``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the ``+\hat{\bm{n}}`` direction.
+De-embedding ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift
+the reference plane toward the device (removing waveguide), consistent with [[12]](#References).
 
 ### Scattering Parameters
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -374,7 +374,12 @@ For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
 
 To Do:
 
-  - Fix dembedding sign and normal sign convention (outward vs inward normal)
+  - Fix dembedding sign and normal sign convention (outward vs inward normal):
+    In the boundarymode-2d branch, the normal sign convention: ``+\hat{\bm{n}}`` is the outward mesh normal.
+    The mode eigenvalue gives ``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the
+    ``+\hat{\bm{n}}`` direction. De-embedding
+    ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift the
+    reference plane toward the device (removing waveguide), consistent with [[8]](#References).
   - Update with 1/2 factors if we move to average power definition
   - link to impedance post-processing docs section once available.
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -211,7 +211,7 @@ which separately contribute to the Poynting vector.
 
 There is an additional normalization related to voltages and currents. For AC simulations of
 microwave networks, circuit ``V`` and ``I`` are not generally well defined and have to be fixed by
-convention [11,12]. This is tantamount to relating the circuit characteristic impedance
+convention [[11, 12]](#References). This is tantamount to relating the circuit characteristic impedance
 
 ```math
 Z = \frac{V^{inc}}{I^{inc}} = \frac{\vert V^{inc} \vert^2}{[P^{inc}]^*},
@@ -327,7 +327,7 @@ source term ``\bm{U}^{inc}`` at excited ports.
 For more information on the implementation of numeric wave ports, see [[3]](#References).
 
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
-determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
+determined by the electromagnetic fields and must be fixed by convention [[11, 12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
 form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. The
 wave port configuration uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
@@ -915,8 +915,8 @@ Waves, *Physical Review*, 56, 1, (1939), 99-107.\
 [7] P. Benner, D. C. Sorensen, and V. Mehrmann, Eds., _Dimension Reduction of
 Large-Scale Systems_, Lecture Notes in Computational Science and Engineering,
 vol. 45, Springer, 2005. doi: [10.1007/3-540-27909-1](https://doi.org/10.1007/3-540-27909-1).\
-[8] A. C. Antoulas, _Approximation of Large-Scale Dynamical Systems_, SIAM,
-2005. doi: [10.1137/1.9780898718713](https://doi.org/10.1137/1.9780898718713).\
+[8] A. C. Antoulas, _Approximation of Large-Scale Dynamical Systems_, SIAM, (2005). doi:
+[10.1137/1.9780898718713](https://doi.org/10.1137/1.9780898718713).\
 [9] D. Pradovera, Toward a certified greedy Loewner framework with minimal
 sampling, _Advances in Computational Mathematics_ 49, 92 (2023). doi:
 [10.1007/s10444-023-10091-7](https://doi.org/10.1007/s10444-023-10091-7).\

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
-*Palace* calculate solutions of Maxwell's equation for five different "Problem Types":
+*Palace* calculates solutions of Maxwell's equation for five different "Problem Types":
 
   - Electrostatics: time-independent voltage sources,
   - Magnetostatics: time-independent current sources,
@@ -309,10 +309,67 @@ source term ``\bm{U}^{inc}`` at excited ports.
 
 For more information on the implementation of numeric wave ports, see [[3]](#References).
 
+For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
+determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
+to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
+form, wave port ``V`` and ``I`` are obtained from path integrals along user-specified paths on the
+port cross-section.
+
+**Voltage.** The mode voltage is defined as a path integral of the electric field:
+
+```math
+V = \int_\mathcal{C} \bm{E} \cdot d\bm{l}
+```
+
+where ``\mathcal{C}`` is a user-specified path between two conductors on the port cross-section. For
+TEM and TM modes, this integral depends only on the endpoints and not on the path between them; for
+TE and hybrid modes, it is path-dependent [[11]](#References).
+
+**Current.** The mode current is defined as a closed-loop path integral of the in-plane magnetic
+field:
+
+```math
+I = \oint_\mathcal{L} \bm{H}_t \cdot d\bm{l}
+```
+
+where ``\mathcal{L}`` is a user-specified closed contour encircling one conductor. The in-plane
+magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode fields via
+
+```math
+\bm{B}_t = -\frac{k_n}{\omega}(\hat{\bm{n}}\times\bm{E}_t)
+    + \frac{1}{i\omega}(\nabla_t E_n \times\hat{\bm{n}})
+```
+
+where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
+constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
+field component on the port.
+
+**Impedance.** Two impedance quantities are reported. The *power-voltage* characteristic impedance
+is defined as
+
+```math
+Z_{PV} = \frac{|V|^2}{P}
+```
+
+where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
+time-averaged power flux through the port cross-section. For TEM modes with a voltage path between the
+two conductors, ``Z_{PV}`` reduces to the conventional TEM characteristic impedance.
+
+As a diagnostic, the *voltage-current* impedance magnitude is also reported:
+
+```math
+Z_{VI} = |V| / |I|
+```
+
+where ``V`` and ``I`` are computed independently from different paths. Note that independently
+specifying both voltage and current does not in general define a valid characteristic impedance [[11]](#References).
+For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
+
 To Do:
 
-  - Discuss V / I / Z convention choice here.
   - Fix dembedding sign and normal sign convention (outward vs inward normal)
+  - Update with 1/2 factors if we move to average power definition
+  - link to impedance post-processing docs section once available.
 
 ### Scattering Parameters
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -259,7 +259,7 @@ respectively. If ``Z`` is a combination of LRC responses, these add in parallel
 Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
 
 In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
-``Ls``, ``Rs``, ``Cs`` corresponding to ``Z_s``. For a single-element port, these will just be
+``L_s``, ``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
 converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
 to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
 Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
@@ -270,9 +270,6 @@ Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
 ```
 
 Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
-
-An excited lumped port must be purely resistive, with nonzero ``R`` or ``Rs`` and zero inductance
-and capacitance.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
 tangential component of the incident field at an excited port boundary by
@@ -316,8 +313,8 @@ For more information on the implementation of numeric wave ports, see [[3]](#Ref
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
 determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
-form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. A 3D
-wave port uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
+form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. The
+wave port configuration uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
 ``V`` and mode polarity, while
 [boundary-mode impedance postprocessing](config/reference.md#config-boundaries-postprocessing-impedance)
 can additionally define a current path for ``I``.
@@ -349,9 +346,7 @@ magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode field
 
 where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
 constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
-field component on the port. The current path is a postprocessing convention and does not set the
-3D wave-port polarity. The current postprocessor currently integrates ``\bm{B}_t`` directly, so
-``Z_{VI}`` follows this ``\bm{H}_t`` definition when ``\mu_r = 1`` along the contour.
+field component on the port.
 
 **Impedance.** The *power-voltage* characteristic impedance is defined as
 
@@ -362,7 +357,7 @@ Z_{PV} = \frac{|V|^2}{P}
 where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
 peak-phasor power flux through the port cross-section, equal to twice the time-averaged power. For
 TEM modes with a voltage path between the two conductors, ``Z_{PV}`` reduces to the conventional TEM
-characteristic impedance. For 3D wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
+characteristic impedance. For wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
 specified.
 
 As a diagnostic, boundary-mode impedance postprocessing also reports the *voltage-current*

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -211,7 +211,7 @@ which separately contribute to the Poynting vector.
 
 There is an additional normalization related to voltages and currents. For AC simulations of
 microwave networks, circuit ``V`` and ``I`` are not generally well defined and have to be fixed by
-convention [11,12]. This is tantamount to relating the circuit characteristic impedance
+convention [[11, 12]](#References). This is tantamount to relating the circuit characteristic impedance
 
 ```math
 Z = \frac{V^{inc}}{I^{inc}} = \frac{\vert V^{inc} \vert^2}{[P^{inc}]^*},
@@ -320,7 +320,7 @@ source term ``\bm{U}^{inc}`` at excited ports.
 For more information on the implementation of numeric wave ports, see [[3]](#References).
 
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
-determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
+determined by the electromagnetic fields and must be fixed by convention [[11, 12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
 form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. The
 wave port configuration uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
@@ -868,8 +868,8 @@ Waves, *Physical Review*, 56, 1, (1939), 99-107.\
 [7] P. Benner, D. C. Sorensen, and V. Mehrmann, Eds., _Dimension Reduction of
 Large-Scale Systems_, Lecture Notes in Computational Science and Engineering,
 vol. 45, Springer, 2005. doi: [10.1007/3-540-27909-1](https://doi.org/10.1007/3-540-27909-1).\
-[8] A. C. Antoulas, _Approximation of Large-Scale Dynamical Systems_, SIAM,
-2005. doi: [10.1137/1.9780898718713](https://doi.org/10.1137/1.9780898718713).\
+[8] A. C. Antoulas, _Approximation of Large-Scale Dynamical Systems_, SIAM, (2005). doi:
+[10.1137/1.9780898718713](https://doi.org/10.1137/1.9780898718713).\
 [9] D. Pradovera, Toward a certified greedy Loewner framework with minimal
 sampling, _Advances in Computational Mathematics_ 49, 92 (2023). doi:
 [10.1007/s10444-023-10091-7](https://doi.org/10.1007/s10444-023-10091-7).\

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,6 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
+*Palace* calculate solutions of Maxwell's equation for five different "Problem Types":
+
+  - Electrostatics: time-independent voltage sources,
+  - Magnetostatics: time-independent current sources,
+  - Driven: monochromatic excitations ``\bm{U}^{inc}(f)``,
+  - Eigenmode: resonances of the system,
+  - Transient: time-dependant excitations ``\bm{U}^{inc}(t)``.
+
+Here, we will summarize the mathematics of each, provide a description of boundary conditions, and
+specify convention choices. This should be read in conjunction with the "User Guide" and
+"Configuration File" documentation.
+
 ## Mathematical background
 
 The solver computes a finite element approximation to the three-dimensional, time-harmonic
@@ -170,59 +182,105 @@ The eigenmodes are normalized such that they have unit norm and their mean phase
 
 ## Lumped ports and wave ports
 
-For lumped port boundaries, the surface impedance can be related to an equivalent circuit
-impedance, ``Z``. There are two common cases:
+Ports have two effects. First, they impose a boundary condition that relates the electric and
+magnetic fields on the surface. Second, for the driven and transient solver, they can excite the
+system with an incident field.
 
- 1. *Rectangular ports*: ``Z = Z_s l / w``, where ``l`` and ``w`` are the length and width
-    of the port, respectively (length here is defined as the distance between the two
-    conductors).
+For lumped ports, the boundary condition is an impedance condition as described above — tangential
+fields satisfy ``\bm{E}_t = Z_s \bm{H}_t \times \bm{n}``. Here ``Z_s`` is the physical surface
+impedance (per unit area) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
+analytically specified.
 
- 2. *Coaxial ports*: ``Z = Z_s \ln(b/a) / 2\pi``, where ``a`` and ``b`` denote the inner and
-    outer radii of the port, respectively.
+For wave ports, a solver performs eigenmode simulations on the boundary to find supported modes of a
+transmission line with the wave-port cross section. The boundary modes will be used to relate
+``\bm{E}`` and ``\bm{H}``, which will only be impedance-like for TEM, TE or TM modes. Additionally,
+users can choose which of the found modes to excite.
 
-A lumped parallel RLC circuit boundary has a circuit impedance
+We normalize port fields so the total power flow is ``\vert P^{inc} \vert = 1~\mathrm{W}``, where
 
-```math
-\frac{1}{Z} = \frac{1}{R}+\frac{1}{i\omega L}+i\omega C \,.
-```
-
-Thus, the relationships between the circuit and surface element parameters for the user to
-specify are given by ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``, where
-``\alpha = w/l`` for a rectangular port or ``\alpha = 2\pi / \ln(b/a)`` for a coaxial
-port.
-
-For multielement lumped ports, the effective circuit impedance is given by
+[TODO: Right now this is peak power, not the average. This is the Palace convention, but needs
+adjusting].
 
 ```math
-\frac{1}{Z} = \sum_k \frac{1}{Z_k} \,.
+P^{inc} = V^{inc} [I^{inc}]^*  = \sum_e \int_{\Gamma_e} dS_e \,  \bm{n}_e \cdot (\bm{E}_e^{inc} \times [\bm{H}_e^{inc}]^*).
 ```
 
-That is, the circuit impedances of each port contributing to the multielement port add in
-parallel. For the specific case of a two element multielement port with two identical
-lumped elements, we have ``Z = (1/Z_1 + 1/Z_2)^{-1} = Z_k / 2``, where ``Z_k`` is the
-circuit impedance of a single port element.
+Here we have allowed for the possibility that a port can be made of disjoint surface elements ``e``,
+which separately contribute to the Poynting vector.
+
+There is an additional normalization related to voltages and currents. For AC simulations of
+microwave networks, circuit ``V`` and ``I`` are not generally well defined and have to be fixed by
+convention [11,12]. This is tantamount to relating the circuit characteristic impedance
+
+```math
+Z = \frac{V^{inc}}{I^{inc}} = \frac{\vert V^{inc} \vert^2}{[P^{inc}]^*},
+```
+
+to the physical surface (wave) impedance ``Z_s``. We discuss this for each port type below.
+
+### Lumped Ports
+
+Lumped ports in *Palace* can be composed of two types of elements:
+
+ 1. *Rectangular*: The incident field is ``\bm{E}^{inc} = E_0 \, \hat{\bm{l}}``. Here ``E_0`` is a
+    normalization constant and ``\hat{\bm{l}}`` is the user-defined polarization direction, which
+    should point between two conductors. We denote the length of the port along the polarization as
+    ``l`` and the perpendicular width as ``w``.
+
+ 2. *Coaxial*: ``\bm{E}^{inc} = {E_0 r_0} \hat{\bm{r}} / {r}``, where ``E_0 r_0`` is a
+    normalization constant, ``r`` is the distance from the port center, and ``\hat{\bm{r}}`` is the
+    unit radial vector. We denote the inner and outer radii as ``a`` and ``b``.
+
+We define the voltage across each element as averages over the area, rather than line integrals. For
+an electric field ``\bm{E}``, the voltage across element ``e`` is:
+
+ 1. *Rectangular*: ``V_{e} = \int_{\Gamma_e}dS\, \bm{E} \cdot\hat{\bm{l}}_e / w_e``,
+
+ 2. *Coaxial*: ``V_{e} = \int_{\Gamma_e}dS\, \bm{E} \cdot\hat{\bm{r}}_e / (2 \pi r)``.
+
+This is a convention choice. For electrostatics or for TEM and TM transmission lines, the voltage in
+the port plane is path-independent between different conductors; in general, it is not.
+
+The power normalization and voltage convention now fix the coefficients ``E_0, r_0`` in the port
+definition and relate the physical surface impedance to the circuit impedance. For each element:
+
+ 1. *Rectangular*: ``Z = Z_s l / w``,
+
+ 2. *Coaxial*: ``Z = Z_s \ln(b/a) / (2\pi)``,
+
+which we also write as ``Z = Z_s / \alpha``  where ``\alpha = w/l`` or ``\alpha = 2\pi / \ln(b/a)``
+respectively. If ``Z`` is a combination of LRC responses, these add in parallel
+
+```math
+\frac{1}{Z} = \frac{1}{R}+\frac{1}{i\omega L}+i\omega C.
+```
+
+Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
+
+In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
+``L_s`` ,``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
+converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
+to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
+Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
+surface impedance depending on their shape ``\alpha_e``:
+
+```math
+Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
+```
+
+Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
-incident field at an excited port boundary by
+tangential component of the incident field at an excited port boundary by
 
 ```math
-\bm{U}^{inc} = -2\gamma(\bm{n}\times\bm{E}^{inc})\times\bm{n}
+\bm{U}^{inc} = - 2 \gamma \bm{E}^{inc}_t = -2\gamma(\bm{n}\times\bm{E}^{inc})\times\bm{n}.
 ```
 
-where ``(\bm{n}\times\bm{E}^{inc})\times\bm{n}`` is just the projection of the excitation
-field onto the port surface. The incident fields for lumped ports depend on the port
-shape:
+The excitation amplitude is fixed at the unit-power mode normalization described above
+``1~\mathrm{W}``.
 
- 1. *Rectangular ports*: ``\bm{E}^{inc} = E_0 \, \hat{\bm{l}}``, where ``E_0`` is a uniform
-    constant field strength and ``\hat{\bm{l}}`` a unit vector defining the direction of
-    polarization on the port (typically should be the direction between the two conductors).
-
- 2. *Coaxial ports*: ``\bm{E}^{inc} = \frac{E_0 r_0}{r} \, \hat{\bm{r}}``, where ``E_0`` is
-    again a uniform constant field strength, ``r_0`` is a characteristic length for the
-    port, ``r`` is the distance from the port center, and ``\hat{\bm{r}}`` a unit vector
-    specifying the port radial direction.
-
-In the time domain formulation, the source term ``\bm{U}^{inc}`` appears as
+In the time-domain formulation, the source term ``\bm{U}^{inc}`` appears as
 
 ```math
 \bm{U}^{inc} = -2 Z_s^{-1}\left(\bm{n}\times\frac{\partial\bm{E}^{inc}}{\partial t}\right)
@@ -235,9 +293,28 @@ The incident field ``\bm{E}^{inc}(\bm{x},t)`` is
 \bm{E}^{inc}(\bm{x},t) = p(t)\bm{E}^{inc}(\bm{x})
 ```
 
-where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the frequency
-domain formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible
-options include a sinusoidal, Gaussian, modulated Gaussian, or step excitation.
+where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the frequency domain
+formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options include a
+sinusoidal, Gaussian, modulated Gaussian, or step excitation.
+
+### Wave ports
+
+Numeric wave ports assume a field with known normal-direction dependence
+``\bm{E}(\bm{x}) = \bm{e}(\bm{x}_t)e^{ik_n x_n}`` where ``k_n`` is the propagation constant. For each operating
+frequency ``\omega``, a two-dimensional eigenvalue problem is solved on the port yielding the mode
+shapes ``\bm{e}_m`` and associated propagation constants ``k_{n,m}``. These are used in the full 3D
+model where the Robin port boundary condition has coefficient
+``\gamma = i\text{Re}\{k_{n,m}\}/\mu_r`` and the computed mode is used to compute the incident field in the
+source term ``\bm{U}^{inc}`` at excited ports.
+
+For more information on the implementation of numeric wave ports, see [[3]](#References).
+
+To Do:
+
+  - Discuss V / I / Z convention choice here.
+  - Fix dembedding sign and normal sign convention (outward vs inward normal)
+
+### Scattering Parameters
 
 In the frequency domain, the scattering parameters can be postprocessed from the computed
 electric field for each lumped port with boundary ``\Gamma_i`` as
@@ -247,26 +324,12 @@ S_{ij} = \frac{\displaystyle\int_{\Gamma_i}\bm{E}\cdot\bm{E}^{inc}_i\,dS}
     {\displaystyle\int_{\Gamma_i}\bm{E}^{inc}_i\cdot\bm{E}^{inc}_i\,dS} - \delta_{ij} \,.
 ```
 
-In the time domain, the time histories of the port voltages can be Fourier-transformed to
-get their frequency domain representation for scattering parameter calculation.
-
-Numeric wave ports assume a field with known normal-direction dependence
-``\bm{E}(\bm{x}) = \bm{e}(\bm{x}_t)e^{ik_n x_n}`` where ``k_n`` is the propagation constant.
-For each operating frequency ``\omega``, a two-dimensional eigenvalue problem is solved on
-the port yielding the mode shapes ``\bm{e}_m`` and associated propagation constants
-``k_{n,m}``. These are used in the full 3D model where the Robin port boundary condition has
-coefficient ``\gamma = i\text{Re}\{k_{n,m}\}/\mu_r`` and the computed mode is used to
-compute the incident field in the source term ``\bm{U}^{inc}`` at excited ports. Scattering
-parameter postprocessing takes the same form as the lumped port counterpart using the
-computed modal solutions. Since the propagation constants are known for each wave port,
-scattering parameter de-embedding can be performed by specifying an offset distance ``d``
-for each port:
+For wave ports, since the propagation constants are known, we allow additional de-embedding by
+specifying an offset distance ``d`` for each wave port:
 
 ```math
 \tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j} \,.
 ```
-
-For more information on the implementation of numeric wave ports, see [[3]](#References).
 
 ## Adaptive driven solver and reduced-order modeling
 
@@ -545,7 +608,7 @@ quality factor for interface ``j`` is given by
 where ``\bm{E}_n`` denotes the normal field to the interface and
 ``\bm{E}_t = \bm{E}-\bm{E}_n`` denotes the tangential field.
 
-## Lumped parameter extraction
+## Electrostatic Simulations
 
 For electrostatic simulations, the Maxwell capacitance matrix is computed in the following
 manner. First, the Laplace equation subject to Dirichlet boundary conditions is solved for
@@ -572,6 +635,8 @@ capacitance matrix, ``\bm{C}``, are given by
 ```math
 \bm{C}_{ij} = \mathcal{E}(V_i+V_j)-\frac{1}{2}(\bm{C}_{ii}+\bm{C}_{jj}) \,.
 ```
+
+## Magnetostatic Simulations
 
 Magnetostatic problems for inductance matrix extraction are based on the magnetic vector
 potential formulation:
@@ -718,18 +783,17 @@ previous section and implemented in *Palace*.
 
 ## References
 
-[1] J.-M. Jin, _The Finite Element Method in Electromagnetics_, Wiley-IEEE Press, Hoboken,
+[1] J.-M. Jin, *The Finite Element Method in Electromagnetics*, Wiley-IEEE Press, Hoboken,
 NJ, Third edition, 2014.\
-[2] P. Monk, _Finite Element Methods for Maxwell's Equations_, Oxford University Press,
+[2] P. Monk, *Finite Element Methods for Maxwell's Equations*, Oxford University Press,
 Oxford, 2003.\
 [3] L. Vardapetyan and L. Demkowicz, Full-wave analysis of dielectric waveguides at a given
-frequency, _Mathematics of Computation_ 72 (2003) 105-129.\
+frequency, *Mathematics of Computation* 72 (2003) 105-129.\
 [4] J. Wenner, R. Barends, R. C. Bialczak, et al., Surface loss of superconducting coplanar
-waveguide resonators, _Applied Physics Letters_ 99, 113513 (2011).\
-[5] S. Nicaise, On Zienkiewicz-Zhu error estimators for Maxwell’s equations, _Comptes Rendus
-Mathematique_ 340 (2005) 697-702.\
+waveguide resonators, *Applied Physics Letters* 99, 113513 (2011).\
+[5] S. Nicaise, On Zienkiewicz-Zhu error estimators for Maxwell’s equations, *Comptes Rendus Mathematique* 340 (2005) 697-702.\
 [6] J. A, Stratton and L. J. Chu, Diffraction theory of Electromagnetic
-Waves, _Physical Review_, 56, 1, (1939), 99-107.\
+Waves, *Physical Review*, 56, 1, (1939), 99-107.\
 [7] P. Benner, D. C. Sorensen, and V. Mehrmann, Eds., _Dimension Reduction of
 Large-Scale Systems_, Lecture Notes in Computational Science and Engineering,
 vol. 45, Springer, 2005. doi: [10.1007/3-540-27909-1](https://doi.org/10.1007/3-540-27909-1).\
@@ -741,4 +805,6 @@ sampling, _Advances in Computational Mathematics_ 49, 92 (2023). doi:
 [10] D. Pradovera, Interpolatory rational model order reduction of parametric
 problems lacking uniform inf-sup stability, _SIAM Journal on Numerical
 Analysis_ 58 (2020) 2265-2293. doi:
-[10.1137/19M1269695](https://doi.org/10.1137/19M1269695).
+[10.1137/19M1269695](https://doi.org/10.1137/19M1269695).\
+[11] R. B. Marks and D. F. Williams, A general waveguide circuit theory, *J. Res. Natl. Inst. Stan.* 97, 533 (1992).\
+[12] D. M. Pozar, *Microwave engineering*, Fourth edition. John Wiley & Sons, Hoboken, NJ, 2012.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -298,6 +298,16 @@ where ``\bm{E}^{inc}(\bm{x})`` is identical to the spatial excitation in the fre
 formulation, and ``p(t)`` describes the temporal shape of the excitation. Possible options include a
 sinusoidal, Gaussian, modulated Gaussian, or step excitation.
 
+For AC simulations, a surface-current source and a resistive lumped port with the same geometry
+produce right-hand-side source terms with the same spatial form, up to an overall normalization. A
+surface-current source is normalized to unit current and only drives the right-hand side: it
+prescribes no boundary condition and provides no termination or dissipation. A lumped port is
+normalized to the unit incident power described above and also imposes its impedance (Robin)
+boundary condition, so a nonzero resistance allows energy to leave the model through the port. Thus,
+use a surface current for an ideal nondissipative drive and a lumped port when a terminating
+impedance is part of the physical model. Without any other loss, the driven system can become
+ill-conditioned near an eigenfrequency.
+
 ### Wave ports
 
 Numeric wave ports assume a field with known normal-direction dependence

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,13 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reference
 
-*Palace* calculates solutions of Maxwell's equation for five different "Problem Types":
+*Palace* calculates solutions of Maxwell's equation for six different "Problem Types":
 
   - Electrostatics: time-independent voltage sources,
   - Magnetostatics: time-independent current sources,
   - Driven: monochromatic excitations ``\bm{U}^{inc}(f)``,
   - Eigenmode: resonances of the system,
-  - Transient: time-dependant excitations ``\bm{U}^{inc}(t)``.
+  - Transient: time-dependent excitations ``\bm{U}^{inc}(t)``,
+  - Boundary mode: guided modes on a waveguide cross section.
 
 Here, we will summarize the mathematics of each, provide a description of boundary conditions, and
 specify convention choices. This should be read in conjunction with the "User Guide" and
@@ -188,7 +189,7 @@ system with an incident field.
 
 For lumped ports, the boundary condition is an impedance condition as described above — tangential
 fields satisfy ``\bm{E}_t = Z_s \bm{H}_t \times \bm{n}``. Here ``Z_s`` is the physical surface
-impedance (per unit area) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
+impedance (per square) and ``\bm{n}`` the port normal. The excitation modes ``\bm{E}^{inc}`` are
 analytically specified.
 
 For wave ports, a solver performs eigenmode simulations on the boundary to find supported modes of a
@@ -198,8 +199,8 @@ users can choose which of the found modes to excite.
 
 We normalize port fields so the total power flow is ``\vert P^{inc} \vert = 1~\mathrm{W}``, where
 
-[TODO: Right now this is peak power, not the average. This is the Palace convention, but needs
-adjusting].
+*Palace* uses peak phasors for this convention, so ``P^{inc}`` is twice the time-averaged power for
+a propagating mode.
 
 ```math
 P^{inc} = V^{inc} [I^{inc}]^*  = \sum_e \int_{\Gamma_e} dS_e \,  \bm{n}_e \cdot (\bm{E}_e^{inc} \times [\bm{H}_e^{inc}]^*).
@@ -258,7 +259,7 @@ respectively. If ``Z`` is a combination of LRC responses, these add in parallel
 Specifically, ``R_s = \alpha R``, ``L_s = \alpha L``, and ``C_s = C/\alpha``.
 
 In the configuration file, a user specifies either ``L``, ``R``, ``C``, corresponding to ``Z``, or
-``L_s`` ,``R_s``, ``C_s`` corresponding to ``Z_s``. For a single-element port, these will just be
+``Ls``, ``Rs``, ``Cs`` corresponding to ``Z_s``. For a single-element port, these will just be
 converted using the single scale factor ``\alpha``. For a multi-element port, we require impedances
 to add in parallel ``{1}/{Z} = \sum_e {1}/{Z_e}``, so that each element sees the same voltage.
 Specifying a lumped ``Z`` in the config means that each element ``e`` can have a different physical
@@ -269,6 +270,9 @@ Z_{s, e} = n_\mathrm{elem} \alpha_{e} Z.
 ```
 
 Conversely, specifying ``Z_s`` means elements of different shape will have different ``Z_e``.
+
+An excited lumped port must be purely resistive, with nonzero ``R`` or ``Rs`` and zero inductance
+and capacitance.
 
 The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is related to the
 tangential component of the incident field at an excited port boundary by
@@ -312,8 +316,11 @@ For more information on the implementation of numeric wave ports, see [[3]](#Ref
 For a general waveguide mode, the circuit quantities ``V``, ``I``, and ``Z`` are not uniquely
 determined by the electromagnetic fields and must be fixed by convention [[11,12]](#References). In contrast
 to lumped ports, where the voltage is defined as an area-averaged integral with a specific analytic
-form, wave port ``V`` and ``I`` are obtained from path integrals along user-specified paths on the
-port cross-section.
+form, wave port ``V`` and ``I`` are obtained from line integrals on the port cross-section. A 3D
+wave port uses [`"VoltagePath"`](config/reference.md#config-boundaries-waveport-voltagepath) for
+``V`` and mode polarity, while
+[boundary-mode impedance postprocessing](config/reference.md#config-boundaries-postprocessing-impedance)
+can additionally define a current path for ``I``.
 
 **Voltage.** The mode voltage is defined as a path integral of the electric field:
 
@@ -342,20 +349,24 @@ magnetic field ``\bm{H}_t = \mu_r^{-1}\bm{B}_t`` is obtained from the mode field
 
 where ``\hat{\bm{n}}`` is the port normal (propagation direction), ``k_n`` is the propagation
 constant, ``\bm{E}_t`` the transverse electric field, and ``E_n`` the normal (longitudinal) electric
-field component on the port.
+field component on the port. The current path is a postprocessing convention and does not set the
+3D wave-port polarity. The current postprocessor currently integrates ``\bm{B}_t`` directly, so
+``Z_{VI}`` follows this ``\bm{H}_t`` definition when ``\mu_r = 1`` along the contour.
 
-**Impedance.** Two impedance quantities are reported. The *power-voltage* characteristic impedance
-is defined as
+**Impedance.** The *power-voltage* characteristic impedance is defined as
 
 ```math
 Z_{PV} = \frac{|V|^2}{P}
 ```
 
 where ``P = \int_\Gamma\text{Re}\{(\bm{E}\times\bm{H}^*)\cdot\hat{\bm{n}}\}\,dS`` is the
-time-averaged power flux through the port cross-section. For TEM modes with a voltage path between the
-two conductors, ``Z_{PV}`` reduces to the conventional TEM characteristic impedance.
+peak-phasor power flux through the port cross-section, equal to twice the time-averaged power. For
+TEM modes with a voltage path between the two conductors, ``Z_{PV}`` reduces to the conventional TEM
+characteristic impedance. For 3D wave ports, ``Z_{PV}`` is reported when `"VoltagePath"` is
+specified.
 
-As a diagnostic, the *voltage-current* impedance magnitude is also reported:
+As a diagnostic, boundary-mode impedance postprocessing also reports the *voltage-current*
+impedance magnitude when a current path is specified:
 
 ```math
 Z_{VI} = |V| / |I|
@@ -365,16 +376,10 @@ where ``V`` and ``I`` are computed independently from different paths. Note that
 specifying both voltage and current does not in general define a valid characteristic impedance [[11]](#References).
 For TEM modes ``Z_{VI} = Z_{PV}``; for other modes they will generally differ.
 
-To Do:
-
-  - Fix dembedding sign and normal sign convention (outward vs inward normal):
-    In the boundarymode-2d branch, the normal sign convention: ``+\hat{\bm{n}}`` is the outward mesh normal.
-    The mode eigenvalue gives ``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the
-    ``+\hat{\bm{n}}`` direction. De-embedding
-    ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift the
-    reference plane toward the device (removing waveguide), consistent with [[8]](#References).
-  - Update with 1/2 factors if we move to average power definition
-  - link to impedance post-processing docs section once available.
+The normal convention ``+\hat{\bm{n}}`` is the outward mesh normal. The mode eigenvalue gives
+``\text{Re}\{k_n\}\ge 0``, corresponding to forward propagation in the ``+\hat{\bm{n}}`` direction.
+De-embedding ``\tilde{S}_{ij} = S_{ij}e^{ik_{n,i}d_i}e^{ik_{n,j}d_j}`` uses positive ``d`` to shift
+the reference plane toward the device (removing waveguide), consistent with [[12]](#References).
 
 ### Scattering Parameters
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -304,9 +304,8 @@ surface-current source is normalized to unit current and only drives the right-h
 prescribes no boundary condition and provides no termination or dissipation. A lumped port is
 normalized to the unit incident power described above and also imposes its impedance (Robin)
 boundary condition, so a nonzero resistance allows energy to leave the model through the port. Thus,
-use a surface current for an ideal nondissipative drive and a lumped port when a terminating
-impedance is part of the physical model. Without any other loss, the driven system can become
-ill-conditioned near an eigenfrequency.
+surface current should be used for an ideal nondissipative drive and a lumped port when a terminating
+impedance is part of the physical model.
 
 ### Wave ports
 


### PR DESCRIPTION
Improve description of lumped and wave ports in `reference.md`. Based mostly on #696.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
