### PR TITLE
Reject retained domains without materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Fixed validation of domain material coverage so postprocessing and retained mesh
+    attributes without a corresponding `config["Domains"]["Materials"]` entry are rejected
+    instead of silently assigning zero material coefficients to retained volumes. [PR
+    840](https://github.com/awslabs/palace/pull/840).
   - Fixed saving output to non-shared filesystems [PR 813](https://github.com/awslabs/palace/pull/813).
   - Fixed S-parameter post-processing for mixed Floquet + lumped/wave port configurations.
     Previously, `MeasureSParameter()` skipped processing when Floquet ports coexisted with

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <limits>
 #include <unordered_set>
+#include <fmt/format.h>
 #include "linalg/densematrix.hpp"
 #include "utils/communication.hpp"
 #include "utils/geodata.hpp"
@@ -373,6 +374,29 @@ void MaterialOperator::SetUpMaterialProperties(
 
     count++;
   }
+
+  // Every domain retained in the mesh needs a material definition. This is normally
+  // guaranteed by unused-element cleaning, but must also hold when cleaning is disabled.
+  // Attribute presence is rank-local, so report the globally smallest missing attribute
+  // only after every rank has participated in the reduction. Skip the local scan on an
+  // element-empty rank because BuildCeedAttributes inserts a synthetic attribute 1 there.
+  int missing_attr = std::numeric_limits<int>::max();
+  if (mesh.GetNE() > 0)
+  {
+    for (const auto &[attr, local_attr] : loc_attr)
+    {
+      if (attr_mat[local_attr - 1] < 0)
+      {
+        missing_attr = std::min(missing_attr, attr);
+      }
+    }
+  }
+  Mpi::GlobalMin(1, &missing_attr, mesh.GetComm());
+  MFEM_VERIFY(missing_attr == std::numeric_limits<int>::max(),
+              fmt::format("Mesh domain attribute {:d} has no corresponding entry in "
+                          "config[\"Domains\"][\"Materials\"]!",
+                          missing_attr));
+
   bool has_attr[4] = {has_losstan_attr, has_conductivity_attr, has_london_attr,
                       has_wave_attr};
   Mpi::GlobalOr(4, has_attr, mesh.GetComm());

--- a/palace/utils/configfile.cpp
+++ b/palace/utils/configfile.cpp
@@ -350,10 +350,11 @@ DomainData::DomainData(const json &domains)
   attributes.shrink_to_fit();
   for (const auto &attr : postpro.attributes)
   {
-    MFEM_VERIFY(std::lower_bound(attributes.begin(), attributes.end(), attr) !=
-                    attributes.end(),
-                "Domain postprocessing can only be enabled on domains which have a "
-                "corresponding \"Materials\" entry!");
+    MFEM_VERIFY(
+        std::binary_search(attributes.begin(), attributes.end(), attr),
+        fmt::format("Domain postprocessing attribute {:d} has no corresponding entry in "
+                    "config[\"Domains\"][\"Materials\"]!",
+                    attr));
   }
 }
 

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -11,6 +11,7 @@
 #include <nlohmann/json.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include "embedded_schema.hpp"
 #include "linalg/ksp.hpp"
 #include "utils/configfile.hpp"
@@ -140,6 +141,40 @@ std::vector<std::string> SchemaCoverageGaps(const std::string &pointer,
 }
 
 }  // namespace
+
+TEST_CASE("Config Domain Postprocessing", "[config][Serial]")
+{
+  auto MakeDomains = [](const std::vector<int> &material_attributes,
+                        const std::vector<int> &postprocessing_attributes)
+  {
+    return json{
+        {"Materials", {{{"Attributes", material_attributes}}}},
+        {"Postprocessing",
+         {{"Energy", {{{"Index", 1}, {"Attributes", postprocessing_attributes}}}}}}};
+  };
+
+  SECTION("Postprocessing material domain is accepted")
+  {
+    CHECK_NOTHROW(config::DomainData(MakeDomains({1, 3}, {1, 3})));
+  }
+
+  SECTION("Postprocessing domain between material attributes is rejected")
+  {
+    // This specifically exercises a missing value whose lower bound is not end().
+    CHECK_THROWS_WITH(config::DomainData(MakeDomains({1, 3}, {2})),
+                      Catch::Matchers::ContainsSubstring(
+                          "Domain postprocessing attribute 2 has no corresponding entry in "
+                          "config[\"Domains\"][\"Materials\"]!"));
+  }
+
+  SECTION("Postprocessing domain above material attributes is rejected")
+  {
+    CHECK_THROWS_WITH(config::DomainData(MakeDomains({1, 3}, {4})),
+                      Catch::Matchers::ContainsSubstring(
+                          "Domain postprocessing attribute 4 has no corresponding entry in "
+                          "config[\"Domains\"][\"Materials\"]!"));
+  }
+}
 
 TEST_CASE("Config Boundary Ports", "[config][Serial]")
 {

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <vector>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
@@ -80,6 +82,62 @@ TEST_CASE("MaterialOperator IsIsotropic", "[materialoperator][Serial]")
                               palace_mesh);
       REQUIRE(mat_op.IsIsotropic(1) == false);
     }
+  }
+}
+
+TEST_CASE("MaterialOperator requires materials for retained mesh domains",
+          "[materialoperator][Serial][Parallel]")
+{
+  MPI_Comm comm = Mpi::World();
+  const int size = Mpi::Size(comm);
+
+  // Give every rank two contiguous x-directed coarse cells. Attribute 2 is confined to
+  // the first cell on rank 0, with an attribute-1 cell separating it from the partition
+  // interface. Thus no other rank sees attribute 2, even through a shared-face neighbor.
+  auto serial_mesh = std::make_unique<mfem::Mesh>(mfem::Mesh::MakeCartesian3D(
+      2 * size, 1, 1, mfem::Element::TETRAHEDRON, 2.0 * size, 1.0, 1.0));
+  std::vector<int> partitioning(serial_mesh->GetNE());
+  for (int i = 0; i < serial_mesh->GetNE(); i++)
+  {
+    const auto *element = serial_mesh->GetElement(i);
+    const auto *vertices = element->GetVertices();
+    double center_x = 0.0;
+    for (int j = 0; j < element->GetNVertices(); j++)
+    {
+      center_x += serial_mesh->GetVertex(vertices[j])[0];
+    }
+    center_x /= element->GetNVertices();
+    serial_mesh->SetAttribute(i, center_x < 1.0 ? 2 : 1);
+    partitioning[i] = static_cast<int>(center_x / 2.0);
+  }
+  serial_mesh->SetAttributes();
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh, partitioning.data());
+  Mesh palace_mesh(std::move(par_mesh));
+
+  const auto &local_attributes = palace_mesh.GetCeedAttributes();
+  const bool has_attr2 = local_attributes.find(2) != local_attributes.end();
+  CHECK(has_attr2 == (Mpi::Rank(comm) == 0));
+  CHECK(palace_mesh.GetNE() > 0);
+
+  config::MaterialData material1;
+  material1.attributes = {1};
+  config::MaterialData material2;
+  material2.attributes = {2};
+  config::PeriodicBoundaryData periodic;
+
+  SECTION("All retained attributes have materials")
+  {
+    CHECK_NOTHROW(MaterialOperator({material1, material2}, periodic,
+                                   ProblemType::ELECTROSTATIC, palace_mesh));
+  }
+
+  SECTION("Missing material is rejected collectively")
+  {
+    CHECK_THROWS_WITH(
+        MaterialOperator({material1}, periodic, ProblemType::ELECTROSTATIC, palace_mesh),
+        Catch::Matchers::ContainsSubstring(
+            "Mesh domain attribute 2 has no corresponding entry in "
+            "config[\"Domains\"][\"Materials\"]!"));
   }
 }
 


### PR DESCRIPTION
## Summary

- require every domain postprocessing attribute to exactly match an attribute declared in `config["Domains"]["Materials"]`;
- report the offending postprocessing attribute and configuration path;
- collectively reject retained mesh domain attributes without material definitions, including when `config["Model"]["CleanUnusedElements"]` is `false`; and
- add focused serial and parallel regressions for both validation layers.

## Motivation

The existing postprocessing check used `lower_bound(...) != end()` as a membership test. A missing postprocessing attribute was therefore accepted whenever any larger material attribute existed. Mesh cleanup retained that postprocessing-only volume, while material coefficient assembly intentionally mapped its unassigned attribute to zero. This left supported finite-element degrees of freedom with exact zero operator rows and allowed the failure to surface much later in solver setup.

`binary_search` now enforces exact membership during configuration parsing and reports:

```text
Domain postprocessing attribute N has no corresponding entry in config["Domains"]["Materials"]!
```

A second validation at `MaterialOperator` construction closes the same pre-existing gap for undeclared mesh domains explicitly retained with unused-element cleaning disabled. Attribute presence is rank-local, so Palace reduces the globally smallest missing attribute before every rank performs the same check:

```text
Mesh domain attribute N has no corresponding entry in config["Domains"]["Materials"]!
```

This leaves the reserved-zero coefficient behavior intact for legitimate restricted coefficients while preventing a full-domain operator from silently acquiring zero-material volumes.

## Tests

Built through the Palace Spack development environment with unit tests enabled (`spack install --test=root -j4`).

- Focused domain-postprocessing test: 3 assertions passed.
- Focused retained-domain material test: 6 assertions passed in serial, two-rank MPI, and four-rank MPI.
- The parallel regression uses an explicit geometric partition where attribute 2 is visible only on rank 0; all ranks nevertheless receive the globally reduced error.
- Full serial unit suite: 121,437 assertions; 118 passed, 1 skipped.
- Full two-rank MPI suite: 31,190 assertions in 41 test cases passed.
- Public two-rank end-to-end cases confirmed both errors occur before spectral solver setup.

## Field verification

Unchanged configurations from the affected failure family were rerun with the published PR container and their original execution shapes. Every configuration is now rejected during parsing with the intended missing-material error on every rank, before mesh preprocessing or solver setup. Separate smoother-validation runs confirmed that the previously accepted inputs otherwise construct H1 operators with exact-zero rows and fail later during spectral setup.

A numerical completion would require the input owner to supply the physically correct material or remove/correct the invalid postprocessing request; Palace must not invent that choice.
