### PR TITLE
Allow publishing containers without a PR

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -40,6 +40,11 @@ runs:
         # resolve head.repo to the fork, so this stays false for them — they must
         # never reach the instance-role push credentials on the public repo.
         LABEL_PUSH: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'push-containers') && github.event.pull_request.head.repo.full_name == github.repository }}
+        # 'true' iff a manual dispatch requested a push. GitHub only lets users
+        # with write access dispatch a workflow, and dispatch always runs a
+        # branch of this repo (never a fork), so this path is push-safe without
+        # the head.repo guard the label path needs.
+        DISPATCH_PUSH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push == 'true' }}
       run: |
         ARCH_LABEL=$(spack arch -t)
 
@@ -54,15 +59,17 @@ runs:
         #   - push to   main        -> "main"         (rolling dev), pushed
         #   - PR w/ push-containers -> "dev-<branch>" (prototype), pushed
         #                              (same-repo PRs only; forks never push)
+        #   - dispatch w/ push=true -> "dev-<branch>" (prototype), pushed
+        #                              (no PR needed; write-access users only)
         #   - everything else       -> "dev-<branch>", build only, never pushed
-        #                              (plain PRs, manual dispatch re-runs).
+        #                              (plain PRs, build-only dispatch re-runs).
         # ECR tags can't contain '/', so VERSION uses '-' while the S3 prefix
         # keeps '/' for a tidy bucket layout.
         if [ "$EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
           VERSION="main"; S3_PREFIX="main"; PUSH=true
         elif [ "$EVENT_NAME" = "push" ] && [ "${GITHUB_REF#refs/tags/v}" != "$GITHUB_REF" ]; then
           VERSION="${GITHUB_REF#refs/tags/v}"; S3_PREFIX="$VERSION"; PUSH=true
-        elif [ "$LABEL_PUSH" = "true" ]; then
+        elif [ "$LABEL_PUSH" = "true" ] || [ "$DISPATCH_PUSH" = "true" ]; then
           VERSION="dev-${BRANCH_SLUG}"; S3_PREFIX="dev/${BRANCH_SLUG}"; PUSH=true
         else
           VERSION="dev-${BRANCH_SLUG}"; S3_PREFIX="dev/${BRANCH_SLUG}"; PUSH=false

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -13,9 +13,16 @@ on:
     # 'labeled' so adding the `push-containers` label triggers a prototype
     # deploy; the rest are the usual PR-build triggers.
     types: [opened, reopened, synchronize, labeled]
-  # Manual build-only re-run (e.g. after a transient runner failure). Never
-  # publishes — prototype deploys go through the `push-containers` PR label.
+  # Manual run from any branch. Leaving `push` unchecked is a build-only
+  # re-run (e.g. after a transient runner failure); checking it publishes a
+  # `dev-<branch>` prototype without opening a PR. GitHub restricts dispatch
+  # to users with write access, so forks can never reach the push path.
   workflow_dispatch:
+    inputs:
+      push:
+        description: 'Publish a dev-<branch> prototype to ECR + S3 (unchecked = build only)'
+        type: boolean
+        default: false
 
 permissions:
   packages: write
@@ -57,17 +64,19 @@ jobs:
         arch: [arm64, x64]
     runs-on: [self-hosted, '${{ matrix.arch }}']
     steps:
-      # Release tags bypass the paths-filter: a tag is usually cut on a commit
-      # already on main, so the diff is empty and the filter would skip — which
-      # would silently drop the versioned ECR/S3 publish. Tags must always build.
+      # Release tags and manual dispatches bypass the paths-filter: a tag is
+      # usually cut on a commit already on main, so the diff is empty and the
+      # filter would skip — silently dropping the versioned ECR/S3 publish; and
+      # a manual run was explicitly requested, so it must build regardless of
+      # what changed. Tags and dispatches must always build.
       - uses: actions/checkout@v6
-        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v')
+        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         with:
           # Fetch tags so the release channel can derive the version from the
           # git ref (and `git describe` works if ever needed).
           fetch-depth: 0
       - uses: ./.github/actions/build-container
-        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v')
+        if: needs.filter.outputs.test == 'true' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
 
   # neoverse_v2 (Graviton4 / c8g) is a release-only performance build
   build-containers-neoverse-v2:

--- a/docs/src/developer/notes.md
+++ b/docs/src/developer/notes.md
@@ -492,6 +492,27 @@ spack spec local.palace@develop
 will show you the spec for your most recent `palace` package, which you can
 compare with the one for `builtin.palace@develop`.
 
+## Publishing a container without a PR
+
+To publish a `dev-<branch>` prototype straight from a branch, trigger the
+workflow manually with the `push` input enabled. Only users with write access
+can dispatch the workflow, and dispatch always runs a branch of this repository
+(never a fork), so this path is push-safe.
+
+Using the [GitHub CLI](https://cli.github.com/):
+
+```bash
+# Publish a dev-<branch> prototype from the current branch.
+gh workflow run containers.yml --ref "$(git branch --show-current)" -f push=true
+
+# Follow the run that was just started.
+gh run watch "$(gh run list --workflow=containers.yml --limit=1 --json databaseId --jq '.[0].databaseId')"
+```
+
+Omit `-f push=true` (or set `push=false`) for a build-only run that verifies the image
+builds without publishing. From the web UI, the same controls live under
+Actions → Containers → Run workflow, where you pick the branch and tick push.
+
 ## Changelog
 
 Code contributions should generally be accompanied by an entry in the


### PR DESCRIPTION
The only way to publish a dev-<branch> prototype container was to open a PR and add the `push-containers` label; workflow_dispatch existed but was hard-wired to build-only. This PR adds a boolean `push` input to the dispatch trigger so a container can be published straight from a branch without creating a PR first.
