### PR TITLE
Build full microarchitecture container matrix on release tags

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -1,6 +1,16 @@
 name: Build Palace Containers
 description: Build a Palace container image from the stored Spack environment
 
+inputs:
+  target:
+    description: >-
+      Spack microarchitecture to build for (e.g. x86_64_v3, neoverse_v2).
+      Empty means build for the runner's native microarchitecture
+      (spack arch -t). Must be at or below the runner's native ISA so
+      build-time binaries remain executable on the host.
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -40,8 +50,13 @@ runs:
         # resolve head.repo to the fork, so this stays false for them — they must
         # never reach the instance-role push credentials on the public repo.
         LABEL_PUSH: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'push-containers') && github.event.pull_request.head.repo.full_name == github.repository }}
+        # Requested Spack microarchitecture; empty means build native.
+        TARGET: ${{ inputs.target }}
       run: |
-        ARCH_LABEL=$(spack arch -t)
+        # Build for the requested target if given, else the runner's native
+        # microarchitecture. A target must be <= the host's native ISA (the
+        # workflow matrix guarantees this) so build-time binaries can run here.
+        ARCH_LABEL="${TARGET:-$(spack arch -t)}"
 
         # Sanitize the branch into an ECR-tag/S3-prefix-safe slug: ECR tags allow
         # only [A-Za-z0-9_.-], and '/' is illegal, so collapse everything else
@@ -88,6 +103,29 @@ runs:
         IMAGE_NAME="palace-${ARCH_LABEL}-${SHORT_HASH}"
         echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
         echo "Image name: ${IMAGE_NAME}"
+
+    - name: Pin build target
+      # Steer concretization to a specific microarchitecture for release matrix
+      # builds. Skipped when target is empty (native builds concretize for the
+      # runner's own microarch, unchanged).
+      # 
+      # Uses a target PREFERENCE (packages:all:target), not a `require`: a hard
+      # require applies to host-detected externals too (glibc, the gcc compiler,
+      # system curl), which are fixed at the runner's own microarch. Forcing them
+      # to a different target is unsatisfiable ("Cannot select a single
+      # node_target for package glibc/gcc").
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: |
+        if [ -n "$TARGET" ]; then
+          cd .github/actions/build-container/spack_env
+          spack -e . config add "packages:all:target:[${TARGET}]"
+          echo "Set preferred concretization target to ${TARGET}:"
+          spack -e . config get packages
+        else
+          echo "No target pin requested; building for native microarchitecture."
+        fi
 
     - name: Generate Dockerfile
       shell: bash

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,9 +1,18 @@
 name: Containers
 
-# Build OCI/SIF containers for:
-# - sapphirerapids   (x64,       c7i)        — every publish event
-# - neoverse_v1      (arm64,     c7g)        — every publish event
-# - neoverse_v2      (arm64-8g,  c8g)        — release tags only
+# Build OCI/SIF containers.
+#
+# Non-tag events (push to main, PRs, manual dispatch) build the runner's native
+# microarchitecture:
+# - sapphirerapids   (x64,       c7i)
+# - neoverse_v1      (arm64,     c7g)
+#
+# Release tags (vX.Y.Z) build a full microarchitecture matrix instead
+# (build-containers-release):
+# - x86_64_v3, x86_64_v4, sapphirerapids   on the x64 (sapphirerapids) host
+# - aarch64, neoverse_v1, neoverse_v2      on the arm64-8g (neoverse_v2) host
+# Each target is at or below its host's native ISA, so build-time binaries run
+# on the host (no cross-compile-up).
 
 on:
   push:
@@ -49,34 +58,45 @@ jobs:
               - '.github/actions/**'
               - '.github/workflows/containers.yml'
 
+  # Non-tag events (push to main, PRs, manual dispatch): build the runner's
+  # native microarchitecture. Release tags are handled by build-containers-
+  # release below, so this job is gated off for them to avoid double builds.
   build-containers:
     needs: filter
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     strategy:
       fail-fast: false
       matrix:
         arch: [arm64, x64]
     runs-on: [self-hosted, '${{ matrix.arch }}']
     steps:
-      # Release tags bypass the paths-filter: a tag is usually cut on a commit
-      # already on main, so the diff is empty and the filter would skip — which
-      # would silently drop the versioned ECR/S3 publish. Tags must always build.
       - uses: actions/checkout@v6
-        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v')
-        with:
-          # Fetch tags so the release channel can derive the version from the
-          # git ref (and `git describe` works if ever needed).
-          fetch-depth: 0
+        if: needs.filter.outputs.test == 'true'
       - uses: ./.github/actions/build-container
-        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v')
+        if: needs.filter.outputs.test == 'true'
 
-  # neoverse_v2 (Graviton4 / c8g) is a release-only performance build
-  build-containers-neoverse-v2:
-    needs: filter
+  # Release tags (vX.Y.Z): build the full microarchitecture matrix. No paths-
+  # filter — a tag is usually cut on a commit already on main, so the diff is
+  # empty and the filter would skip, silently dropping the versioned publish.
+  # Each target is at or below its host's native ISA (see header comment).
+  build-containers-release:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: [self-hosted, arm64-8g]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {runner: x64,      target: x86_64_v3}
+          - {runner: x64,      target: x86_64_v4}
+          - {runner: x64,      target: sapphirerapids}
+          - {runner: arm64-8g, target: aarch64}
+          - {runner: arm64-8g, target: neoverse_v1}
+          - {runner: arm64-8g, target: neoverse_v2}
+    runs-on: [self-hosted, '${{ matrix.runner }}']
     steps:
       - uses: actions/checkout@v6
         with:
           # Fetch tags so the release channel can derive the version from the ref.
           fetch-depth: 0
       - uses: ./.github/actions/build-container
+        with:
+          target: ${{ matrix.target }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,9 +10,12 @@ name: Containers
 # Release tags (vX.Y.Z) build a full microarchitecture matrix instead
 # (build-containers-release):
 # - x86_64_v3, x86_64_v4, sapphirerapids   on the x64 (sapphirerapids) host
-# - aarch64, neoverse_v1, neoverse_v2      on the arm64-8g (neoverse_v2) host
+# - aarch64, neoverse_v2                   on the arm64-8g (neoverse_v2) host
+# - neoverse_v1                            on the arm64 (neoverse_v1) host
 # Each target is at or below its host's native ISA, so build-time binaries run
-# on the host (no cross-compile-up).
+# on the host (no cross-compile-up). neoverse_v1 builds on its own native V1
+# host: the target pin is only a preference, and on the V2 host Spack ignored it
+# and concretized to neoverse_v2 (publishing a V2 binary under the V1 tag).
 
 on:
   push:
@@ -89,7 +92,7 @@ jobs:
           - {runner: x64,      target: x86_64_v4}
           - {runner: x64,      target: sapphirerapids}
           - {runner: arm64-8g, target: aarch64}
-          - {runner: arm64-8g, target: neoverse_v1}
+          - {runner: arm64,    target: neoverse_v1}
           - {runner: arm64-8g, target: neoverse_v2}
     runs-on: [self-hosted, '${{ matrix.runner }}']
     steps:


### PR DESCRIPTION
On release tags, build a matrix of microarchitecture-specific containers instead of only the runner's native arch:
  - x86_64_v3, x86_64_v4, sapphirerapids   
  - aarch64, neoverse_v1, neoverse_v2       

Passing here: https://github.com/awslabs/palace/actions/runs/29653166956
