### PR TITLE
Centralize container publishing in a trusted workflow

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -39,68 +39,24 @@ runs:
 
         end_timer "Setup podman and apptainer"
 
-    - name: Compute container metadata
-      id: meta
-      shell: bash
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        # The PR's source branch (pull_request events) or the dispatched branch.
-        HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
-        # 'true' iff a same-repo PR carries the push-containers label. Fork PRs
-        # resolve head.repo to the fork, so this stays false for them — they must
-        # never reach the instance-role push credentials on the public repo.
-        LABEL_PUSH: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'push-containers') && github.event.pull_request.head.repo.full_name == github.repository }}
-        # Requested Spack microarchitecture; empty means build native.
-        TARGET: ${{ inputs.target }}
-      run: |
-        # Build for the requested target if given, else the runner's native
-        # microarchitecture. A target must be <= the host's native ISA (the
-        # workflow matrix guarantees this) so build-time binaries can run here.
-        ARCH_LABEL="${TARGET:-$(spack arch -t)}"
-
-        # Sanitize the branch into an ECR-tag/S3-prefix-safe slug: ECR tags allow
-        # only [A-Za-z0-9_.-], and '/' is illegal, so collapse everything else
-        # to '-'. The dev-<branch> name is intentionally MOVING (a re-push to the
-        # same branch overwrites its prototype image).
-        BRANCH_SLUG=$(echo "$HEAD_BRANCH" | sed 's#[^A-Za-z0-9_.-]#-#g')
-
-        # Decide the published name and whether to push, by trigger:
-        #   - tag push  vX.Y.Z      -> "X.Y.Z"        (release), pushed
-        #   - push to   main        -> "main"         (rolling dev), pushed
-        #   - PR w/ push-containers -> "dev-<branch>" (prototype), pushed
-        #                              (same-repo PRs only; forks never push)
-        #   - everything else       -> "dev-<branch>", build only, never pushed
-        #                              (plain PRs, manual dispatch re-runs).
-        # ECR tags can't contain '/', so VERSION uses '-' while the S3 prefix
-        # keeps '/' for a tidy bucket layout.
-        if [ "$EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
-          VERSION="main"; S3_PREFIX="main"; PUSH=true
-        elif [ "$EVENT_NAME" = "push" ] && [ "${GITHUB_REF#refs/tags/v}" != "$GITHUB_REF" ]; then
-          VERSION="${GITHUB_REF#refs/tags/v}"; S3_PREFIX="$VERSION"; PUSH=true
-        elif [ "$LABEL_PUSH" = "true" ]; then
-          VERSION="dev-${BRANCH_SLUG}"; S3_PREFIX="dev/${BRANCH_SLUG}"; PUSH=true
-        else
-          VERSION="dev-${BRANCH_SLUG}"; S3_PREFIX="dev/${BRANCH_SLUG}"; PUSH=false
-        fi
-
-        echo "arch_label=${ARCH_LABEL}" >> "$GITHUB_OUTPUT"
-        echo "version=${VERSION}"       >> "$GITHUB_OUTPUT"
-        echo "s3_prefix=${S3_PREFIX}"   >> "$GITHUB_OUTPUT"
-        echo "push=${PUSH}"             >> "$GITHUB_OUTPUT"
-
-        echo "Arch label: ${ARCH_LABEL}"
-        echo "Version:    ${VERSION}"
-        echo "S3 prefix:  ${S3_PREFIX}"
-        echo "Push:       ${PUSH}"
-
     - name: Compute image name
       id: name
       shell: bash
       env:
-        ARCH_LABEL: ${{ steps.meta.outputs.arch_label }}
+        # Requested Spack microarchitecture; empty means build native.
+        TARGET: ${{ inputs.target }}
+        # The commit being built. Only makes the image name unique/readable —
+        # not load-bearing (the publish workflow takes the authoritative sha
+        # from the workflow_run payload, not this name).
+        SOURCE_SHA: ${{ github.sha }}
       run: |
-        SHORT_HASH=$(git rev-parse --short HEAD)
-        IMAGE_NAME="palace-${ARCH_LABEL}-${SHORT_HASH}"
+        # Build for the requested target if given, else the runner's native
+        # microarchitecture. A target must be <= the host's native ISA (the
+        # workflow matrix guarantees this) so build-time binaries can run here.
+        # The arch label names the image, from which the publish workflow later
+        # recovers it to tag/key this build's artifacts.
+        ARCH_LABEL="${TARGET:-$(spack arch -t)}"
+        IMAGE_NAME="palace-${ARCH_LABEL}-${SOURCE_SHA:0:7}"
         echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
         echo "Image name: ${IMAGE_NAME}"
 
@@ -168,57 +124,6 @@ runs:
         sudo chmod a+r ${{ steps.name.outputs.image_name }}.sif
         end_timer "Convert to SIF"
 
-    - name: Push OCI image to ECR
-      if: steps.meta.outputs.push == 'true'
-      shell: bash
-      env:
-        AWS_REGION: us-west-2
-        ECR_REPOSITORY: palace
-        VERSION: ${{ steps.meta.outputs.version }}
-        ARCH_LABEL: ${{ steps.meta.outputs.arch_label }}
-        IMAGE_NAME: ${{ steps.name.outputs.image_name }}
-      run: |
-        # Pushes on main/tag builds and push-containers-labelled PRs (see the
-        # metadata step). Auth is ambient via the runner's EC2 instance role.
-        source /tmp/timing_functions.sh
-        start_timer
-
-        ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-        # Redact the account ID from all subsequent log output.
-        echo "::add-mask::${ACCOUNT_ID}"
-        REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-        REMOTE_TAG="${REGISTRY}/${ECR_REPOSITORY}:${VERSION}-${ARCH_LABEL}"
-
-        aws ecr get-login-password --region "$AWS_REGION" \
-          | sudo podman login --username AWS --password-stdin "$REGISTRY"
-
-        sudo podman tag "${IMAGE_NAME}:latest" "$REMOTE_TAG"
-        sudo podman push "$REMOTE_TAG"
-
-        echo "Pushed image to ${REMOTE_TAG}"
-        end_timer "Push OCI image to ECR"
-
-    - name: Upload SIF to S3
-      # Pushes on main/tag builds and push-containers-labelled PRs (see the
-      # metadata step). Auth is ambient via the runner's EC2 instance role.
-      if: steps.meta.outputs.push == 'true'
-      shell: bash
-      env:
-        AWS_REGION: us-west-2
-        S3_BUCKET: palace-ci-containers
-        S3_PREFIX: ${{ steps.meta.outputs.s3_prefix }}
-        ARCH_LABEL: ${{ steps.meta.outputs.arch_label }}
-        IMAGE_NAME: ${{ steps.name.outputs.image_name }}
-      run: |
-        source /tmp/timing_functions.sh
-        start_timer
-
-        S3_KEY="s3://${S3_BUCKET}/${S3_PREFIX}/${ARCH_LABEL}.sif"
-        aws s3 cp --region "$AWS_REGION" "${IMAGE_NAME}.sif" "$S3_KEY"
-
-        echo "Uploaded SIF to ${S3_KEY}"
-        end_timer "Upload SIF to S3"
-
     - name: Upload OCI image
       uses: actions/upload-artifact@v7
       with:
@@ -237,3 +142,5 @@ runs:
       shell: bash
       run: |
         cat /tmp/timing.log
+
+    # When this job completed, the publish-container workflow is triggered.

--- a/.github/publish_containers/authorize.py
+++ b/.github/publish_containers/authorize.py
@@ -110,17 +110,35 @@ class GitHubApi:
         self.repo = repo
 
     def _get(self, path: str) -> object | None:
+        """Decoded JSON body, or None if the resource does not exist (404).
+
+        Only an explicit 404 means "absent". Every other failure — auth, rate
+        limit, 5xx, transport, non-JSON body — raises, because silently reading
+        it as "absent" would turn an outage into an unauthorized publish: a
+        release could then finish green having published nothing.
+        """
+        # --include prints the status line and headers before the body, which is
+        # the only way to tell 404 apart from the rest (gh exits 1 for all of
+        # them).
         proc = subprocess.run(
-            ["gh", "api", path],
+            ["gh", "api", "--include", path],
             capture_output=True,
             text=True,
         )
-        if proc.returncode != 0:
-            return None  # 404 / not found → treat as absent, never as an error blob
-        try:
-            return json.loads(proc.stdout)
-        except json.JSONDecodeError:
+        headers, _, body = proc.stdout.replace("\r\n", "\n").partition("\n\n")
+        match = re.match(r"^HTTP/\S+ ([0-9]{3})(?:\s|\Z)", headers)
+        if match is None:
+            detail = proc.stderr.strip() or "missing HTTP status"
+            raise RuntimeError(f"GitHub API request failed for {path}: {detail}")
+        status = int(match.group(1))
+        if status == 404:
             return None
+        if proc.returncode != 0 or not 200 <= status < 300:
+            raise RuntimeError(f"GitHub API request failed for {path}: HTTP {status}")
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"GitHub API returned invalid JSON for {path}") from exc
 
     def ref_sha(self, kind: str, name: str) -> str | None:
         """Commit sha a ref points at, or None. Peels annotated tags.

--- a/.github/publish_containers/authorize.py
+++ b/.github/publish_containers/authorize.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization decision for the trusted container publish workflow.
+
+The publish workflow runs from the default branch (via ``workflow_run``), so
+this code — not the PR-controlled build — decides whether a build may publish
+and to which selector. The decision uses only trusted inputs: the event facts
+GitHub reports for the build run, plus live lookups against the GitHub API. The
+build passes no authorization data of its own.
+
+Two entry points, one decision function:
+
+- default: emit ``authorized=`` / ``selector=`` to ``$GITHUB_OUTPUT``.
+- ``--reverify EXPECTED``: recompute the decision immediately before the writes
+  (TOCTOU guard) and fail unless it still authorizes the same selector.
+
+A build is authorized to publish only when, checked against the live GitHub
+API:
+- it did NOT come from a fork (head repo == base repo); and
+- the triggering event is one of:
+  - push to `main`, and `main` still points at the built commit
+    -> publishes the `main` channel;
+  - push of a `vX.Y.Z` release tag that still points at the built commit
+    -> publishes the `X.Y.Z` channel;
+  - manual `workflow_dispatch` on a branch that still points at the built
+    commit -> publishes `dev-<branch>`;
+  - a same-repo `pull_request` whose head (matched by sha AND ref) is an OPEN
+    PR currently carrying the `push-containers` label -> publishes
+    `dev-<branch>`.
+
+For the two `dev-<branch>` paths the branch name must match `DEV_BRANCH_RE`.
+
+The GitHub API is reached through a small seam (the `GitHubApi` class) so the
+decision logic is unit-tested with a fake client and no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+PUSH_CONTAINERS_LABEL = "push-containers"
+RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+\Z")  # \Z, not $: see DEV_BRANCH_RE
+
+# Dev-channel (dispatch / labeled-PR) branch names must match this shape: a
+# hyphen-free, slash-free prefix, exactly one "/", then a segment with no
+# further "/" (e.g., `gbozzola/test-containers`). The reason for this is that
+# ECR has restrictions on what characters are allowed and we sanitize them in
+# slugify in such a way that could lead to collisions. We could remove this
+# restriction by using hashes adding much more infrastructure, but, honestly,
+# YAGNI.
+#
+# \Z (not $) so a trailing newline can't sneak past the anchor.
+DEV_BRANCH_RE = re.compile(r"^[A-Za-z0-9_.]+/[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
+
+
+@dataclass(frozen=True)
+class Facts:
+    """Trusted facts about the build run, from the ``workflow_run`` payload."""
+
+    repo: str  # owner/repo, e.g. "awslabs/palace"
+    event: str  # "push" | "workflow_dispatch" | "pull_request" | ...
+    head_sha: str
+    head_branch: str  # branch or tag name (refs/heads/ and refs/tags/ stripped)
+    head_repo: str  # head_repository.full_name
+    base_repo: str  # repository.full_name
+
+
+@dataclass(frozen=True)
+class Decision:
+    authorized: bool
+    selector: str
+    reason: str
+
+
+def _reject(reason: str) -> Decision:
+    return Decision(False, "", reason)
+
+
+def _unsupported_branch_reason(branch: str) -> str:
+    return (
+        f"branch '{branch}' is not supported for dev publishing yet: the name "
+        f"must look like 'prefix/name' (a hyphen-free prefix, one '/', then a "
+        f"name of [A-Za-z0-9_.-] starting alphanumeric), e.g. 'user/my-feature'. "
+        f"This restriction keeps the dev-<branch> selector collision-free. "
+        f"main and release-tag publishing are unaffected."
+    )
+
+
+def slugify(branch: str) -> str:
+    """Collapse a branch name to an ECR-tag / S3-prefix-safe slug.
+
+    ECR tags allow only ``[A-Za-z0-9_.-]`` and ``/`` is illegal, so everything
+    else becomes ``-``. ``dev-<branch>`` is intentionally a MOVING selector.
+    """
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", branch)
+
+
+class GitHubApi:
+    """Live GitHub API access via the ``gh`` CLI (authenticated by GH_TOKEN)."""
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def _get(self, path: str) -> object | None:
+        proc = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            return None  # 404 / not found → treat as absent, never as an error blob
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return None
+
+    def ref_sha(self, kind: str, name: str) -> str | None:
+        """Commit sha a ref points at, or None. Peels annotated tags.
+
+        ``kind`` is "heads" or "tags". For an annotated tag, the ref object is
+        the tag object, so we peel it to the commit it targets.
+        """
+        ref = self._get(f"repos/{self.repo}/git/ref/{kind}/{name}")
+        if not isinstance(ref, dict):
+            return None
+        obj = ref.get("object") or {}
+        sha, obj_type = obj.get("sha"), obj.get("type")
+        if obj_type == "tag":
+            tag = self._get(f"repos/{self.repo}/git/tags/{sha}")
+            if not isinstance(tag, dict):
+                return None
+            sha = (tag.get("object") or {}).get("sha")
+        return sha
+
+    def pr_for_head(self, sha: str, ref: str) -> tuple[int, str, str] | None:
+        """(PR number, head repo full_name, state) for the PR whose head is
+        ``sha`` AND whose head branch is ``ref``.
+
+        ``state`` is "open" or "closed".
+        """
+        pulls = self._get(f"repos/{self.repo}/commits/{sha}/pulls")
+        if not isinstance(pulls, list):
+            return None
+        for pr in pulls:
+            if not isinstance(pr, dict):
+                continue
+            head = pr.get("head") or {}
+            # ``/commits/{sha}/pulls`` returns PRs that merely *contain* the
+            # commit (filtered out by matching ``head.sha``), and multiple PRs
+            # can share a head commit (e.g. two branches at the same sha), so
+            # we ALSO match ``head.ref`` to pin the PR for the branch that
+            # actually built, not some other PR that happens to sit on the same
+            # commit.
+            if head.get("sha") == sha and head.get("ref") == ref:
+                repo = (head.get("repo") or {}).get("full_name") or ""
+                state = pr.get("state") or ""
+                number = pr.get("number")
+                if number is None:
+                    return None
+                return int(number), repo, state
+        return None
+
+    def pr_has_label(self, number: int, label: str) -> bool:
+        labels = self._get(f"repos/{self.repo}/issues/{number}/labels")
+        if not isinstance(labels, list):
+            return False
+        return any(isinstance(lbl, dict) and lbl.get("name") == label for lbl in labels)
+
+
+def decide(facts, api) -> Decision:
+    """Decide whether ``facts`` authorizes a publish, and to which selector.
+
+    ``api`` is anything providing ref_sha(kind, name), pr_for_head(sha, ref),
+    and pr_has_label(number, label) — the live GitHubApi in production, a fake
+    in tests. Every branch re-derives from trusted facts / live API state, so
+    calling ``decide`` again just before the writes is a valid TOCTOU re-check.
+    """
+    # Forks never publish, regardless of event. A maintainer approving a fork
+    # build authorizes EXECUTING its code on a runner, never publishing.
+    if facts.head_repo != facts.base_repo:
+        return _reject(f"head repo '{facts.head_repo}' != base repo '{facts.base_repo}' (fork)")
+
+    if facts.event == "push":
+        # head_branch strips both refs/heads/ and refs/tags/, so it is
+        # ambiguous; resolve each ref kind explicitly and require it to point at
+        # the built commit right now.
+        if facts.head_branch == "main":
+            if api.ref_sha("heads", "main") == facts.head_sha:
+                return Decision(True, "main", f"push to main at {facts.head_sha}")
+            return _reject("main does not currently point at the built sha")
+        if RELEASE_TAG_RE.match(facts.head_branch):
+            if api.ref_sha("tags", facts.head_branch) == facts.head_sha:
+                selector = facts.head_branch[1:]  # drop leading "v"
+                return Decision(True, selector, f"release tag {facts.head_branch} at {facts.head_sha}")
+            return _reject(f"release tag {facts.head_branch} does not point at the built sha")
+        return _reject(f"push ref '{facts.head_branch}' is neither main nor a vX.Y.Z release tag")
+
+    if facts.event == "workflow_dispatch":
+        # Dispatch = publish request for a branch. GitHub gates dispatch to
+        # write-access users; require the ref to be a branch at the built sha.
+        if api.ref_sha("heads", facts.head_branch) != facts.head_sha:
+            return _reject(f"dispatch ref '{facts.head_branch}' is not a branch at the built sha")
+        if not DEV_BRANCH_RE.match(facts.head_branch):
+            return _reject(_unsupported_branch_reason(facts.head_branch))
+        return Decision(True, f"dev-{slugify(facts.head_branch)}", f"dispatch on branch {facts.head_branch} at {facts.head_sha}")
+
+    if facts.event == "pull_request":
+        pr = api.pr_for_head(facts.head_sha, facts.head_branch)
+        if pr is None:
+            return _reject(f"no PR has head {facts.head_branch} at {facts.head_sha}")
+        number, pr_head_repo, state = pr
+        if pr_head_repo != facts.base_repo:
+            return _reject(f"PR #{number} head repo '{pr_head_repo}' is a fork")
+        if state != "open":
+            return _reject(f"PR #{number} is not open (state '{state}')")
+        if not api.pr_has_label(number, PUSH_CONTAINERS_LABEL):
+            return _reject(f"PR #{number} does not currently carry the {PUSH_CONTAINERS_LABEL} label")
+        if not DEV_BRANCH_RE.match(facts.head_branch):
+            return _reject(_unsupported_branch_reason(facts.head_branch))
+        return Decision(True, f"dev-{slugify(facts.head_branch)}", f"labeled same-repo PR #{number} at {facts.head_sha}")
+
+    # Unknown / unsupported event → fail closed.
+    return _reject(f"unsupported source event '{facts.event}'")
+
+
+def facts_from_env() -> Facts:
+    return Facts(
+        repo=os.environ["OWNER_REPO"],
+        event=os.environ["SOURCE_EVENT"],
+        head_sha=os.environ["HEAD_SHA"],
+        head_branch=os.environ["HEAD_BRANCH"],
+        head_repo=os.environ["HEAD_REPO"],
+        base_repo=os.environ["BASE_REPO"],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reverify",
+        metavar="EXPECTED_SELECTOR",
+        help="TOCTOU re-check: recompute the decision and fail unless it still "
+        "authorizes this exact selector.",
+    )
+    args = parser.parse_args(argv)
+
+    facts = facts_from_env()
+    decision = decide(facts, GitHubApi(facts.repo))
+
+    if args.reverify is not None:
+        expected = args.reverify
+        if not decision.authorized or decision.selector != expected:
+            print(
+                f"::error::Re-verification failed for selector '{expected}' "
+                f"({facts.event} at {facts.head_sha}): {decision.reason}; "
+                f"aborting before any publish.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Re-verified '{expected}' still current at {facts.head_sha}; proceeding to publish.")
+        return 0
+
+    authorized = "true" if decision.authorized else "false"
+    print(f"Authorization: authorized={authorized} selector='{decision.selector}' ({decision.reason})")
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(f"authorized={authorized}\n")
+            fh.write(f"selector={decision.selector}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/publish_containers/publish.py
+++ b/.github/publish_containers/publish.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish a build run's container artifacts to ECR (OCI) and S3 (SIF).
+
+Runs only after :mod:`authorize` has authorized the publish and produced the
+selector. Splits cleanly into:
+
+- :func:`plan` — pure logic: map each downloaded artifact leg to its ECR tag
+  and S3 URI. Unit-tested, no I/O.
+- :func:`main` — thin glue: ECR login, then run each planned copy via skopeo /
+  aws with explicit argument lists (no shell, so no quoting pitfalls).
+
+A native build produces one leg per arch; a release build one leg per
+microarchitecture target. Each leg is a pair of downloaded artifacts:
+``<image>-oci/<image>.tar`` and ``<image>-sif/<image>.sif`` where ``<image>`` is
+``palace-<arch_label>-<shorthash>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PublishItem:
+    image_name: str
+    arch_label: str
+    oci_tar: Path
+    sif: Path
+    ecr_tag: str  # full ECR ref, e.g. <registry>/palace:main-sapphirerapids
+    s3_uri: str  # full s3:// destination for the SIF
+
+
+IMAGE_NAME_RE = re.compile(r"^palace-(?P<label>[a-z0-9_]+)-(?P<hash>[0-9a-f]+)$")
+
+
+def arch_label_from_image(image_name: str) -> str:
+    """``palace-<arch_label>-<shorthash>`` -> ``<arch_label>``.
+
+    Arch labels are ``[a-z0-9_]`` (no hyphens) and the short hash is hex, so the
+    shape is unambiguous.
+    """
+    # We match that exact shape rather than split on the last hyphen: a loose
+    # split would mis-read e.g. ``palace-foo-latest`` as label ``foo`` (hash
+    # ``latest``) or absorb a hyphen into the label, and two names collapsing to
+    # one label would then overwrite each other's tag/key.
+    m = IMAGE_NAME_RE.match(image_name)
+    if not m:
+        raise ValueError(
+            f"image name '{image_name}' is not palace-<label>-<hexhash> "
+            f"(label [a-z0-9_], hash hex)"
+        )
+    return m.group("label")
+
+
+def s3_prefix_for(selector: str) -> str:
+    """S3 key prefix for a selector, preserving the dev/<branch> layout.
+
+    ``dev-<branch>`` selectors publish under ``dev/<branch>/``; ``main`` and
+    release selectors publish under ``<selector>/``.
+    """
+    if selector.startswith("dev-"):
+        return f"dev/{selector[len('dev-'):]}"
+    return selector
+
+
+def plan(
+    artifacts_dir: Path,
+    selector: str,
+    registry: str,
+    ecr_repo: str,
+    s3_bucket: str,
+) -> list[PublishItem]:
+    """Build the publish plan from the downloaded artifacts. Pure; no I/O beyond
+    reading the artifact directory.
+
+    Every leg must be complete (both the OCI tar and the SIF present) and its
+    arch label unique, so an incomplete or mislabelled leg is a hard error
+    rather than a silently partial publish. Completeness of the set of legs is
+    guaranteed upstream: this workflow only runs when the whole `Containers`
+    matrix succeeded (workflow_run.conclusion == 'success'), and the build's
+    artifact uploads are unconditional, so a successful run has every leg.
+    """
+    items: list[PublishItem] = []
+    seen_labels: set[str] = set()
+    for oci_tar in sorted(artifacts_dir.glob("*-oci/*.tar")):
+        image_name = oci_tar.parent.name[: -len("-oci")]  # strip "-oci" dir suffix
+        arch_label = arch_label_from_image(image_name)
+        if arch_label in seen_labels:
+            raise ValueError(f"duplicate arch label '{arch_label}' among artifacts")
+        seen_labels.add(arch_label)
+        sif = artifacts_dir / f"{image_name}-sif" / f"{image_name}.sif"
+        if not sif.is_file():
+            raise ValueError(f"leg '{image_name}' has an OCI tar but no SIF at {sif}")
+        ecr_tag = f"{registry}/{ecr_repo}:{selector}-{arch_label}"
+        s3_uri = f"s3://{s3_bucket}/{s3_prefix_for(selector)}/{arch_label}.sif"
+        items.append(PublishItem(image_name, arch_label, oci_tar, sif, ecr_tag, s3_uri))
+
+    return items
+
+
+def _run(cmd: list[str]) -> None:
+    print("+ " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--selector", required=True)
+    parser.add_argument("--artifacts-dir", default="./artifacts")
+    args = parser.parse_args(argv)
+
+    region = os.environ["AWS_REGION"]
+    ecr_repo = os.environ["ECR_REPOSITORY"]
+    s3_bucket = os.environ["S3_CONTAINERS_BUCKET"]
+
+    account_id = subprocess.run(
+        ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    print(f"::add-mask::{account_id}")
+    registry = f"{account_id}.dkr.ecr.{region}.amazonaws.com"
+
+    try:
+        items = plan(Path(args.artifacts_dir), args.selector, registry, ecr_repo, s3_bucket)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    if not items:
+        print("::error::no OCI artifacts found to publish", file=sys.stderr)
+        return 1
+
+    # Log skopeo into ECR once (writes an auth file), so the registry password
+    # is never placed on a command line / visible in the process list.
+    ecr_pass = subprocess.run(
+        ["aws", "ecr", "get-login-password", "--region", region],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["skopeo", "login", "--username", "AWS", "--password-stdin", registry],
+        input=ecr_pass, text=True, check=True,
+    )
+
+    for item in items:
+        print(f"Publishing {item.image_name} -> {item.ecr_tag}")
+        # skopeo is pre-installed on ubuntu-latest. The tar is
+        # `podman save --format docker`, so use the docker-archive transport.
+        _run(["skopeo", "copy", f"docker-archive:{item.oci_tar}", f"docker://{item.ecr_tag}"])
+        _run(["aws", "s3", "cp", "--region", region, str(item.sif), item.s3_uri])
+
+    print(f"Published {len(items)} image(s) for selector '{args.selector}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/publish_containers/test_authorize.py
+++ b/.github/publish_containers/test_authorize.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the container-publish authorization decision.
 
-Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+Run: python3 -m unittest discover -s .github/publish_containers -p 'test_*.py'
 
 The decision logic is exercised with a FakeApi returning canned responses, so
 these run offline and deterministically. Cases mirror the real GitHub API

--- a/.github/publish_containers/test_authorize.py
+++ b/.github/publish_containers/test_authorize.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the container-publish authorization decision.
+
+Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+
+The decision logic is exercised with a FakeApi returning canned responses, so
+these run offline and deterministically. Cases mirror the real GitHub API
+behaviors verified live during development (annotated-tag peeling, PRs that
+merely contain a commit vs. head it, empty pull lists, missing refs).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from authorize import Decision, Facts, decide, slugify
+
+SHA = "c45e4ab4f2356589ba40f4fde2403f5854282826"
+OTHER_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+REPO = "awslabs/palace"
+
+
+class FakeApi:
+    """Stand-in for GitHubApi. All lookups come from constructor data."""
+
+    def __init__(self, *, refs=None, pr_for_head=None, labels=None):
+        # refs: {("heads"|"tags", name): commit_sha}
+        self._refs = refs or {}
+        # pr_for_head: {(head_sha, head_ref): (number, head_repo_full_name, state)}
+        self._pr = pr_for_head or {}
+        # labels: {pr_number: set(label names)}
+        self._labels = labels or {}
+
+    def ref_sha(self, kind, name):
+        return self._refs.get((kind, name))
+
+    def pr_for_head(self, sha, ref):
+        return self._pr.get((sha, ref))
+
+    def pr_has_label(self, number, label):
+        return label in self._labels.get(number, set())
+
+
+def facts(**kw):
+    base = dict(
+        repo=REPO,
+        event="push",
+        head_sha=SHA,
+        head_branch="main",
+        head_repo=REPO,
+        base_repo=REPO,
+    )
+    base.update(kw)
+    return Facts(**base)
+
+
+class ForkRejection(unittest.TestCase):
+    def test_fork_head_repo_rejected_regardless_of_event(self):
+        for event in ("push", "workflow_dispatch", "pull_request"):
+            d = decide(facts(event=event, head_repo="attacker/palace"), FakeApi())
+            self.assertFalse(d.authorized)
+            self.assertIn("fork", d.reason)
+
+
+class PushMain(unittest.TestCase):
+    def test_main_at_built_sha_authorizes(self):
+        api = FakeApi(refs={("heads", "main"): SHA})
+        d = decide(facts(head_branch="main", head_sha=SHA), api)
+        self.assertEqual(d, Decision(True, "main", d.reason))
+
+    def test_stale_main_rejected(self):
+        api = FakeApi(refs={("heads", "main"): OTHER_SHA})
+        d = decide(facts(head_branch="main", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertEqual(d.selector, "")
+
+
+class ReleaseTag(unittest.TestCase):
+    def test_release_tag_authorizes_and_strips_v(self):
+        api = FakeApi(refs={("tags", "v0.18.0"): SHA})
+        d = decide(facts(head_branch="v0.18.0", head_sha=SHA), api)
+        self.assertTrue(d.authorized)
+        self.assertEqual(d.selector, "0.18.0")
+
+    def test_release_tag_wrong_sha_rejected(self):
+        api = FakeApi(refs={("tags", "v0.18.0"): OTHER_SHA})
+        d = decide(facts(head_branch="v0.18.0", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+
+    def test_nonexistent_tag_rejected(self):
+        d = decide(facts(head_branch="v9.9.9", head_sha=SHA), FakeApi())
+        self.assertFalse(d.authorized)
+
+    def test_bad_syntax_tag_rejected(self):
+        # ref exists at the sha but name is not strict vX.Y.Z
+        api = FakeApi(refs={("tags", "v1.2"): SHA})
+        d = decide(facts(head_branch="v1.2", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+
+    def test_feature_branch_push_rejected(self):
+        d = decide(facts(head_branch="some-feature", head_sha=SHA), FakeApi())
+        self.assertFalse(d.authorized)
+
+
+class Dispatch(unittest.TestCase):
+    def test_branch_at_built_sha_authorizes_moving_dev_selector(self):
+        api = FakeApi(refs={("heads", "my/feature"): SHA})
+        d = decide(facts(event="workflow_dispatch", head_branch="my/feature", head_sha=SHA), api)
+        self.assertTrue(d.authorized)
+        self.assertEqual(d.selector, "dev-my-feature")  # slash slugified
+
+    def test_dispatch_on_tag_ref_rejected(self):
+        # A tag isn't a branch, so heads/<name> resolves to nothing.
+        api = FakeApi(refs={("tags", "v0.18.0"): SHA})
+        d = decide(facts(event="workflow_dispatch", head_branch="v0.18.0", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+
+    def test_dispatch_stale_branch_rejected(self):
+        api = FakeApi(refs={("heads", "team/b"): OTHER_SHA})
+        d = decide(facts(event="workflow_dispatch", head_branch="team/b", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+
+    def test_dispatch_unsupported_branch_shape_rejected(self):
+        # Branch is real and at the built sha, but its name is not the
+        # collision-free prefix/name shape -> unsupported for dev publishing.
+        # Includes "team/b\n": $ would accept it (matching before the newline)
+        # and it slug-collides with "team/b-"; \Z rejects it.
+        for bad in ("myfeature", "feature-a/b", "a/b/c", "/leading", "team/-dash", "team/b\n"):
+            api = FakeApi(refs={("heads", bad): SHA})
+            d = decide(facts(event="workflow_dispatch", head_branch=bad, head_sha=SHA), api)
+            self.assertFalse(d.authorized, f"{bad!r} should be rejected")
+            self.assertIn("not supported", d.reason)
+
+
+class PullRequest(unittest.TestCase):
+    # FakeApi.pr_for_head is keyed on (head_sha, head_ref); facts' head_branch
+    # is the ref, so the key must be (SHA, <branch>).
+    def test_labeled_open_same_repo_pr_authorizes(self):
+        api = FakeApi(pr_for_head={(SHA, "team/feat"): (840, REPO, "open")}, labels={840: {"push-containers"}})
+        d = decide(facts(event="pull_request", head_branch="team/feat", head_sha=SHA), api)
+        self.assertTrue(d.authorized)
+        self.assertEqual(d.selector, "dev-team-feat")
+
+    def test_labeled_pr_unsupported_branch_shape_rejected(self):
+        # Passes fork/open/label, but the branch name is not the supported shape.
+        api = FakeApi(pr_for_head={(SHA, "flat-name"): (843, REPO, "open")}, labels={843: {"push-containers"}})
+        d = decide(facts(event="pull_request", head_branch="flat-name", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertIn("not supported", d.reason)
+
+    def test_unlabeled_pr_rejected(self):
+        api = FakeApi(pr_for_head={(SHA, "team/x"): (841, REPO, "open")}, labels={841: {"no-long-tests"}})
+        d = decide(facts(event="pull_request", head_branch="team/x", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertIn("label", d.reason)
+
+    def test_closed_but_labeled_pr_rejected(self):
+        # A closed (or merged) PR must not publish even if it still carries the label.
+        api = FakeApi(pr_for_head={(SHA, "team/x"): (842, REPO, "closed")}, labels={842: {"push-containers"}})
+        d = decide(facts(event="pull_request", head_branch="team/x", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertIn("not open", d.reason)
+
+    def test_no_pr_heads_this_sha_rejected(self):
+        # e.g. the sha is a main commit or only a member of a PR, not its head
+        d = decide(facts(event="pull_request", head_branch="team/x", head_sha=SHA), FakeApi(pr_for_head={}))
+        self.assertFalse(d.authorized)
+        self.assertIn("no PR", d.reason)
+
+    def test_fork_pr_via_head_repo_rejected(self):
+        # Same-repo base check passed, but the PR's own head repo is a fork.
+        api = FakeApi(pr_for_head={(SHA, "team/x"): (900, "attacker/palace", "open")}, labels={900: {"push-containers"}})
+        d = decide(facts(event="pull_request", head_branch="team/x", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertIn("fork", d.reason)
+
+    def test_shared_commit_picks_pr_for_the_built_branch(self):
+        # Two PRs share the built commit: an authorized labeled PR on the branch
+        # that built (team/real), and an UNLABELED PR on another branch at the
+        # same sha (team/evil). Matching on ref must pick the built branch's PR,
+        # not inherit the other's authorization. Here the build is team/evil
+        # (unlabeled) and must be rejected despite team/real carrying the label.
+        api = FakeApi(
+            pr_for_head={
+                (SHA, "team/real"): (10, REPO, "open"),
+                (SHA, "team/evil"): (11, REPO, "open"),
+            },
+            labels={10: {"push-containers"}},  # only the real branch's PR is labeled
+        )
+        d = decide(facts(event="pull_request", head_branch="team/evil", head_sha=SHA), api)
+        self.assertFalse(d.authorized)
+        self.assertIn("label", d.reason)  # checked #11's (absent) label, not #10's
+
+
+class UnknownEvent(unittest.TestCase):
+    def test_schedule_fails_closed(self):
+        d = decide(facts(event="schedule"), FakeApi())
+        self.assertFalse(d.authorized)
+        self.assertIn("unsupported", d.reason)
+
+
+class Slugify(unittest.TestCase):
+    def test_slash_and_metachars_collapse(self):
+        self.assertEqual(slugify("feature/a b"), "feature-a-b")
+        self.assertEqual(slugify("ok.name_1-2"), "ok.name_1-2")  # allowed chars kept
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/publish_containers/test_github_api.py
+++ b/.github/publish_containers/test_github_api.py
@@ -2,21 +2,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the REAL GitHubApi methods (ref_sha / pr_for_head / pr_has_label).
+"""Tests for the REAL GitHubApi methods (_get / ref_sha / pr_for_head /
+pr_has_label).
 
 test_authorize.py exercises decide() against a FakeApi, which necessarily
 *pre-bakes* the sha+ref filtering these methods implement. So these tests cover
 the actual logic — annotated-tag peeling, the head.sha+head.ref filter over the
 "PRs containing this commit" list, and malformed-response handling — by mocking
-only the subprocess boundary (GitHubApi._get) with canned API responses keyed on
-the request path.
+only the subprocess boundary with canned API responses keyed on the request
+path: StubApi replaces ``_get`` for the method tests, while ``gh_response``
+replaces ``subprocess.run`` to cover ``_get`` itself.
 
-Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+Run: python3 -m unittest discover -s .github/publish_containers -p 'test_*.py'
 """
 
 from __future__ import annotations
 
+import subprocess
 import unittest
+from unittest import mock
 
 from authorize import GitHubApi
 
@@ -29,7 +33,7 @@ class StubApi(GitHubApi):
     """GitHubApi with the subprocess boundary (_get) replaced by canned data.
 
     ``responses`` maps an API path to the object _get would have returned (a
-    dict/list on success, or None to simulate a 404 / non-JSON / non-zero exit).
+    dict/list on success, or None to simulate a 404).
     """
 
     def __init__(self, responses):
@@ -38,6 +42,63 @@ class StubApi(GitHubApi):
 
     def _get(self, path):
         return self._responses.get(path)
+
+
+def gh_response(status, body, *, returncode=None, stderr=""):
+    """A `gh api --include` result: status line, headers, blank line, body.
+
+    Headers use CRLF and the status line LF, matching real `gh` output. gh exits
+    non-zero for any non-2xx, so returncode defaults to match ``status``.
+    """
+    if returncode is None:
+        returncode = 0 if 200 <= status < 300 else 1
+    stdout = (
+        f"HTTP/2.0 {status} Reason\n"
+        "Content-Type: application/json; charset=utf-8\r\n"
+        "\r\n"
+        f"{body}"
+    )
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class Get(unittest.TestCase):
+    """_get: only an explicit 404 is "absent"; every other failure raises."""
+
+    def _get(self, completed):
+        with mock.patch("subprocess.run", return_value=completed):
+            return GitHubApi(REPO)._get("repos/x/y")
+
+    def test_success_returns_decoded_body(self):
+        self.assertEqual(self._get(gh_response(200, '{"ok": true}')), {"ok": True})
+
+    def test_not_found_returns_none(self):
+        self.assertIsNone(self._get(gh_response(404, '{"message": "Not Found"}')))
+
+    def test_forbidden_raises(self):
+        # A rate limit or a revoked token must fail the job, not read as absent:
+        # otherwise a release publishes nothing and still exits green.
+        for status in (401, 403, 429, 500, 502):
+            with self.subTest(status=status):
+                with self.assertRaises(RuntimeError):
+                    self._get(gh_response(status, '{"message": "nope"}'))
+
+    def test_transport_failure_raises(self):
+        # gh could not reach the API, so it printed no status line at all.
+        no_status = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="dial tcp: i/o timeout"
+        )
+        with self.assertRaises(RuntimeError):
+            self._get(no_status)
+
+    def test_non_json_success_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._get(gh_response(200, "<html>gateway</html>"))
+
+    def test_success_status_but_nonzero_exit_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._get(gh_response(200, '{"ok": true}', returncode=1))
 
 
 class RefSha(unittest.TestCase):

--- a/.github/publish_containers/test_github_api.py
+++ b/.github/publish_containers/test_github_api.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the REAL GitHubApi methods (ref_sha / pr_for_head / pr_has_label).
+
+test_authorize.py exercises decide() against a FakeApi, which necessarily
+*pre-bakes* the sha+ref filtering these methods implement. So these tests cover
+the actual logic — annotated-tag peeling, the head.sha+head.ref filter over the
+"PRs containing this commit" list, and malformed-response handling — by mocking
+only the subprocess boundary (GitHubApi._get) with canned API responses keyed on
+the request path.
+
+Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from authorize import GitHubApi
+
+REPO = "awslabs/palace"
+COMMIT = "c45e4ab4f2356589ba40f4fde2403f5854282826"
+TAG_OBJ = "b4523792f95f2e796762476255b6adefeb399914"
+
+
+class StubApi(GitHubApi):
+    """GitHubApi with the subprocess boundary (_get) replaced by canned data.
+
+    ``responses`` maps an API path to the object _get would have returned (a
+    dict/list on success, or None to simulate a 404 / non-JSON / non-zero exit).
+    """
+
+    def __init__(self, responses):
+        super().__init__(REPO)
+        self._responses = responses
+
+    def _get(self, path):
+        return self._responses.get(path)
+
+
+class RefSha(unittest.TestCase):
+    def test_lightweight_tag_or_branch_returns_commit(self):
+        api = StubApi({
+            f"repos/{REPO}/git/ref/heads/main": {"object": {"type": "commit", "sha": COMMIT}},
+        })
+        self.assertEqual(api.ref_sha("heads", "main"), COMMIT)
+
+    def test_annotated_tag_is_peeled_to_commit(self):
+        # Annotated tag: the ref object is the TAG object; must peel via git/tags.
+        api = StubApi({
+            f"repos/{REPO}/git/ref/tags/v0.18.0": {"object": {"type": "tag", "sha": TAG_OBJ}},
+            f"repos/{REPO}/git/tags/{TAG_OBJ}": {"object": {"type": "commit", "sha": COMMIT}},
+        })
+        self.assertEqual(api.ref_sha("tags", "v0.18.0"), COMMIT)
+
+    def test_missing_ref_returns_none(self):
+        self.assertIsNone(StubApi({}).ref_sha("heads", "nope"))
+
+    def test_malformed_ref_object_returns_none(self):
+        api = StubApi({f"repos/{REPO}/git/ref/heads/x": {"unexpected": True}})
+        self.assertIsNone(api.ref_sha("heads", "x"))
+
+    def test_annotated_tag_peel_404_returns_none(self):
+        api = StubApi({
+            f"repos/{REPO}/git/ref/tags/v9.9.9": {"object": {"type": "tag", "sha": TAG_OBJ}},
+            # git/tags/<obj> intentionally absent -> peel fails -> None
+        })
+        self.assertIsNone(api.ref_sha("tags", "v9.9.9"))
+
+
+class PrForHead(unittest.TestCase):
+    def _pulls(self, entries):
+        return {f"repos/{REPO}/commits/{COMMIT}/pulls": entries}
+
+    def test_matches_on_sha_and_ref(self):
+        api = StubApi(self._pulls([
+            {"number": 10, "state": "open",
+             "head": {"sha": COMMIT, "ref": "team/real", "repo": {"full_name": REPO}}},
+        ]))
+        self.assertEqual(api.pr_for_head(COMMIT, "team/real"), (10, REPO, "open"))
+
+    def test_ignores_pr_that_only_contains_commit_wrong_ref(self):
+        # The API returns PRs merely CONTAINING the commit: same sha, different
+        # ref must NOT match (this is the shared-commit / label-ride defense).
+        api = StubApi(self._pulls([
+            {"number": 11, "state": "open",
+             "head": {"sha": COMMIT, "ref": "team/other", "repo": {"full_name": REPO}}},
+        ]))
+        self.assertIsNone(api.pr_for_head(COMMIT, "team/real"))
+
+    def test_ignores_pr_whose_head_sha_differs(self):
+        api = StubApi(self._pulls([
+            {"number": 12, "state": "open",
+             "head": {"sha": "differentsha", "ref": "team/real", "repo": {"full_name": REPO}}},
+        ]))
+        self.assertIsNone(api.pr_for_head(COMMIT, "team/real"))
+
+    def test_picks_correct_pr_among_several_sharing_commit(self):
+        api = StubApi(self._pulls([
+            {"number": 11, "state": "open",
+             "head": {"sha": COMMIT, "ref": "team/evil", "repo": {"full_name": REPO}}},
+            {"number": 10, "state": "closed",
+             "head": {"sha": COMMIT, "ref": "team/real", "repo": {"full_name": "fork/palace"}}},
+        ]))
+        self.assertEqual(api.pr_for_head(COMMIT, "team/real"), (10, "fork/palace", "closed"))
+
+    def test_empty_or_missing_list_returns_none(self):
+        self.assertIsNone(StubApi({}).pr_for_head(COMMIT, "team/real"))
+        self.assertIsNone(StubApi(self._pulls([])).pr_for_head(COMMIT, "team/real"))
+
+    def test_malformed_elements_do_not_crash(self):
+        api = StubApi(self._pulls([
+            "not-a-dict",
+            {"head": {"sha": COMMIT, "ref": "team/real", "repo": {"full_name": REPO}}},  # no number
+        ]))
+        # First element is skipped (not a dict); second matches sha+ref but has
+        # no number -> returns None rather than raising.
+        self.assertIsNone(api.pr_for_head(COMMIT, "team/real"))
+
+
+class PrHasLabel(unittest.TestCase):
+    def _labels(self, num, entries):
+        return {f"repos/{REPO}/issues/{num}/labels": entries}
+
+    def test_present(self):
+        api = StubApi(self._labels(10, [{"name": "push-containers"}, {"name": "x"}]))
+        self.assertTrue(api.pr_has_label(10, "push-containers"))
+
+    def test_absent(self):
+        api = StubApi(self._labels(10, [{"name": "x"}]))
+        self.assertFalse(api.pr_has_label(10, "push-containers"))
+
+    def test_missing_list_is_false(self):
+        self.assertFalse(StubApi({}).pr_has_label(10, "push-containers"))
+
+    def test_malformed_element_does_not_crash(self):
+        api = StubApi(self._labels(10, ["not-a-dict", {"name": "push-containers"}]))
+        self.assertTrue(api.pr_has_label(10, "push-containers"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/publish_containers/test_publish.py
+++ b/.github/publish_containers/test_publish.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the container-publish plan (pure logic; no I/O).
+
+Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from publish import PublishItem, arch_label_from_image, plan, s3_prefix_for
+
+REGISTRY = "123456789012.dkr.ecr.us-west-2.amazonaws.com"
+ECR_REPO = "palace"
+BUCKET = "palace-ci-containers"
+
+
+def make_artifacts(root: Path, image_names: list[str]) -> None:
+    """Create the downloaded-artifact layout: <image>-oci/<image>.tar and
+    <image>-sif/<image>.sif for each image name."""
+    for name in image_names:
+        (root / f"{name}-oci").mkdir(parents=True)
+        (root / f"{name}-oci" / f"{name}.tar").write_text("tar")
+        (root / f"{name}-sif").mkdir(parents=True)
+        (root / f"{name}-sif" / f"{name}.sif").write_text("sif")
+
+
+class ArchLabel(unittest.TestCase):
+    def test_native_label(self):
+        self.assertEqual(arch_label_from_image("palace-sapphirerapids-abc1234"), "sapphirerapids")
+
+    def test_release_target_with_underscores(self):
+        self.assertEqual(arch_label_from_image("palace-x86_64_v3-deadbee"), "x86_64_v3")
+
+    def test_rejects_non_palace(self):
+        with self.assertRaises(ValueError):
+            arch_label_from_image("notpalace-x-abc1234")
+
+    def test_rejects_missing_hash(self):
+        with self.assertRaises(ValueError):
+            arch_label_from_image("palace-onlylabel")
+
+    def test_rejects_non_hex_trailing_segment(self):
+        # A loose last-hyphen split would read this as label "foo", hash "latest".
+        with self.assertRaises(ValueError):
+            arch_label_from_image("palace-foo-latest")
+
+    def test_rejects_hyphen_in_label(self):
+        # Arch labels are [a-z0-9_] (no hyphens); a hyphenated label is invalid,
+        # not silently absorbed.
+        with self.assertRaises(ValueError):
+            arch_label_from_image("palace-a-b-deadbee")
+
+
+class S3Prefix(unittest.TestCase):
+    def test_main(self):
+        self.assertEqual(s3_prefix_for("main"), "main")
+
+    def test_release(self):
+        self.assertEqual(s3_prefix_for("0.18.0"), "0.18.0")
+
+    def test_dev_expands_to_slash(self):
+        self.assertEqual(s3_prefix_for("dev-myfeature"), "dev/myfeature")
+
+
+class Plan(unittest.TestCase):
+    def test_release_matrix_six_targets(self):
+        names = [f"palace-{t}-abc1234" for t in
+                 ("x86_64_v3", "x86_64_v4", "sapphirerapids", "aarch64", "neoverse_v1", "neoverse_v2")]
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, names)
+            items = plan(root, "0.18.0", REGISTRY, ECR_REPO, BUCKET)
+        self.assertEqual(len(items), 6)
+        by_label = {i.arch_label: i for i in items}
+        self.assertEqual(
+            by_label["neoverse_v2"].ecr_tag,
+            f"{REGISTRY}/palace:0.18.0-neoverse_v2",
+        )
+        self.assertEqual(
+            by_label["neoverse_v2"].s3_uri,
+            f"s3://{BUCKET}/0.18.0/neoverse_v2.sif",
+        )
+
+    def test_dev_selector_s3_layout(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, ["palace-sapphirerapids-abc1234"])
+            items = plan(root, "dev-myfeature", REGISTRY, ECR_REPO, BUCKET)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].ecr_tag, f"{REGISTRY}/palace:dev-myfeature-sapphirerapids")
+        self.assertEqual(items[0].s3_uri, f"s3://{BUCKET}/dev/myfeature/sapphirerapids.sif")
+
+    def test_empty_artifacts_yields_empty_plan(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(plan(Path(d), "main", REGISTRY, ECR_REPO, BUCKET), [])
+
+    def test_item_points_at_real_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, ["palace-aarch64-abc1234"])
+            item = plan(root, "main", REGISTRY, ECR_REPO, BUCKET)[0]
+        self.assertTrue(item.oci_tar.name.endswith(".tar"))
+        self.assertTrue(item.sif.name.endswith(".sif"))
+        self.assertIsInstance(item, PublishItem)
+
+
+class PlanGuards(unittest.TestCase):
+    def test_oci_without_sif_is_rejected(self):
+        # A leg with an OCI tar but no SIF must fail the plan (not publish the
+        # OCI then die mid-loop on the missing SIF).
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "palace-aarch64-abc1234-oci").mkdir(parents=True)
+            (root / "palace-aarch64-abc1234-oci" / "palace-aarch64-abc1234.tar").write_text("tar")
+            # no -sif dir
+            with self.assertRaises(ValueError) as cm:
+                plan(root, "main", REGISTRY, ECR_REPO, BUCKET)
+            self.assertIn("no SIF", str(cm.exception))
+
+    def test_duplicate_arch_label_is_rejected(self):
+        # Two legs collapsing to the same arch label would overwrite each other's
+        # tag/key; reject instead.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, ["palace-aarch64-abc1234", "palace-aarch64-deadbee"])
+            with self.assertRaises(ValueError) as cm:
+                plan(root, "main", REGISTRY, ECR_REPO, BUCKET)
+            self.assertIn("duplicate arch label", str(cm.exception))
+
+    def test_full_release_matrix_all_legs_complete(self):
+        # A complete 6-leg release plan builds cleanly (no set check needed —
+        # completeness of the leg set is guaranteed by the workflow_run success
+        # gate; plan() just requires each present leg to be a complete pair).
+        names = [f"palace-{t}-abc1234" for t in
+                 ("x86_64_v3", "x86_64_v4", "sapphirerapids", "aarch64", "neoverse_v1", "neoverse_v2")]
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, names)
+            items = plan(root, "0.18.0", REGISTRY, ECR_REPO, BUCKET)
+        self.assertEqual(len(items), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/publish_containers/test_publish.py
+++ b/.github/publish_containers/test_publish.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the container-publish plan (pure logic; no I/O).
 
-Run: python3 -m unittest discover -s .github/publish -p 'test_*.py'
+Run: python3 -m unittest discover -s .github/publish_containers -p 'test_*.py'
 """
 
 from __future__ import annotations

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -76,13 +76,26 @@ jobs:
         arch: [arm64, x64]
     runs-on: [self-hosted, '${{ matrix.arch }}']
     steps:
-      # A manual dispatch bypasses the paths-filter: dispatching is an explicit
-      # publish request, so it must build regardless of what changed. (Release
-      # tags are handled by build-containers-release, which has no filter.)
+      # Two events bypass the paths-filter:
+      #
+      # - workflow_dispatch: dispatching is an explicit publish request, so it
+      #   must build regardless of what changed.
+      # - push to main: every commit on main must produce artifacts, because the
+      #   `main` channel publishes at an exact SHA. If a docs-only push skipped
+      #   the build, its `Containers` run would still succeed and trigger a
+      #   publisher with nothing to publish — and worse, it would move `main` off
+      #   the SHA a real container build is still publishing, so that build's
+      #   re-verify would fail and the rolling channel would stay stale until the
+      #   next container change landed. The cost is two cached builds on
+      #   docs-only pushes; the benefit is that a genuine build failure on main
+      #   also shows up as a red `Containers` run.
+      #
+      # (Release tags are handled by build-containers-release, which has no
+      # filter.)
       - uses: actions/checkout@v6
-        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
       - uses: ./.github/actions/build-container
-        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch'
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
 
   # Release tags (vX.Y.Z): build the full microarchitecture matrix. No paths-
   # filter — a tag is usually cut on a commit already on main, so the diff is

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,8 +25,11 @@ on:
     # 'labeled' so adding the `push-containers` label triggers a prototype
     # deploy; the rest are the usual PR-build triggers.
     types: [opened, reopened, synchronize, labeled]
-  # Manual build-only re-run (e.g. after a transient runner failure). Never
-  # publishes — prototype deploys go through the `push-containers` PR label.
+  # Manual run from a branch. Dispatching IS a publish request: the trusted
+  # publish-containers workflow (which runs from `main`) authorizes it — the
+  # actor must have write access (GitHub gates dispatch), the ref must be a
+  # branch, and it publishes a moving `dev-<branch>` prototype. This build
+  # workflow itself holds no credentials and makes no publish decision.
   workflow_dispatch:
 
 permissions:
@@ -73,10 +76,13 @@ jobs:
         arch: [arm64, x64]
     runs-on: [self-hosted, '${{ matrix.arch }}']
     steps:
+      # A manual dispatch bypasses the paths-filter: dispatching is an explicit
+      # publish request, so it must build regardless of what changed. (Release
+      # tags are handled by build-containers-release, which has no filter.)
       - uses: actions/checkout@v6
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch'
       - uses: ./.github/actions/build-container
-        if: needs.filter.outputs.test == 'true'
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch'
 
   # Release tags (vX.Y.Z): build the full microarchitecture matrix. No paths-
   # filter — a tag is usually cut on a commit already on main, so the diff is

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -60,13 +60,19 @@ jobs:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: ubuntu-latest
-    # Concurrency is keyed on the authorized selector (only known now), so a
-    # newer publish for the same channel cancels an older in-flight one, while an
-    # unauthorized run — which never reaches this job — can never enter the
-    # group. Releases use distinct selectors, so they never cancel each other.
+    # Concurrency is keyed on the authorized selector (only known now), so
+    # publishes to one channel serialize while different channels (including
+    # each release) run independently, and an unauthorized run — which never
+    # reaches this job — can never enter the group.
+    #
+    # NOT cancel-in-progress: cancelling a publisher partway through would leave
+    # a channel holding ECR tags and S3 objects from different commits. A queued
+    # publisher instead waits its turn; if it has gone stale in the meantime the
+    # re-verify step below fails it, and if it is still current it runs last and
+    # becomes final.
     concurrency:
       group: publish-containers-${{ needs.authorize.outputs.selector }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     # The OIDC subject is scoped to this environment
     # (repo:awslabs/palace:environment:palace-container-publish), restricted to
     # `main` in repo settings; that restriction (plus workflow_run always running
@@ -104,9 +110,10 @@ jobs:
           #
           # Ask the API how many artifacts the build run has BEFORE downloading,
           # so we can tell "legitimately zero" apart from "download dropped some".
-          #   - zero  -> clean skip (e.g. a docs-only push to main where the
-          #     paths-filter skipped the build; the run still succeeds and is
-          #     authorized, but there is nothing to publish);
+          #   - zero  -> clean skip (e.g. a labeled PR whose push touched no
+          #     container-relevant path, so the paths-filter skipped the build;
+          #     the run still succeeds and is authorized, but there is nothing to
+          #     publish). Pushes to main always build, so main never lands here;
           #   - >0    -> the download MUST succeed and yield that exact count, or
           #     we fail. A partial download must never publish a subset (which
           #     would update some architectures and leave the others stale).

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,154 @@
+# Container publish workflow.
+#
+# The `Containers` build workflow produces artifacts. This workflow is triggered
+# after `Containers` completes, runs in a trusted environment, and has
+# permissions to push to AWS through a least-privilege OIDC role.
+#
+# Two jobs: `authorize` decides whether this build may publish and derives the
+# selector while holding no credentials; `publish` runs only if authorized, keys
+# its concurrency on the authorized selector, and holds the OIDC role.
+
+name: Publish Containers
+
+on:
+  workflow_run:
+    workflows: [Containers]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  authorize:
+    # Only consider builds that succeeded. Fork rejection / selector derivation
+    # are enforced in authorize.py.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # git-refs / repo lookups via gh
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OWNER_REPO: ${{ github.repository }}
+      # From the triggering build run: trusted GitHub-provided facts about the
+      # run (event/sha/repos), NOT build-authored content.
+      SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+      BASE_REPO: ${{ github.event.workflow_run.repository.full_name }}
+    outputs:
+      authorized: ${{ steps.authz.outputs.authorized }}
+      selector: ${{ steps.authz.outputs.selector }}
+    steps:
+      # Check out the trusted publish code (authorize.py, etc.). In a
+      # workflow_run event the default ref is the commit the workflow was loaded
+      # from — the default-branch (main) tip — NOT the build's head. We must
+      # never check out the build's ref/SHA, or PR-controlled code would run.
+      # No `ref:` is set, so the default (main) applies. Pinned to a full SHA.
+      - name: Check out trusted publish code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Decide whether this build may publish and to which selector, from
+      # trusted event facts + live GitHub API lookups (never the build's
+      # artifacts). Logic and its unit tests live in .github/publish_containers/.
+      - name: Authorize publication and derive selector
+        id: authz
+        shell: bash
+        run: python3 .github/publish_containers/authorize.py
+
+  publish:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    # Concurrency is keyed on the authorized selector (only known now), so a
+    # newer publish for the same channel cancels an older in-flight one, while an
+    # unauthorized run — which never reaches this job — can never enter the
+    # group. Releases use distinct selectors, so they never cancel each other.
+    concurrency:
+      group: publish-containers-${{ needs.authorize.outputs.selector }}
+      cancel-in-progress: true
+    # The OIDC subject is scoped to this environment
+    # (repo:awslabs/palace:environment:palace-container-publish), restricted to
+    # `main` in repo settings; that restriction (plus workflow_run always running
+    # from the default branch) is what limits who can assume the publish role.
+    environment: palace-container-publish
+    permissions:
+      id-token: write   # mint the OIDC JWT for AWS
+      actions: read     # download artifacts from the triggering run
+      contents: read    # git-refs / repo lookups via gh (re-verify)
+      pull-requests: read
+    env:
+      AWS_REGION: us-west-2
+      ECR_REPOSITORY: palace
+      S3_CONTAINERS_BUCKET: palace-ci-containers
+      GH_TOKEN: ${{ github.token }}
+      OWNER_REPO: ${{ github.repository }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+      BASE_REPO: ${{ github.event.workflow_run.repository.full_name }}
+    steps:
+      # Trusted publish code again (this is a separate job/runner from authorize).
+      - name: Check out trusted publish code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download build artifacts
+        id: download
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Fetch all artifacts from the exact triggering run. -R is explicit so
+          # the target repo never depends on the checkout's working directory.
+          #
+          # Ask the API how many artifacts the build run has BEFORE downloading,
+          # so we can tell "legitimately zero" apart from "download dropped some".
+          #   - zero  -> clean skip (e.g. a docs-only push to main where the
+          #     paths-filter skipped the build; the run still succeeds and is
+          #     authorized, but there is nothing to publish);
+          #   - >0    -> the download MUST succeed and yield that exact count, or
+          #     we fail. A partial download must never publish a subset (which
+          #     would update some architectures and leave the others stale).
+          expected="$(gh api "repos/${OWNER_REPO}/actions/runs/${RUN_ID}/artifacts" \
+                        --jq '.total_count')"
+          echo "Build run reports $expected artifact(s)."
+          if [ "$expected" -eq 0 ]; then
+            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+            echo "No artifacts; nothing to publish."
+            exit 0
+          fi
+
+          rm -rf ./artifacts
+          gh run download "$RUN_ID" -R "$OWNER_REPO" --dir ./artifacts   # no `|| true`: a failed download must fail the job
+          # gh run download creates one directory per artifact; require all of them.
+          got="$(find ./artifacts -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          if [ "$got" -ne "$expected" ]; then
+            echo "::error::downloaded $got of $expected artifacts; refusing to publish a partial set"
+            exit 1
+          fi
+          echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
+          echo "Downloaded all $expected artifact(s):"
+          find ./artifacts -type f -printf '%p (%s bytes)\n'
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.download.outputs.has_artifacts == 'true'
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.PALACE_CONTAINER_PUBLISH_ROLE_ARN }}
+          aws-region: us-west-2
+
+      # Authorize ran in a prior job; downloading artifacts and assuming the role
+      # opened a window in which the moving ref/label could change. Recompute the
+      # decision and fail unless it still authorizes this exact selector, so a
+      # stale ref/removed label aborts before any write (TOCTOU).
+      - name: Re-verify authorization before publishing
+        if: steps.download.outputs.has_artifacts == 'true'
+        shell: bash
+        run: python3 .github/publish_containers/authorize.py --reverify "${{ needs.authorize.outputs.selector }}"
+
+      # Publish each downloaded build leg: OCI tar -> ECR (skopeo), SIF -> S3.
+      - name: Publish OCI images to ECR and SIFs to S3
+        if: steps.download.outputs.has_artifacts == 'true'
+        shell: bash
+        run: python3 .github/publish_containers/publish.py --selector "${{ needs.authorize.outputs.selector }}"

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -65,14 +65,25 @@ jobs:
     # each release) run independently, and an unauthorized run — which never
     # reaches this job — can never enter the group.
     #
-    # NOT cancel-in-progress: cancelling a publisher partway through would leave
-    # a channel holding ECR tags and S3 objects from different commits. A queued
-    # publisher instead waits its turn; if it has gone stale in the meantime the
-    # re-verify step below fails it, and if it is still current it runs last and
-    # becomes final.
+    # NOT cancel-in-progress: cancelling a publisher partway through the
+    # per-leg copy loop would leave a channel holding ECR tags and S3 objects
+    # from different commits. A queued publisher instead waits its turn; if it
+    # has gone stale in the meantime the re-verify step below fails it, and if it
+    # is still current it runs last and becomes final.
+    #
+    # This narrows the torn-channel window but does not close it: the publish
+    # loop writes each leg in turn with no staging or rollback, so a mid-loop
+    # failure (skopeo/S3 error, timeout, runner death) still leaves earlier legs
+    # live at the new commit and later legs stale. Making a channel flip
+    # atomically needs content-addressed writes plus a single pointer update —
+    # tracked as the content-addressing follow-up, not solved here.
     concurrency:
       group: publish-containers-${{ needs.authorize.outputs.selector }}
       cancel-in-progress: false
+    # Bounds how long a stuck publisher can hold its channel's queue. Without
+    # cancel-in-progress there is nothing else to evict it, and the default job
+    # limit is 6 hours. Publishing moves ~0.5 GiB and takes a few minutes.
+    timeout-minutes: 45
     # The OIDC subject is scoped to this environment
     # (repo:awslabs/palace:environment:palace-container-publish), restricted to
     # `main` in repo settings; that restriction (plus workflow_run always running

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -99,3 +99,13 @@ jobs:
         with:
           config: .github/license-check/config.json
           strict: false
+
+  # Unit tests for the trusted container-publish scripts (.github/publish_containers/).
+  # These guard the publish authorization decision, so they must run on every
+  # change. Stdlib unittest only — no dependencies to install.
+  check-publish-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run publish script tests
+        run: python3 -m unittest discover -s .github/publish_containers -p 'test_*.py' -v

--- a/docs/src/developer/notes.md
+++ b/docs/src/developer/notes.md
@@ -523,7 +523,14 @@ a release publishes a tuned image for each target:
 
 ### Publishing a `dev-<branch>` prototype from a branch
 
-To publish a `dev-<branch>` container, just trigger the `Containers` workflow.
+To publish a `dev-<branch>` container, trigger the `Containers` workflow. The
+branch must be named `prefix/name`, with exactly one `/`: the prefix may contain
+only letters, numbers, `_`, or `.`, and the name must start with a letter or
+number and may also contain `_`, `.`, or `-` (for example,
+`yourname/my-feature`). Other names build fine but are refused at publication,
+because the `dev-<branch>` selector has to stay collision-free once the name is
+sanitized for ECR. `main` and release-tag publishing are unaffected.
+
 Using the [GitHub CLI](https://cli.github.com/):
 
 ```bash

--- a/docs/src/developer/notes.md
+++ b/docs/src/developer/notes.md
@@ -492,6 +492,56 @@ spack spec local.palace@develop
 will show you the spec for your most recent `palace` package, which you can
 compare with the one for `builtin.palace@develop`.
 
+## Publishing containers
+
+Palace containers are built by the `Containers` workflow. Publishing is handled
+by a separate `Publish Containers` workflow that runs after a build completes:
+the build only produces artifacts and makes no publishing decision, and the
+publish workflow decides (from the triggering event) whether and what to
+publish. Which channel a build publishes to depends on the event:
+
+| Event                                       | Published channel |
+|:------------------------------------------- |:----------------- |
+| Push to `main`                              | `main` (rolling)  |
+| Push of a release tag `vX.Y.Z`              | `X.Y.Z` (release) |
+| Manual dispatch of `Containers` on a branch | `dev-<branch>`    |
+| Pull request labeled `push-containers`      | `dev-<branch>`    |
+
+### What gets built
+
+Regular builds (push to `main`, pull requests, and manual dispatches) build only
+each runner's native microarchitecture:
+
+  - `sapphirerapids` (x64)
+  - `neoverse_v1` (arm64)
+
+Release tags (`vX.Y.Z`) build the full microarchitecture matrix instead, so
+a release publishes a tuned image for each target:
+
+  - `x86_64_v3`, `x86_64_v4`, `sapphirerapids` (x64)
+  - `aarch64`, `neoverse_v1`, `neoverse_v2` (arm64)
+
+### Publishing a `dev-<branch>` prototype from a branch
+
+To publish a `dev-<branch>` container, just trigger the `Containers` workflow.
+Using the [GitHub CLI](https://cli.github.com/):
+
+```bash
+# Build and publish a dev-<branch> prototype from the current branch.
+branch=$(git branch --show-current)
+gh workflow run containers.yml --ref "$branch"
+
+# Then follow the run (give it a moment to register), and note that publication
+# happens afterward in the separate Publish Containers workflow:
+gh run list --workflow=containers.yml --branch "$branch" --limit 1
+gh run watch <run-id-from-above>
+```
+
+From the web UI the same control is under `Actions → Containers → Run workflow`, where you pick the branch.
+
+Alternatively, apply the `push-containers` label to a pull request to publish
+its `dev-<branch>` prototype and keep it updated as you push new commits.
+
 ## Changelog
 
 Code contributions should generally be accompanied by an entry in the


### PR DESCRIPTION
Container publishing now runs in a dedicated workflow, separate from the build. The build produces artifacts only; a workflow_run-triggered publish workflow (always loaded from main) authorizes the publish from GitHub-verified event data and holds the only AWS credentials, obtained via a least-privilege OIDC role.

- build-container: emits OCI/SIF + build-metadata artifacts; no AWS access.
- publish-containers (new): authorizes by event (forks excluded, tag/branch resolved via git-refs, PR label + head SHA checked), assumes the OIDC role, and publishes to ECR + S3.
- containers: workflow_dispatch is a publish request.

Note that a drawback of this approach is that making changes to the publishing code becomes harder, because the code that is run is always the one on main, so testing is not easy.

I tested it in my Palace fork (as much as I could).

Supersedes #832 
Closes #832 