### PR TITLE
Publish config-schema.json alongside containers

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -138,6 +138,18 @@ runs:
         path: ${{ steps.name.outputs.image_name }}.sif
         retention-days: 1
 
+    - name: Upload config schema
+      # Bundle the exact config-schema.json this image was built from, so the
+      # trusted publish job can push it to the schema bucket alongside the SIF —
+      # matching the schema to the image's provenance (build-container has no AWS
+      # access; publish.py does the upload). Arch-independent, but uploaded per
+      # leg under a unique name so parallel matrix jobs don't collide.
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.name.outputs.image_name }}-schema
+        path: scripts/schema/config-schema.json
+        retention-days: 1
+
     - name: Timing information
       shell: bash
       run: |

--- a/.github/publish_containers/publish.py
+++ b/.github/publish_containers/publish.py
@@ -107,6 +107,31 @@ def plan(
     return items
 
 
+def schema_s3_uri(selector: str, schema_bucket: str) -> str:
+    """S3 destination for this build's config schema.
+
+    The schema is arch-independent, so a single object per selector suffices; it
+    mirrors the SIF prefix layout (``dev-<branch>`` -> ``dev/<branch>/``).
+    """
+    return f"s3://{schema_bucket}/{s3_prefix_for(selector)}/schema.json"
+
+
+def find_schema(artifacts_dir: Path) -> Path:
+    """Locate the bundled config schema among the downloaded artifacts.
+
+    ``build-container`` uploads ``config-schema.json`` once per build leg as
+    ``<image>-schema/config-schema.json``. The legs are byte-identical (the
+    schema does not vary by architecture), so any one is authoritative — we take
+    the first. Every build bundles it, so absence is a hard error (a
+    silently-unpublished schema would leave downstream tools unable to validate
+    against this build), mirroring the missing-SIF check in :func:`plan`.
+    """
+    matches = sorted(artifacts_dir.glob("*-schema/config-schema.json"))
+    if not matches:
+        raise ValueError("no config-schema.json artifact found among build artifacts")
+    return matches[0]
+
+
 def _run(cmd: list[str]) -> None:
     print("+ " + " ".join(cmd))
     subprocess.run(cmd, check=True)
@@ -121,6 +146,7 @@ def main(argv: list[str] | None = None) -> int:
     region = os.environ["AWS_REGION"]
     ecr_repo = os.environ["ECR_REPOSITORY"]
     s3_bucket = os.environ["S3_CONTAINERS_BUCKET"]
+    schema_bucket = os.environ["S3_SCHEMAS_BUCKET"]
 
     account_id = subprocess.run(
         ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
@@ -131,6 +157,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         items = plan(Path(args.artifacts_dir), args.selector, registry, ecr_repo, s3_bucket)
+        # Resolve the schema up front too, so a missing one fails before any
+        # push rather than after the images are already live.
+        schema = find_schema(Path(args.artifacts_dir))
     except ValueError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
@@ -157,6 +186,14 @@ def main(argv: list[str] | None = None) -> int:
         _run(["aws", "s3", "cp", "--region", region, str(item.sif), item.s3_uri])
 
     print(f"Published {len(items)} image(s) for selector '{args.selector}'.")
+
+    # Publish the config schema (resolved above) alongside the images so
+    # downstream tools can fetch the exact contract this build was compiled
+    # from. One arch-independent object per selector.
+    schema_uri = schema_s3_uri(args.selector, schema_bucket)
+    print(f"Publishing schema {schema} -> {schema_uri}")
+    _run(["aws", "s3", "cp", "--region", region, str(schema), schema_uri])
+
     return 0
 
 

--- a/.github/publish_containers/test_publish.py
+++ b/.github/publish_containers/test_publish.py
@@ -13,21 +13,32 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from publish import PublishItem, arch_label_from_image, plan, s3_prefix_for
+from publish import (
+    PublishItem,
+    arch_label_from_image,
+    find_schema,
+    plan,
+    s3_prefix_for,
+    schema_s3_uri,
+)
 
 REGISTRY = "123456789012.dkr.ecr.us-west-2.amazonaws.com"
 ECR_REPO = "palace"
 BUCKET = "palace-ci-containers"
+SCHEMA_BUCKET = "palace-ci-schemas"
 
 
 def make_artifacts(root: Path, image_names: list[str]) -> None:
-    """Create the downloaded-artifact layout: <image>-oci/<image>.tar and
-    <image>-sif/<image>.sif for each image name."""
+    """Create the downloaded-artifact layout for each image name, as
+    build-container uploads it: <image>-oci/<image>.tar, <image>-sif/<image>.sif,
+    and <image>-schema/config-schema.json (bundled once per leg)."""
     for name in image_names:
         (root / f"{name}-oci").mkdir(parents=True)
         (root / f"{name}-oci" / f"{name}.tar").write_text("tar")
         (root / f"{name}-sif").mkdir(parents=True)
         (root / f"{name}-sif" / f"{name}.sif").write_text("sif")
+        (root / f"{name}-schema").mkdir(parents=True)
+        (root / f"{name}-schema" / "config-schema.json").write_text('{"$id": "urn:palace:schema:1-0-0"}')
 
 
 class ArchLabel(unittest.TestCase):
@@ -144,6 +155,54 @@ class PlanGuards(unittest.TestCase):
             make_artifacts(root, names)
             items = plan(root, "0.18.0", REGISTRY, ECR_REPO, BUCKET)
         self.assertEqual(len(items), 6)
+
+
+class SchemaUri(unittest.TestCase):
+    def test_release_layout(self):
+        self.assertEqual(
+            schema_s3_uri("0.18.0", SCHEMA_BUCKET),
+            f"s3://{SCHEMA_BUCKET}/0.18.0/schema.json",
+        )
+
+    def test_main_layout(self):
+        self.assertEqual(
+            schema_s3_uri("main", SCHEMA_BUCKET),
+            f"s3://{SCHEMA_BUCKET}/main/schema.json",
+        )
+
+    def test_dev_expands_to_slash(self):
+        self.assertEqual(
+            schema_s3_uri("dev-myfeature", SCHEMA_BUCKET),
+            f"s3://{SCHEMA_BUCKET}/dev/myfeature/schema.json",
+        )
+
+
+class FindSchema(unittest.TestCase):
+    def test_finds_bundled_schema(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, ["palace-sapphirerapids-abc1234"])
+            found = find_schema(root)
+        self.assertEqual(found.name, "config-schema.json")
+
+    def test_returns_first_of_identical_legs(self):
+        # A release matrix bundles one schema per leg; any one is authoritative.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            make_artifacts(root, ["palace-x86_64_v3-abc1234", "palace-neoverse_v2-abc1234"])
+            found = find_schema(root)
+        self.assertEqual(found.name, "config-schema.json")
+
+    def test_raises_when_no_schema_bundled(self):
+        # Every build bundles the schema, so absence is a hard error, not a skip.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            # OCI/SIF legs but no -schema dir (simulate a broken/old build).
+            (root / "palace-aarch64-abc1234-oci").mkdir(parents=True)
+            (root / "palace-aarch64-abc1234-oci" / "palace-aarch64-abc1234.tar").write_text("tar")
+            with self.assertRaises(ValueError) as cm:
+                find_schema(root)
+            self.assertIn("config-schema.json", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -59,6 +59,7 @@ jobs:
             test:
               - 'palace/**'
               - 'cmake/**'
+              - 'scripts/schema/**'
               - 'extern/**'
               - 'spack_repo/**'
               - '.github/actions/**'

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -98,6 +98,7 @@ jobs:
       AWS_REGION: us-west-2
       ECR_REPOSITORY: palace
       S3_CONTAINERS_BUCKET: palace-ci-containers
+      S3_SCHEMAS_BUCKET: palace-ci-schemas
       GH_TOKEN: ${{ github.token }}
       OWNER_REPO: ${{ github.repository }}
       RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Publish config-schema.json alongside containers, so that users of containers can validate configs without running Palace.
