### PR TITLE
Fix wave port targeting for anisotropic materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     permittivity term was missing. [PR 778](https://github.com/awslabs/palace/pull/778).
   - Fixed numeric wave port and automatic boundary-mode targeting for anisotropic
     materials, which could select an evanescent mode instead of the mode with the largest
-    propagation constant.
+    propagation constant. [PR 836](https://github.com/awslabs/palace/pull/836).
 
 ## [0.17.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     [PR 778](https://github.com/awslabs/palace/pull/778).
   - Fixed a bug in the 2D mode eigensolver for lossy cross-sections, where a complex
     permittivity term was missing. [PR 778](https://github.com/awslabs/palace/pull/778).
+  - Fixed numeric wave port and automatic boundary-mode targeting for anisotropic
+    materials, which could select an evanescent mode instead of the mode with the largest
+    propagation constant.
 
 ## [0.17.0] - 2026-06-28
 

--- a/palace/drivers/boundarymodesolver.cpp
+++ b/palace/drivers/boundarymodesolver.cpp
@@ -258,12 +258,10 @@ BoundaryModeSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   }
   else
   {
-    double c_min = mode_op.GetMaterialOp().GetLightSpeedMax().Min();
-    Mpi::GlobalMin(1, &c_min, mode_op.GetComm());
-    MFEM_VERIFY(c_min > 0.0 && c_min < mfem::infinity(),
-                "Invalid material speed of light!");
-    kn_target = omega / c_min * std::sqrt(1.1);
-    Mpi::Print(" Auto kn_target = {:.6e} (from c_min = {:.6e})\n", kn_target, c_min);
+    const double mu_eps_max = mode_op.GetMaterialOp().GetMaxMuEpsilon();
+    kn_target = omega * std::sqrt(1.1 * mu_eps_max);
+    Mpi::Print(" Auto kn_target = {:.6e} (from max(mu_r) * max(epsilon_r) = {:.6e})\n",
+               kn_target, mu_eps_max);
   }
 
   // Solve the eigenvalue problem.

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -3,6 +3,7 @@
 
 #include "materialoperator.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <unordered_set>
@@ -187,6 +188,7 @@ void MaterialOperator::SetUpMaterialProperties(
   mat_invLondon.SetSize(sdim, sdim, nmats);
   mat_c0_min.SetSize(nmats);
   mat_c0_max.SetSize(nmats);
+  mat_mu_eps_max.SetSize(nmats);
   mat_muinvkx.SetSize(sdim, sdim, nmats);
   mat_kxTmuinvkx.SetSize(sdim, sdim, nmats);
   mat_kx.SetSize(sdim, sdim, nmats);
@@ -203,6 +205,14 @@ void MaterialOperator::SetUpMaterialProperties(
       continue;
     }
     const auto &data = materials[i];
+    double mu_max = 0.0, eps_max = 0.0;
+    for (std::size_t d = 0; d < data.mu_r.s.size(); d++)
+    {
+      mu_max = std::max(mu_max, std::abs(data.mu_r.s[d]));
+      eps_max = std::max(eps_max, std::abs(data.epsilon_r.s[d]));
+    }
+    mat_mu_eps_max[count] = mu_max * eps_max;
+
     if (problem_type == ProblemType::ELECTROSTATIC)
     {
       MFEM_VERIFY(internal::mat::IsValid(data.epsilon_r),
@@ -370,6 +380,15 @@ void MaterialOperator::SetUpMaterialProperties(
   has_conductivity_attr = has_attr[1];
   has_london_attr = has_attr[2];
   has_wave_attr = has_attr[3];
+}
+
+double MaterialOperator::GetMaxMuEpsilon() const
+{
+  double mu_eps_max = mat_mu_eps_max.Size() > 0 ? mat_mu_eps_max.Max() : 0.0;
+  Mpi::GlobalMax(1, &mu_eps_max, mesh.GetComm());
+  MFEM_VERIFY(mu_eps_max > 0.0 && mu_eps_max < mfem::infinity(),
+              "Invalid material permeability or permittivity!");
+  return mu_eps_max;
 }
 
 void MaterialOperator::SetUpFloquetWaveVector(const config::PeriodicBoundaryData &periodic,

--- a/palace/models/materialoperator.hpp
+++ b/palace/models/materialoperator.hpp
@@ -36,7 +36,7 @@ private:
   mfem::Vector wave_vector;        // BZ-wrapped k_F (fixed) or k₀ = k_F/ω (freq-scaled).
   mfem::Vector wave_vector_bz;     // BZ-wrapped k_F (always k_F, never k₀). For BZ offset.
   double floquet_omega_ref = 0.0;  // Nondimensional; when > 0, k_F scales with frequency.
-  mfem::Array<double> mat_c0_min, mat_c0_max;
+  mfem::Array<double> mat_c0_min, mat_c0_max, mat_mu_eps_max;
 
   // Are materials isotropic? True when all the material properties are effectively
   // scalar-valued (ie, true scalars or vectors with identical entries). Also true when a
@@ -134,6 +134,12 @@ public:
 
   const auto &GetLightSpeedMin() const { return mat_c0_min; }
   const auto &GetLightSpeedMax() const { return mat_c0_max; }
+
+  // Conservative upper bound on (k_n / omega)^2 for bulk waves, computed as
+  // lambda_max(mu_r) * lambda_max(epsilon_r) and maximized over this mesh's materials.
+  // Keeping the tensor extrema separate is required for anisotropic media because the
+  // electric and magnetic polarizations generally lie on different material axes.
+  double GetMaxMuEpsilon() const;
 
   bool HasLossTangent() const { return has_losstan_attr; }
   bool HasConductivity() const { return has_conductivity_attr; }

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -506,13 +506,11 @@ WavePortData::WavePortData(const config::WavePortData &data,
   e0.SetSize(port_nd_fespace->GetTrueVSize() + port_h1_fespace->GetTrueVSize());
   e0.UseDevice(true);
 
-  // Set the shift-and-invert target as the maximum propagation constant.
-  double c_min = mat_op.GetLightSpeedMax().Min();
-  Mpi::GlobalMin(1, &c_min, nd_fespace.GetComm());
-  MFEM_VERIFY(c_min > 0.0 && c_min < mfem::infinity(),
-              "Invalid material speed of light detected in WavePortOperator!");
-  mu_eps_max = 1.0 / (c_min * c_min) * 1.1;  // Add a safety factor for maximum
-                                             // propagation constant possible
+  // Set the shift-and-invert target above the bulk propagation constants of materials
+  // present on this port. For anisotropic media the electric and magnetic polarizations
+  // can sample different material axes, so max(mu_r * epsilon_r) is not a safe bound;
+  // use max(mu_r) * max(epsilon_r) instead.
+  mu_eps_max = port_mat_op->GetMaxMuEpsilon() * 1.1;
 
   // Configure a communicator for the processes which have elements for this port.
   MPI_Comm comm = nd_fespace.GetComm();

--- a/test/unit/test-boundarymodeoperator.cpp
+++ b/test/unit/test-boundarymodeoperator.cpp
@@ -101,9 +101,7 @@ ModeResult SolveRectangularModes(double width, double height, double freq_ghz,
 
   double omega =
       2.0 * M_PI * iodata.units.Nondimensionalize<Units::ValueType::FREQUENCY>(freq_ghz);
-  double c_min = mat_op.GetLightSpeedMax().Min();
-  Mpi::GlobalMin(1, &c_min, nd_fespace.GetComm());
-  double kn_target = omega / c_min * std::sqrt(1.1);
+  double kn_target = omega * std::sqrt(1.1 * mat_op.GetMaxMuEpsilon());
 
   // ModeEigenSolver requires a positive Krylov subspace size (num_vec). Mirror the
   // formula used by IoData::CheckConfiguration for eigenmode.max_size.

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -83,6 +83,26 @@ TEST_CASE("MaterialOperator IsIsotropic", "[materialoperator][Serial]")
   }
 }
 
+TEST_CASE("MaterialOperator anisotropic wave-number bound", "[materialoperator][Serial]")
+{
+  auto serial_mesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::TETRAHEDRON));
+  auto par_mesh = std::make_unique<mfem::ParMesh>(Mpi::World(), *serial_mesh);
+  Mesh palace_mesh(std::move(par_mesh));
+
+  config::MaterialData material;
+  material.attributes = {1};
+  material.mu_r.s = {4.0, 1.0, 1.0};
+  material.epsilon_r.s = {1.0, 4.0, 1.0};
+
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({material}, periodic, ProblemType::DRIVEN, palace_mesh);
+
+  // Same-axis products max(mu_i * epsilon_i) are only 4, but a wave polarized with E
+  // along y and H along x samples mu_x * epsilon_y = 16.
+  CHECK(mat_op.GetMaxMuEpsilon() == Approx(16.0));
+}
+
 TEST_CASE("MaterialOperator utility functions", "[materialoperator][Serial]")
 {
   SECTION("IsOrthonormal")

--- a/test/unit/test-waveportimpedance.cpp
+++ b/test/unit/test-waveportimpedance.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <complex>
 #include <mfem.hpp>
@@ -217,6 +218,88 @@ TEST_CASE("WavePort TE10 mode polarity sign", "[waveportimpedance][Serial]")
   const auto &port = wave_port_op.GetPort(1);
   CHECK(port.GetModePolaritySign(/*high_attr=*/2, /*low_attr=*/4) == +1);
   CHECK(port.GetModePolaritySign(/*high_attr=*/4, /*low_attr=*/2) == -1);
+}
+
+TEST_CASE("WavePort anisotropic mode ordering", "[waveportimpedance][Serial][Parallel]")
+{
+  MPI_Comm comm = Mpi::World();
+
+  // WR-28 guide propagating along z. The dominant TE10 mode has E along y and H along x.
+  const double a_m = 7.112e-3;
+  const double b_m = 3.556e-3;
+  const double L_m = 8.0e-3;
+  const double f_GHz = 20.0;
+
+  auto solve_kn =
+      [&](const std::array<double, 3> &mu_r, const std::array<double, 3> &epsilon_r)
+  {
+    auto serial_mesh = std::make_unique<mfem::Mesh>(
+        mfem::Mesh::MakeCartesian3D(8, 4, 2, mfem::Element::TETRAHEDRON, a_m, b_m, L_m));
+
+    Units units(1.0, 1.0);
+    IoData iodata(units);
+    iodata.model.L0 = 1.0;
+    iodata.model.Lc = 1.0;
+
+    auto &material = iodata.domains.materials.emplace_back();
+    material.attributes = {1};
+    material.mu_r.s = mu_r;
+    material.epsilon_r.s = epsilon_r;
+
+    // MakeCartesian3D face 1 is z=0; use it as the port and make all other faces PEC.
+    iodata.boundaries.pec.attributes = {2, 3, 4, 5, 6};
+    auto &wave = iodata.boundaries.waveport.try_emplace(1).first->second;
+    wave.attributes = {1};
+    wave.mode_idx = 1;
+    wave.active = true;
+    wave.eig_tol = 1.0e-9;
+    wave.ksp_tol = 1.0e-9;
+    wave.ksp_max_its = 200;
+    wave.max_size = std::max(2 * wave.mode_idx, wave.mode_idx + 15);
+
+    iodata.solver.order = 1;
+    iodata.solver.linear.tol = 1.0e-9;
+    iodata.solver.linear.max_it = 200;
+    iodata.problem.type = ProblemType::DRIVEN;
+
+    iodata.NondimensionalizeInputs(serial_mesh);
+    auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+    iodata.CheckConfiguration();
+    Mesh palace_mesh(std::move(par_mesh));
+
+    auto nd_fec = std::make_unique<mfem::ND_FECollection>(iodata.solver.order,
+                                                          palace_mesh.Dimension());
+    auto h1_fec = std::make_unique<mfem::H1_FECollection>(iodata.solver.order,
+                                                          palace_mesh.Dimension());
+    FiniteElementSpace nd_fespace(palace_mesh, nd_fec.get());
+    FiniteElementSpace h1_fespace(palace_mesh, h1_fec.get());
+    MaterialOperator mat_op(iodata, palace_mesh);
+
+    ExposedWavePortOperator wave_port_op(iodata, mat_op, nd_fespace.Get(),
+                                         h1_fespace.Get());
+    wave_port_op.SetSuppressOutput(true);
+    const double omega =
+        2.0 * M_PI * iodata.units.Nondimensionalize<Units::ValueType::FREQUENCY>(f_GHz);
+    wave_port_op.Initialize(omega);
+
+    const double kn_scale =
+        1.0 / iodata.units.Dimensionalize<Units::ValueType::LENGTH>(1.0);
+    return wave_port_op.GetPort(1).kn0 * kn_scale;
+  };
+
+  const double k0 = 2.0 * M_PI * f_GHz * 1.0e9 / electromagnetics::c0_;
+  const double kc = M_PI / a_m;
+  auto te10_kn =
+      [&](const std::array<double, 3> &mu_r, const std::array<double, 3> &epsilon_r)
+  { return std::sqrt(mu_r[0] * epsilon_r[1] * k0 * k0 - (mu_r[0] / mu_r[2]) * kc * kc); };
+
+  const std::array<double, 3> mu_r = {1.0, 1.0, 1.0};
+  const std::array<double, 3> epsilon_r = {2.0, 4.0, 3.0};
+  const auto kn = solve_kn(mu_r, epsilon_r);
+  const double kn_ref = te10_kn(mu_r, epsilon_r);
+  CAPTURE(kn, kn_ref);
+  CHECK_THAT(kn.real(), WithinRel(kn_ref, 0.02));
+  CHECK_THAT(kn.imag(), WithinAbs(0.0, 0.01 * kn_ref));
 }
 
 // Validate the COMPLEX-frequency wave-port cross-section solve


### PR DESCRIPTION
The waveport eigensolver target was previously incorrect for anisotropic materials, possibly leading to missing the modes with the largest propagation constants, as reported in #835. This PR fixes the issue and adds an anisotropic waveport unit test. Closes #835.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
