### PR TITLE
Use Hermitian similarity for smoother spectral estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     attributes without a corresponding `config["Domains"]["Materials"]` entry are rejected
     instead of silently assigning zero material coefficients to retained volumes. [PR
     840](https://github.com/awslabs/palace/pull/840).
+  - Fixed smoother spectral estimates to pass a Hermitian similarity operator to the HEP
+    solver [PR 837](https://github.com/awslabs/palace/pull/837).
   - Fixed saving output to non-shared filesystems [PR 813](https://github.com/awslabs/palace/pull/813).
   - Fixed S-parameter post-processing for mixed Floquet + lumped/wave port configurations.
     Previously, `MeasureSParameter()` skipped processing when Floquet ports coexisted with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     attributes without a corresponding `config["Domains"]["Materials"]` entry are rejected
     instead of silently assigning zero material coefficients to retained volumes. [PR
     840](https://github.com/awslabs/palace/pull/840).
+  - Fixed smoother spectral estimates to pass a Hermitian similarity operator to the HEP
+    solver [PR 837](https://github.com/awslabs/palace/pull/837).
   - Fixed saving output to non-shared filesystems [PR 813](https://github.com/awslabs/palace/pull/813).
   - Fixed S-parameter post-processing for mixed Floquet + lumped/wave port configurations.
     Previously, `MeasureSParameter()` skipped processing when Floquet ports coexisted with

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -13,18 +13,28 @@ namespace
 
 double GetLambdaMax(MPI_Comm comm, const Operator &A, const Vector &dinv)
 {
-  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
-  DiagonalOperator Dinv(dinv);
-  ProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, true);
+  // D⁻¹A is generally not Hermitian, but is similar to the Hermitian operator
+  // D⁻¹ᐟ²AD⁻¹ᐟ² under the existing SPD assumption.
+  Vector dinv_sqrt(dinv);
+  linalg::Sqrt(dinv_sqrt);
+  DiagonalOperator DinvSqrt(dinv_sqrt);
+  ProductOperator S(DinvSqrt, A, DinvSqrt);
+  return linalg::SpectralNorm(comm, S, true);
 }
 
 double GetLambdaMax(MPI_Comm comm, const ComplexOperator &A, const ComplexVector &dinv)
 {
-  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
+  if (A.IsReal())
+  {
+    ComplexVector dinv_sqrt(dinv);
+    linalg::Sqrt(dinv_sqrt.Real());
+    ComplexDiagonalOperator DinvSqrt(dinv_sqrt);
+    ComplexProductOperator S(DinvSqrt, A, DinvSqrt);
+    return linalg::SpectralNorm(comm, S, true);
+  }
   ComplexDiagonalOperator Dinv(dinv);
   ComplexProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, A.IsReal());
+  return linalg::SpectralNorm(comm, DinvA, false);
 }
 
 template <bool Transpose = false>

--- a/palace/linalg/chebyshev.cpp
+++ b/palace/linalg/chebyshev.cpp
@@ -3,6 +3,7 @@
 
 #include "chebyshev.hpp"
 
+#include <cmath>
 #include <mfem/general/forall.hpp>
 
 namespace palace
@@ -11,14 +12,40 @@ namespace palace
 namespace
 {
 
+bool HasPositiveFiniteDiagonal(MPI_Comm comm, const Vector &real,
+                               const Vector *imag = nullptr)
+{
+  int valid = 1;
+  if (real.Size() > 0)
+  {
+    const auto *R = real.HostRead();
+    const auto *I = imag ? imag->HostRead() : nullptr;
+    for (int i = 0; i < real.Size(); i++)
+    {
+      if (!(std::isfinite(R[i]) && R[i] > 0.0) ||
+          (I && !(std::isfinite(I[i]) && I[i] == 0.0)))
+      {
+        valid = 0;
+        break;
+      }
+    }
+  }
+  Mpi::GlobalMin(1, &valid, comm);
+  return valid;
+}
+
 double GetLambdaMax(MPI_Comm comm, const Operator &A, const Vector &dinv)
 {
   // D⁻¹A is generally not Hermitian, but is similar to the Hermitian operator
-  // D⁻¹ᐟ²AD⁻¹ᐟ² under the existing SPD assumption.
+  // D⁻¹ᐟ²AD⁻¹ᐟ² when A has a finite, strictly positive diagonal.
+  MFEM_VERIFY(HasPositiveFiniteDiagonal(comm, dinv),
+              "Chebyshev smoother spectral estimation requires a finite, strictly "
+              "positive operator diagonal!");
   Vector dinv_sqrt(dinv);
   linalg::Sqrt(dinv_sqrt);
   DiagonalOperator DinvSqrt(dinv_sqrt);
-  ProductOperator S(DinvSqrt, A, DinvSqrt);
+  ProductOperator ADinvSqrt(A, DinvSqrt);
+  ProductOperator S(DinvSqrt, ADinvSqrt);
   return linalg::SpectralNorm(comm, S, true);
 }
 
@@ -26,10 +53,14 @@ double GetLambdaMax(MPI_Comm comm, const ComplexOperator &A, const ComplexVector
 {
   if (A.IsReal())
   {
+    MFEM_VERIFY(HasPositiveFiniteDiagonal(comm, dinv.Real(), &dinv.Imag()),
+                "Chebyshev smoother spectral estimation requires a finite, strictly "
+                "positive real operator diagonal!");
     ComplexVector dinv_sqrt(dinv);
     linalg::Sqrt(dinv_sqrt.Real());
     ComplexDiagonalOperator DinvSqrt(dinv_sqrt);
-    ComplexProductOperator S(DinvSqrt, A, DinvSqrt);
+    ComplexProductOperator ADinvSqrt(A, DinvSqrt);
+    ComplexProductOperator S(DinvSqrt, ADinvSqrt);
     return linalg::SpectralNorm(comm, S, true);
   }
   ComplexDiagonalOperator Dinv(dinv);
@@ -190,8 +221,8 @@ void ChebyshevSmoother<OperType>::SetOperator(const OperType &op)
   // Set up Chebyshev coefficients using the computed maximum eigenvalue estimate. See
   // mfem::OperatorChebyshevSmoother or Adams et al. (2003).
   lambda_max = sf_max * GetLambdaMax(comm, *A, dinv);
-  MFEM_VERIFY(lambda_max > 0.0,
-              "Encountered zero maximum eigenvalue in Chebyshev smoother!");
+  MFEM_VERIFY(std::isfinite(lambda_max) && lambda_max > 0.0,
+              "Encountered invalid maximum eigenvalue in Chebyshev smoother!");
 
   this->height = op.Height();
   this->width = op.Width();
@@ -257,8 +288,8 @@ void ChebyshevSmoother1stKind<OperType>::SetOperator(const OperType &op)
     sf_min = 1.69 / (std::pow(order, 1.68) + 2.11 * order + 1.98);
   }
   const double lambda_max = sf_max * GetLambdaMax(comm, *A, dinv);
-  MFEM_VERIFY(lambda_max > 0.0,
-              "Encountered zero maximum eigenvalue in Chebyshev smoother!");
+  MFEM_VERIFY(std::isfinite(lambda_max) && lambda_max > 0.0,
+              "Encountered invalid maximum eigenvalue in Chebyshev smoother!");
   const double lambda_min = sf_min * lambda_max;
   theta = 0.5 * (lambda_max + lambda_min);
   delta = 0.5 * (lambda_max - lambda_min);

--- a/palace/linalg/jacobi.cpp
+++ b/palace/linalg/jacobi.cpp
@@ -3,6 +3,7 @@
 
 #include "jacobi.hpp"
 
+#include <cmath>
 #include <mfem/general/forall.hpp>
 
 namespace palace
@@ -11,14 +12,40 @@ namespace palace
 namespace
 {
 
+bool HasPositiveFiniteDiagonal(MPI_Comm comm, const Vector &real,
+                               const Vector *imag = nullptr)
+{
+  int valid = 1;
+  if (real.Size() > 0)
+  {
+    const auto *R = real.HostRead();
+    const auto *I = imag ? imag->HostRead() : nullptr;
+    for (int i = 0; i < real.Size(); i++)
+    {
+      if (!(std::isfinite(R[i]) && R[i] > 0.0) ||
+          (I && !(std::isfinite(I[i]) && I[i] == 0.0)))
+      {
+        valid = 0;
+        break;
+      }
+    }
+  }
+  Mpi::GlobalMin(1, &valid, comm);
+  return valid;
+}
+
 double GetLambdaMax(MPI_Comm comm, const Operator &A, const Vector &dinv)
 {
   // D⁻¹A is generally not Hermitian, but is similar to the Hermitian operator
-  // D⁻¹ᐟ²AD⁻¹ᐟ² under the existing SPD assumption.
+  // D⁻¹ᐟ²AD⁻¹ᐟ² when A has a finite, strictly positive diagonal.
+  MFEM_VERIFY(HasPositiveFiniteDiagonal(comm, dinv),
+              "Jacobi smoother spectral estimation requires a finite, strictly positive "
+              "operator diagonal!");
   Vector dinv_sqrt(dinv);
   linalg::Sqrt(dinv_sqrt);
   DiagonalOperator DinvSqrt(dinv_sqrt);
-  ProductOperator S(DinvSqrt, A, DinvSqrt);
+  ProductOperator ADinvSqrt(A, DinvSqrt);
+  ProductOperator S(DinvSqrt, ADinvSqrt);
   return linalg::SpectralNorm(comm, S, true);
 }
 
@@ -26,10 +53,14 @@ double GetLambdaMax(MPI_Comm comm, const ComplexOperator &A, const ComplexVector
 {
   if (A.IsReal())
   {
+    MFEM_VERIFY(HasPositiveFiniteDiagonal(comm, dinv.Real(), &dinv.Imag()),
+                "Jacobi smoother spectral estimation requires a finite, strictly positive "
+                "real operator diagonal!");
     ComplexVector dinv_sqrt(dinv);
     linalg::Sqrt(dinv_sqrt.Real());
     ComplexDiagonalOperator DinvSqrt(dinv_sqrt);
-    ComplexProductOperator S(DinvSqrt, A, DinvSqrt);
+    ComplexProductOperator ADinvSqrt(A, DinvSqrt);
+    ComplexProductOperator S(DinvSqrt, ADinvSqrt);
     return linalg::SpectralNorm(comm, S, true);
   }
   ComplexDiagonalOperator Dinv(dinv);
@@ -93,9 +124,15 @@ void JacobiSmoother<OperType>::SetOperator(const OperType &op)
   // damping factor.
   if (omega == 0.0)
   {
-    auto lambda_max = GetLambdaMax(comm, op, dinv);
-    auto lambda_min = (sf_max - 1.0) * lambda_max;
-    omega = 2.0 / (lambda_min + lambda_max);
+    const auto lambda_max = GetLambdaMax(comm, op, dinv);
+    MFEM_VERIFY(std::isfinite(lambda_max) && lambda_max > 0.0,
+                "Encountered invalid maximum eigenvalue in Jacobi smoother!");
+    const auto lambda_min = (sf_max - 1.0) * lambda_max;
+    const auto denominator = lambda_min + lambda_max;
+    MFEM_VERIFY(std::isfinite(denominator) && denominator > 0.0,
+                "Automatic Jacobi damping requires a finite, strictly positive damping "
+                "denominator!");
+    omega = 2.0 / denominator;
   }
   if (omega != 1.0)
   {

--- a/palace/linalg/jacobi.cpp
+++ b/palace/linalg/jacobi.cpp
@@ -13,18 +13,28 @@ namespace
 
 double GetLambdaMax(MPI_Comm comm, const Operator &A, const Vector &dinv)
 {
-  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
-  DiagonalOperator Dinv(dinv);
-  ProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, true);
+  // D⁻¹A is generally not Hermitian, but is similar to the Hermitian operator
+  // D⁻¹ᐟ²AD⁻¹ᐟ² under the existing SPD assumption.
+  Vector dinv_sqrt(dinv);
+  linalg::Sqrt(dinv_sqrt);
+  DiagonalOperator DinvSqrt(dinv_sqrt);
+  ProductOperator S(DinvSqrt, A, DinvSqrt);
+  return linalg::SpectralNorm(comm, S, true);
 }
 
 double GetLambdaMax(MPI_Comm comm, const ComplexOperator &A, const ComplexVector &dinv)
 {
-  // Assumes A SPD (diag(A) > 0) to use Hermitian eigenvalue solver.
+  if (A.IsReal())
+  {
+    ComplexVector dinv_sqrt(dinv);
+    linalg::Sqrt(dinv_sqrt.Real());
+    ComplexDiagonalOperator DinvSqrt(dinv_sqrt);
+    ComplexProductOperator S(DinvSqrt, A, DinvSqrt);
+    return linalg::SpectralNorm(comm, S, true);
+  }
   ComplexDiagonalOperator Dinv(dinv);
   ComplexProductOperator DinvA(Dinv, A);
-  return linalg::SpectralNorm(comm, DinvA, A.IsReal());
+  return linalg::SpectralNorm(comm, DinvA, false);
 }
 
 template <bool Transpose = false>

--- a/palace/linalg/operator.hpp
+++ b/palace/linalg/operator.hpp
@@ -6,7 +6,6 @@
 
 #include <complex>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -262,9 +261,8 @@ public:
 using SumOperator = BaseSumOperator<Operator>;
 using SumComplexOperator = BaseSumOperator<ComplexOperator>;
 
-// Wraps a sequence of operators such that: (ABC)ᵀ = CᵀBᵀAᵀ and, for complex symmetric
-// operators, the Hermitian transpose operation is (ABC)ᴴ = CᴴBᴴAᴴ. The caller must
-// ensure the referenced operators outlive this object.
+// Wraps two operators such that: (AB)ᵀ = BᵀAᵀ and, for complex symmetric operators, the
+// Hermitian transpose operation is (AB)ᴴ = BᴴAᴴ.
 template <typename ProductOperator, typename OperType>
 class ProductOperatorHelper : public OperType
 {
@@ -316,35 +314,13 @@ class BaseProductOperator
                                 std::complex<double>, double>::type;
 
 private:
-  std::unique_ptr<BaseProductOperator> data_B;
   const OperType &A, &B;
   mutable VecType z;
 
 public:
   BaseProductOperator(const OperType &A, const OperType &B)
     : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(A.Height(), B.Width()),
-      data_B(nullptr), A(A), B(B), z(B.Height())
-  {
-    z.UseDevice(true);
-  }
-
-  BaseProductOperator(const BaseProductOperator &other)
-    : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(other.Height(),
-                                                                     other.Width()),
-      data_B(other.data_B ? std::make_unique<BaseProductOperator>(*other.data_B) : nullptr),
-      A(other.A), B(data_B ? *data_B : other.B), z(other.z)
-  {
-  }
-
-  BaseProductOperator(BaseProductOperator &&) = default;
-
-  template <typename... T>
-  BaseProductOperator(const OperType &A, const OperType &B, const OperType &C,
-                      const T &...input)
-    : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(
-          A.Height(), std::get<sizeof...(T)>(std::tie(C, input...)).Width()),
-      data_B(std::make_unique<BaseProductOperator>(B, C, input...)), A(A), B(*data_B),
-      z(data_B->Height())
+      A(A), B(B), z(B.Height())
   {
     z.UseDevice(true);
   }

--- a/palace/linalg/operator.hpp
+++ b/palace/linalg/operator.hpp
@@ -6,6 +6,7 @@
 
 #include <complex>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -261,8 +262,9 @@ public:
 using SumOperator = BaseSumOperator<Operator>;
 using SumComplexOperator = BaseSumOperator<ComplexOperator>;
 
-// Wraps two operators such that: (AB)ᵀ = BᵀAᵀ and, for complex symmetric operators, the
-// Hermitian transpose operation is (AB)ᴴ = BᴴAᴴ.
+// Wraps a sequence of operators such that: (ABC)ᵀ = CᵀBᵀAᵀ and, for complex symmetric
+// operators, the Hermitian transpose operation is (ABC)ᴴ = CᴴBᴴAᴴ. The caller must
+// ensure the referenced operators outlive this object.
 template <typename ProductOperator, typename OperType>
 class ProductOperatorHelper : public OperType
 {
@@ -314,13 +316,35 @@ class BaseProductOperator
                                 std::complex<double>, double>::type;
 
 private:
+  std::unique_ptr<BaseProductOperator> data_B;
   const OperType &A, &B;
   mutable VecType z;
 
 public:
   BaseProductOperator(const OperType &A, const OperType &B)
     : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(A.Height(), B.Width()),
-      A(A), B(B), z(B.Height())
+      data_B(nullptr), A(A), B(B), z(B.Height())
+  {
+    z.UseDevice(true);
+  }
+
+  BaseProductOperator(const BaseProductOperator &other)
+    : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(other.Height(),
+                                                                     other.Width()),
+      data_B(other.data_B ? std::make_unique<BaseProductOperator>(*other.data_B) : nullptr),
+      A(other.A), B(data_B ? *data_B : other.B), z(other.z)
+  {
+  }
+
+  BaseProductOperator(BaseProductOperator &&) = default;
+
+  template <typename... T>
+  BaseProductOperator(const OperType &A, const OperType &B, const OperType &C,
+                      const T &...input)
+    : ProductOperatorHelper<BaseProductOperator<OperType>, OperType>(
+          A.Height(), std::get<sizeof...(T)>(std::tie(C, input...)).Width()),
+      data_B(std::make_unique<BaseProductOperator>(B, C, input...)), A(A), B(*data_B),
+      z(data_B->Height())
   {
     z.UseDevice(true);
   }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-rap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-smoother.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-rap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-smoother.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-spaceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp

--- a/test/unit/test-smoother.cpp
+++ b/test/unit/test-smoother.cpp
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "linalg/chebyshev.hpp"
+#include "linalg/jacobi.hpp"
+#include "utils/communication.hpp"
+
+namespace palace
+{
+
+using namespace Catch::Matchers;
+
+namespace
+{
+
+class TestOperator : public Operator
+{
+public:
+  TestOperator() : Operator(2) {}
+
+  void AssembleDiagonal(Vector &diag) const override
+  {
+    diag.SetSize(2);
+    diag[0] = 100.0;
+    diag[1] = 2.0;
+  }
+
+  void Mult(const Vector &x, Vector &y) const override
+  {
+    y.SetSize(2);
+    const double x0 = x[0], x1 = x[1];
+    y[0] = 100.0 * x0 + 10.0 * x1;
+    y[1] = 10.0 * x0 + 2.0 * x1;
+  }
+
+  void MultTranspose(const Vector &x, Vector &y) const override { Mult(x, y); }
+};
+
+template <typename Smoother>
+void Check(Smoother &smoother, const Operator &A, double expected)
+{
+  smoother.SetOperator(A);
+  Vector x(2), y(2);
+  x[0] = 100.0;
+  x[1] = 2.0;
+  smoother.Mult(x, y);
+  CHECK_THAT(y[0], WithinRel(expected, 2.0e-3));
+  CHECK_THAT(y[1], WithinRel(expected, 2.0e-3));
+}
+
+template <typename Smoother>
+void Check(Smoother &smoother, const ComplexOperator &A, double expected)
+{
+  smoother.SetOperator(A);
+  ComplexVector x(2), y(2);
+  x = 0.0;
+  x.Real()[0] = 100.0;
+  x.Real()[1] = 2.0;
+  smoother.Mult(x, y);
+  CHECK_THAT(y.Real()[0], WithinRel(expected, 2.0e-3));
+  CHECK_THAT(y.Real()[1], WithinRel(expected, 2.0e-3));
+  CHECK(y.Imag().Normlinf() == 0.0);
+}
+
+}  // namespace
+
+TEST_CASE("Smoother estimates use the Hermitian Jacobi similarity",
+          "[smoother][Serial][Parallel]")
+{
+  // D⁻¹A is not symmetric, while D⁻¹ᐟ²AD⁻¹ᐟ² has eigenvalues 1 ± 1/√2.
+  TestOperator A;
+  ComplexWrapperOperator Ac(&A, nullptr);
+  const double lambda_max = 1.0 + 1.0 / std::sqrt(2.0);
+
+  ChebyshevSmoother<Operator> chebyshev(Mpi::World(), 1, 1, 1.0);
+  Check(chebyshev, A, 4.0 / (3.0 * lambda_max));
+  ChebyshevSmoother<ComplexOperator> chebyshev_c(Mpi::World(), 1, 1, 1.0);
+  Check(chebyshev_c, Ac, 4.0 / (3.0 * lambda_max));
+  JacobiSmoother<Operator> jacobi(Mpi::World(), 0.0);
+  Check(jacobi, A, 2.0 / lambda_max);
+  JacobiSmoother<ComplexOperator> jacobi_c(Mpi::World(), 0.0);
+  Check(jacobi_c, Ac, 2.0 / lambda_max);
+}
+
+}  // namespace palace

--- a/test/unit/test-smoother.cpp
+++ b/test/unit/test-smoother.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "linalg/chebyshev.hpp"
 #include "linalg/jacobi.hpp"
@@ -35,6 +36,34 @@ public:
     const double x0 = x[0], x1 = x[1];
     y[0] = 100.0 * x0 + 10.0 * x1;
     y[1] = 10.0 * x0 + 2.0 * x1;
+  }
+
+  void MultTranspose(const Vector &x, Vector &y) const override { Mult(x, y); }
+};
+
+class DiagonalTestOperator : public Operator
+{
+private:
+  const bool has_negative_entry;
+
+public:
+  DiagonalTestOperator(bool has_negative_entry)
+    : Operator(2), has_negative_entry(has_negative_entry)
+  {
+  }
+
+  void AssembleDiagonal(Vector &diag) const override
+  {
+    diag.SetSize(2);
+    diag[0] = 1.0;
+    diag[1] = has_negative_entry ? -1.0 : 1.0;
+  }
+
+  void Mult(const Vector &x, Vector &y) const override
+  {
+    y.SetSize(2);
+    y[0] = x[0];
+    y[1] = has_negative_entry ? -x[1] : x[1];
   }
 
   void MultTranspose(const Vector &x, Vector &y) const override { Mult(x, y); }
@@ -84,6 +113,37 @@ TEST_CASE("Smoother estimates use the Hermitian Jacobi similarity",
   Check(jacobi, A, 2.0 / lambda_max);
   JacobiSmoother<ComplexOperator> jacobi_c(Mpi::World(), 0.0);
   Check(jacobi_c, Ac, 2.0 / lambda_max);
+}
+
+TEST_CASE("Smoother estimates reject nonpositive Jacobi diagonals",
+          "[smoother][Serial][Parallel]")
+{
+  // Only one rank has an invalid entry so the parallel test exercises the collective
+  // validation before entering a collective eigensolver.
+  DiagonalTestOperator A(Mpi::Root(Mpi::World()));
+  ComplexWrapperOperator Ac(&A, nullptr);
+
+  ChebyshevSmoother<Operator> chebyshev(Mpi::World(), 1, 1, 1.0);
+  CHECK_THROWS_WITH(chebyshev.SetOperator(A),
+                    ContainsSubstring("finite, strictly positive operator diagonal"));
+  ChebyshevSmoother<ComplexOperator> chebyshev_c(Mpi::World(), 1, 1, 1.0);
+  CHECK_THROWS_WITH(chebyshev_c.SetOperator(Ac),
+                    ContainsSubstring("finite, strictly positive real operator diagonal"));
+  JacobiSmoother<Operator> jacobi(Mpi::World(), 0.0);
+  CHECK_THROWS_WITH(jacobi.SetOperator(A),
+                    ContainsSubstring("finite, strictly positive operator diagonal"));
+  JacobiSmoother<ComplexOperator> jacobi_c(Mpi::World(), 0.0);
+  CHECK_THROWS_WITH(jacobi_c.SetOperator(Ac),
+                    ContainsSubstring("finite, strictly positive real operator diagonal"));
+}
+
+TEST_CASE("Automatic Jacobi rejects an invalid damping denominator",
+          "[smoother][Serial][Parallel]")
+{
+  TestOperator A;
+  JacobiSmoother<Operator> jacobi(Mpi::World(), 0.0, 0.0);
+  CHECK_THROWS_WITH(jacobi.SetOperator(A),
+                    ContainsSubstring("finite, strictly positive damping denominator"));
 }
 
 }  // namespace palace


### PR DESCRIPTION
## Summary

- Estimate real and exactly-real complex Chebyshev and automatically damped Jacobi spectra using the Hermitian similarity operator `D^-1/2 A D^-1/2`.
- Extend `ProductOperator` and `ComplexProductOperator` to compose three or more factors.
- Leave the general-complex non-Hermitian path unchanged.

## Motivation

For nonconstant positive diagonal `D`, `D^-1 A` is generally not Euclidean-Hermitian even when `A` is Hermitian. Passing it to SLEPc as a Hermitian eigenproblem violates the solver contract.

`D^-1/2 A D^-1/2` is Hermitian under the existing SPD assumption and is similar to `D^-1 A`, so it provides the required spectrum while satisfying that contract.

## Tests

- The focused regression fails with the previous estimator and passes with this change.
- Full serial and two-rank MPI unit suites pass.
- Required CI and long tests pass.
