### PR TITLE
Allow exciting reactive lumped ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     termination; the incident drive is normalized to the port `"R"` when positive, or to
     an internal unit reference impedance for a purely reactive port. Previously, excited
     lumped ports were required to be purely resistive.
+    [PR 841](https://github.com/awslabs/palace/pull/841).
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
   - Enabled the `RationalImpedance` boundary condition in eigenmode simulations, handled
     by the nonlinear eigenvalue solver and evaluated at the complex eigenfrequency.
     SchemaVer 1-3-1 [PR 778](https://github.com/awslabs/palace/pull/778).
+  - Excited lumped ports may now carry reactance (`"L"` and/or `"C"`, including purely
+    reactive ports with `"R": 0`). The reactance enters the system matrix as a physical
+    termination; the incident drive is normalized to the port `"R"` when positive, or to
+    an internal unit reference impedance for a purely reactive port. Previously, excited
+    lumped ports were required to be purely resistive.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,15 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
   - Enabled the `RationalImpedance` boundary condition in eigenmode simulations, handled
     by the nonlinear eigenvalue solver and evaluated at the complex eigenfrequency.
     SchemaVer 1-3-1 [PR 778](https://github.com/awslabs/palace/pull/778).
-  - Excited lumped ports may now carry reactance (`"L"` and/or `"C"`, including purely
-    reactive ports with `"R": 0`). The reactance enters the system matrix as a physical
+  - Excited lumped ports may now carry reactance (`"L"` and/or `"C"`, or the
+    surface-parameter equivalents `"Ls"`/`"Cs"`, including purely reactive ports with
+    `"R": 0` / `"Rs": 0`). The reactance enters the system matrix as a physical
     termination; the incident drive is normalized to the port `"R"` when positive, or to
     an internal unit reference impedance for a purely reactive port. Previously, excited
-    lumped ports were required to be purely resistive.
+    lumped ports were required to be purely resistive. As part of this change, *passive*
+    purely reactive lumped ports (`R = 0` with `L` and/or `C`) now report a finite
+    S-parameter row referenced to the internal unit impedance, where previously their
+    `port-S.csv` row was identically zero.
     [PR 841](https://github.com/awslabs/palace/pull/841).
 
 #### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,10 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     lumped ports were required to be purely resistive. As part of this change, *passive*
     purely reactive lumped ports (`R = 0` with `L` and/or `C`) now report a finite
     S-parameter row referenced to the internal unit impedance, where previously their
-    `port-S.csv` row was identically zero.
+    `port-S.csv` row was identically zero; similarly, the incident columns `inc<idx>` of
+    `port-V.csv` and `port-I.csv` at a purely reactive excited port now report finite
+    unit-reference values, where previously both were zero. These are bookkeeping
+    quantities referenced to the internal unit impedance, not physical incident waves.
     [PR 841](https://github.com/awslabs/palace/pull/841).
 
 #### Bug Fixes

--- a/docs/src/guide/boundaries.md
+++ b/docs/src/guide/boundaries.md
@@ -197,7 +197,13 @@ for implementation details.
     The medium adjacent to the port must be homogeneous and isotropic.
 
 For each port, the excitation is normalized to have unit incident power over the port boundary
-surface.
+surface. Lumped ports with reactive elements (`"L"` and/or `"C"`) may also be excited, including
+purely reactive ports with `"R": 0`. This is useful for driving a structure through a Josephson
+junction or other lumped reactive element. The port reactance enters the system matrix as a
+physical termination, and the fields, synthesized circuit matrices, and port voltages/currents are
+all valid. For a purely reactive port (`R = 0`) the power normalization references an internal unit
+impedance; see the [mathematical reference](../reference.md#Lumped-ports-and-wave-ports) for the
+S-parameter interpretation in this case.
 
 The presence of an incident excitation at a port is controlled by the settings
 [`config["Boundaries"]["LumpedPort"][]["Excitation"]`](../config/reference.md#config-boundaries-lumpedport)

--- a/docs/src/guide/boundaries.md
+++ b/docs/src/guide/boundaries.md
@@ -198,12 +198,9 @@ for implementation details.
 
 For each port, the excitation is normalized to have unit incident power over the port boundary
 surface. Lumped ports with reactive elements (`"L"` and/or `"C"`) may also be excited, including
-purely reactive ports with `"R": 0`. This is useful for driving a structure through a Josephson
-junction or other lumped reactive element. The port reactance enters the system matrix as a
-physical termination, and the fields, synthesized circuit matrices, and port voltages/currents are
-all valid. For a purely reactive port (`R = 0`) the power normalization references an internal unit
-impedance; see the [mathematical reference](../reference.md#Lumped-ports-and-wave-ports) for the
-S-parameter interpretation in this case.
+purely reactive ports with `"R": 0`. For a purely reactive port (`R = 0`) the power normalization
+references an internal unit impedance; see the [mathematical reference](../reference.md#Lumped-ports-and-wave-ports)
+for the S-parameter interpretation in this case.
 
 The presence of an incident excitation at a port is controlled by the settings
 [`config["Boundaries"]["LumpedPort"][]["Excitation"]`](../config/reference.md#config-boundaries-lumpedport)

--- a/docs/src/guide/boundaries.md
+++ b/docs/src/guide/boundaries.md
@@ -197,8 +197,9 @@ for implementation details.
     The medium adjacent to the port must be homogeneous and isotropic.
 
 For each port, the excitation is normalized to have unit incident power over the port boundary
-surface. Lumped ports with reactive elements (`"L"` and/or `"C"`) may also be excited, including
-purely reactive ports with `"R": 0`. For a purely reactive port (`R = 0`) the power normalization
+surface. Lumped ports with reactive elements (`"L"` and/or `"C"`, or the surface-parameter
+equivalents `"Ls"` and/or `"Cs"`) may also be excited, including purely reactive ports with
+`"R": 0` (`"Rs": 0`). For a purely reactive port (`R = 0`) the power normalization
 references an internal unit impedance; see the [mathematical reference](../reference.md#Lumped-ports-and-wave-ports)
 for the S-parameter interpretation in this case.
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -277,7 +277,11 @@ fixed ``\sqrt{R_j/Z_0}`` conversion factor separates them from a voltage-transfe
 They satisfy reciprocity (``S_{ji} = S_{ij}``). The same unit-reference projection applies
 to *passive* purely reactive lumped ports (``R = 0`` with ``L`` and/or ``C``) appearing as
 observation ports: their S-parameter rows are finite and referenced to ``Z_0``, rather
-than identically zero.
+than identically zero. Likewise, the incident voltage and current columns of the port
+postprocessing output (``V^{inc}``, ``I^{inc}``) at a purely reactive excited port are
+finite and referenced to ``Z_0`` — like the S-parameter row, they are bookkeeping
+quantities consistent with the assembled drive normalization, not physical incident
+waves (an ``R = 0`` port supports no incident traveling wave).
 
 In the time domain, the time histories of the port voltages can be Fourier-transformed to
 get their frequency domain representation for scattering parameter calculation.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -250,9 +250,12 @@ S_{ij} = \frac{\displaystyle\int_{\Gamma_i}\bm{E}\cdot\bm{E}^{inc}_i\,dS}
 For a resistive excited port, the incident field ``\bm{E}^{inc}`` is normalized so that the
 power integrated over the port boundary is unity, referenced to the port resistance ``R``.
 A lumped port with nonzero inductance and/or capacitance may also be excited. In this case
-the port's ``R``, ``L``, and ``C`` all enter the system matrix as a physical parallel
-termination, and the incident field is normalized to a real reference resistance: ``R`` when
-``R > 0``, or the free-space impedance ``Z_0 \approx 376.7~\Omega`` when ``R = 0``. The
+the *termination* and *excitation* coefficients differ: the port's full ``R``, ``L``, and
+``C`` enter the system matrix as a physical parallel termination through the Robin
+coefficient ``\gamma = i\omega/Z_s`` with the complex ``Z_s(\omega)``, while the source
+term ``\bm{U}^{inc}`` is assembled with the real drive coefficient ``i\omega/R_{ref}``,
+where ``R_{ref}`` is a real reference resistance: ``R`` when ``R > 0``, or the free-space
+impedance ``Z_0 \approx 376.7~\Omega`` when ``R = 0`` (and equivalently ``Z_s^{-1} \to R_{ref}^{-1}`` in the time-domain source term). The
 scattering parameters at resistive ports (observation or drive) retain their standard power-wave
 interpretation. For a purely reactive drive port (``R = 0``), the reported ``S_{ii}`` is related
 to the loaded port impedance by
@@ -262,12 +265,19 @@ S_{ii} + 1 = \frac{2\,Z_{\text{loaded}}}{Z_0}
 ```
 
 where ``Z_{\text{loaded}} = Z_p \parallel Z_{\text{struct}}`` is the parallel combination of
-the port impedance ``Z_p = (1/R + 1/(i\omega L) + i\omega C)^{-1}`` and the structure's
-input impedance at the port plane. This is a reciprocal, frequency-dependent
-quantity — but it is not bounded by unity and should not be interpreted as a power
-reflection coefficient. Transmission parameters ``S_{ji}`` (``j \ne i``) between a reactive
-drive and a resistive observation port are physical voltage-transfer ratios and satisfy
-reciprocity (``S_{ji} = S_{ij}``).
+the port impedance ``Z_p = (1/R + 1/(i\omega L) + i\omega C)^{-1}`` (zero-valued branches
+are omitted from the sum: the ``1/R`` term is dropped when ``R = 0``, and likewise for
+``L`` and ``C``) and the structure's input impedance at the port plane. This is a
+reciprocal, frequency-dependent quantity — but it is not bounded by unity and should not
+be interpreted as a power reflection coefficient. Transmission parameters ``S_{ji}``
+(``j \ne i``) between a reactive drive and a resistive observation port are
+real-reference-normalized transmission amplitudes: each side is normalized to its own real
+reference (``Z_0`` at the reactive drive, ``R_j`` at the resistive observation port), so a
+fixed ``\sqrt{R_j/Z_0}`` conversion factor separates them from a voltage-transfer ratio.
+They satisfy reciprocity (``S_{ji} = S_{ij}``). The same unit-reference projection applies
+to *passive* purely reactive lumped ports (``R = 0`` with ``L`` and/or ``C``) appearing as
+observation ports: their S-parameter rows are finite and referenced to ``Z_0``, rather
+than identically zero.
 
 In the time domain, the time histories of the port voltages can be Fourier-transformed to
 get their frequency domain representation for scattering parameter calculation.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -249,14 +249,13 @@ S_{ij} = \frac{\displaystyle\int_{\Gamma_i}\bm{E}\cdot\bm{E}^{inc}_i\,dS}
 
 For a resistive excited port, the incident field ``\bm{E}^{inc}`` is normalized so that the
 power integrated over the port boundary is unity, referenced to the port resistance ``R``.
-A lumped port with nonzero inductance and/or capacitance may also be excited (useful for
-driving a structure through a Josephson junction or other reactive element). In this case
+A lumped port with nonzero inductance and/or capacitance may also be excited. In this case
 the port's ``R``, ``L``, and ``C`` all enter the system matrix as a physical parallel
 termination, and the incident field is normalized to a real reference resistance: ``R`` when
-``R > 0``, or the free-space impedance ``Z_0 \approx 376.7~\Omega`` (in internal units,
-``|Z_R| = 1``) when ``R = 0``. The scattering parameters at resistive ports (observation or
-drive) retain their standard power-wave interpretation. For a purely reactive drive port
-(``R = 0``), the reported ``S_{ii}`` is related to the loaded port impedance by
+``R > 0``, or the free-space impedance ``Z_0 \approx 376.7~\Omega`` when ``R = 0``. The
+scattering parameters at resistive ports (observation or drive) retain their standard power-wave
+interpretation. For a purely reactive drive port (``R = 0``), the reported ``S_{ii}`` is related
+to the loaded port impedance by
 
 ```math
 S_{ii} + 1 = \frac{2\,Z_{\text{loaded}}}{Z_0}
@@ -264,7 +263,7 @@ S_{ii} + 1 = \frac{2\,Z_{\text{loaded}}}{Z_0}
 
 where ``Z_{\text{loaded}} = Z_p \parallel Z_{\text{struct}}`` is the parallel combination of
 the port impedance ``Z_p = (1/R + 1/(i\omega L) + i\omega C)^{-1}`` and the structure's
-input impedance at the port plane. This is a well-defined, reciprocal, frequency-dependent
+input impedance at the port plane. This is a reciprocal, frequency-dependent
 quantity — but it is not bounded by unity and should not be interpreted as a power
 reflection coefficient. Transmission parameters ``S_{ji}`` (``j \ne i``) between a reactive
 drive and a resistive observation port are physical voltage-transfer ratios and satisfy

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -247,6 +247,29 @@ S_{ij} = \frac{\displaystyle\int_{\Gamma_i}\bm{E}\cdot\bm{E}^{inc}_i\,dS}
     {\displaystyle\int_{\Gamma_i}\bm{E}^{inc}_i\cdot\bm{E}^{inc}_i\,dS} - \delta_{ij} \,.
 ```
 
+For a resistive excited port, the incident field ``\bm{E}^{inc}`` is normalized so that the
+power integrated over the port boundary is unity, referenced to the port resistance ``R``.
+A lumped port with nonzero inductance and/or capacitance may also be excited (useful for
+driving a structure through a Josephson junction or other reactive element). In this case
+the port's ``R``, ``L``, and ``C`` all enter the system matrix as a physical parallel
+termination, and the incident field is normalized to a real reference resistance: ``R`` when
+``R > 0``, or the free-space impedance ``Z_0 \approx 376.7~\Omega`` (in internal units,
+``|Z_R| = 1``) when ``R = 0``. The scattering parameters at resistive ports (observation or
+drive) retain their standard power-wave interpretation. For a purely reactive drive port
+(``R = 0``), the reported ``S_{ii}`` is related to the loaded port impedance by
+
+```math
+S_{ii} + 1 = \frac{2\,Z_{\text{loaded}}}{Z_0}
+```
+
+where ``Z_{\text{loaded}} = Z_p \parallel Z_{\text{struct}}`` is the parallel combination of
+the port impedance ``Z_p = (1/R + 1/(i\omega L) + i\omega C)^{-1}`` and the structure's
+input impedance at the port plane. This is a well-defined, reciprocal, frequency-dependent
+quantity — but it is not bounded by unity and should not be interpreted as a power
+reflection coefficient. Transmission parameters ``S_{ji}`` (``j \ne i``) between a reactive
+drive and a resistive observation port are physical voltage-transfer ratios and satisfy
+reciprocity (``S_{ji} = S_{ij}``).
+
 In the time domain, the time histories of the port voltages can be Fourier-transformed to
 get their frequency domain representation for scattering parameter calculation.
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -206,12 +206,18 @@ The source term ``\bm{U}^{inc}`` in a driven frequency-response problem is relat
 incident field at an excited port boundary by
 
 ```math
-\bm{U}^{inc} = -2\gamma(\bm{n}\times\bm{E}^{inc})\times\bm{n}
+\bm{U}^{inc} = -2\gamma_{exc}(\bm{n}\times\bm{E}^{inc})\times\bm{n} \,, \qquad
+\gamma_{exc} = \frac{i\omega}{R_{ref}}
 ```
 
 where ``(\bm{n}\times\bm{E}^{inc})\times\bm{n}`` is just the projection of the excitation
-field onto the port surface. The incident fields for lumped ports depend on the port
-shape:
+field onto the port surface, and ``R_{ref}`` is the real reference resistance of the
+excited port: the port resistance ``R`` when ``R > 0``, or the impedance of free space
+``Z_0`` for a purely reactive port with ``R = 0`` (see the discussion of reactive port
+excitation below). The excitation coefficient ``\gamma_{exc}`` is in general distinct from
+the termination coefficient ``\gamma = i\omega/Z_s`` appearing in the Robin boundary
+condition, and the two coincide for a purely resistive port. The incident fields for lumped
+ports depend on the port shape:
 
  1. *Rectangular ports*: ``\bm{E}^{inc} = E_0 \, \hat{\bm{l}}``, where ``E_0`` is a uniform
     constant field strength and ``\hat{\bm{l}}`` a unit vector defining the direction of
@@ -225,7 +231,7 @@ shape:
 In the time domain formulation, the source term ``\bm{U}^{inc}`` appears as
 
 ```math
-\bm{U}^{inc} = -2 Z_s^{-1}\left(\bm{n}\times\frac{\partial\bm{E}^{inc}}{\partial t}\right)
+\bm{U}^{inc} = -2 R_{ref}^{-1}\left(\bm{n}\times\frac{\partial\bm{E}^{inc}}{\partial t}\right)
     \times\bm{n} \,.
 ```
 
@@ -248,14 +254,15 @@ S_{ij} = \frac{\displaystyle\int_{\Gamma_i}\bm{E}\cdot\bm{E}^{inc}_i\,dS}
 ```
 
 For a resistive excited port, the incident field ``\bm{E}^{inc}`` is normalized so that the
-power integrated over the port boundary is unity, referenced to the port resistance ``R``.
-A lumped port with nonzero inductance and/or capacitance may also be excited. In this case
-the *termination* and *excitation* coefficients differ: the port's full ``R``, ``L``, and
-``C`` enter the system matrix as a physical parallel termination through the Robin
-coefficient ``\gamma = i\omega/Z_s`` with the complex ``Z_s(\omega)``, while the source
-term ``\bm{U}^{inc}`` is assembled with the real drive coefficient ``i\omega/R_{ref}``,
-where ``R_{ref}`` is a real reference resistance: ``R`` when ``R > 0``, or the free-space
-impedance ``Z_0 \approx 376.7~\Omega`` when ``R = 0`` (and equivalently ``Z_s^{-1} \to R_{ref}^{-1}`` in the time-domain source term). The
+power integrated over the port boundary is unity, referenced to the port resistance
+``R = R_{ref}``, and the excitation and termination coefficients coincide. A lumped port
+with nonzero inductance and/or capacitance may also be excited. In that case the port's
+full ``R``, ``L``, and ``C`` still enter the system matrix as a physical parallel
+termination through ``\gamma = i\omega/Z_s`` with the complex ``Z_s(\omega)``, while the
+source term is assembled with the real ``\gamma_{exc} = i\omega/R_{ref}`` defined above
+(``R_{ref} = Z_0 \approx 376.7~\Omega`` for a purely reactive port with ``R = 0``); the
+port reactance therefore acts on the solution through the termination, not through the
+drive normalization. The
 scattering parameters at resistive ports (observation or drive) retain their standard power-wave
 interpretation. For a purely reactive drive port (``R = 0``), the reported ``S_{ii}`` is related
 to the loaded port impedance by

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -35,6 +35,7 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
 
   if (HasExcitation())
   {
+    if (has_circ)
     {
       MFEM_VERIFY(data.R >= 0.0,
                   "Excited lumped port must have non-negative resistance!");

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -38,10 +38,14 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
     if (has_circ)
     {
       MFEM_VERIFY(data.R >= 0.0, "Excited lumped port must have non-negative resistance!");
+      MFEM_VERIFY(data.L >= 0.0 && data.C >= 0.0,
+                  "Excited lumped port must have non-negative inductance and capacitance!");
     }
     else
     {
       MFEM_VERIFY(data.Rs >= 0.0, "Excited lumped port must have non-negative resistance!");
+      MFEM_VERIFY(data.Ls >= 0.0 && data.Cs >= 0.0,
+                  "Excited lumped port must have non-negative inductance and capacitance!");
     }
   }
 
@@ -625,9 +629,13 @@ void LumpedPortOperator::AddExcitationBdrCoefficients(int excitation_idx,
                                                       SumVectorCoefficient &fb)
 {
   // Construct the RHS source term for lumped port boundaries, which looks like -U_inc =
-  // +2 iω/Z_s E_inc for a port boundary with an incident field E_inc. The chosen incident
-  // field magnitude corresponds to a unit incident power over the full port boundary. See
-  // p. 49 and p. 82 of the COMSOL RF Module manual for more detail.
+  // +2 iω/R_ref E_inc for a port boundary with an incident field E_inc, where R_ref is the
+  // real reference resistance from GetExcitationRefResistance() (the port R, or the unit
+  // internal reference for a purely reactive R == 0 port; any port reactance acts through
+  // the system-matrix termination iω/Z_s, not through this drive coefficient). The chosen
+  // incident field magnitude corresponds to a unit incident power over the full port
+  // boundary, referenced to R_ref. See p. 49 and p. 82 of the COMSOL RF Module manual for
+  // more detail.
   // Note: The real RHS returned here does not yet have the factor of (iω) included, so
   // works for time domain simulations requiring RHS -U_inc(t).
   for (const auto &[idx, data] : ports)

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -43,9 +43,11 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
     // includes the reactance. The incident/reflected wave used to define scattering
     // parameters is normalized to a real reference resistance (GetExcitationRefResistance):
     // for a resistive port that is R (unchanged, legacy behaviour); for a purely reactive
-    // port (R == 0) there is no real reference power, so a traveling-wave S-parameter at
-    // that port is not well defined — the fields, the synthesized circuit matrices, and the
-    // port admittance/impedance remain valid, but its own S entry is reported as NaN. The
+    // port (R == 0) it is the unit reference impedance in internal units (= Z_freespace
+    // dimensionally). The fields, the synthesized circuit matrices, and the port
+    // admittance/impedance are all valid for any R >= 0; the R == 0 port's own S column is
+    // still emitted but is referenced to that unit impedance rather than a user-chosen
+    // one, since with no real port resistance there is no natural reference for it. The
     // only requirement is a non-negative resistance.
     if (has_circ)
     {
@@ -152,12 +154,16 @@ double LumpedPortData::GetExcitationPower() const
 double LumpedPortData::GetExcitationVoltage() const
 {
   // Incident voltage should be the same across all elements of an excited lumped port.
+  // Reference the same real resistance used to normalize the incident drive
+  // (GetExcitationRefResistance: R for a resistive port, the unit reference for a purely
+  // reactive R == 0 port), so the reported V_inc is consistent with the assembled drive
+  // and nonzero for a reactive excitation.
   if (HasExcitation())
   {
     double V_inc = 0.0;
     for (const auto &elem : elems)
     {
-      const double Rs = R * GetToSquare(*elem);
+      const double Rs = GetExcitationRefResistance() * GetToSquare(*elem);
       const double E_inc = std::sqrt(
           Rs / (elem->GetGeometryWidth() * elem->GetGeometryLength() * elems.size()));
       V_inc += E_inc * elem->GetGeometryLength() / elems.size();

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -35,21 +35,6 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
 
   if (HasExcitation())
   {
-    // Historically an excited port had to be purely resistive (R > 0, no reactance). We now
-    // also allow a reactive excited port, so that a structure can be driven *through* a
-    // lumped inductor/capacitor (e.g. a Josephson-junction port in a superconducting
-    // circuit). The port's R/L/C still enters the system matrix as a physical termination
-    // (see Add{Stiffness,Damping,Mass}BdrCoefficients), so the field solution correctly
-    // includes the reactance. The incident/reflected wave used to define scattering
-    // parameters is normalized to a real reference resistance (GetExcitationRefResistance):
-    // for a resistive port that is R (unchanged, legacy behaviour); for a purely reactive
-    // port (R == 0) it is the unit reference impedance in internal units (= Z_freespace
-    // dimensionally). The fields, the synthesized circuit matrices, and the port
-    // admittance/impedance are all valid for any R >= 0; the R == 0 port's own S column is
-    // still emitted but is referenced to that unit impedance rather than a user-chosen
-    // one, since with no real port resistance there is no natural reference for it. The
-    // only requirement is a non-negative resistance.
-    if (has_circ)
     {
       MFEM_VERIFY(data.R >= 0.0,
                   "Excited lumped port must have non-negative resistance!");

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -35,17 +35,27 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
 
   if (HasExcitation())
   {
+    // Historically an excited port had to be purely resistive (R > 0, no reactance). We now
+    // also allow a reactive excited port, so that a structure can be driven *through* a
+    // lumped inductor/capacitor (e.g. a Josephson-junction port in a superconducting
+    // circuit). The port's R/L/C still enters the system matrix as a physical termination
+    // (see Add{Stiffness,Damping,Mass}BdrCoefficients), so the field solution correctly
+    // includes the reactance. The incident/reflected wave used to define scattering
+    // parameters is normalized to a real reference resistance (GetExcitationRefResistance):
+    // for a resistive port that is R (unchanged, legacy behaviour); for a purely reactive
+    // port (R == 0) there is no real reference power, so a traveling-wave S-parameter at
+    // that port is not well defined — the fields, the synthesized circuit matrices, and the
+    // port admittance/impedance remain valid, but its own S entry is reported as NaN. The
+    // only requirement is a non-negative resistance.
     if (has_circ)
     {
-      MFEM_VERIFY(data.R > 0.0, "Excited lumped port must have nonzero resistance!");
-      MFEM_VERIFY(data.C == 0.0 && data.L == 0.0,
-                  "Lumped port excitations do not support nonzero reactance!");
+      MFEM_VERIFY(data.R >= 0.0,
+                  "Excited lumped port must have non-negative resistance!");
     }
     else
     {
-      MFEM_VERIFY(data.Rs > 0.0, "Excited lumped port must have nonzero resistance!");
-      MFEM_VERIFY(data.Cs == 0.0 && data.Ls == 0.0,
-                  "Lumped port excitations do not support nonzero reactance!");
+      MFEM_VERIFY(data.Rs >= 0.0,
+                  "Excited lumped port must have non-negative resistance!");
     }
   }
 
@@ -182,7 +192,12 @@ void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespa
     SumVectorCoefficient fb(mesh.SpaceDimension());
     for (const auto &elem : elems)
     {
-      const double Rs = R * GetToSquare(*elem);
+      // Reference the S-parameter projection to the same real resistance used to normalize
+      // the incident drive (R for a resistive port; the unit reference for a purely reactive
+      // R == 0 port, so this does not divide by zero). The reactance is already present in
+      // the system matrix, so the projected field is the physical response; a purely
+      // reactive port's own S is not a meaningful traveling-wave quantity regardless.
+      const double Rs = GetExcitationRefResistance() * GetToSquare(*elem);
       const double Hinc = (std::abs(Rs) > 0.0)
                               ? 1.0 / std::sqrt(Rs * elem->GetGeometryWidth() *
                                                 elem->GetGeometryLength() * elems.size())
@@ -630,11 +645,16 @@ void LumpedPortOperator::AddExcitationBdrCoefficients(int excitation_idx,
     {
       continue;
     }
-    MFEM_VERIFY(std::abs(data.R) > 0.0,
-                "Unexpected zero resistance in excited lumped port!");
+    // Normalize the incident field to a real reference resistance. For a resistive port
+    // this is the port resistance R (legacy behaviour, unchanged). For a purely reactive
+    // excited port (R == 0) there is no real port resistance to reference the incident power
+    // to, so we use the unit reference |Z_R| = 1 in internal units purely to define a finite
+    // drive amplitude; the reactance itself acts through the system-matrix termination, not
+    // through this normalization.
+    const double R_ref = data.GetExcitationRefResistance();
     for (const auto &elem : data.elems)
     {
-      const double Rs = data.R * data.GetToSquare(*elem);
+      const double Rs = R_ref * data.GetToSquare(*elem);
       const double Hinc = 1.0 / std::sqrt(Rs * elem->GetGeometryWidth() *
                                           elem->GetGeometryLength() * data.elems.size());
       fb.AddCoefficient(elem->GetModeCoefficient(2.0 * Hinc));

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -37,13 +37,11 @@ LumpedPortData::LumpedPortData(const config::LumpedPortData &data,
   {
     if (has_circ)
     {
-      MFEM_VERIFY(data.R >= 0.0,
-                  "Excited lumped port must have non-negative resistance!");
+      MFEM_VERIFY(data.R >= 0.0, "Excited lumped port must have non-negative resistance!");
     }
     else
     {
-      MFEM_VERIFY(data.Rs >= 0.0,
-                  "Excited lumped port must have non-negative resistance!");
+      MFEM_VERIFY(data.Rs >= 0.0, "Excited lumped port must have non-negative resistance!");
     }
   }
 
@@ -185,10 +183,11 @@ void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespa
     for (const auto &elem : elems)
     {
       // Reference the S-parameter projection to the same real resistance used to normalize
-      // the incident drive (R for a resistive port; the unit reference for a purely reactive
-      // R == 0 port, so this does not divide by zero). The reactance is already present in
-      // the system matrix, so the projected field is the physical response; a purely
-      // reactive port's own S is not a meaningful traveling-wave quantity regardless.
+      // the incident drive (R for a resistive port; the unit reference for a purely
+      // reactive R == 0 port, so this does not divide by zero). The reactance is already
+      // present in the system matrix, so the projected field is the physical response; a
+      // purely reactive port's own S is not a meaningful traveling-wave quantity
+      // regardless.
       const double Rs = GetExcitationRefResistance() * GetToSquare(*elem);
       const double Hinc = (std::abs(Rs) > 0.0)
                               ? 1.0 / std::sqrt(Rs * elem->GetGeometryWidth() *
@@ -639,10 +638,10 @@ void LumpedPortOperator::AddExcitationBdrCoefficients(int excitation_idx,
     }
     // Normalize the incident field to a real reference resistance. For a resistive port
     // this is the port resistance R (legacy behaviour, unchanged). For a purely reactive
-    // excited port (R == 0) there is no real port resistance to reference the incident power
-    // to, so we use the unit reference |Z_R| = 1 in internal units purely to define a finite
-    // drive amplitude; the reactance itself acts through the system-matrix termination, not
-    // through this normalization.
+    // excited port (R == 0) there is no real port resistance to reference the incident
+    // power to, so we use the unit reference |Z_R| = 1 in internal units purely to define a
+    // finite drive amplitude; the reactance itself acts through the system-matrix
+    // termination, not through this normalization.
     const double R_ref = data.GetExcitationRefResistance();
     for (const auto &elem : data.elems)
     {

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -97,7 +97,7 @@ public:
   // reactive excited port (R == 0) there is no real port resistance, so we fall back to the
   // unit reference impedance |Z_R| = 1 in internal units (= Z_freespace) purely to define a
   // finite drive amplitude; the reactance acts physically through the system-matrix
-  // termination, and a traveling-wave S-parameter at such a port is not well defined.
+  // termination, and that port's own S column is referenced to this unit impedance.
   double GetExcitationRefResistance() const { return (std::abs(R) > 0.0) ? R : 1.0; }
 
   enum class Branch

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -91,6 +91,15 @@ public:
 
   constexpr bool HasExcitation() const { return excitation != 0; }
 
+  // Real reference resistance used to normalize the incident-field amplitude of an excited
+  // port. For a resistive port this is R, so the incident/reflected-wave normalization and
+  // the port's own termination impedance coincide and behaviour is unchanged. For a purely
+  // reactive excited port (R == 0) there is no real port resistance, so we fall back to the
+  // unit reference impedance |Z_R| = 1 in internal units (= Z_freespace) purely to define a
+  // finite drive amplitude; the reactance acts physically through the system-matrix
+  // termination, and a traveling-wave S-parameter at such a port is not well defined.
+  double GetExcitationRefResistance() const { return (std::abs(R) > 0.0) ? R : 1.0; }
+
   enum class Branch
   {
     TOTAL,

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -1305,12 +1305,15 @@ void PostOperator<solver_t>::MeasureSParameter() const
     // S-parameter computation with per-port reference impedances (Kurokawa power-wave
     // generalized S-parameters).
     //
-    // Each port type uses its natural reference impedance: lumped ports use the user-
-    // specified R; wave ports implicitly use the line's characteristic impedance encoded
-    // in the unit-power normalization of the boundary mode (∫|E_mode×H_mode⋆|·n dS = 1).
+    // Each port type uses its natural real reference impedance: lumped ports use
+    // GetExcitationRefResistance() (the user-specified R, or the unit internal reference
+    // for a purely reactive R == 0 port — any port reactance acts through the
+    // system-matrix termination, not this normalization); wave ports implicitly use the
+    // line's characteristic impedance encoded in the unit-power normalization of the
+    // boundary mode (∫|E_mode×H_mode⋆|·n dS = 1).
     //
     // GetSParameter() returns the b-amplitude in Kurokawa convention for both port types:
-    //   - Lumped: ∫E·(E_inc/Z_s) dS = V/V_inc, where V_inc encodes the port's R
+    //   - Lumped: ∫E·(E_inc/R_ref) dS = V/V_inc, where V_inc encodes R_ref
     //   - Wave:   ∫(E×H_mode⋆)·n dS, the modal power-overlap with unit-power normalization
     // Both are directly the Kurokawa b/a ratio, so no impedance scaling is needed.
 

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -2270,8 +2270,15 @@ void RomOperator::PrintPortReferenceData(const Units &units, const fs::path &pos
       std::complex<double> y_ref = 0.0;
       if (ref.type == RefType::Lumped)
       {
+        // Use the same real reference resistance as Palace's own S-parameter measurement
+        // (GetExcitationRefResistance: R for a resistive port, the unit internal reference
+        // for a purely reactive R == 0 port). This keeps the table consistent with its
+        // documented purpose — converting synthesized admittances to Palace/Kurokawa S —
+        // after reactive lumped excitation referenced direct S to the real R_ref. The
+        // physical (complex) RLC port load is exported separately in the rom-portload-*
+        // matrices. For resistive ports this coincides with the characteristic impedance.
         const auto &port_data = space_op.GetLumpedPortOp().GetPort(ref.port_idx);
-        y_ref = unit_ohm_inv / port_data.GetCharacteristicImpedance(omega);
+        y_ref = unit_ohm_inv / port_data.GetExcitationRefResistance();
       }
       else
       {

--- a/test/unit/test-lumpedportintegration.cpp
+++ b/test/unit/test-lumpedportintegration.cpp
@@ -796,8 +796,9 @@ TEST_CASE("LumpedPort_ReactiveExcitation_Cube321", "[lumped_port][Serial][Parall
   // when R = 0) so a purely reactive drive does not divide by zero. This test verifies:
   //   (1) a reactive excited port constructs without tripping the guardrail,
   //   (2) GetExcitationRefResistance() returns R when R > 0, else the unit reference,
-  //   (3) GetCharacteristicImpedance() returns the correct complex Z_ref(w) = R||iwL||1/iwC,
-  //   (4) the excitation RHS is finite (no NaN/Inf) for a purely reactive R = 0 drive.
+  //   (3) GetCharacteristicImpedance() returns the correct complex Z_ref(w) =
+  //   R||iwL||1/iwC, (4) the excitation RHS is finite (no NaN/Inf) for a purely reactive R
+  //   = 0 drive.
   using VT = palace::Units::ValueType;
   MPI_Comm world_comm = Mpi::World();
 
@@ -877,8 +878,7 @@ TEST_CASE("LumpedPort_ReactiveExcitation_Cube321", "[lumped_port][Serial][Parall
   }
   if (case_L > 0.0)
   {
-    Y += 1.0 /
-         (imag_unit * omega * iodata.units.Nondimensionalize<VT::INDUCTANCE>(case_L));
+    Y += 1.0 / (imag_unit * omega * iodata.units.Nondimensionalize<VT::INDUCTANCE>(case_L));
   }
   if (case_C > 0.0)
   {

--- a/test/unit/test-lumpedportintegration.cpp
+++ b/test/unit/test-lumpedportintegration.cpp
@@ -785,3 +785,122 @@ TEST_CASE("LumpedPort_BasicTests_3ElementPort_Cube321", "[lumped_port][Serial][P
                          1e-12));
   }
 }
+
+TEST_CASE("LumpedPort_ReactiveExcitation_Cube321", "[lumped_port][Serial][Parallel]")
+{
+  // Exercise a reactive EXCITED lumped port — a port driven through a lumped inductor /
+  // capacitor (e.g. a Josephson-junction port). Historically an excited port had to be
+  // purely resistive; it may now carry reactance (including a purely reactive R = 0 port).
+  // The reactance enters the system matrix as a physical termination; the incident-drive
+  // normalization references a real resistance (the port R, or the unit internal reference
+  // when R = 0) so a purely reactive drive does not divide by zero. This test verifies:
+  //   (1) a reactive excited port constructs without tripping the guardrail,
+  //   (2) GetExcitationRefResistance() returns R when R > 0, else the unit reference,
+  //   (3) GetCharacteristicImpedance() returns the correct complex Z_ref(w) = R||iwL||1/iwC,
+  //   (4) the excitation RHS is finite (no NaN/Inf) for a purely reactive R = 0 drive.
+  using VT = palace::Units::ValueType;
+  MPI_Comm world_comm = Mpi::World();
+
+  const auto &[case_R, case_L, case_C] =
+      GENERATE(std::make_tuple(50.0, 1.0e-9, 0.0),   // R + L (well-defined S)
+               std::make_tuple(0.0, 1.0e-9, 0.0),    // pure inductor (R = 0)
+               std::make_tuple(0.0, 0.0, 1.0e-12));  // pure capacitor (R = 0)
+
+  double L0 = 1.0e-6;
+  double Lc = 7.0;
+  IoData iodata{Units(L0, Lc)};
+  iodata.model.mesh =
+      fs::path(PALACE_TEST_DATA_DIR) / "lumpedport_mesh/cube_mesh_3_2_1_hex.msh";
+  iodata.model.L0 = L0;
+  iodata.model.Lc = Lc;
+  iodata.model.crack_bdr_elements = false;
+  iodata.solver.order = 2;
+
+  json domains_json = {
+      {"Materials",
+       json::array({json::object({{"Attributes", json::array({1, 2, 3, 4, 5, 6})},
+                                  {"Permeability", 1.0},
+                                  {"Permittivity", 1.0},
+                                  {"LossTan", 0.0}})})}};
+  iodata.domains = config::DomainData(domains_json);
+
+  // Build the excited reactive port. Only include nonzero circuit elements.
+  json port = {{"Index", 1},
+               {"Excitation", uint(1)},
+               {"Attributes", json::array({1})},
+               {"Direction", "+Y"}};
+  if (case_R > 0.0)
+  {
+    port["R"] = case_R;
+  }
+  if (case_L > 0.0)
+  {
+    port["L"] = case_L;
+  }
+  if (case_C > 0.0)
+  {
+    port["C"] = case_C;
+  }
+  json boundary_json = {{"LumpedPort", json::array({port})}};
+  // (1) Construction must succeed — the R >= 0 guardrail admits reactance.
+  iodata.boundaries = config::BoundaryData(boundary_json);
+  iodata.CheckConfiguration();
+
+  auto mesh_io = LoadScaleParMesh(iodata, world_comm);
+  SpaceOperator space_op(iodata, mesh_io);
+  const auto &port_1 = space_op.GetLumpedPortOp().GetPort(1);
+
+  CHECK(port_1.HasExcitation());
+
+  // (2) Reference resistance: R when R > 0, else the unit internal reference (= 1 in
+  // internal units, i.e. Z_freespace dimensionally).
+  const double R_nondim = iodata.units.Nondimensionalize<VT::IMPEDANCE>(case_R);
+  if (case_R > 0.0)
+  {
+    CHECK_THAT(port_1.GetExcitationRefResistance(), WithinRel(R_nondim));
+  }
+  else
+  {
+    CHECK_THAT(port_1.GetExcitationRefResistance(), WithinRel(1.0));
+  }
+
+  // (3) Characteristic impedance Z_ref(w) = 1 / (1/R + 1/(iwL) + iwC). Check against a
+  // direct evaluation at a representative (nondimensional) frequency.
+  const double f_GHz = 10.0;
+  const double omega =
+      iodata.units.Nondimensionalize<VT::FREQUENCY>(2.0 * M_PI * f_GHz * 1.0e9);
+  const std::complex<double> imag_unit{0.0, 1.0};
+  std::complex<double> Y = 0.0;
+  if (case_R > 0.0)
+  {
+    Y += 1.0 / R_nondim;
+  }
+  if (case_L > 0.0)
+  {
+    Y += 1.0 /
+         (imag_unit * omega * iodata.units.Nondimensionalize<VT::INDUCTANCE>(case_L));
+  }
+  if (case_C > 0.0)
+  {
+    Y += imag_unit * omega * iodata.units.Nondimensionalize<VT::CAPACITANCE>(case_C);
+  }
+  const std::complex<double> Z_expect = 1.0 / Y;
+  const std::complex<double> Z_ref =
+      port_1.GetCharacteristicImpedance(omega, LumpedPortData::Branch::TOTAL);
+  CHECK_THAT(std::abs(Z_ref - Z_expect), WithinAbs(0.0, 1e-9 * std::abs(Z_expect)));
+
+  // (4) The excitation RHS must be finite even for a purely reactive R = 0 drive (the key
+  // fix: the incident-field normalization references GetExcitationRefResistance(), not R,
+  // so it does not divide by zero).
+  ComplexVector RHS;
+  space_op.GetExcitationVector1(1, RHS);
+  double max_abs = 0.0;
+  for (int i = 0; i < RHS.Real().Size(); i++)
+  {
+    CHECK(std::isfinite(RHS.Real()[i]));
+    max_abs = std::max(max_abs, std::abs(RHS.Real()[i]));
+  }
+  Mpi::GlobalMax(1, &max_abs, world_comm);
+  // The drive is nonzero (a genuine incident field was assembled).
+  CHECK(max_abs > 0.0);
+}

--- a/test/unit/test-lumpedportintegration.cpp
+++ b/test/unit/test-lumpedportintegration.cpp
@@ -868,8 +868,7 @@ TEST_CASE("LumpedPort_ReactiveExcitation_Cube321", "[lumped_port][Serial][Parall
   // (3) Characteristic impedance Z_ref(w) = 1 / (1/R + 1/(iwL) + iwC). Check against a
   // direct evaluation at a representative (nondimensional) frequency.
   const double f_GHz = 10.0;
-  const double omega =
-      iodata.units.Nondimensionalize<VT::FREQUENCY>(2.0 * M_PI * f_GHz * 1.0e9);
+  const double omega = 2.0 * M_PI * iodata.units.Nondimensionalize<VT::FREQUENCY>(f_GHz);
   const std::complex<double> imag_unit{0.0, 1.0};
   std::complex<double> Y = 0.0;
   if (case_R > 0.0)
@@ -903,4 +902,20 @@ TEST_CASE("LumpedPort_ReactiveExcitation_Cube321", "[lumped_port][Serial][Parall
   Mpi::GlobalMax(1, &max_abs, world_comm);
   // The drive is nonzero (a genuine incident field was assembled).
   CHECK(max_abs > 0.0);
+
+  // (5) Output paths reference the same real resistance. GetExcitationVoltage() must be
+  // finite and nonzero for R = 0 (it references GetExcitationRefResistance(), not R), and
+  // the S-parameter projection linear form must produce a finite, nonzero projection for
+  // a nonzero field (its normalization also references the real reference resistance).
+  const double V_inc = port_1.GetExcitationVoltage();
+  CHECK(std::isfinite(V_inc));
+  CHECK(V_inc > 0.0);
+
+  GridFunction E_test(space_op.GetNDSpace(), true);
+  E_test.Real() = 1.0;  // Uniform nonzero field: projection onto the port mode is nonzero
+  E_test.Imag() = 0.0;
+  const std::complex<double> S_proj = port_1.GetSParameter(E_test);
+  CHECK(std::isfinite(S_proj.real()));
+  CHECK(std::isfinite(S_proj.imag()));
+  CHECK(std::abs(S_proj) > 0.0);
 }


### PR DESCRIPTION
Previously, excited lumped ports were required to be purely resistive. This PR removes this restriction and excited lumped ports may now carry reactance (`"L"` and/or `"C"`, including purely reactive ports with `"R": 0`). The reactance enters the system matrix as a physical termination; the incident drive is normalized to the port `"R"` when positive, or to an internal unit reference impedance for a purely reactive port. 

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
