### PR TITLE
Build the cuDSS communication layer for the selected MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ set(PALACE_WITH_SUPERLU ON CACHE BOOL "Build with SuperLU_DIST sparse direct sol
 set(PALACE_WITH_STRUMPACK OFF CACHE BOOL "Build with STRUMPACK sparse direct solver")
 set(PALACE_WITH_MUMPS OFF CACHE BOOL "Build with MUMPS sparse direct solver")
 set(PALACE_WITH_CUDSS OFF CACHE BOOL "Build with cuDSS sparse direct solver")
+set(CUDSS_COMM_LIB "" CACHE FILEPATH
+  "Full path to a cuDSS communication layer built for the selected MPI")
 set(PALACE_WITH_SLEPC ON CACHE BOOL "Build with SLEPc eigenvalue solver")
 set(PALACE_WITH_ARPACK OFF CACHE BOOL "Build with ARPACK eigenvalue solver")
 set(PALACE_WITH_LIBXSMM ON CACHE BOOL "Build with LIBXSMM backend for libCEED")

--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -128,6 +128,49 @@ if(PALACE_WITH_CUDA)
       "-DCUDSS_DIR=${CUDSS_DIR}"
     )
   endif()
+  if(PALACE_WITH_CUDSS)
+    if("${CUDSS_COMM_LIB}" STREQUAL "")
+      # NVIDIA ships an Open MPI communication layer with cuDSS. Use it only after
+      # positively identifying Open MPI; all other MPI implementations need a
+      # matching layer supplied explicitly.
+      include(CMakePushCheckState)
+      include(CheckCXXSourceCompiles)
+      cmake_push_check_state(RESET)
+      set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_CXX)
+      unset(PALACE_MPI_IS_OPENMPI CACHE)
+      check_cxx_source_compiles([[#include <mpi.h>
+#ifndef OMPI_MAJOR_VERSION
+#error Not Open MPI
+#endif
+int main() { return 0; }
+]] PALACE_MPI_IS_OPENMPI)
+      cmake_pop_check_state()
+      if(NOT PALACE_MPI_IS_OPENMPI)
+        message(FATAL_ERROR
+          "The selected MPI was not positively identified as Open MPI; "
+          "PALACE_WITH_CUDSS requires CUDSS_COMM_LIB to name a matching communication layer"
+        )
+      endif()
+      unset(PALACE_CUDSS_OPENMPI_COMM_LIB CACHE)
+      find_library(PALACE_CUDSS_OPENMPI_COMM_LIB
+        NAMES cudss_commlayer_openmpi
+        HINTS "${CUDSS_DIR}"
+        PATH_SUFFIXES lib lib64
+      )
+      if(NOT PALACE_CUDSS_OPENMPI_COMM_LIB)
+        message(FATAL_ERROR "Could not find the bundled cuDSS Open MPI communication layer")
+      endif()
+      set(CUDSS_COMM_LIB "${PALACE_CUDSS_OPENMPI_COMM_LIB}")
+      message(STATUS "Using bundled cuDSS Open MPI communication layer: ${CUDSS_COMM_LIB}")
+    endif()
+    get_filename_component(CUDSS_COMM_LIB "${CUDSS_COMM_LIB}" ABSOLUTE)
+    if(NOT EXISTS "${CUDSS_COMM_LIB}" OR IS_DIRECTORY "${CUDSS_COMM_LIB}")
+      message(FATAL_ERROR "CUDSS_COMM_LIB is not a library file: ${CUDSS_COMM_LIB}")
+    endif()
+    list(APPEND MFEM_OPTIONS
+      "-DMFEM_CUDSS_COMM_LIB=${CUDSS_COMM_LIB}"
+    )
+  endif()
   if(NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
     list(APPEND MFEM_OPTIONS
       "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -194,7 +194,10 @@ Additional build options are (with default values in brackets):
   - `PALACE_WITH_MUMPS [OFF]` :  Build with MUMPS sparse direct solver
   - `PALACE_WITH_CUDSS [OFF]` :  Build with NVIDIA cuDSS sparse direct solver (requires
     `PALACE_WITH_CUDA=ON`; the cuDSS installation directory can be specified with
-    `CUDSS_DIR`)
+    `CUDSS_DIR`). With Open MPI, Palace uses the communication layer bundled with
+    cuDSS by default. `CUDSS_COMM_LIB` overrides this default; for any MPI implementation
+    not recognized as Open MPI, it must specify the full path to a matching communication
+    layer. This path is forwarded to MFEM as its build-time default.
   - `PALACE_WITH_SLEPC [ON]` :  Build with SLEPc eigenvalue solver
   - `PALACE_WITH_ARPACK [OFF]` :  Build with ARPACK eigenvalue solver
   - `PALACE_WITH_LIBXSMM [ON]` :  Build with LIBXSMM backend for libCEED

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -232,7 +232,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
 
         depends_on("mfem+libunwind", when="build_type=Debug")
         depends_on("mfem+cudss", when="+cudss")
-        depends_on("cudss", when="+cudss")
+        depends_on("cudss+mpi", when="+cudss")
         depends_on("eigen@3.5:", type="build")
 
     with when("+libxsmm"):

--- a/spack_repo/patches/cudss_mpi_commlayer.diff
+++ b/spack_repo/patches/cudss_mpi_commlayer.diff
@@ -1,0 +1,41 @@
+diff --git a/repos/spack_repo/builtin/packages/cudss/package.py b/repos/spack_repo/builtin/packages/cudss/package.py
+index 2dc0d83..534235b 100644
+--- a/repos/spack_repo/builtin/packages/cudss/package.py
++++ b/repos/spack_repo/builtin/packages/cudss/package.py
+@@ -67,7 +67,34 @@ class Cudss(Package):
+         if pkg:
+             version(ver, sha256=pkg[0], url=pkg[1])
+-
++
++    variant(
++        "mpi",
++        default=False,
++        description="Build a communication layer for the selected MPI implementation",
++    )
++
+     depends_on("cuda@12:")
++    depends_on("mpi", when="+mpi")
+-
++
+     def install(self, spec, prefix):
+         install_tree(".", prefix)
++
++        if "+mpi" in spec:
++            # NVIDIA's source and build script use the name "openmpi", but the
++            # implementation only uses the standard MPI API and can be built against
++            # any MPI provider. Give the result a provider-neutral name so downstream
++            # packages never mistake NVIDIA's prebuilt Open MPI layer for this one.
++            with working_dir("src"):
++                with set_env(
++                    CUDA_PATH=spec["cuda"].prefix,
++                    CUDSS_PATH=self.stage.source_path,
++                    MPI_PATH=spec["mpi"].prefix,
++                    NVCC_PREPEND_FLAGS="-Xlinker=-rpath -Xlinker=%s:%s"
++                    % (spec["mpi"].prefix.lib64, spec["mpi"].prefix.lib),
++                ):
++                    bash = which("bash", required=True)
++                    bash("./cudss_build_commlayer.sh", "openmpi")
++                install(
++                    "libcudss_commlayer_openmpi.so",
++                    join_path(prefix.lib, "libcudss_commlayer_mpi.so"),
++                )

--- a/spack_repo/patches/pr5124_mfem_cudss.diff
+++ b/spack_repo/patches/pr5124_mfem_cudss.diff
@@ -1,5 +1,5 @@
 diff --git a/repos/spack_repo/builtin/packages/mfem/package.py b/repos/spack_repo/builtin/packages/mfem/package.py
-index e0e7d762..d760729d 100644
+index 6e2bced..62a5617 100644
 --- a/repos/spack_repo/builtin/packages/mfem/package.py
 +++ b/repos/spack_repo/builtin/packages/mfem/package.py
 @@ -188,6 +188,12 @@ class Mfem(Package, CudaPackage, ROCmPackage):
@@ -23,15 +23,16 @@ index e0e7d762..d760729d 100644
      conflicts("+mpi~cuda ^hypre+cuda")
      conflicts("+mpi~rocm ^hypre+rocm")
  
-@@ -530,6 +537,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
+@@ -530,6 +537,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
      depends_on("enzyme@0.0.176:", when="+enzyme")
      requires("%cxx=llvm", when="+enzyme~rocm")
      depends_on("cuda+allow-unsupported-compilers", when="+enzyme+cuda")
-+    depends_on("cudss", when="+cudss")
++    depends_on("cudss+mpi", when="+cudss+mpi")
++    depends_on("cudss~mpi", when="+cudss~mpi")
      depends_on("enzyme %libllvm=llvm-amdgpu", when="+enzyme+rocm")
      requires("%cxx=llvm-amdgpu", when="+enzyme+rocm")
  
-@@ -693,6 +701,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
+@@ -693,6 +702,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
              "MFEM_MPIEXEC_NP=%s" % mfem_mpiexec_np,
              "MFEM_USE_EXCEPTIONS=%s" % yes_no("+exceptions"),
              "MFEM_USE_MUMPS=%s" % yes_no("+mumps"),
@@ -39,7 +40,7 @@ index e0e7d762..d760729d 100644
          ]
          if spec.satisfies("@4.7.0:"):
              options += ["MFEM_PRECISION=%s" % spec.variants["precision"].value]
-@@ -1054,6 +1063,39 @@ class Mfem(Package, CudaPackage, ROCmPackage):
+@@ -1054,6 +1064,35 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                      raise InstallError("Required CUDA libraries not found: %s" % culibs)
                  options += ["CUDA_LIB=%s" % ld_flags_from_library_list(cuda_libs)]
  
@@ -55,20 +56,16 @@ index e0e7d762..d760729d 100644
 +                "CUDSS_LIB=%s" % ld_flags_from_library_list(cudss_libs),
 +            ]
 +
-+            # cuDSS loads communication/threading layers dynamically. Passing absolute
-+            # paths through config.hpp avoids relying on user runtime environment vars.
++            # cudss+mpi builds this provider-specific layer against the same MPI
++            # dependency as MFEM. Requiring the provider-neutral filename avoids
++            # accidentally selecting NVIDIA's prebuilt Open MPI layer for MPICH.
 +            if "+mpi" in spec:
-+                comm_candidates = ["libcudss_commlayer_openmpi"]
-+                if "^mpich" in spec or "^mvapich" in spec:
-+                    comm_candidates = [
-+                        "libcudss_commlayer_mpich",
-+                        "libcudss_commlayer_openmpi",
-+                    ]
 +                comm_libs = find_libraries(
-+                    comm_candidates, cudss.prefix.lib, shared=True, recursive=True
++                    "libcudss_commlayer_mpi", cudss.prefix.lib, shared=True, recursive=True
 +                )
-+                if comm_libs:
-+                    options += ["MFEM_CUDSS_COMM_LIB=%s" % next(iter(comm_libs))]
++                if not comm_libs:
++                    raise InstallError("Required cuDSS MPI communication layer not found")
++                options += ["MFEM_CUDSS_COMM_LIB=%s" % next(iter(comm_libs))]
 +            if "+openmp" in spec:
 +                thread_libs = find_libraries(
 +                    "libcudss_mtlayer_gomp", cudss.prefix.lib, shared=True, recursive=True


### PR DESCRIPTION
Follow-up to #717.

- Add a `CUDSS_COMM_LIB` superbuild option and forward its absolute path to MFEM as `MFEM_CUDSS_COMM_LIB`.
- Use NVIDIA's bundled Open MPI communication layer by default only when the selected MPI is positively identified as Open MPI; any other MPI must supply a matching layer via `CUDSS_COMM_LIB`.
- Spack: depend on `cudss+mpi`, which builds the communication layer against the concrete MPI provider. The `cudss+mpi` variant and MFEM's consumption of `libcudss_commlayer_mpi` are now upstream in spack-packages, so the recipe patches this PR originally carried have been dropped.

Validation (pre-rebase): configure probe for Open MPI auto-selection, MPICH missing-path rejection, and MPICH explicit-path selection; MFEM and Palace built through Spack with MPICH + CUDA + cuDSS; two-rank GPU solve with MPICH and `CUDSS_COMM_LIB` unset at runtime.