### PR TITLE
Add non-tensor libCEED AtPoints dependency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Added non-tensor libCEED AtPoints dependency support for CPU and GPU
+    postprocessing and forwarded CUDA host compiler selection through superbuilds.
   - Added a `RationalImpedance` boundary condition: a surface (Robin) impedance boundary
     whose per-square impedance is an arbitrary rational function of frequency,
     `Zs(s) = N(s)/D(s)` with `s = iω`, given by numerator and denominator polynomial

--- a/cmake/ExternalGitTags.cmake
+++ b/cmake/ExternalGitTags.cmake
@@ -76,7 +76,7 @@ set(EXTERN_LIBCEED_GIT_BRANCH
   "Git branch for external libCEED build"
 )
 set(EXTERN_LIBCEED_GIT_TAG
-  "95bd1e908b16e04a70015e3a9a7fddec5e9c3fc8" CACHE STRING
+  "64e0491369518e158481079ef966c29e2fa4f8fd" CACHE STRING
   "Git tag for external libCEED build"
 )
 
@@ -89,9 +89,9 @@ set(EXTERN_LIBXSMM_GIT_BRANCH
   "main" CACHE STRING
   "Git branch for external LIBXSMM build"
 )
-# libxsmm does not tag versions very often (last was Dec 2021)
+# libCEED requires LIBXSMM 2.0 or newer.
 set(EXTERN_LIBXSMM_GIT_TAG
-  "ea0b20499a41377bab148257240adbbfe1b4a333" CACHE STRING
+  "5ce29626ddad947f0d5c433ce78c58ff64dfbbdb" CACHE STRING
   "Git tag for external LIBXSMM build"
 )
 

--- a/cmake/ExternalLibCEED.cmake
+++ b/cmake/ExternalLibCEED.cmake
@@ -107,6 +107,11 @@ endif()
 string(REPLACE ";" "; " LIBCEED_OPTIONS_PRINT "${LIBCEED_OPTIONS}")
 message(STATUS "LIBCEED_OPTIONS: ${LIBCEED_OPTIONS_PRINT}")
 
+# Patches to libCEED for Palace GPU postprocessing support.
+set(LIBCEED_PATCH_FILES
+  "${CMAKE_SOURCE_DIR}/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff"
+)
+
 include(ExternalProject)
 ExternalProject_Add(libCEED
   DEPENDS           ${LIBCEED_DEPENDENCIES}
@@ -117,6 +122,10 @@ ExternalProject_Add(libCEED
   PREFIX            ${CMAKE_BINARY_DIR}/extern/libCEED-cmake
   BUILD_IN_SOURCE   TRUE
   UPDATE_COMMAND    ""
+  PATCH_COMMAND
+    git reset --hard &&
+    git clean -fd &&
+    git apply ${LIBCEED_PATCH_FILES}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ${CMAKE_MAKE_PROGRAM} ${LIBCEED_OPTIONS} install

--- a/cmake/ExternalPalace.cmake
+++ b/cmake/ExternalPalace.cmake
@@ -105,6 +105,14 @@ if(PALACE_WITH_CUDA)
     "-DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}"
     "-DCMAKE_CUDA_FLAGS=${CMAKE_CUDA_FLAGS}"
   )
+  if(NOT "${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "")
+    # Forward the CUDA host compiler: BLT (via the umpire/camp CMake configs from
+    # MAGMA's dependencies) errors out if CMAKE_CUDA_HOST_COMPILER is not set before
+    # CUDA language enablement in the inner Palace configure.
+    list(APPEND PALACE_OPTIONS
+      "-DCMAKE_CUDA_HOST_COMPILER=${CMAKE_CUDA_HOST_COMPILER}"
+    )
+  endif()
   if(NOT "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
     list(APPEND PALACE_OPTIONS
       "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"

--- a/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff
+++ b/extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff
@@ -1,0 +1,3459 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 996c8f04e0d656d54714173d2670bee1796c8db9..b25d52b91151bb9c60677445ad0da738d416e087 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -23,6 +23,7 @@ These functions will be removed when the SYCL backends are updated to reflect th
+ 
+ ### New features
+ 
++- Add non-tensor basis AtPoints interpolation and H1 gradient evaluation for line, triangle, tetrahedron, prism, and pyramid elements to the host, CUDA reference, and CUDA/HIP MAGMA backends.
+ - Add `CeedOperatorCreateAtPoints` which evaluates the `CeedQFunction` at arbitrary locations in each element, for use in Particle in Cell, Material Point Method, and similar methods.
+ - Add `CeedElemRestrictionGetLLayout` to provide L-vector layout for strided `CeedElemRestriction` created with `CEED_BACKEND_STRIDES`.
+ - Add `CeedVectorReturnCeed` and similar when parent `Ceed` context for a libCEED object is only needed once in a calling scope.
+diff --git a/backends/cuda-ref/ceed-cuda-ref-basis.c b/backends/cuda-ref/ceed-cuda-ref-basis.c
+index 684f329e898dbb34fbdce336010b2c6851261360..19d3c1d066e5239a55e728548fc3ce5bdee7c1b8 100644
+--- a/backends/cuda-ref/ceed-cuda-ref-basis.c
++++ b/backends/cuda-ref/ceed-cuda-ref-basis.c
+@@ -10,6 +10,7 @@
+ #include <ceed/jit-tools.h>
+ #include <cuda.h>
+ #include <cuda_runtime.h>
++#include <math.h>
+ #include <string.h>
+ 
+ #include "../cuda/ceed-cuda-common.h"
+@@ -255,6 +256,209 @@ static int CeedBasisApplyAddAtPoints_Cuda(CeedBasis basis, const CeedInt num_ele
+   return CEED_ERROR_SUCCESS;
+ }
+ 
++//------------------------------------------------------------------------------
++// Basis apply - non-tensor AtPoints
++//------------------------------------------------------------------------------
++static int CeedSizeMultiplyAtPoints_Cuda(Ceed ceed, CeedSize factor_1, CeedSize factor_2, CeedSize *product) {
++  CeedCheck(factor_1 >= 0 && factor_2 >= 0, ceed, CEED_ERROR_DIMENSION, "Cannot multiply negative vector dimensions");
++  CeedCheck(!factor_1 || factor_2 <= PTRDIFF_MAX / factor_1, ceed, CEED_ERROR_DIMENSION, "AtPoints vector dimension exceeds CeedSize range");
++  *product = factor_1 * factor_2;
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisUpdatePointsAtPoints_Cuda(Ceed ceed, CeedBasisNonTensor_Cuda *data, CeedInt num_elem, const CeedInt *num_points) {
++  CeedSize num_bytes;
++
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, num_elem, sizeof(CeedInt), &num_bytes));
++  if (num_elem == data->num_elem_at_points && !memcmp(data->h_points_per_elem, num_points, num_bytes)) return CEED_ERROR_SUCCESS;
++
++  CeedInt *d_points_new = NULL, *h_points_new = NULL;
++  CUresult cuda_result;
++
++  CeedCallBackend(CeedCalloc(num_elem, &h_points_new));
++  memcpy(h_points_new, num_points, num_bytes);
++  cuda_result = (CUresult)cudaMalloc((void **)&d_points_new, num_bytes);
++  if (cuda_result != CUDA_SUCCESS) {
++    (void)CeedFree(&h_points_new);
++    CeedChk_Cu(ceed, cuda_result);
++  }
++  cuda_result = (CUresult)cudaMemcpy(d_points_new, num_points, num_bytes, cudaMemcpyHostToDevice);
++  if (cuda_result != CUDA_SUCCESS) {
++    (void)cudaFree(d_points_new);
++    (void)CeedFree(&h_points_new);
++    CeedChk_Cu(ceed, cuda_result);
++  }
++  {
++    CeedInt *d_points_old = data->d_points_per_elem, *h_points_old = data->h_points_per_elem;
++
++    data->d_points_per_elem  = d_points_new;
++    data->h_points_per_elem  = h_points_new;
++    data->num_elem_at_points = num_elem;
++    cuda_result              = d_points_old ? (CUresult)cudaFree(d_points_old) : CUDA_SUCCESS;
++    CeedCallBackend(CeedFree(&h_points_old));
++    CeedChk_Cu(ceed, cuda_result);
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensorCore_Cuda(CeedBasis basis, bool apply_add, const CeedInt num_elem, const CeedInt *num_points,
++                                                    CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed       ceed         = CeedBasisReturnCeed(basis);
++  const bool is_transpose = t_mode == CEED_TRANSPOSE;
++  CeedInt    dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, max_num_points = 0, storage_points_per_elem;
++  CeedSize   u_len, v_len, points_stride, compact_uniform_size, nodes_len;
++  const CeedScalar        *d_x, *d_u, *modal_at_points;
++  CeedScalar              *d_v;
++  CeedBasisNonTensor_Cuda *data;
++  bool                     is_padded;
++
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCallBackend(CeedVectorSetValue(v, 1.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCallBackend(CeedBasisGetData(basis, &data));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++
++  for (CeedInt i = 0; i < num_elem; i++) max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  if (max_num_points == 0) {
++    if (is_transpose && !apply_add) CeedCallBackend(CeedVectorSetValue(v, 0.0));
++    return CEED_ERROR_SUCCESS;
++  }
++  CeedCallBackend(CeedBasisGetAtPointsLayout(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v, &is_padded, &points_stride));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, num_elem, max_num_points, &compact_uniform_size));
++  CeedCheck(is_padded || points_stride == compact_uniform_size, ceed, CEED_ERROR_BACKEND,
++            "CUDA non-tensor AtPoints requires compact point storage to have a uniform number of points per element");
++  CeedCheck(points_stride / num_elem <= INT_MAX, ceed, CEED_ERROR_DIMENSION, "AtPoints padding exceeds CeedInt range");
++  storage_points_per_elem = (CeedInt)(points_stride / num_elem);
++  CeedCallBackend(CeedVectorGetLength(u, &u_len));
++  CeedCallBackend(CeedVectorGetLength(v, &v_len));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, num_elem, num_nodes, &nodes_len));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, nodes_len, num_comp, &nodes_len));
++  CeedCheck((is_transpose ? v_len : u_len) >= nodes_len, ceed, CEED_ERROR_BACKEND,
++            "Vector at nodes incompatible with non-tensor BasisApplyAtPoints. Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++            is_transpose ? v_len : u_len, nodes_len);
++
++  CeedCallBackend(CeedBasisGetNonTensorAtPoints(basis, eval_mode, &modal_topology, &degree_at_points, &num_modes_at_points, &modal_at_points));
++
++  CeedCallBackend(CeedBasisUpdatePointsAtPoints_Cuda(ceed, data, num_elem, num_points));
++
++  {
++    CeedScalar **d_modal_at_points = eval_mode == CEED_EVAL_INTERP ? &data->d_interp_at_points : &data->d_grad_at_points;
++
++    if (!*d_modal_at_points) {
++      CeedScalar *d_modal_new = NULL;
++      CeedSize    modal_size, modal_bytes;
++      CUresult    cuda_result;
++
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, q_comp, num_modes_at_points, &modal_size));
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, modal_size, num_nodes, &modal_size));
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Cuda(ceed, modal_size, sizeof(CeedScalar), &modal_bytes));
++      cuda_result = (CUresult)cudaMalloc((void **)&d_modal_new, modal_bytes);
++      CeedChk_Cu(ceed, cuda_result);
++      cuda_result = (CUresult)cudaMemcpy(d_modal_new, modal_at_points, modal_bytes, cudaMemcpyHostToDevice);
++      if (cuda_result != CUDA_SUCCESS) {
++        (void)cudaFree(d_modal_new);
++        CeedChk_Cu(ceed, cuda_result);
++      }
++      *d_modal_at_points = d_modal_new;
++    }
++  }
++
++  {
++    CUmodule   *module_at_points = eval_mode == CEED_EVAL_INTERP ? &data->moduleInterpAtPoints : &data->moduleGradAtPoints;
++    CUfunction *kernel_at_points = eval_mode == CEED_EVAL_INTERP ? &data->InterpAtPoints : &data->GradAtPoints;
++    CUfunction *kernel_transpose = eval_mode == CEED_EVAL_INTERP ? &data->InterpTransposeAtPoints : &data->GradTransposeAtPoints;
++    CeedInt    *kernel_degree    = eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_degree_at_points : &data->grad_kernel_degree_at_points;
++    CeedInt    *kernel_num_modes = eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_num_modes_at_points : &data->grad_kernel_num_modes_at_points;
++    CeedInt    *kernel_modal_topology =
++        eval_mode == CEED_EVAL_INTERP ? &data->interp_kernel_modal_topology_at_points : &data->grad_kernel_modal_topology_at_points;
++
++    if (*kernel_degree != degree_at_points || *kernel_num_modes != num_modes_at_points || *kernel_modal_topology != modal_topology) {
++      const char basis_kernel_source[] = "// Nontensor basis AtPoints source\n#include <ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h>\n";
++      CUmodule   module_new            = NULL;
++      CUfunction kernel_new = NULL, kernel_transpose_new = NULL;
++      CeedInt    q_comp_interp;
++      int        ierr;
++
++      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++      ierr = CeedCompile_Cuda(ceed, basis_kernel_source, "basis_nontensor_at_points", &module_new, 7, "BASIS_P", num_nodes, "BASIS_NUM_COMP",
++                              num_comp, "BASIS_Q_COMP_INTERP", q_comp_interp, "BASIS_POLY_DEGREE", degree_at_points, "BASIS_NUM_MODES",
++                              num_modes_at_points, "BASIS_DIM", dim, "BASIS_MODAL_TOPOLOGY", modal_topology);
++      if (ierr) goto compile_cleanup;
++      ierr = CeedGetKernel_Cuda(ceed, module_new, eval_mode == CEED_EVAL_INTERP ? "InterpAtPoints" : "GradAtPoints", &kernel_new);
++      if (ierr) goto compile_cleanup;
++      ierr = CeedGetKernel_Cuda(ceed, module_new, eval_mode == CEED_EVAL_INTERP ? "InterpTransposeAtPoints" : "GradTransposeAtPoints",
++                                &kernel_transpose_new);
++      if (ierr) goto compile_cleanup;
++      if (*module_at_points) {
++        const CUresult cuda_result = cuModuleUnload(*module_at_points);
++
++        if (cuda_result != CUDA_SUCCESS) {
++          (void)cuModuleUnload(module_new);
++          CeedChk_Cu(ceed, cuda_result);
++        }
++      }
++      *module_at_points      = module_new;
++      *kernel_at_points      = kernel_new;
++      *kernel_transpose      = kernel_transpose_new;
++      *kernel_degree         = degree_at_points;
++      *kernel_num_modes      = num_modes_at_points;
++      *kernel_modal_topology = modal_topology;
++      goto compile_done;
++
++    compile_cleanup:
++      if (module_new) (void)cuModuleUnload(module_new);
++      return ierr;
++    compile_done:;
++    }
++  }
++
++  CeedCallBackend(CeedVectorGetArrayRead(x_ref, CEED_MEM_DEVICE, &d_x));
++  CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
++  if (apply_add) {
++    CeedCallBackend(CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v));
++  } else {
++    if (is_transpose) CeedCallBackend(CeedVectorSetValue(v, 0.0));
++    CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
++  }
++  {
++    CeedScalar *d_B = eval_mode == CEED_EVAL_INTERP ? data->d_interp_at_points : data->d_grad_at_points;
++    CUfunction  kernel;
++    void       *basis_args[] = {(void *)&num_elem, &storage_points_per_elem, &d_B, &data->d_points_per_elem, &d_x, &d_u, &d_v};
++    CeedInt     block_size;
++
++    if (eval_mode == CEED_EVAL_INTERP) {
++      kernel = is_transpose ? data->InterpTransposeAtPoints : data->InterpAtPoints;
++    } else {
++      kernel = is_transpose ? data->GradTransposeAtPoints : data->GradAtPoints;
++    }
++    block_size = CeedIntMin(is_transpose ? num_nodes : max_num_points, 128);
++    CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, num_elem, block_size, basis_args));
++  }
++  CeedCallBackend(CeedVectorRestoreArrayRead(x_ref, &d_x));
++  CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
++  CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Cuda(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Cuda(basis, false, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAddAtPointsNonTensor_Cuda(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                   CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Cuda(basis, true, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
+ //------------------------------------------------------------------------------
+ // Basis apply - non-tensor
+ //------------------------------------------------------------------------------
+@@ -392,11 +596,17 @@ static int CeedBasisDestroyNonTensor_Cuda(CeedBasis basis) {
+   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
+   CeedCallBackend(CeedBasisGetData(basis, &data));
+   CeedCallCuda(ceed, cuModuleUnload(data->module));
++  if (data->moduleInterpAtPoints) CeedCallCuda(ceed, cuModuleUnload(data->moduleInterpAtPoints));
++  if (data->moduleGradAtPoints) CeedCallCuda(ceed, cuModuleUnload(data->moduleGradAtPoints));
+   if (data->d_q_weight) CeedCallCuda(ceed, cudaFree(data->d_q_weight));
++  CeedCallBackend(CeedFree(&data->h_points_per_elem));
++  if (data->d_points_per_elem) CeedCallCuda(ceed, cudaFree(data->d_points_per_elem));
+   CeedCallCuda(ceed, cudaFree(data->d_interp));
+   CeedCallCuda(ceed, cudaFree(data->d_grad));
+   CeedCallCuda(ceed, cudaFree(data->d_div));
+   CeedCallCuda(ceed, cudaFree(data->d_curl));
++  if (data->d_interp_at_points) CeedCallCuda(ceed, cudaFree(data->d_interp_at_points));
++  if (data->d_grad_at_points) CeedCallCuda(ceed, cudaFree(data->d_grad_at_points));
+   CeedCallBackend(CeedFree(&data));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -499,6 +709,8 @@ int CeedBasisCreateH1_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -554,6 +766,8 @@ int CeedBasisCreateHdiv_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_nod
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -609,6 +823,8 @@ int CeedBasisCreateHcurl_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_no
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Cuda));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Cuda));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Cuda));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+diff --git a/backends/cuda-ref/ceed-cuda-ref.h b/backends/cuda-ref/ceed-cuda-ref.h
+index 11b45f3452e6f2ff2ba7ffbdd4b6f14c3abcda88..3c8411cef21ab946a9e0b35a9bb52fe8c3438a02 100644
+--- a/backends/cuda-ref/ceed-cuda-ref.h
++++ b/backends/cuda-ref/ceed-cuda-ref.h
+@@ -89,11 +89,28 @@ typedef struct {
+   CUfunction  Deriv;
+   CUfunction  DerivTranspose;
+   CUfunction  Weight;
++  CUmodule    moduleInterpAtPoints;
++  CUmodule    moduleGradAtPoints;
++  CUfunction  InterpAtPoints;
++  CUfunction  InterpTransposeAtPoints;
++  CUfunction  GradAtPoints;
++  CUfunction  GradTransposeAtPoints;
+   CeedScalar *d_interp;
+   CeedScalar *d_grad;
+   CeedScalar *d_div;
+   CeedScalar *d_curl;
+   CeedScalar *d_q_weight;
++  CeedScalar *d_interp_at_points;
++  CeedScalar *d_grad_at_points;
++  CeedInt     num_elem_at_points;
++  CeedInt    *h_points_per_elem;
++  CeedInt    *d_points_per_elem;
++  CeedInt     interp_kernel_num_modes_at_points;
++  CeedInt     interp_kernel_degree_at_points;
++  CeedInt     interp_kernel_modal_topology_at_points;
++  CeedInt     grad_kernel_num_modes_at_points;
++  CeedInt     grad_kernel_degree_at_points;
++  CeedInt     grad_kernel_modal_topology_at_points;
+ } CeedBasisNonTensor_Cuda;
+ 
+ typedef struct {
+diff --git a/backends/magma/ceed-magma-basis.c b/backends/magma/ceed-magma-basis.c
+index 85cc251d4277b87faeb02521b9c5949473bb5aeb..31e1fcc8ca76b86dfa30671936289eb3cd7e9851 100644
+--- a/backends/magma/ceed-magma-basis.c
++++ b/backends/magma/ceed-magma-basis.c
+@@ -8,6 +8,7 @@
+ #include <ceed.h>
+ #include <ceed/backend.h>
+ #include <ceed/jit-tools.h>
++#include <math.h>
+ #include <string.h>
+ 
+ #ifdef CEED_MAGMA_USE_HIP
+@@ -277,6 +278,223 @@ int CeedBasisApplyAtPoints_Magma(CeedBasis basis, const CeedInt num_elem, const
+   return CeedError(CeedBasisReturnCeed(basis), CEED_ERROR_BACKEND, "Backend does not implement CeedBasisApplyAtPoints");
+ }
+ 
++//------------------------------------------------------------------------------
++// Basis apply - non-tensor AtPoints
++//------------------------------------------------------------------------------
++static int CeedSizeMultiplyAtPoints_Magma(Ceed ceed, CeedSize factor_1, CeedSize factor_2, CeedSize *product) {
++  CeedCheck(factor_1 >= 0 && factor_2 >= 0, ceed, CEED_ERROR_DIMENSION, "Cannot multiply negative vector dimensions");
++  CeedCheck(!factor_1 || factor_2 <= PTRDIFF_MAX / factor_1, ceed, CEED_ERROR_DIMENSION, "AtPoints vector dimension exceeds CeedSize range");
++  *product = factor_1 * factor_2;
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisUpdatePointsAtPoints_Magma(Ceed ceed, Ceed_Magma *data, CeedBasisNonTensor_Magma *impl, CeedInt num_elem,
++                                               const CeedInt *num_points) {
++  CeedSize num_bytes;
++
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, num_elem, sizeof(CeedInt), &num_bytes));
++  if (num_elem == impl->num_elem_at_points && !memcmp(impl->h_points_per_elem, num_points, num_bytes)) return CEED_ERROR_SUCCESS;
++
++  CeedInt *d_points_new = NULL, *h_points_new = NULL;
++  int      ierr;
++
++  CeedCallBackend(CeedCalloc(num_elem, &h_points_new));
++  memcpy(h_points_new, num_points, num_bytes);
++  ierr = magma_malloc((void **)&d_points_new, num_bytes);
++  if (ierr) {
++    (void)CeedFree(&h_points_new);
++    return ierr;
++  }
++  magma_setvector(num_elem, sizeof(CeedInt), num_points, 1, d_points_new, 1, data->queue);
++  ceed_magma_queue_sync(data->queue);
++  {
++    CeedInt *d_points_old = impl->d_points_per_elem, *h_points_old = impl->h_points_per_elem;
++
++    impl->d_points_per_elem  = d_points_new;
++    impl->h_points_per_elem  = h_points_new;
++    impl->num_elem_at_points = num_elem;
++    ierr                     = d_points_old ? magma_free(d_points_old) : 0;
++    CeedCallBackend(CeedFree(&h_points_old));
++    if (ierr) return ierr;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensorCore_Magma(CeedBasis basis, bool apply_add, const CeedInt num_elem, const CeedInt *num_points,
++                                                     CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed        ceed         = CeedBasisReturnCeed(basis);
++  const bool  is_transpose = t_mode == CEED_TRANSPOSE;
++  Ceed_Magma *data;
++  CeedInt     dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, max_num_points = 0, storage_points_per_elem;
++  CeedSize    u_len, v_len, points_stride, compact_uniform_size, nodes_len;
++  const CeedScalar         *d_x, *d_u, *modal_at_points;
++  CeedScalar               *d_v;
++  CeedBasisNonTensor_Magma *impl;
++  bool                      is_padded;
++
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCallBackend(CeedVectorSetValue(v, 1.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCallBackend(CeedGetData(ceed, &data));
++  CeedCallBackend(CeedBasisGetData(basis, &impl));
++  CeedCallBackend(CeedBasisGetDimension(basis, &dim));
++  CeedCallBackend(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++
++  for (CeedInt i = 0; i < num_elem; i++) max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  if (max_num_points == 0) {
++    if (is_transpose && !apply_add) CeedCallBackend(CeedVectorSetValue(v, 0.0));
++    return CEED_ERROR_SUCCESS;
++  }
++  CeedCallBackend(CeedBasisGetAtPointsLayout(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v, &is_padded, &points_stride));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, num_elem, max_num_points, &compact_uniform_size));
++  CeedCheck(is_padded || points_stride == compact_uniform_size, ceed, CEED_ERROR_BACKEND,
++            "MAGMA non-tensor AtPoints requires compact point storage to have a uniform number of points per element");
++  CeedCheck(points_stride / num_elem <= INT_MAX, ceed, CEED_ERROR_DIMENSION, "AtPoints padding exceeds CeedInt range");
++  storage_points_per_elem = (CeedInt)(points_stride / num_elem);
++  CeedCallBackend(CeedVectorGetLength(u, &u_len));
++  CeedCallBackend(CeedVectorGetLength(v, &v_len));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, num_elem, num_nodes, &nodes_len));
++  CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, nodes_len, num_comp, &nodes_len));
++  CeedCheck((is_transpose ? v_len : u_len) >= nodes_len, ceed, CEED_ERROR_BACKEND,
++            "Vector at nodes incompatible with non-tensor BasisApplyAtPoints. Found %" CeedSize_FMT ", Required %" CeedSize_FMT,
++            is_transpose ? v_len : u_len, nodes_len);
++
++  CeedCallBackend(CeedBasisGetNonTensorAtPoints(basis, eval_mode, &modal_topology, &degree_at_points, &num_modes_at_points, &modal_at_points));
++
++  CeedCallBackend(CeedBasisUpdatePointsAtPoints_Magma(ceed, data, impl, num_elem, num_points));
++
++  {
++    CeedScalar **d_modal_at_points = eval_mode == CEED_EVAL_INTERP ? &impl->d_interp_at_points : &impl->d_grad_at_points;
++
++    if (!*d_modal_at_points) {
++      CeedScalar *d_modal_new = NULL;
++      CeedSize    modal_size, modal_bytes;
++
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, q_comp, num_modes_at_points, &modal_size));
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, modal_size, num_nodes, &modal_size));
++      CeedCheck(modal_size <= INT_MAX, ceed, CEED_ERROR_DIMENSION, "Non-tensor AtPoints modal data exceeds MAGMA index range");
++      CeedCallBackend(CeedSizeMultiplyAtPoints_Magma(ceed, modal_size, sizeof(CeedScalar), &modal_bytes));
++      CeedCallBackend(magma_malloc((void **)&d_modal_new, modal_bytes));
++      magma_setvector((magma_int_t)modal_size, sizeof(CeedScalar), modal_at_points, 1, d_modal_new, 1, data->queue);
++      *d_modal_at_points = d_modal_new;
++    }
++  }
++
++  {
++    CeedMagmaModule   *module_at_points = eval_mode == CEED_EVAL_INTERP ? &impl->moduleInterpAtPoints : &impl->moduleGradAtPoints;
++    CeedMagmaFunction *kernel_at_points = eval_mode == CEED_EVAL_INTERP ? &impl->InterpAtPoints : &impl->GradAtPoints;
++    CeedMagmaFunction *kernel_transpose = eval_mode == CEED_EVAL_INTERP ? &impl->InterpTransposeAtPoints : &impl->GradTransposeAtPoints;
++    CeedInt           *kernel_degree    = eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_degree_at_points : &impl->grad_kernel_degree_at_points;
++    CeedInt *kernel_num_modes = eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_num_modes_at_points : &impl->grad_kernel_num_modes_at_points;
++    CeedInt *kernel_modal_topology =
++        eval_mode == CEED_EVAL_INTERP ? &impl->interp_kernel_modal_topology_at_points : &impl->grad_kernel_modal_topology_at_points;
++
++    if (*kernel_degree != degree_at_points || *kernel_num_modes != num_modes_at_points || *kernel_modal_topology != modal_topology) {
++      const char basis_kernel_source[] = "// Nontensor basis AtPoints source\n#include <ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h>\n";
++      CeedMagmaModule   module_new     = NULL;
++      CeedMagmaFunction kernel_new = NULL, kernel_transpose_new = NULL;
++      Ceed              ceed_delegate = NULL;
++      CeedInt           q_comp_interp;
++      int               ierr, ierr_destroy;
++
++      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++      CeedCallBackend(CeedGetDelegate(ceed, &ceed_delegate));
++      ierr = CeedCompileMagma(ceed_delegate, basis_kernel_source, "basis_nontensor_at_points", &module_new, 7, "BASIS_P", num_nodes, "BASIS_NUM_COMP",
++                              num_comp, "BASIS_Q_COMP_INTERP", q_comp_interp, "BASIS_POLY_DEGREE", degree_at_points, "BASIS_NUM_MODES",
++                              num_modes_at_points, "BASIS_DIM", dim, "BASIS_MODAL_TOPOLOGY", modal_topology);
++      ierr_destroy = CeedDestroy(&ceed_delegate);
++      if (!ierr) ierr = ierr_destroy;
++      if (ierr) goto compile_cleanup;
++      ierr = CeedGetKernelMagma(ceed, module_new, eval_mode == CEED_EVAL_INTERP ? "InterpAtPoints" : "GradAtPoints", &kernel_new);
++      if (ierr) goto compile_cleanup;
++      ierr = CeedGetKernelMagma(ceed, module_new, eval_mode == CEED_EVAL_INTERP ? "InterpTransposeAtPoints" : "GradTransposeAtPoints",
++                                &kernel_transpose_new);
++      if (ierr) goto compile_cleanup;
++      if (*module_at_points) {
++#ifdef CEED_MAGMA_USE_HIP
++        const hipError_t unload_result = hipModuleUnload(*module_at_points);
++
++        if (unload_result != hipSuccess) {
++          (void)hipModuleUnload(module_new);
++          CeedCallHip(ceed, unload_result);
++        }
++#else
++        const CUresult unload_result = cuModuleUnload(*module_at_points);
++
++        if (unload_result != CUDA_SUCCESS) {
++          (void)cuModuleUnload(module_new);
++          CeedChk_Cu(ceed, unload_result);
++        }
++#endif
++      }
++      *module_at_points      = module_new;
++      *kernel_at_points      = kernel_new;
++      *kernel_transpose      = kernel_transpose_new;
++      *kernel_degree         = degree_at_points;
++      *kernel_num_modes      = num_modes_at_points;
++      *kernel_modal_topology = modal_topology;
++      goto compile_done;
++
++    compile_cleanup:
++      if (module_new) {
++#ifdef CEED_MAGMA_USE_HIP
++        (void)hipModuleUnload(module_new);
++#else
++        (void)cuModuleUnload(module_new);
++#endif
++      }
++      return ierr;
++    compile_done:;
++    }
++  }
++
++  CeedCallBackend(CeedVectorGetArrayRead(x_ref, CEED_MEM_DEVICE, &d_x));
++  CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
++  if (apply_add) {
++    CeedCallBackend(CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v));
++  } else {
++    if (is_transpose) CeedCallBackend(CeedVectorSetValue(v, 0.0));
++    CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
++  }
++  {
++    CeedScalar       *d_B = eval_mode == CEED_EVAL_INTERP ? impl->d_interp_at_points : impl->d_grad_at_points;
++    CeedMagmaFunction kernel;
++    void             *basis_args[] = {(void *)&num_elem, &storage_points_per_elem, &d_B, &impl->d_points_per_elem, &d_x, &d_u, &d_v};
++    CeedInt           block_size;
++
++    if (eval_mode == CEED_EVAL_INTERP) {
++      kernel = is_transpose ? impl->InterpTransposeAtPoints : impl->InterpAtPoints;
++    } else {
++      kernel = is_transpose ? impl->GradTransposeAtPoints : impl->GradAtPoints;
++    }
++    block_size = CeedIntMin(is_transpose ? num_nodes : max_num_points, 128);
++    CeedCallBackend(CeedRunKernelMagma(ceed, kernel, num_elem, block_size, basis_args));
++  }
++  ceed_magma_queue_sync(data->queue);
++  CeedCallBackend(CeedVectorRestoreArrayRead(x_ref, &d_x));
++  CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
++  CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Magma(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                 CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Magma(basis, false, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAddAtPointsNonTensor_Magma(CeedBasis basis, const CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                                    CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  CeedCallBackend(CeedBasisApplyAtPointsNonTensorCore_Magma(basis, true, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++  return CEED_ERROR_SUCCESS;
++}
++
+ //------------------------------------------------------------------------------
+ // Basis apply - non-tensor
+ //------------------------------------------------------------------------------
+@@ -516,11 +734,29 @@ static int CeedBasisDestroyNonTensor_Magma(CeedBasis basis) {
+ #endif
+     }
+   }
++  if (impl->moduleInterpAtPoints) {
++#ifdef CEED_MAGMA_USE_HIP
++    CeedCallHip(ceed, hipModuleUnload(impl->moduleInterpAtPoints));
++#else
++    CeedCallCuda(ceed, cuModuleUnload(impl->moduleInterpAtPoints));
++#endif
++  }
++  if (impl->moduleGradAtPoints) {
++#ifdef CEED_MAGMA_USE_HIP
++    CeedCallHip(ceed, hipModuleUnload(impl->moduleGradAtPoints));
++#else
++    CeedCallCuda(ceed, cuModuleUnload(impl->moduleGradAtPoints));
++#endif
++  }
+   CeedCallBackend(magma_free(impl->d_interp));
+   CeedCallBackend(magma_free(impl->d_grad));
+   CeedCallBackend(magma_free(impl->d_div));
+   CeedCallBackend(magma_free(impl->d_curl));
+   if (impl->d_q_weight) CeedCallBackend(magma_free(impl->d_q_weight));
++  CeedCallBackend(CeedFree(&impl->h_points_per_elem));
++  if (impl->d_points_per_elem) CeedCallBackend(magma_free(impl->d_points_per_elem));
++  if (impl->d_interp_at_points) CeedCallBackend(magma_free(impl->d_interp_at_points));
++  if (impl->d_grad_at_points) CeedCallBackend(magma_free(impl->d_grad_at_points));
+   CeedCallBackend(CeedFree(&impl));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -663,6 +899,8 @@ int CeedBasisCreateH1_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_node
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -721,6 +959,8 @@ int CeedBasisCreateHdiv_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_no
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+@@ -779,6 +1019,8 @@ int CeedBasisCreateHcurl_Magma(CeedElemTopology topo, CeedInt dim, CeedInt num_n
+   // Register backend functions
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApplyNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAdd", CeedBasisApplyAddNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAtPoints", CeedBasisApplyAtPointsNonTensor_Magma));
++  CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "ApplyAddAtPoints", CeedBasisApplyAddAtPointsNonTensor_Magma));
+   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Destroy", CeedBasisDestroyNonTensor_Magma));
+   CeedCallBackend(CeedDestroy(&ceed));
+   return CEED_ERROR_SUCCESS;
+diff --git a/backends/magma/ceed-magma.h b/backends/magma/ceed-magma.h
+index c800f2a6ab1bae92c0c133372bbd87393e351d00..cfcd85f7c35ec251cc135809b316025ac8ab7c09 100644
+--- a/backends/magma/ceed-magma.h
++++ b/backends/magma/ceed-magma.h
+@@ -66,6 +66,12 @@ typedef struct {
+   CeedMagmaFunction DerivTranspose[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedMagmaFunction DerivTransposeAdd[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedMagmaFunction Weight;
++  CeedMagmaModule   moduleInterpAtPoints;
++  CeedMagmaModule   moduleGradAtPoints;
++  CeedMagmaFunction InterpAtPoints;
++  CeedMagmaFunction InterpTransposeAtPoints;
++  CeedMagmaFunction GradAtPoints;
++  CeedMagmaFunction GradTransposeAtPoints;
+   CeedInt           NB_interp[MAGMA_NONTENSOR_KERNEL_INSTANCES], NB_interp_t[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedInt           NB_deriv[MAGMA_NONTENSOR_KERNEL_INSTANCES], NB_deriv_t[MAGMA_NONTENSOR_KERNEL_INSTANCES];
+   CeedScalar       *d_interp;
+@@ -73,6 +79,17 @@ typedef struct {
+   CeedScalar       *d_div;
+   CeedScalar       *d_curl;
+   CeedScalar       *d_q_weight;
++  CeedScalar       *d_interp_at_points;
++  CeedScalar       *d_grad_at_points;
++  CeedInt           num_elem_at_points;
++  CeedInt          *h_points_per_elem;
++  CeedInt          *d_points_per_elem;
++  CeedInt           interp_kernel_num_modes_at_points;
++  CeedInt           interp_kernel_degree_at_points;
++  CeedInt           interp_kernel_modal_topology_at_points;
++  CeedInt           grad_kernel_num_modes_at_points;
++  CeedInt           grad_kernel_degree_at_points;
++  CeedInt           grad_kernel_modal_topology_at_points;
+ } CeedBasisNonTensor_Magma;
+ 
+ CEED_INTERN int CeedBasisCreateTensorH1_Magma(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
+diff --git a/include/ceed-impl.h b/include/ceed-impl.h
+index 549dde8308c73158ca13c73438b6719e6b81971e..921aa5e8526ddb1d52e13e65a94ce28b3aa1f14c 100644
+--- a/include/ceed-impl.h
++++ b/include/ceed-impl.h
+@@ -229,6 +229,10 @@ struct CeedBasis_private {
+   CeedScalar *div; /* row-major matrix of shape [Q, P] expressing the divergence of basis functions at quadrature points for H(div) discretizations */
+   CeedScalar *curl; /* row-major matrix of shape [curl_dim * Q, P], curl_dim = 1 if dim < 3 else dim, expressing the curl of basis functions at
+                        quadrature points for H(curl) discretizations */
++  CeedScalar *interp_at_points; /* modal reconstruction coefficients for non-tensor interpolation at arbitrary points */
++  CeedScalar *grad_at_points;   /* modal reconstruction coefficients for non-tensor H1 gradients at arbitrary points */
++  CeedInt     interp_degree_at_points, interp_num_modes_at_points;
++  CeedInt     grad_degree_at_points, grad_num_modes_at_points;
+   CeedVector  vec_chebyshev;
+   CeedBasis   basis_chebyshev; /* basis interpolating from nodes to Chebyshev polynomial coefficients */
+   void       *data;            /* place for the backend to store any data */
+diff --git a/include/ceed/backend.h b/include/ceed/backend.h
+index a993e0dffea69d564260ad4cabf667e972c79b54..4e725cd69a62749996398b4b772f98f36ac86adb 100644
+--- a/include/ceed/backend.h
++++ b/include/ceed/backend.h
+@@ -347,6 +347,11 @@ CEED_EXTERN int CeedBasisGetData(CeedBasis basis, void *data);
+ CEED_EXTERN int CeedBasisSetData(CeedBasis basis, void *data);
+ CEED_EXTERN int CeedBasisReference(CeedBasis basis);
+ CEED_EXTERN int CeedBasisGetNumQuadratureComponents(CeedBasis basis, CeedEvalMode eval_mode, CeedInt *q_comp);
++CEED_INTERN int CeedBasisGetNonTensorAtPoints(CeedBasis basis, CeedEvalMode eval_mode, CeedInt *modal_topology, CeedInt *degree, CeedInt *num_modes,
++                                              const CeedScalar **modal_at_points);
++CEED_INTERN int CeedBasisGetAtPointsLayout(CeedBasis basis, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
++                                           CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v, bool *is_padded,
++                                           CeedSize *points_stride);
+ CEED_EXTERN int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEvalMode eval_mode, bool is_at_points, CeedInt num_points,
+                                           CeedSize *flops);
+ CEED_EXTERN int CeedBasisGetFESpace(CeedBasis basis, CeedFESpace *fe_space);
+diff --git a/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..a0a9633113feb04f239c452a6aa244b8ca07e52f
+--- /dev/null
++++ b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-at-points.h
+@@ -0,0 +1,275 @@
++// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
++// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
++//
++// SPDX-License-Identifier: BSD-2-Clause
++//
++// This file is part of CEED:  http://github.com/ceed
++
++/// @file
++/// Internal header for CUDA non-tensor product basis with AtPoints evaluation
++#include <ceed/types.h>
++
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++//------------------------------------------------------------------------------
++// Non-tensor modal values
++//------------------------------------------------------------------------------
++template <int DEGREE>
++inline __device__ void PowersAtPoint(const CeedScalar x, CeedScalar *x_pow) {
++  x_pow[0] = 1.0;
++  for (CeedInt i = 1; i <= DEGREE; i++) x_pow[i] = x * x_pow[i - 1];
++}
++
++template <int DEGREE, int NUM_MODES>
++inline __device__ void NonTensorModesAtPoint(const CeedScalar x, const CeedScalar y, const CeedScalar z, CeedScalar *phi) {
++  CeedScalar x_pow[DEGREE + 1], y_pow[DEGREE + 1], z_pow[DEGREE + 1];
++  CeedInt    mode = 0;
++
++  PowersAtPoint<DEGREE>(x, x_pow);
++  PowersAtPoint<DEGREE>(y, y_pow);
++  PowersAtPoint<DEGREE>(z, z_pow);
++
++#if BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_LINE
++  for (CeedInt i = 0; i <= DEGREE; i++) phi[mode++] = x_pow[i];
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_TRIANGLE
++  for (CeedInt total = 0; total <= DEGREE; total++) {
++    for (CeedInt i = 0; i <= total; i++) {
++      const CeedInt j = total - i;
++
++      phi[mode++] = x_pow[i] * y_pow[j];
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_TET
++  for (CeedInt total = 0; total <= DEGREE; total++) {
++    for (CeedInt i = 0; i <= total; i++) {
++      for (CeedInt j = 0; j <= total - i; j++) {
++        const CeedInt k = total - i - j;
++
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_PRISM
++  for (CeedInt k = 0; k <= DEGREE; k++) {
++    for (CeedInt total = 0; total <= DEGREE; total++) {
++      for (CeedInt i = 0; i <= total; i++) {
++        const CeedInt j = total - i;
++
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#elif BASIS_MODAL_TOPOLOGY == CEED_BASIS_NONTENSOR_MODAL_PYRAMID
++  for (CeedInt k = 0; k <= DEGREE; k++) {
++    const CeedInt xy_degree = DEGREE - k;
++
++    for (CeedInt i = 0; i <= xy_degree; i++) {
++      for (CeedInt j = 0; j <= xy_degree; j++) {
++        phi[mode++] = x_pow[i] * y_pow[j] * z_pow[k];
++      }
++    }
++  }
++#endif
++}
++
++//------------------------------------------------------------------------------
++// Non-tensor interpolation at points
++//------------------------------------------------------------------------------
++extern "C" __global__ void InterpAtPoints(const CeedInt num_elem, const CeedInt points_per_elem_stride, const CeedScalar *__restrict__ d_B,
++                                          const CeedInt *__restrict__ points_per_elem, const CeedScalar *__restrict__ d_X,
++                                          const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt  t_id          = threadIdx.x;
++  const CeedSize u_elem_stride = BASIS_P;
++  const CeedSize v_elem_stride = points_per_elem_stride;
++  const CeedSize u_comp_stride = (CeedSize)num_elem * BASIS_P;
++  const CeedSize v_comp_stride = (CeedSize)num_elem * points_per_elem_stride;
++  const CeedSize v_q_stride    = (CeedSize)BASIS_NUM_COMP * num_elem * points_per_elem_stride;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt p = t_id; p < num_points; p += blockDim.x) {
++      const CeedScalar x = d_X[elem * v_elem_stride + 0 * v_comp_stride + p];
++#if BASIS_DIM > 1
++      const CeedScalar y = d_X[elem * v_elem_stride + 1 * v_comp_stride + p];
++#else
++      const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++      const CeedScalar z = d_X[elem * v_elem_stride + 2 * v_comp_stride + p];
++#else
++      const CeedScalar z = 0.0;
++#endif
++      CeedScalar phi[BASIS_NUM_MODES];
++
++      NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        const CeedScalar *U = &d_U[elem * u_elem_stride + comp * u_comp_stride];
++
++        for (CeedInt d = 0; d < BASIS_Q_COMP_INTERP; d++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt node = 0; node < BASIS_P; node++) {
++            CeedScalar shape = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape += d_B[(CeedSize)node + (CeedSize)mode * BASIS_P + (CeedSize)d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape * U[node];
++          }
++          d_V[elem * v_elem_stride + comp * v_comp_stride + d * v_q_stride + p] = value;
++        }
++      }
++    }
++  }
++}
++
++extern "C" __global__ void InterpTransposeAtPoints(const CeedInt num_elem, const CeedInt points_per_elem_stride, const CeedScalar *__restrict__ d_B,
++                                                   const CeedInt *__restrict__ points_per_elem, const CeedScalar *__restrict__ d_X,
++                                                   const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt  t_id          = threadIdx.x;
++  const CeedSize u_elem_stride = points_per_elem_stride;
++  const CeedSize v_elem_stride = BASIS_P;
++  const CeedSize u_comp_stride = (CeedSize)num_elem * points_per_elem_stride;
++  const CeedSize v_comp_stride = (CeedSize)num_elem * BASIS_P;
++  const CeedSize u_q_stride    = (CeedSize)BASIS_NUM_COMP * num_elem * points_per_elem_stride;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt node = t_id; node < BASIS_P; node += blockDim.x) {
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        CeedScalar value = 0.0;
++
++        for (CeedInt p = 0; p < num_points; p++) {
++          const CeedScalar x = d_X[elem * u_elem_stride + 0 * u_comp_stride + p];
++#if BASIS_DIM > 1
++          const CeedScalar y = d_X[elem * u_elem_stride + 1 * u_comp_stride + p];
++#else
++          const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++          const CeedScalar z = d_X[elem * u_elem_stride + 2 * u_comp_stride + p];
++#else
++          const CeedScalar z = 0.0;
++#endif
++          CeedScalar phi[BASIS_NUM_MODES];
++
++          NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++          for (CeedInt d = 0; d < BASIS_Q_COMP_INTERP; d++) {
++            CeedScalar shape = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape += d_B[(CeedSize)node + (CeedSize)mode * BASIS_P + (CeedSize)d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape * d_U[elem * u_elem_stride + comp * u_comp_stride + d * u_q_stride + p];
++          }
++        }
++        d_V[elem * v_elem_stride + comp * v_comp_stride + node] += value;
++      }
++    }
++  }
++}
++
++//------------------------------------------------------------------------------
++// Non-tensor H^1 gradient at points
++//------------------------------------------------------------------------------
++extern "C" __global__ void GradAtPoints(const CeedInt num_elem, const CeedInt points_per_elem_stride, const CeedScalar *__restrict__ d_B,
++                                        const CeedInt *__restrict__ points_per_elem, const CeedScalar *__restrict__ d_X,
++                                        const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt  t_id          = threadIdx.x;
++  const CeedSize u_elem_stride = BASIS_P;
++  const CeedSize v_elem_stride = points_per_elem_stride;
++  const CeedSize u_comp_stride = (CeedSize)num_elem * BASIS_P;
++  const CeedSize v_comp_stride = (CeedSize)num_elem * points_per_elem_stride;
++  const CeedSize v_dim_stride  = (CeedSize)BASIS_NUM_COMP * num_elem * points_per_elem_stride;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt p = t_id; p < num_points; p += blockDim.x) {
++      const CeedScalar x = d_X[elem * v_elem_stride + 0 * v_comp_stride + p];
++#if BASIS_DIM > 1
++      const CeedScalar y = d_X[elem * v_elem_stride + 1 * v_comp_stride + p];
++#else
++      const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++      const CeedScalar z = d_X[elem * v_elem_stride + 2 * v_comp_stride + p];
++#else
++      const CeedScalar z = 0.0;
++#endif
++      CeedScalar phi[BASIS_NUM_MODES];
++
++      NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        const CeedScalar *U = &d_U[elem * u_elem_stride + comp * u_comp_stride];
++
++        for (CeedInt d = 0; d < BASIS_DIM; d++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt node = 0; node < BASIS_P; node++) {
++            CeedScalar shape_grad = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape_grad += d_B[(CeedSize)node + (CeedSize)mode * BASIS_P + (CeedSize)d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape_grad * U[node];
++          }
++          d_V[elem * v_elem_stride + comp * v_comp_stride + d * v_dim_stride + p] = value;
++        }
++      }
++    }
++  }
++}
++
++extern "C" __global__ void GradTransposeAtPoints(const CeedInt num_elem, const CeedInt points_per_elem_stride, const CeedScalar *__restrict__ d_B,
++                                                 const CeedInt *__restrict__ points_per_elem, const CeedScalar *__restrict__ d_X,
++                                                 const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
++  const CeedInt  t_id          = threadIdx.x;
++  const CeedSize u_elem_stride = points_per_elem_stride;
++  const CeedSize v_elem_stride = BASIS_P;
++  const CeedSize u_comp_stride = (CeedSize)num_elem * points_per_elem_stride;
++  const CeedSize v_comp_stride = (CeedSize)num_elem * BASIS_P;
++  const CeedSize u_dim_stride  = (CeedSize)BASIS_NUM_COMP * num_elem * points_per_elem_stride;
++
++  for (CeedInt elem = blockIdx.x; elem < num_elem; elem += gridDim.x) {
++    const CeedInt num_points = points_per_elem[elem];
++
++    for (CeedInt node = t_id; node < BASIS_P; node += blockDim.x) {
++      for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
++        CeedScalar value = 0.0;
++
++        for (CeedInt p = 0; p < num_points; p++) {
++          const CeedScalar x = d_X[elem * u_elem_stride + 0 * u_comp_stride + p];
++#if BASIS_DIM > 1
++          const CeedScalar y = d_X[elem * u_elem_stride + 1 * u_comp_stride + p];
++#else
++          const CeedScalar y = 0.0;
++#endif
++#if BASIS_DIM > 2
++          const CeedScalar z = d_X[elem * u_elem_stride + 2 * u_comp_stride + p];
++#else
++          const CeedScalar z = 0.0;
++#endif
++          CeedScalar phi[BASIS_NUM_MODES];
++
++          NonTensorModesAtPoint<BASIS_POLY_DEGREE, BASIS_NUM_MODES>(x, y, z, phi);
++          for (CeedInt d = 0; d < BASIS_DIM; d++) {
++            CeedScalar shape_grad = 0.0;
++
++            for (CeedInt mode = 0; mode < BASIS_NUM_MODES; mode++) {
++              shape_grad += d_B[(CeedSize)node + (CeedSize)mode * BASIS_P + (CeedSize)d * BASIS_P * BASIS_NUM_MODES] * phi[mode];
++            }
++            value += shape_grad * d_U[elem * u_elem_stride + comp * u_comp_stride + d * u_dim_stride + p];
++          }
++        }
++        d_V[elem * v_elem_stride + comp * v_comp_stride + node] += value;
++      }
++    }
++  }
++}
+diff --git a/interface/ceed-basis.c b/interface/ceed-basis.c
+index e90f7d1a88597904effae62c206a93e3cb7934b6..f678376aaa1ae8ee750e8d9f9938d09c4dfb4c6f 100644
+--- a/interface/ceed-basis.c
++++ b/interface/ceed-basis.c
+@@ -10,6 +10,7 @@
+ #include <ceed/backend.h>
+ #include <math.h>
+ #include <stdbool.h>
++#include <stdint.h>
+ #include <stdio.h>
+ #include <string.h>
+ 
+@@ -400,28 +401,87 @@ static int CeedBasisApplyCheckDims(CeedBasis basis, CeedInt num_elem, CeedTransp
+ 
+   @ref Developer
+ **/
++static int CeedSizeMultiplyAtPoints(Ceed ceed, CeedSize factor_1, CeedSize factor_2, CeedSize *product) {
++  CeedCheck(factor_1 >= 0 && factor_2 >= 0, ceed, CEED_ERROR_DIMENSION, "Cannot multiply negative vector dimensions");
++  CeedCheck(!factor_1 || factor_2 <= PTRDIFF_MAX / factor_1, ceed, CEED_ERROR_DIMENSION, "AtPoints vector dimension exceeds CeedSize range");
++  *product = factor_1 * factor_2;
++  return CEED_ERROR_SUCCESS;
++}
++
++int CeedBasisGetAtPointsLayout(CeedBasis basis, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode, CeedEvalMode eval_mode,
++                               CeedVector x_ref, CeedVector u, CeedVector v, bool *is_padded, CeedSize *points_stride) {
++  Ceed     ceed = CeedBasisReturnCeed(basis);
++  CeedInt  dim, num_comp, q_comp, max_num_points = 0;
++  CeedSize total_num_points = 0, x_length, point_vector_length, compact_coordinates_size, compact_points_size, value_components;
++  CeedSize point_length_divisor;
++
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCall(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++  CeedCall(CeedVectorGetLength(x_ref, &x_length));
++  CeedCall(CeedVectorGetLength(t_mode == CEED_TRANSPOSE ? u : v, &point_vector_length));
++  for (CeedInt i = 0; i < num_elem; i++) {
++    CeedCheck(total_num_points <= PTRDIFF_MAX - (CeedSize)num_points[i], ceed, CEED_ERROR_DIMENSION, "Total number of points exceeds CeedSize range");
++    total_num_points += num_points[i];
++    max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  }
++  CeedCall(CeedSizeMultiplyAtPoints(ceed, num_comp, q_comp, &value_components));
++  CeedCall(CeedSizeMultiplyAtPoints(ceed, total_num_points, dim, &compact_coordinates_size));
++  CeedCall(CeedSizeMultiplyAtPoints(ceed, total_num_points, value_components, &compact_points_size));
++  if (x_length == compact_coordinates_size && point_vector_length == compact_points_size) {
++    *is_padded     = false;
++    *points_stride = total_num_points;
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCall(CeedSizeMultiplyAtPoints(ceed, dim, num_elem, &point_length_divisor));
++  CeedCheck(point_length_divisor > 0 && x_length % point_length_divisor == 0, ceed, CEED_ERROR_DIMENSION,
++            "AtPoints coordinate vector is neither compact nor uniformly padded");
++  {
++    const CeedSize points_per_elem = x_length / point_length_divisor;
++    CeedSize       padded_points_size;
++
++    CeedCheck(points_per_elem >= max_num_points, ceed, CEED_ERROR_DIMENSION, "AtPoints coordinate padding is shorter than an element point count");
++    CeedCall(CeedSizeMultiplyAtPoints(ceed, points_per_elem, num_elem, points_stride));
++    CeedCall(CeedSizeMultiplyAtPoints(ceed, *points_stride, value_components, &padded_points_size));
++    CeedCheck(point_vector_length == padded_points_size, ceed, CEED_ERROR_DIMENSION,
++              "AtPoints coordinate and point vectors do not use the same uniformly padded layout. Found point length %" CeedSize_FMT
++              ", expected %" CeedSize_FMT,
++              point_vector_length, padded_points_size);
++  }
++  *is_padded = true;
++  return CEED_ERROR_SUCCESS;
++}
++
+ static int CeedBasisApplyAtPointsCheckDims(CeedBasis basis, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
+                                            CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
+-  CeedInt  dim, num_comp, num_q_comp, num_nodes, P_1d = 1, Q_1d = 1, total_num_points = 0;
+-  CeedSize x_length = 0, u_length = 0, v_length;
++  CeedInt  num_comp, num_q_comp, num_nodes;
++  CeedSize total_num_points = 0, nodes_size, points_size, u_length = 0, v_length, points_stride;
++  bool     is_padded;
+ 
+-  CeedCall(CeedBasisGetDimension(basis, &dim));
+-  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
+-  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+   CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+   CeedCall(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &num_q_comp));
+   CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
+   CeedCall(CeedVectorGetLength(v, &v_length));
+-  if (x_ref != CEED_VECTOR_NONE) CeedCall(CeedVectorGetLength(x_ref, &x_length));
+   if (u != CEED_VECTOR_NONE) CeedCall(CeedVectorGetLength(u, &u_length));
+ 
++  CeedCheck(num_elem > 0, CeedBasisReturnCeed(basis), CEED_ERROR_DIMENSION, "CeedBasisApplyAtPoints requires at least one element");
++  CeedCheck(num_points, CeedBasisReturnCeed(basis), CEED_ERROR_DIMENSION, "CeedBasisApplyAtPoints requires a point-count array");
++
+   // Check compatibility coordinates vector
+-  for (CeedInt i = 0; i < num_elem; i++) total_num_points += num_points[i];
+-  CeedCheck((x_length >= (CeedSize)total_num_points * (CeedSize)dim) || (eval_mode == CEED_EVAL_WEIGHT), CeedBasisReturnCeed(basis),
+-            CEED_ERROR_DIMENSION,
+-            "Length of reference coordinate vector incompatible with basis dimension and number of points."
+-            " Found reference coordinate vector of length %" CeedSize_FMT ", not of length %" CeedSize_FMT ".",
+-            x_length, (CeedSize)total_num_points * (CeedSize)dim);
++  for (CeedInt i = 0; i < num_elem; i++) {
++    CeedCheck(num_points[i] >= 0, CeedBasisReturnCeed(basis), CEED_ERROR_DIMENSION,
++              "Number of points must be nonnegative, found %" CeedInt_FMT " for element %" CeedInt_FMT, num_points[i], i);
++    CeedCheck(total_num_points <= PTRDIFF_MAX - (CeedSize)num_points[i], CeedBasisReturnCeed(basis), CEED_ERROR_DIMENSION,
++              "Total number of points exceeds CeedSize range");
++    total_num_points += num_points[i];
++  }
++  CeedCall(CeedSizeMultiplyAtPoints(CeedBasisReturnCeed(basis), total_num_points, num_q_comp, &points_size));
++  CeedCall(CeedSizeMultiplyAtPoints(CeedBasisReturnCeed(basis), points_size, num_comp, &points_size));
++  CeedCall(CeedSizeMultiplyAtPoints(CeedBasisReturnCeed(basis), num_elem, num_nodes, &nodes_size));
++  CeedCall(CeedSizeMultiplyAtPoints(CeedBasisReturnCeed(basis), nodes_size, num_comp, &nodes_size));
++  if (eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD)
++    CeedCall(CeedBasisGetAtPointsLayout(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v, &is_padded, &points_stride));
+ 
+   // Check CEED_EVAL_WEIGHT only on CEED_NOTRANSPOSE
+   CeedCheck(eval_mode != CEED_EVAL_WEIGHT || t_mode == CEED_NOTRANSPOSE, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
+@@ -431,16 +491,9 @@ static int CeedBasisApplyAtPointsCheckDims(CeedBasis basis, CeedInt num_elem, co
+   bool has_good_dims = true;
+   switch (eval_mode) {
+     case CEED_EVAL_INTERP:
+-      has_good_dims = ((t_mode == CEED_TRANSPOSE && (u_length >= (CeedSize)total_num_points * (CeedSize)num_q_comp ||
+-                                                     v_length >= (CeedSize)num_elem * (CeedSize)num_nodes * (CeedSize)num_comp)) ||
+-                       (t_mode == CEED_NOTRANSPOSE && (v_length >= (CeedSize)total_num_points * (CeedSize)num_q_comp ||
+-                                                       u_length >= (CeedSize)num_elem * (CeedSize)num_nodes * (CeedSize)num_comp)));
+-      break;
+     case CEED_EVAL_GRAD:
+-      has_good_dims = ((t_mode == CEED_TRANSPOSE && (u_length >= (CeedSize)total_num_points * (CeedSize)num_q_comp * (CeedSize)dim ||
+-                                                     v_length >= (CeedSize)num_elem * (CeedSize)num_nodes * (CeedSize)num_comp)) ||
+-                       (t_mode == CEED_NOTRANSPOSE && (v_length >= (CeedSize)total_num_points * (CeedSize)num_q_comp * (CeedSize)dim ||
+-                                                       u_length >= (CeedSize)num_elem * (CeedSize)num_nodes * (CeedSize)num_comp)));
++      has_good_dims = ((t_mode == CEED_TRANSPOSE && u_length >= points_size && v_length >= nodes_size) ||
++                       (t_mode == CEED_NOTRANSPOSE && v_length >= points_size && u_length >= nodes_size));
+       break;
+     case CEED_EVAL_WEIGHT:
+       has_good_dims = t_mode == CEED_NOTRANSPOSE && (v_length >= total_num_points);
+@@ -478,6 +531,585 @@ static int CeedBasisApplyAtPointsCheckDims(CeedBasis basis, CeedInt num_elem, co
+ 
+   @ref Developer
+ **/
++//------------------------------------------------------------------------------
++// Basis apply at points - non-tensor host implementation
++//------------------------------------------------------------------------------
++#define CEED_BASIS_NONTENSOR_MODAL_LINE 1
++#define CEED_BASIS_NONTENSOR_MODAL_TRIANGLE 2
++#define CEED_BASIS_NONTENSOR_MODAL_TET 3
++#define CEED_BASIS_NONTENSOR_MODAL_PRISM 4
++#define CEED_BASIS_NONTENSOR_MODAL_PYRAMID 5
++
++static int CeedBasisNonTensorModalTopologyAtPoints(CeedElemTopology topo, CeedInt *modal_topology) {
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_LINE;
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TRIANGLE;
++      break;
++    case CEED_TOPOLOGY_TET:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_TET;
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PRISM;
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      *modal_topology = CEED_BASIS_NONTENSOR_MODAL_PYRAMID;
++      break;
++    default:
++      *modal_topology = 0;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static bool CeedBasisMultiplyNumModesAtPoints(CeedSize factor, CeedSize *num_modes) {
++  if (factor && *num_modes > INT_MAX / factor) return false;
++  *num_modes *= factor;
++  return true;
++}
++
++static CeedInt CeedBasisNonTensorNumModesAtPoints(CeedElemTopology topo, CeedInt degree) {
++  CeedSize factors[3] = {(CeedSize)degree + 1, (CeedSize)degree + 2, (CeedSize)degree + 3};
++  CeedInt  num_factors, denominator;
++
++  if (degree < 0) return 0;
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      return factors[0] <= INT_MAX ? (CeedInt)factors[0] : 0;
++    case CEED_TOPOLOGY_TRIANGLE:
++      num_factors = 2;
++      denominator = 2;
++      break;
++    case CEED_TOPOLOGY_TET:
++      num_factors = 3;
++      denominator = 6;
++      break;
++    case CEED_TOPOLOGY_PRISM: {
++      const CeedInt tri_modes = CeedBasisNonTensorNumModesAtPoints(CEED_TOPOLOGY_TRIANGLE, degree);
++
++      return tri_modes && factors[0] <= INT_MAX / tri_modes ? (CeedInt)(tri_modes * factors[0]) : 0;
++    }
++    case CEED_TOPOLOGY_PYRAMID:
++      factors[2]  = 2 * (CeedSize)degree + 3;
++      num_factors = 3;
++      denominator = 6;
++      break;
++    default:
++      return 0;
++  }
++  for (CeedInt divisor = 2; divisor <= 3; divisor++) {
++    if (denominator % divisor) continue;
++    for (CeedInt i = 0; i < num_factors; i++) {
++      if (factors[i] % divisor == 0) {
++        factors[i] /= divisor;
++        denominator /= divisor;
++        break;
++      }
++    }
++  }
++  CeedSize num_modes = 1;
++
++  for (CeedInt i = 0; i < num_factors; i++) {
++    if (!CeedBasisMultiplyNumModesAtPoints(factors[i], &num_modes)) return 0;
++  }
++  return denominator == 1 ? (CeedInt)num_modes : 0;
++}
++
++static bool CeedBasisNonTensorDegreeAtPoints(CeedElemTopology topo, CeedInt num_modes, CeedInt *degree) {
++  for (CeedInt p = 0; p < num_modes; p++) {
++    if (CeedBasisNonTensorNumModesAtPoints(topo, p) == num_modes) {
++      *degree = p;
++      return true;
++    }
++  }
++  return false;
++}
++
++static CeedScalar CeedBasisPowIntAtPoints(CeedScalar x, CeedInt p) {
++  CeedScalar y = 1.0;
++
++  for (CeedInt i = 0; i < p; i++) y *= x;
++  return y;
++}
++
++static int CeedBasisNonTensorModesAtPoint(CeedElemTopology topo, CeedInt degree, CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *phi) {
++  CeedInt mode = 0;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      for (CeedInt i = 0; i <= degree; i++) phi[mode++] = CeedBasisPowIntAtPoints(x, i);
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          const CeedInt j = total - i;
++
++          phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j);
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_TET:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          for (CeedInt j = 0; j <= total - i; j++) {
++            const CeedInt k = total - i - j;
++
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      for (CeedInt k = 0; k <= degree; k++) {
++        for (CeedInt total = 0; total <= degree; total++) {
++          for (CeedInt i = 0; i <= total; i++) {
++            const CeedInt j = total - i;
++
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      for (CeedInt k = 0; k <= degree; k++) {
++        const CeedInt xy_degree = degree - k;
++
++        for (CeedInt i = 0; i <= xy_degree; i++) {
++          for (CeedInt j = 0; j <= xy_degree; j++) {
++            phi[mode++] = CeedBasisPowIntAtPoints(x, i) * CeedBasisPowIntAtPoints(y, j) * CeedBasisPowIntAtPoints(z, k);
++          }
++        }
++      }
++      break;
++    default:
++      break;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static CeedScalar CeedBasisPowDerivativeAtPoints(CeedScalar x, CeedInt p) { return p ? p * CeedBasisPowIntAtPoints(x, p - 1) : 0.0; }
++
++static int CeedBasisNonTensorModeGradientsAtPoint(CeedElemTopology topo, CeedInt degree, CeedScalar x, CeedScalar y, CeedScalar z,
++                                                  CeedScalar *grad_phi) {
++  const CeedInt num_modes = CeedBasisNonTensorNumModesAtPoints(topo, degree);
++  CeedInt       mode      = 0;
++
++  switch (topo) {
++    case CEED_TOPOLOGY_LINE:
++      for (CeedInt i = 0; i <= degree; i++) grad_phi[mode++] = CeedBasisPowDerivativeAtPoints(x, i);
++      break;
++    case CEED_TOPOLOGY_TRIANGLE:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          const CeedInt    j     = total - i;
++          const CeedScalar x_pow = CeedBasisPowIntAtPoints(x, i), y_pow = CeedBasisPowIntAtPoints(y, j);
++
++          grad_phi[0 * num_modes + mode] = CeedBasisPowDerivativeAtPoints(x, i) * y_pow;
++          grad_phi[1 * num_modes + mode] = x_pow * CeedBasisPowDerivativeAtPoints(y, j);
++          mode++;
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_TET:
++      for (CeedInt total = 0; total <= degree; total++) {
++        for (CeedInt i = 0; i <= total; i++) {
++          for (CeedInt j = 0; j <= total - i; j++) {
++            const CeedInt    k     = total - i - j;
++            const CeedScalar x_pow = CeedBasisPowIntAtPoints(x, i), y_pow = CeedBasisPowIntAtPoints(y, j), z_pow = CeedBasisPowIntAtPoints(z, k);
++
++            grad_phi[0 * num_modes + mode] = CeedBasisPowDerivativeAtPoints(x, i) * y_pow * z_pow;
++            grad_phi[1 * num_modes + mode] = x_pow * CeedBasisPowDerivativeAtPoints(y, j) * z_pow;
++            grad_phi[2 * num_modes + mode] = x_pow * y_pow * CeedBasisPowDerivativeAtPoints(z, k);
++            mode++;
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PRISM:
++      for (CeedInt k = 0; k <= degree; k++) {
++        for (CeedInt total = 0; total <= degree; total++) {
++          for (CeedInt i = 0; i <= total; i++) {
++            const CeedInt    j     = total - i;
++            const CeedScalar x_pow = CeedBasisPowIntAtPoints(x, i), y_pow = CeedBasisPowIntAtPoints(y, j), z_pow = CeedBasisPowIntAtPoints(z, k);
++
++            grad_phi[0 * num_modes + mode] = CeedBasisPowDerivativeAtPoints(x, i) * y_pow * z_pow;
++            grad_phi[1 * num_modes + mode] = x_pow * CeedBasisPowDerivativeAtPoints(y, j) * z_pow;
++            grad_phi[2 * num_modes + mode] = x_pow * y_pow * CeedBasisPowDerivativeAtPoints(z, k);
++            mode++;
++          }
++        }
++      }
++      break;
++    case CEED_TOPOLOGY_PYRAMID:
++      for (CeedInt k = 0; k <= degree; k++) {
++        const CeedInt xy_degree = degree - k;
++
++        for (CeedInt i = 0; i <= xy_degree; i++) {
++          for (CeedInt j = 0; j <= xy_degree; j++) {
++            const CeedScalar x_pow = CeedBasisPowIntAtPoints(x, i), y_pow = CeedBasisPowIntAtPoints(y, j), z_pow = CeedBasisPowIntAtPoints(z, k);
++
++            grad_phi[0 * num_modes + mode] = CeedBasisPowDerivativeAtPoints(x, i) * y_pow * z_pow;
++            grad_phi[1 * num_modes + mode] = x_pow * CeedBasisPowDerivativeAtPoints(y, j) * z_pow;
++            grad_phi[2 * num_modes + mode] = x_pow * y_pow * CeedBasisPowDerivativeAtPoints(z, k);
++            mode++;
++          }
++        }
++      }
++      break;
++    default:
++      break;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildModalAtPoints(Ceed ceed, CeedElemTopology topo, CeedInt dim, CeedInt num_qpts, const CeedScalar *q_ref, CeedInt q_comp,
++                                       CeedInt num_nodes, const CeedScalar *tabulation, CeedInt requested_degree, bool require_overdetermined,
++                                       const char *label, CeedInt *degree, CeedInt *num_modes, CeedScalar **modal_at_points) {
++  const CeedInt first_degree = requested_degree >= 0 ? requested_degree : 0;
++  const CeedInt last_degree  = requested_degree >= 0 ? requested_degree : num_qpts - 1;
++
++  for (CeedInt p = first_degree; p <= last_degree; p++) {
++    const CeedInt modes       = CeedBasisNonTensorNumModesAtPoints(topo, p);
++    CeedScalar   *vandermonde = NULL, *vandermonde_pinv = NULL, *rank_work = NULL, *column_norms = NULL, *candidate = NULL;
++    CeedScalar    max_error = 0.0, tabulation_scale = 1.0;
++    CeedSize      matrix_size, pseudoinverse_square_size, candidate_size;
++    bool          is_valid = true;
++    int           ierr     = CEED_ERROR_SUCCESS;
++
++    if (!modes || modes > num_qpts) break;
++    if (require_overdetermined && num_qpts <= modes) continue;
++
++    ierr = CeedSizeMultiplyAtPoints(ceed, num_qpts, modes, &matrix_size);
++    if (ierr) goto cleanup;
++    ierr = CeedSizeMultiplyAtPoints(ceed, num_qpts, num_qpts, &pseudoinverse_square_size);
++    if (ierr) goto cleanup;
++    CeedCheck(matrix_size <= INT_MAX && pseudoinverse_square_size <= INT_MAX, ceed, CEED_ERROR_DIMENSION,
++              "%s AtPoints reconstruction exceeds the supported pseudoinverse workspace", label);
++    ierr = CeedSizeMultiplyAtPoints(ceed, q_comp, modes, &candidate_size);
++    if (ierr) goto cleanup;
++    ierr = CeedSizeMultiplyAtPoints(ceed, candidate_size, num_nodes, &candidate_size);
++    if (ierr) goto cleanup;
++    ierr = CeedCalloc(matrix_size, &vandermonde);
++    if (ierr) goto cleanup;
++    ierr = CeedCalloc(matrix_size, &vandermonde_pinv);
++    if (ierr) goto cleanup;
++    ierr = CeedCalloc(matrix_size, &rank_work);
++    if (ierr) goto cleanup;
++    ierr = CeedCalloc(modes, &column_norms);
++    if (ierr) goto cleanup;
++    ierr = CeedCalloc(candidate_size, &candidate);
++    if (ierr) goto cleanup;
++
++    for (CeedInt q = 0; q < num_qpts; q++) {
++      const CeedScalar x = q_ref[0 * num_qpts + q];
++      const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++      const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++      ierr = CeedBasisNonTensorModesAtPoint(topo, p, x, y, z, &vandermonde[q * modes]);
++      if (ierr) goto cleanup;
++    }
++    for (CeedInt mode = 0; mode < modes; mode++) {
++      for (CeedInt q = 0; q < num_qpts; q++) column_norms[mode] += vandermonde[q * modes + mode] * vandermonde[q * modes + mode];
++      column_norms[mode] = sqrt(column_norms[mode]);
++      if (!(column_norms[mode] > 0.0)) {
++        is_valid = false;
++        goto cleanup;
++      }
++      for (CeedInt q = 0; q < num_qpts; q++) vandermonde[q * modes + mode] /= column_norms[mode];
++    }
++    memcpy(rank_work, vandermonde, matrix_size * sizeof(*rank_work));
++    for (CeedInt mode = 0; mode < modes; mode++) {
++      for (CeedInt previous = 0; previous < mode; previous++) {
++        CeedScalar projection = 0.0;
++
++        for (CeedInt q = 0; q < num_qpts; q++) projection += rank_work[q * modes + previous] * rank_work[q * modes + mode];
++        for (CeedInt q = 0; q < num_qpts; q++) rank_work[q * modes + mode] -= projection * rank_work[q * modes + previous];
++      }
++      CeedScalar norm = 0.0;
++
++      for (CeedInt q = 0; q < num_qpts; q++) norm += rank_work[q * modes + mode] * rank_work[q * modes + mode];
++      norm = sqrt(norm);
++      if (!(norm > 100.0 * sqrt(CEED_EPSILON))) {
++        is_valid = false;
++        goto cleanup;
++      }
++      for (CeedInt q = 0; q < num_qpts; q++) rank_work[q * modes + mode] /= norm;
++    }
++    ierr = CeedMatrixPseudoinverse(ceed, vandermonde, num_qpts, modes, vandermonde_pinv);
++    if (ierr) goto cleanup;
++    for (CeedInt d = 0; d < q_comp; d++) {
++      ierr = CeedMatrixMatrixMultiply(ceed, vandermonde_pinv, &tabulation[d * num_qpts * num_nodes], &candidate[d * modes * num_nodes], modes,
++                                      num_nodes, num_qpts);
++      if (ierr) goto cleanup;
++    }
++
++    for (CeedInt d = 0; d < q_comp; d++) {
++      for (CeedInt q = 0; q < num_qpts; q++) {
++        for (CeedInt node = 0; node < num_nodes; node++) {
++          CeedScalar value = 0.0;
++
++          for (CeedInt mode = 0; mode < modes; mode++)
++            value += vandermonde[q * modes + mode] * candidate[d * modes * num_nodes + mode * num_nodes + node];
++          const CeedScalar tabulation_value = tabulation[d * num_qpts * num_nodes + q * num_nodes + node];
++          const CeedScalar error            = fabs(value - tabulation_value);
++
++          max_error        = max_error > error ? max_error : error;
++          tabulation_scale = tabulation_scale > fabs(tabulation_value) ? tabulation_scale : fabs(tabulation_value);
++        }
++      }
++    }
++    is_valid = max_error <= 10000. * CEED_EPSILON * tabulation_scale * CeedIntMax(num_qpts, modes);
++    if (is_valid) {
++      for (CeedInt d = 0; d < q_comp; d++) {
++        for (CeedInt mode = 0; mode < modes; mode++) {
++          for (CeedInt node = 0; node < num_nodes; node++) candidate[d * modes * num_nodes + mode * num_nodes + node] /= column_norms[mode];
++        }
++      }
++    }
++
++  cleanup:
++    (void)CeedFree(&vandermonde);
++    (void)CeedFree(&vandermonde_pinv);
++    (void)CeedFree(&rank_work);
++    (void)CeedFree(&column_norms);
++    if (ierr) {
++      (void)CeedFree(&candidate);
++      return ierr;
++    }
++    if (is_valid) {
++      *degree          = p;
++      *num_modes       = modes;
++      *modal_at_points = candidate;
++      return CEED_ERROR_SUCCESS;
++    }
++    (void)CeedFree(&candidate);
++  }
++
++  return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
++                   "%s AtPoints requires a full-rank, well-conditioned polynomial reconstruction consistent with the tabulation", label);
++}
++
++static int CeedBasisBuildNonTensorInterpAtPoints(CeedBasis basis) {
++  Ceed              ceed = CeedBasisReturnCeed(basis);
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree = -1, num_modes, modal_topology, q_comp_interp;
++  const CeedScalar *interp, *q_ref;
++
++  CeedCall(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCall(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
++  CeedCall(CeedBasisGetInterp(basis, &interp));
++  CeedCall(CeedBasisGetQRef(basis, &q_ref));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, &modal_topology));
++  CeedCheck(modal_topology, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints interpolation is not supported for this element topology");
++  CeedCheck(interp && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "Non-tensor interpolation AtPoints requires interp and q_ref tables");
++  if (!(fe_space == CEED_FE_SPACE_H1 && CeedBasisNonTensorDegreeAtPoints(topo, num_nodes, &degree))) degree = -1;
++  CeedCall(CeedBasisBuildModalAtPoints(ceed, topo, dim, num_qpts, q_ref, q_comp_interp, num_nodes, interp, degree, degree < 0,
++                                       "Non-tensor interpolation", &degree, &num_modes, &basis->interp_at_points));
++  basis->interp_num_modes_at_points = num_modes;
++  basis->interp_degree_at_points    = degree;
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisValidateNonTensorH1GradAtPoints(CeedBasis basis, CeedElemTopology topo, CeedInt dim, CeedInt num_nodes, CeedInt num_qpts,
++                                                    const CeedScalar *q_ref, const CeedScalar *grad) {
++  Ceed              ceed   = CeedBasisReturnCeed(basis);
++  const CeedInt     degree = basis->interp_degree_at_points, num_modes = basis->interp_num_modes_at_points;
++  const CeedScalar *interp_modal   = basis->interp_at_points;
++  CeedScalar       *mode_gradients = NULL;
++  CeedScalar        max_error = 0.0, tabulation_scale = 1.0;
++  CeedSize          mode_gradient_size;
++
++  CeedCall(CeedSizeMultiplyAtPoints(ceed, dim, num_modes, &mode_gradient_size));
++  CeedCall(CeedCalloc(mode_gradient_size, &mode_gradients));
++  for (CeedInt q = 0; q < num_qpts; q++) {
++    const CeedScalar x = q_ref[0 * num_qpts + q];
++    const CeedScalar y = dim > 1 ? q_ref[1 * num_qpts + q] : 0.0;
++    const CeedScalar z = dim > 2 ? q_ref[2 * num_qpts + q] : 0.0;
++
++    CeedCall(CeedBasisNonTensorModeGradientsAtPoint(topo, degree, x, y, z, mode_gradients));
++    for (CeedInt d = 0; d < dim; d++) {
++      for (CeedInt node = 0; node < num_nodes; node++) {
++        CeedScalar expected = 0.0;
++
++        for (CeedInt mode = 0; mode < num_modes; mode++) expected += interp_modal[mode * num_nodes + node] * mode_gradients[d * num_modes + mode];
++        const CeedScalar tabulation_value = grad[d * num_qpts * num_nodes + q * num_nodes + node];
++        const CeedScalar error            = fabs(expected - tabulation_value);
++
++        max_error        = max_error > error ? max_error : error;
++        tabulation_scale = tabulation_scale > fabs(tabulation_value) ? tabulation_scale : fabs(tabulation_value);
++      }
++    }
++  }
++  CeedCall(CeedFree(&mode_gradients));
++  CeedCheck(max_error <= 10000. * CEED_EPSILON * tabulation_scale * CeedIntMax(num_qpts, num_modes), ceed, CEED_ERROR_UNSUPPORTED,
++            "H^1 non-tensor AtPoints requires gradient tabulation consistent with the reconstructed polynomial interpolation basis");
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisBuildNonTensorGradAtPoints(CeedBasis basis) {
++  Ceed              ceed = CeedBasisReturnCeed(basis);
++  CeedFESpace       fe_space;
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_qpts, degree, grad_degree, num_modes, modal_topology;
++  const CeedScalar *grad, *q_ref;
++
++  CeedCall(CeedBasisGetFESpace(basis, &fe_space));
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
++  CeedCall(CeedBasisGetGrad(basis, &grad));
++  CeedCall(CeedBasisGetQRef(basis, &q_ref));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, &modal_topology));
++  CeedCheck(fe_space == CEED_FE_SPACE_H1 && modal_topology, ceed, CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints gradients are only supported for H^1 bases with supported topologies");
++  CeedCheck(grad && q_ref, ceed, CEED_ERROR_UNSUPPORTED, "H^1 non-tensor gradient AtPoints requires grad and q_ref tables");
++  CeedCheck(CeedBasisNonTensorDegreeAtPoints(topo, num_nodes, &degree), ceed, CEED_ERROR_UNSUPPORTED,
++            "Cannot infer non-tensor H^1 polynomial degree from %" CeedInt_FMT " nodes", num_nodes);
++  if (!basis->interp_at_points) CeedCall(CeedBasisBuildNonTensorInterpAtPoints(basis));
++  CeedCheck(basis->interp_degree_at_points == degree, ceed, CEED_ERROR_UNSUPPORTED,
++            "H^1 non-tensor AtPoints interpolation does not reconstruct at the complete polynomial degree");
++  CeedCall(CeedBasisValidateNonTensorH1GradAtPoints(basis, topo, dim, num_nodes, num_qpts, q_ref, grad));
++
++  grad_degree = (topo == CEED_TOPOLOGY_LINE || topo == CEED_TOPOLOGY_TRIANGLE || topo == CEED_TOPOLOGY_TET) ? CeedIntMax(0, degree - 1) : degree;
++  CeedCall(CeedBasisBuildModalAtPoints(ceed, topo, dim, num_qpts, q_ref, dim, num_nodes, grad, grad_degree, false, "H^1 non-tensor gradient",
++                                       &grad_degree, &num_modes, &basis->grad_at_points));
++  basis->grad_num_modes_at_points = num_modes;
++  basis->grad_degree_at_points    = grad_degree;
++  return CEED_ERROR_SUCCESS;
++}
++
++int CeedBasisGetNonTensorAtPoints(CeedBasis basis, CeedEvalMode eval_mode, CeedInt *modal_topology, CeedInt *degree, CeedInt *num_modes,
++                                  const CeedScalar **modal_at_points) {
++  CeedElemTopology topo;
++
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisNonTensorModalTopologyAtPoints(topo, modal_topology));
++  CeedCheck(*modal_topology, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED, "Non-tensor AtPoints is not supported for this element topology");
++  CeedCheck(eval_mode == CEED_EVAL_INTERP || eval_mode == CEED_EVAL_GRAD, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
++            "Non-tensor AtPoints only supports CEED_EVAL_INTERP and CEED_EVAL_GRAD");
++  if (eval_mode == CEED_EVAL_INTERP) {
++    if (!basis->interp_at_points) CeedCall(CeedBasisBuildNonTensorInterpAtPoints(basis));
++    *degree          = basis->interp_degree_at_points;
++    *num_modes       = basis->interp_num_modes_at_points;
++    *modal_at_points = basis->interp_at_points;
++  } else {
++    if (!basis->grad_at_points) CeedCall(CeedBasisBuildNonTensorGradAtPoints(basis));
++    *degree          = basis->grad_degree_at_points;
++    *num_modes       = basis->grad_num_modes_at_points;
++    *modal_at_points = basis->grad_at_points;
++  }
++  return CEED_ERROR_SUCCESS;
++}
++
++static int CeedBasisApplyAtPointsNonTensor_Core(CeedBasis basis, bool apply_add, CeedInt num_elem, const CeedInt *num_points,
++                                                CeedTransposeMode t_mode, CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
++  Ceed              ceed = CeedBasisReturnCeed(basis);
++  CeedElemTopology  topo;
++  CeedInt           dim, num_nodes, num_comp, q_comp, modal_topology, degree_at_points, num_modes_at_points, max_num_points = 0;
++  CeedSize          v_len = 0, points_stride, padded_elem_stride = 0;
++  const CeedScalar *x_array = NULL, *u_array = NULL, *modal;
++  CeedScalar       *v_array;
++  bool              is_padded;
++
++  if (eval_mode == CEED_EVAL_WEIGHT) {
++    CeedCall(CeedVectorSetValue(v, 1.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCall(CeedBasisGetTopology(basis, &topo));
++  CeedCall(CeedBasisGetDimension(basis, &dim));
++  CeedCall(CeedBasisGetNumNodes(basis, &num_nodes));
++  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
++  CeedCall(CeedBasisGetNumQuadratureComponents(basis, eval_mode, &q_comp));
++
++  for (CeedInt i = 0; i < num_elem; i++) max_num_points = CeedIntMax(max_num_points, num_points[i]);
++  if (max_num_points == 0) {
++    if (t_mode == CEED_TRANSPOSE && !apply_add) CeedCall(CeedVectorSetValue(v, 0.0));
++    return CEED_ERROR_SUCCESS;
++  }
++
++  CeedCall(CeedBasisGetNonTensorAtPoints(basis, eval_mode, &modal_topology, &degree_at_points, &num_modes_at_points, &modal));
++
++  CeedCall(CeedVectorGetLength(v, &v_len));
++  CeedCall(CeedBasisGetAtPointsLayout(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v, &is_padded, &points_stride));
++  if (is_padded) padded_elem_stride = points_stride / num_elem;
++
++  CeedCall(CeedVectorGetArrayRead(x_ref, CEED_MEM_HOST, &x_array));
++  CeedCall(CeedVectorGetArrayRead(u, CEED_MEM_HOST, &u_array));
++  if (apply_add) {
++    CeedCall(CeedVectorGetArray(v, CEED_MEM_HOST, &v_array));
++  } else {
++    CeedCall(CeedVectorGetArrayWrite(v, CEED_MEM_HOST, &v_array));
++  }
++  if (t_mode == CEED_TRANSPOSE && !apply_add) {
++    for (CeedSize i = 0; i < v_len; i++) v_array[i] = 0.0;
++  }
++
++  CeedSize point_offset = 0;
++  for (CeedInt elem = 0; elem < num_elem; elem++) {
++    for (CeedInt p = 0; p < num_points[elem]; p++) {
++      const CeedSize   point_index = is_padded ? (CeedSize)elem * padded_elem_stride + (CeedSize)p : point_offset + (CeedSize)p;
++      const CeedScalar x           = x_array[0 * points_stride + point_index];
++      const CeedScalar y           = dim > 1 ? x_array[1 * points_stride + point_index] : 0.0;
++      const CeedScalar z           = dim > 2 ? x_array[2 * points_stride + point_index] : 0.0;
++      CeedScalar       phi[num_modes_at_points];
++
++      CeedCall(CeedBasisNonTensorModesAtPoint(topo, degree_at_points, x, y, z, phi));
++      if (t_mode == CEED_NOTRANSPOSE) {
++        for (CeedInt comp = 0; comp < num_comp; comp++) {
++          const CeedScalar *U = &u_array[elem * num_nodes + comp * num_elem * num_nodes];
++
++          for (CeedInt q = 0; q < q_comp; q++) {
++            CeedScalar value = 0.0;
++
++            for (CeedInt node = 0; node < num_nodes; node++) {
++              CeedScalar shape = 0.0;
++
++              for (CeedInt mode = 0; mode < num_modes_at_points; mode++) {
++                shape += modal[node + mode * num_nodes + q * num_nodes * num_modes_at_points] * phi[mode];
++              }
++              value += shape * U[node];
++            }
++            const CeedSize v_index = (CeedSize)point_index + ((CeedSize)comp + (CeedSize)q * (CeedSize)num_comp) * points_stride;
++
++            v_array[v_index] = value;
++          }
++        }
++      } else {
++        for (CeedInt comp = 0; comp < num_comp; comp++) {
++          CeedScalar *V = &v_array[elem * num_nodes + comp * num_elem * num_nodes];
++
++          for (CeedInt q = 0; q < q_comp; q++) {
++            const CeedScalar value = u_array[(CeedSize)point_index + ((CeedSize)comp + (CeedSize)q * (CeedSize)num_comp) * points_stride];
++
++            for (CeedInt node = 0; node < num_nodes; node++) {
++              CeedScalar shape = 0.0;
++
++              for (CeedInt mode = 0; mode < num_modes_at_points; mode++) {
++                shape += modal[node + mode * num_nodes + q * num_nodes * num_modes_at_points] * phi[mode];
++              }
++              V[node] += shape * value;
++            }
++          }
++        }
++      }
++    }
++    point_offset += num_points[elem];
++  }
++
++  CeedCall(CeedVectorRestoreArrayRead(x_ref, &x_array));
++  CeedCall(CeedVectorRestoreArrayRead(u, &u_array));
++  CeedCall(CeedVectorRestoreArray(v, &v_array));
++  return CEED_ERROR_SUCCESS;
++}
++
+ static int CeedBasisApplyAtPoints_Core(CeedBasis basis, bool apply_add, CeedInt num_elem, const CeedInt *num_points, CeedTransposeMode t_mode,
+                                        CeedEvalMode eval_mode, CeedVector x_ref, CeedVector u, CeedVector v) {
+   CeedInt dim, num_comp, P_1d = 1, Q_1d = 1, total_num_points = num_points[0];
+@@ -485,18 +1117,20 @@ static int CeedBasisApplyAtPoints_Core(CeedBasis basis, bool apply_add, CeedInt
+   CeedCall(CeedBasisGetDimension(basis, &dim));
+   // Inserting check because clang-tidy doesn't understand this cannot occur
+   CeedCheck(dim > 0, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED, "Malformed CeedBasis, dim > 0 is required");
+-  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
+-  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+-  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+ 
+   // Default implementation
+   {
+     bool is_tensor_basis;
+ 
+     CeedCall(CeedBasisIsTensor(basis, &is_tensor_basis));
+-    CeedCheck(is_tensor_basis, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
+-              "Evaluation at arbitrary points only supported for tensor product bases");
++    if (!is_tensor_basis) {
++      CeedCall(CeedBasisApplyAtPointsNonTensor_Core(basis, apply_add, num_elem, num_points, t_mode, eval_mode, x_ref, u, v));
++      return CEED_ERROR_SUCCESS;
++    }
+   }
++  CeedCall(CeedBasisGetNumNodes1D(basis, &P_1d));
++  CeedCall(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
++  CeedCall(CeedBasisGetNumComponents(basis, &num_comp));
+   CeedCheck(num_elem == 1, CeedBasisReturnCeed(basis), CEED_ERROR_UNSUPPORTED,
+             "Evaluation at arbitrary  points only supported for a single element at a time");
+   if (eval_mode == CEED_EVAL_WEIGHT) {
+@@ -956,7 +1590,6 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
+   bool is_tensor;
+ 
+   CeedCall(CeedBasisIsTensor(basis, &is_tensor));
+-  CeedCheck(!is_at_points || is_tensor, CeedBasisReturnCeed(basis), CEED_ERROR_INCOMPATIBLE, "Can only evaluate tensor-product bases at points");
+   if (is_tensor) {
+     CeedInt dim, num_comp, P_1d, Q_1d;
+ 
+@@ -1072,7 +1705,7 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
+       case CEED_EVAL_GRAD:
+       case CEED_EVAL_DIV:
+       case CEED_EVAL_CURL:
+-        *flops = num_nodes * num_qpts * num_comp * q_comp;
++        *flops = num_nodes * (is_at_points ? num_points : num_qpts) * num_comp * q_comp;
+         break;
+       case CEED_EVAL_WEIGHT:
+         *flops = 0;
+@@ -2132,6 +2765,13 @@ int CeedBasisApplyAdd(CeedBasis basis, CeedInt num_elem, CeedTransposeMode t_mod
+   @param[in]  u          Input `CeedVector`, of length `num_nodes * num_comp` for @ref CEED_NOTRANSPOSE
+   @param[out] v          Output `CeedVector`, of length `num_points * num_q_comp` for @ref CEED_NOTRANSPOSE with @ref CEED_EVAL_INTERP
+ 
++  @note For @ref CEED_EVAL_INTERP and @ref CEED_EVAL_GRAD, `x_ref` and the point-side vector use matching dimension/component-major
++        storage. Compact storage has point stride `sum(num_points)`. Uniformly padded storage has point stride `num_elem * points_per_elem`,
++        where `points_per_elem >= max(num_points)`. Vector lengths must exactly encode one of these layouts.
++
++  @note Non-tensor AtPoints requires a full-rank, well-conditioned complete polynomial reconstruction of the basis tabulation. H^1 gradient
++        tabulation must be derivative-consistent with the reconstructed interpolation basis.
++
+   @return An error code: 0 - success, otherwise - failure
+ 
+   @ref User
+@@ -2154,7 +2794,7 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_elem, const CeedInt *num
+   @param[in]  num_elem   The number of elements to apply the basis evaluation to;
+                           the backend will specify the ordering in @ref CeedElemRestrictionCreate()
+   @param[in]  num_points Array of the number of points to apply the basis evaluation to in each element, size `num_elem`
+-  @param[in]  t_mode     @ref CEED_NOTRANSPOSE to evaluate from nodes to points;
++  @param[in]  t_mode     @ref CEED_TRANSPOSE to apply the transpose, mapping from points to nodes;
+                            @ref CEED_NOTRANSPOSE is not valid for `CeedBasisApplyAddAtPoints()`
+   @param[in]  eval_mode  @ref CEED_EVAL_INTERP to use interpolated values,
+                            @ref CEED_EVAL_GRAD to use gradients,
+@@ -2163,6 +2803,13 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_elem, const CeedInt *num
+   @param[in]  u          Input `CeedVector`, of length `num_nodes * num_comp` for @ref CEED_NOTRANSPOSE
+   @param[out] v          Output `CeedVector`, of length `num_points * num_q_comp` for @ref CEED_NOTRANSPOSE with @ref CEED_EVAL_INTERP
+ 
++  @note For @ref CEED_EVAL_INTERP and @ref CEED_EVAL_GRAD, `x_ref` and the point-side vector use matching dimension/component-major
++        storage. Compact storage has point stride `sum(num_points)`. Uniformly padded storage has point stride `num_elem * points_per_elem`,
++        where `points_per_elem >= max(num_points)`. Vector lengths must exactly encode one of these layouts.
++
++  @note Non-tensor AtPoints requires a full-rank, well-conditioned complete polynomial reconstruction of the basis tabulation. H^1 gradient
++        tabulation must be derivative-consistent with the reconstructed interpolation basis.
++
+   @return An error code: 0 - success, otherwise - failure
+ 
+   @ref User
+@@ -2508,6 +3155,8 @@ int CeedBasisDestroy(CeedBasis *basis) {
+   CeedCall(CeedFree(&(*basis)->grad_1d));
+   CeedCall(CeedFree(&(*basis)->div));
+   CeedCall(CeedFree(&(*basis)->curl));
++  CeedCall(CeedFree(&(*basis)->interp_at_points));
++  CeedCall(CeedFree(&(*basis)->grad_at_points));
+   CeedCall(CeedVectorDestroy(&(*basis)->vec_chebyshev));
+   CeedCall(CeedBasisDestroy(&(*basis)->basis_chebyshev));
+   CeedCall(CeedObjectDestroy_Private(&(*basis)->obj));
+diff --git a/tests/t366-basis.c b/tests/t366-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..0c6c801a97d816a4b0e21c0a4283e79259886ad5
+--- /dev/null
++++ b/tests/t366-basis.c
+@@ -0,0 +1,140 @@
++/// @file
++/// Test non-tensor H^1 tetrahedron gradient at arbitrary points
++/// \test Test non-tensor H^1 tetrahedron gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define NUM_COMP 3
++#define P 10
++#define Q 11
++#define NUM_POINTS 3
++
++static void P2TetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  const CeedScalar l[4]     = {1. - x - y - z, x, y, z};
++  const CeedScalar dl[4][3] = {
++      {-1., -1., -1.},
++      {1.,  0.,  0. },
++      {0.,  1.,  0. },
++      {0.,  0.,  1. }
++  };
++  const CeedInt edge[6][2] = {
++      {0, 1},
++      {1, 2},
++      {0, 2},
++      {0, 3},
++      {1, 3},
++      {2, 3}
++  };
++
++  for (CeedInt i = 0; i < 4; i++) {
++    interp[i] = l[i] * (2. * l[i] - 1.);
++    for (CeedInt d = 0; d < 3; d++) grad[d * P + i] = (4. * l[i] - 1.) * dl[i][d];
++  }
++  for (CeedInt e = 0; e < 6; e++) {
++    const CeedInt i = edge[e][0], j = edge[e][1], node = 4 + e;
++
++    interp[node] = 4. * l[i] * l[j];
++    for (CeedInt d = 0; d < 3; d++) grad[d * P + node] = 4. * (dl[i][d] * l[j] + l[i] * dl[j][d]);
++  }
++}
++
++static CeedScalar Eval(const CeedScalar c[10], CeedScalar x, CeedScalar y, CeedScalar z) {
++  return c[0] + c[1] * x + c[2] * y + c[3] * z + c[4] * x * y + c[5] * x * z + c[6] * y * z + c[7] * x * x + c[8] * y * y + c[9] * z * z;
++}
++
++static CeedScalar EvalGrad(const CeedScalar c[10], CeedInt d, CeedScalar x, CeedScalar y, CeedScalar z) {
++  switch (d) {
++    case 0:
++      return c[1] + c[4] * y + c[5] * z + 2. * c[7] * x;
++    case 1:
++      return c[2] + c[4] * x + c[6] * z + 2. * c[8] * y;
++    default:
++      return c[3] + c[5] * x + c[6] * y + 2. * c[9] * z;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.0, 1.0, 0.0, 0.0, 0.5,  0.5, 0.0, 0.0, 0.5, 0.0, 0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5,
++                             0.5, 0.0, 0.0, 0.5, 0.25, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,  0.0, 0.5, 0.5, 0.5, 0.25};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar g[3 * P];
++
++    P2TetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], &interp[q * P], g);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, NUM_COMP, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_COMP * P, &u);
++  CeedVectorCreate(ceed, NUM_COMP * 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    const CeedScalar coeffs[NUM_COMP][10] = {
++        {1.,  2.,  -1., 3.,  4.,  -2., 5.,  7.,  -3., 6. },
++        {-2., 1.,  4.,  -1., 3.,  2.,  -4., 5.,  6.,  -7.},
++        {3.,  -5., 2.,  1.,  -6., 4.,  3.,  -2., 8.,  5. }
++    };
++    const CeedScalar nodes[3 * P] = {0.,  1.,  0., 0., 0.5, 0.5, 0., 0., 0.5, 0., 0., 0., 1.,  0.,  0.,
++                                     0.5, 0.5, 0., 0., 0.5, 0.,  0., 0., 1.,  0., 0., 0., 0.5, 0.5, 0.5};
++    CeedScalar       u_array[NUM_COMP * P];
++
++    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
++      for (CeedInt i = 0; i < P; i++) {
++        u_array[comp * P + i] = Eval(coeffs[comp], nodes[0 * P + i], nodes[1 * P + i], nodes[2 * P + i]);
++      }
++    }
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v);
++  }
++
++  {
++    const CeedScalar coeffs[NUM_COMP][10] = {
++        {1.,  2.,  -1., 3.,  4.,  -2., 5.,  7.,  -3., 6. },
++        {-2., 1.,  4.,  -1., 3.,  2.,  -4., 5.,  6.,  -7.},
++        {3.,  -5., 2.,  1.,  -6., 4.,  3.,  -2., 8.,  5. }
++    };
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
++      for (CeedInt d = 0; d < 3; d++) {
++        for (CeedInt p = 0; p < NUM_POINTS; p++) {
++          const CeedScalar expected =
++              EvalGrad(coeffs[comp], d, x_array[0 * NUM_POINTS + p], x_array[1 * NUM_POINTS + p], x_array[2 * NUM_POINTS + p]);
++          const CeedScalar actual = v_array[comp * NUM_POINTS + d * NUM_COMP * NUM_POINTS + p];
++
++          if (fabs(actual - expected) > 500. * CEED_EPSILON)
++            printf("%f != %f at comp %" CeedInt_FMT ", dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected, comp, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t367-basis.c b/tests/t367-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..95b5f213ff3d000660474ddd3b78eac6086cc3ce
+--- /dev/null
++++ b/tests/t367-basis.c
+@@ -0,0 +1,87 @@
++/// @file
++/// Test non-tensor H(curl) tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H(curl) tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 5
++#define NUM_POINTS 3
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.25, 0.2, 0.1, 0.6, 0.1, 0.25, 0.3, 0.1, 0.1, 0.6, 0.25};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], curl[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) curl[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  CeedBasisCreateHcurl(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, curl, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P] = {2., -3., 5., 7., -11., 13.};
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar expected[3] = {
++          2. + 7. * x_array[0 * NUM_POINTS + p], -3. - 11. * x_array[1 * NUM_POINTS + p], 5. + 13. * x_array[2 * NUM_POINTS + p]
++      };
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar actual = v_array[d * NUM_POINTS + p];
++
++        if (fabs(actual - expected[d]) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected[d], d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t368-basis.c b/tests/t368-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..15fa9b59d1e461be54e5b9d4b237c1387285d181
+--- /dev/null
++++ b/tests/t368-basis.c
+@@ -0,0 +1,87 @@
++/// @file
++/// Test non-tensor H(div) tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H(div) tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 5
++#define NUM_POINTS 3
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.25, 0.2, 0.1, 0.6, 0.1, 0.25, 0.3, 0.1, 0.1, 0.6, 0.25};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], div[Q * P];
++  for (CeedInt i = 0; i < Q * P; i++) div[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  CeedBasisCreateHdiv(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, div, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.1, 0.1, 0.4};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P] = {2., -3., 5., 7., -11., 13.};
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar expected[3] = {
++          2. + 7. * x_array[0 * NUM_POINTS + p], -3. - 11. * x_array[1 * NUM_POINTS + p], 5. + 13. * x_array[2 * NUM_POINTS + p]
++      };
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar actual = v_array[d * NUM_POINTS + p];
++
++        if (fabs(actual - expected[d]) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected[d], d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t369-basis.c b/tests/t369-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5aa4dab094c32000c573e1f7924c8117dc291de
+--- /dev/null
++++ b/tests/t369-basis.c
+@@ -0,0 +1,126 @@
++/// @file
++/// Test non-tensor H^1 tetrahedron interpolation at arbitrary points
++/// \test Test non-tensor H^1 tetrahedron interpolation at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++#define MAX_NUM_POINTS 3
++
++static CeedScalar Linear(CeedInt elem, CeedScalar x, CeedScalar y, CeedScalar z) { return 2.0 + elem - 3.0 * x + 5.0 * y - 7.0 * z; }
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_ELEM * MAX_NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, NUM_ELEM * MAX_NUM_POINTS, &v);
++  {
++    // Dimension-major, padded by MAX_NUM_POINTS in each element.
++    CeedScalar x_array[3 * NUM_ELEM * MAX_NUM_POINTS] = {
++        0.2, 0.4, 0.1, 0.3, 0.2, 0.0,  // x
++        0.1, 0.2, 0.3, 0.2, 0.4, 0.0,  // y
++        0.1, 0.1, 0.4, 0.1, 0.2, 0.0   // z
++    };
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[NUM_ELEM * P];
++
++    for (CeedInt elem = 0; elem < NUM_ELEM; elem++) {
++      u_array[elem * P + 0] = Linear(elem, 0., 0., 0.);
++      u_array[elem * P + 1] = Linear(elem, 1., 0., 0.);
++      u_array[elem * P + 2] = Linear(elem, 0., 1., 0.);
++      u_array[elem * P + 3] = Linear(elem, 0., 0., 1.);
++    }
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++
++  {
++    const CeedInt     num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt elem = 0; elem < NUM_ELEM; elem++) {
++      for (CeedInt p = 0; p < num_points[elem]; p++) {
++        const CeedScalar x        = x_array[0 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar y        = x_array[1 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar z        = x_array[2 * NUM_ELEM * MAX_NUM_POINTS + elem * MAX_NUM_POINTS + p];
++        const CeedScalar expected = Linear(elem, x, y, z);
++        const CeedScalar actual   = v_array[elem * MAX_NUM_POINTS + p];
++
++        if (fabs(actual - expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at elem %" CeedInt_FMT ", point %" CeedInt_FMT "\n", actual, expected, elem, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  // Reuse the basis with exact storage for a smaller maximum point count.
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&v);
++  CeedVectorCreate(ceed, 3 * NUM_ELEM, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM, &v);
++  {
++    const CeedInt num_points[NUM_ELEM]  = {1, 1};
++    CeedScalar    x_array[3 * NUM_ELEM] = {0.2, 0.3, 0.1, 0.2, 0.1, 0.1};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++  }
++  {
++    const CeedScalar *x_array, *v_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt elem = 0; elem < NUM_ELEM; elem++) {
++      const CeedScalar x        = x_array[0 * NUM_ELEM + elem];
++      const CeedScalar y        = x_array[1 * NUM_ELEM + elem];
++      const CeedScalar z        = x_array[2 * NUM_ELEM + elem];
++      const CeedScalar expected = Linear(elem, x, y, z);
++      const CeedScalar actual   = v_array[elem];
++
++      if (fabs(actual - expected) > 500. * CEED_EPSILON) {
++        printf("%f != %f at elem %" CeedInt_FMT " after point-count update\n", actual, expected, elem);
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t370-basis.c b/tests/t370-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..35801ec23ae2d04720320ced4c317c7b71ddf233
+--- /dev/null
++++ b/tests/t370-basis.c
+@@ -0,0 +1,125 @@
++/// @file
++/// Test non-tensor H^1 prism interpolation and gradient at arbitrary points
++/// \test Test non-tensor H^1 prism interpolation and gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 6
++#define NUM_POINTS 3
++
++static void P1PrismBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  const CeedScalar l[3]     = {1. - x - y, x, y};
++  const CeedScalar dl[3][2] = {
++      {-1., -1.},
++      {1.,  0. },
++      {0.,  1. }
++  };
++
++  for (CeedInt i = 0; i < 3; i++) {
++    interp[i]     = l[i] * (1. - z);
++    interp[3 + i] = l[i] * z;
++
++    grad[0 * P + i]     = dl[i][0] * (1. - z);
++    grad[1 * P + i]     = dl[i][1] * (1. - z);
++    grad[2 * P + i]     = -l[i];
++    grad[0 * P + 3 + i] = dl[i][0] * z;
++    grad[1 * P + 3 + i] = dl[i][1] * z;
++    grad[2 * P + 3 + i] = l[i];
++  }
++}
++
++static CeedScalar PrismPoly(CeedScalar x, CeedScalar y, CeedScalar z) { return 1. + 2. * x - 3. * y + 5. * z + 7. * x * z - 11. * y * z; }
++
++static CeedScalar PrismPolyGrad(CeedInt d, CeedScalar x, CeedScalar y, CeedScalar z) {
++  switch (d) {
++    case 0:
++      return 2. + 7. * z;
++    case 1:
++      return -3. - 11. * z;
++    default:
++      return 5. + 7. * x - 11. * y;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v_interp, v_grad;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 1., 0., 0., 0., 1., 0., 0., 1., 0., 0., 0., 1., 1., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[P], g[3 * P];
++
++    P1PrismBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b, g);
++    for (CeedInt i = 0; i < P; i++) interp[q * P + i] = b[i];
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_PRISM, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.25, 0.75, 0.5};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P];
++
++    for (CeedInt i = 0; i < P; i++) u_array[i] = PrismPoly(q_ref[0 * Q + i], q_ref[1 * Q + i], q_ref[2 * Q + i]);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  }
++
++  {
++    const CeedScalar *x_array, *interp_array, *grad_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &interp_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &grad_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar x               = x_array[0 * NUM_POINTS + p];
++      const CeedScalar y               = x_array[1 * NUM_POINTS + p];
++      const CeedScalar z               = x_array[2 * NUM_POINTS + p];
++      const CeedScalar interp_expected = PrismPoly(x, y, z);
++
++      if (fabs(interp_array[p] - interp_expected) > 500. * CEED_EPSILON) {
++        printf("%f != %f at point %" CeedInt_FMT "\n", interp_array[p], interp_expected, p);
++      }
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar grad_expected = PrismPolyGrad(d, x, y, z);
++        const CeedScalar grad_actual   = grad_array[d * NUM_POINTS + p];
++
++        if (fabs(grad_actual - grad_expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", grad_actual, grad_expected, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v_interp, &interp_array);
++    CeedVectorRestoreArrayRead(v_grad, &grad_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t371-basis.c b/tests/t371-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..00254ba5767ab27d6e456d09f8bc5ef1bd381c67
+--- /dev/null
++++ b/tests/t371-basis.c
+@@ -0,0 +1,128 @@
++/// @file
++/// Test non-tensor H^1 pyramid interpolation and gradient at arbitrary points
++/// \test Test non-tensor H^1 pyramid interpolation and gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 5
++#define Q 5
++#define NUM_POINTS 3
++
++static void P1PyramidBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp, CeedScalar *grad) {
++  interp[0] = 1. - x - y + x * y - z;
++  interp[1] = x - x * y;
++  interp[2] = y - x * y;
++  interp[3] = x * y;
++  interp[4] = z;
++
++  grad[0 * P + 0] = -1. + y;
++  grad[1 * P + 0] = -1. + x;
++  grad[2 * P + 0] = -1.;
++  grad[0 * P + 1] = 1. - y;
++  grad[1 * P + 1] = -x;
++  grad[2 * P + 1] = 0.;
++  grad[0 * P + 2] = -y;
++  grad[1 * P + 2] = 1. - x;
++  grad[2 * P + 2] = 0.;
++  grad[0 * P + 3] = y;
++  grad[1 * P + 3] = x;
++  grad[2 * P + 3] = 0.;
++  grad[0 * P + 4] = 0.;
++  grad[1 * P + 4] = 0.;
++  grad[2 * P + 4] = 1.;
++}
++
++static CeedScalar PyramidPoly(CeedScalar x, CeedScalar y, CeedScalar z) { return 1. + 2. * x - 3. * y + 5. * x * y - 7. * z; }
++
++static CeedScalar PyramidPolyGrad(CeedInt d, CeedScalar x, CeedScalar y) {
++  switch (d) {
++    case 0:
++      return 2. + 5. * y;
++    case 1:
++      return -3. + 5. * x;
++    default:
++      return -7.;
++  }
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v_interp, v_grad;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 1., 0., 0., 0., 1., 1., 0., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[P], g[3 * P];
++
++    P1PyramidBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b, g);
++    for (CeedInt i = 0; i < P; i++) interp[q * P + i] = b[i];
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) grad[d * Q * P + q * P + i] = g[d * P + i];
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_PYRAMID, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.1, 0.2, 0.3, 0.25, 0.1, 0.5};
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++  {
++    CeedScalar u_array[P];
++
++    for (CeedInt i = 0; i < P; i++) u_array[i] = PyramidPoly(q_ref[0 * Q + i], q_ref[1 * Q + i], q_ref[2 * Q + i]);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  }
++
++  {
++    const CeedScalar *x_array, *interp_array, *grad_array;
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &interp_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &grad_array);
++    for (CeedInt p = 0; p < NUM_POINTS; p++) {
++      const CeedScalar x               = x_array[0 * NUM_POINTS + p];
++      const CeedScalar y               = x_array[1 * NUM_POINTS + p];
++      const CeedScalar z               = x_array[2 * NUM_POINTS + p];
++      const CeedScalar interp_expected = PyramidPoly(x, y, z);
++
++      if (fabs(interp_array[p] - interp_expected) > 500. * CEED_EPSILON) {
++        printf("%f != %f at point %" CeedInt_FMT "\n", interp_array[p], interp_expected, p);
++      }
++      for (CeedInt d = 0; d < 3; d++) {
++        const CeedScalar grad_expected = PyramidPolyGrad(d, x, y);
++        const CeedScalar grad_actual   = grad_array[d * NUM_POINTS + p];
++
++        if (fabs(grad_actual - grad_expected) > 500. * CEED_EPSILON) {
++          printf("%f != %f at dim %" CeedInt_FMT ", point %" CeedInt_FMT "\n", grad_actual, grad_expected, d, p);
++        }
++      }
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v_interp, &interp_array);
++    CeedVectorRestoreArrayRead(v_grad, &grad_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t372-basis.c b/tests/t372-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..36deda648ea2d524c0cbde2ed0522e1bca71eef9
+--- /dev/null
++++ b/tests/t372-basis.c
+@@ -0,0 +1,74 @@
++/// @file
++/// Test CUDA/MAGMA non-tensor AtPoints rejects unpadded coordinate vectors
++/// \test Test CUDA/MAGMA non-tensor AtPoints rejects unpadded coordinate vectors
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++#define MAX_NUM_POINTS 3
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  {
++    const char *resource;
++
++    CeedGetResource(ceed, &resource);
++    if (!strstr(resource, "/gpu/cuda/ref") && !strstr(resource, "/gpu/cuda/magma")) {
++      CeedDestroy(&ceed);
++      return 0;
++    }
++  }
++
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  // Packed length is valid for the interface total-point contract, but GPU AtPoints
++  // kernels require element-padded coordinates: dim * NUM_ELEM * MAX_NUM_POINTS.
++  CeedVectorCreate(ceed, 3 * (MAX_NUM_POINTS + MAX_NUM_POINTS - 1), &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, MAX_NUM_POINTS + MAX_NUM_POINTS - 1, &v);
++  {
++    CeedScalar x_array[3 * (MAX_NUM_POINTS + MAX_NUM_POINTS - 1)] = {0.2, 0.4, 0.1, 0.3, 0.2, 0.1, 0.2, 0.3, 0.2, 0.4, 0.1, 0.1, 0.4, 0.1, 0.2};
++    CeedScalar u_array[NUM_ELEM * P]                              = {1., 2., 3., 4., 5., 6., 7., 8.};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  {
++    const CeedInt num_points[NUM_ELEM] = {MAX_NUM_POINTS, MAX_NUM_POINTS - 1};
++    const int     ierr                 = CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected unpadded coordinate vector error\n");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "requires compact point storage to have a uniform number of points per element"))
++      printf("Unexpected error message: %s\n", err_msg);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t373-basis.c b/tests/t373-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..2e8a9f7a558f11395fc7e3c7cc39e6e45f46b9b9
+--- /dev/null
++++ b/tests/t373-basis.c
+@@ -0,0 +1,84 @@
++/// @file
++/// Test non-H1 non-tensor AtPoints rejects underdetermined tabulation
++/// \test Test non-H1 non-tensor AtPoints rejects underdetermined tabulation
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 6
++#define Q 4
++#define NUM_POINTS 2
++
++static void VectorTetBasis(CeedScalar x, CeedScalar y, CeedScalar z, CeedScalar *interp) {
++  for (CeedInt i = 0; i < 3 * P; i++) interp[i] = 0.0;
++  interp[0 * P + 0] = 1.0;
++  interp[1 * P + 1] = 1.0;
++  interp[2 * P + 2] = 1.0;
++  interp[0 * P + 3] = x;
++  interp[1 * P + 4] = y;
++  interp[2 * P + 5] = z;
++}
++
++static int CheckUnderdetermined(Ceed ceed, bool hcurl) {
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++  CeedScalar q_ref[3 * Q] = {0.1, 0.6, 0.1, 0.1, 0.2, 0.1, 0.6, 0.1, 0.3, 0.1, 0.1, 0.6};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[3 * Q * P], curl[3 * Q * P], div[Q * P];
++
++  for (CeedInt i = 0; i < 3 * Q * P; i++) curl[i] = 0.0;
++  for (CeedInt i = 0; i < Q * P; i++) div[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    CeedScalar b[3 * P];
++
++    VectorTetBasis(q_ref[0 * Q + q], q_ref[1 * Q + q], q_ref[2 * Q + q], b);
++    for (CeedInt d = 0; d < 3; d++) {
++      for (CeedInt i = 0; i < P; i++) interp[d * Q * P + q * P + i] = b[d * P + i];
++    }
++  }
++  if (hcurl) {
++    CeedBasisCreateHcurl(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, curl, q_ref, q_weight, &basis);
++  } else {
++    CeedBasisCreateHdiv(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, div, q_ref, q_weight, &basis);
++  }
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &v);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.2, 0.1, 0.1};
++    CeedScalar u_array[P]              = {2., -3., 5., 7., -11., 13.};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points = NUM_POINTS;
++    const int     ierr       = CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++    const char   *err_msg;
++
++    if (!ierr) printf("Expected underdetermined %s AtPoints error\n", hcurl ? "Hcurl" : "Hdiv");
++    CeedGetErrorMessage(ceed, &err_msg);
++    if (!strstr(err_msg, "polynomial reconstruction")) printf("Unexpected error message: %s\n", err_msg);
++    CeedResetErrorMessage(ceed, &err_msg);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  return 0;
++}
++
++int main(int argc, char **argv) {
++  Ceed ceed;
++
++  CeedInit(argv[1], &ceed);
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  CheckUnderdetermined(ceed, true);
++  CheckUnderdetermined(ceed, false);
++
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t374-basis.c b/tests/t374-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..a9f874ea066b8108403d2d0d30b1c554d5bba123
+--- /dev/null
++++ b/tests/t374-basis.c
+@@ -0,0 +1,75 @@
++/// @file
++/// Test non-tensor AtPoints with no points
++/// \test Test non-tensor AtPoints with no points
++#include <ceed.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 4
++#define Q 4
++#define NUM_ELEM 2
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt i = 0; i < 3 * Q * P; i++) grad[i] = 0.0;
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0] = 1.0 - x - y - z;
++    interp[q * P + 1] = x;
++    interp[q * P + 2] = y;
++    interp[q * P + 3] = z;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 0, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &u);
++  CeedVectorCreate(ceed, 0, &v);
++  {
++    CeedScalar u_array[NUM_ELEM * P] = {1., 2., 3., 4., 5., 6., 7., 8.};
++
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++
++  {
++    const CeedInt num_points[NUM_ELEM] = {0, 0};
++    const int     ierr                 = CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++
++    if (ierr) printf("Expected zero-point AtPoints apply to succeed\n");
++  }
++  for (CeedInt mode = 0; mode < 2; mode++) {
++    const CeedEvalMode eval_mode            = mode == 0 ? CEED_EVAL_INTERP : CEED_EVAL_GRAD;
++    const CeedInt      num_points[NUM_ELEM] = {0, 0};
++    const CeedScalar  *u_array;
++
++    CeedVectorSetValue(u, 2.0);
++    CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_TRANSPOSE, eval_mode, x_points, v, u);
++    CeedVectorGetArrayRead(u, CEED_MEM_HOST, &u_array);
++    for (CeedInt i = 0; i < NUM_ELEM * P; i++) {
++      if (u_array[i] != 0.0) printf("Zero-point transpose did not zero node %" CeedInt_FMT "\n", i);
++    }
++    CeedVectorRestoreArrayRead(u, &u_array);
++
++    CeedVectorSetValue(u, 2.0);
++    CeedBasisApplyAddAtPoints(basis, NUM_ELEM, num_points, CEED_TRANSPOSE, eval_mode, x_points, v, u);
++    CeedVectorGetArrayRead(u, CEED_MEM_HOST, &u_array);
++    for (CeedInt i = 0; i < NUM_ELEM * P; i++) {
++      if (u_array[i] != 2.0) printf("Zero-point transpose add changed node %" CeedInt_FMT "\n", i);
++    }
++    CeedVectorRestoreArrayRead(u, &u_array);
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t375-basis.c b/tests/t375-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..5ef211d71346dd5aeee29b96ca4cd808799df032
+--- /dev/null
++++ b/tests/t375-basis.c
+@@ -0,0 +1,100 @@
++/// @file
++/// Test non-tensor AtPoints transpose and ApplyAdd paths
++/// \test Test non-tensor AtPoints transpose and ApplyAdd paths
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++
++#define P 4
++#define Q 4
++#define NUM_POINTS 2
++
++static void CheckVector(CeedVector v, const CeedScalar expected[P], const char *label) {
++  const CeedScalar *v_array;
++
++  CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++  for (CeedInt i = 0; i < P; i++) {
++    if (fabs(v_array[i] - expected[i]) > 100. * CEED_EPSILON) {
++      printf("%s: %f != %f at node %" CeedInt_FMT "\n", label, v_array[i], expected[i], i);
++    }
++  }
++  CeedVectorRestoreArrayRead(v, &v_array);
++}
++
++int main(int argc, char **argv) {
++  Ceed       ceed;
++  CeedBasis  basis;
++  CeedVector x_points, u_interp, u_grad, v_nodes;
++
++  CeedInit(argv[1], &ceed);
++  CeedScalar q_ref[3 * Q] = {0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.};
++  CeedScalar q_weight[Q]  = {1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[3 * Q * P];
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q], z = q_ref[2 * Q + q];
++
++    interp[q * P + 0]           = 1.0 - x - y - z;
++    interp[q * P + 1]           = x;
++    interp[q * P + 2]           = y;
++    interp[q * P + 3]           = z;
++    grad[0 * Q * P + q * P + 0] = -1.0;
++    grad[0 * Q * P + q * P + 1] = 1.0;
++    grad[0 * Q * P + q * P + 2] = 0.0;
++    grad[0 * Q * P + q * P + 3] = 0.0;
++    grad[1 * Q * P + q * P + 0] = -1.0;
++    grad[1 * Q * P + q * P + 1] = 0.0;
++    grad[1 * Q * P + q * P + 2] = 1.0;
++    grad[1 * Q * P + q * P + 3] = 0.0;
++    grad[2 * Q * P + q * P + 0] = -1.0;
++    grad[2 * Q * P + q * P + 1] = 0.0;
++    grad[2 * Q * P + q * P + 2] = 0.0;
++    grad[2 * Q * P + q * P + 3] = 1.0;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TET, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_POINTS, &u_interp);
++  CeedVectorCreate(ceed, 3 * NUM_POINTS, &u_grad);
++  CeedVectorCreate(ceed, P, &v_nodes);
++  {
++    CeedScalar x_array[3 * NUM_POINTS] = {0.2, 0.4, 0.1, 0.2, 0.1, 0.1};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++  }
++
++  const CeedInt num_points = NUM_POINTS;
++  {
++    CeedScalar       u_array[NUM_POINTS] = {5., 6.};
++    const CeedScalar expected[P]         = {4.8, 3.4, 1.7, 1.1};
++    const CeedScalar expected_add[P]     = {5.8, 4.4, 2.7, 2.1};
++
++    CeedVectorSetArray(u_interp, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, u_interp, v_nodes);
++    CheckVector(v_nodes, expected, "Interp transpose");
++
++    CeedVectorSetValue(v_nodes, 1.0);
++    CeedBasisApplyAddAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, u_interp, v_nodes);
++    CheckVector(v_nodes, expected_add, "Interp transpose add");
++  }
++  {
++    CeedScalar       u_array[3 * NUM_POINTS] = {1., 2., 3., 4., 5., 6.};
++    const CeedScalar expected[P]             = {-21., 3., 7., 11.};
++    const CeedScalar expected_add[P]         = {-20., 4., 8., 12.};
++
++    CeedVectorSetArray(u_grad, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_GRAD, x_points, u_grad, v_nodes);
++    CheckVector(v_nodes, expected, "Grad transpose");
++
++    CeedVectorSetValue(v_nodes, 1.0);
++    CeedBasisApplyAddAtPoints(basis, 1, &num_points, CEED_TRANSPOSE, CEED_EVAL_GRAD, x_points, u_grad, v_nodes);
++    CheckVector(v_nodes, expected_add, "Grad transpose add");
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u_interp);
++  CeedVectorDestroy(&u_grad);
++  CeedVectorDestroy(&v_nodes);
++  CeedBasisDestroy(&basis);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t376-basis.c b/tests/t376-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..37960cd35a0b4b10c42f60cdd66887efbd48db97
+--- /dev/null
++++ b/tests/t376-basis.c
+@@ -0,0 +1,132 @@
++/// @file
++/// Test non-tensor H1 line and triangle interpolation and gradient at arbitrary points
++/// \test Test non-tensor H1 line and triangle interpolation and gradient at arbitrary points
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++
++#define NUM_COMP 2
++#define NUM_POINTS 2
++
++static void Check(const CeedScalar *actual, const CeedScalar *expected, CeedInt length, const char *label) {
++  for (CeedInt i = 0; i < length; i++) {
++    if (fabs(actual[i] - expected[i]) > 100. * CEED_EPSILON) {
++      printf("%s: %f != %f at entry %" CeedInt_FMT "\n", label, actual[i], expected[i], i);
++    }
++  }
++}
++
++static void TestLine(Ceed ceed) {
++  enum { P = 2, Q = 3 };
++  const CeedInt num_points = NUM_POINTS;
++  CeedBasis     basis;
++  CeedVector    x_points, u, v_interp, v_grad;
++  CeedScalar    q_ref[Q], q_weight[Q], interp[Q * P], grad[Q * P];
++
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = -1.0 + q;
++
++    q_ref[q]          = x;
++    q_weight[q]       = 1.0;
++    interp[q * P + 0] = 0.5 * (1.0 - x);
++    interp[q * P + 1] = 0.5 * (1.0 + x);
++    grad[q * P + 0]   = -0.5;
++    grad[q * P + 1]   = 0.5;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, NUM_COMP, P, Q, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_COMP * P, &u);
++  CeedVectorCreate(ceed, NUM_COMP * NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, NUM_COMP * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[NUM_POINTS]   = {-0.5, 0.25};
++    CeedScalar u_array[NUM_COMP * P] = {-1.0, 5.0, -6.0, -2.0};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++  CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++  CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  {
++    const CeedScalar  expected_interp[NUM_COMP * NUM_POINTS] = {0.5, 2.75, -5.0, -3.5};
++    const CeedScalar  expected_grad[NUM_COMP * NUM_POINTS]   = {3.0, 3.0, 2.0, 2.0};
++    const CeedScalar *v_array;
++
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &v_array);
++    Check(v_array, expected_interp, NUM_COMP * NUM_POINTS, "Line interp");
++    CeedVectorRestoreArrayRead(v_interp, &v_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &v_array);
++    Check(v_array, expected_grad, NUM_COMP * NUM_POINTS, "Line grad");
++    CeedVectorRestoreArrayRead(v_grad, &v_array);
++  }
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++}
++
++static void TestTriangle(Ceed ceed) {
++  enum { P = 3, Q = 4 };
++  const CeedInt num_points = NUM_POINTS;
++  CeedBasis     basis;
++  CeedVector    x_points, u, v_interp, v_grad;
++  CeedScalar    q_ref[2 * Q] = {0.0, 1.0, 0.0, 1.0 / 3.0, 0.0, 0.0, 1.0, 1.0 / 3.0};
++  CeedScalar    q_weight[Q], interp[Q * P], grad[2 * Q * P];
++
++  for (CeedInt q = 0; q < Q; q++) {
++    const CeedScalar x = q_ref[0 * Q + q], y = q_ref[1 * Q + q];
++
++    q_weight[q]                 = 1.0;
++    interp[q * P + 0]           = 1.0 - x - y;
++    interp[q * P + 1]           = x;
++    interp[q * P + 2]           = y;
++    grad[0 * Q * P + q * P + 0] = -1.0;
++    grad[0 * Q * P + q * P + 1] = 1.0;
++    grad[0 * Q * P + q * P + 2] = 0.0;
++    grad[1 * Q * P + q * P + 0] = -1.0;
++    grad[1 * Q * P + q * P + 1] = 0.0;
++    grad[1 * Q * P + q * P + 2] = 1.0;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_TRIANGLE, NUM_COMP, P, Q, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, 2 * NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, NUM_COMP * P, &u);
++  CeedVectorCreate(ceed, NUM_COMP * NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, 2 * NUM_COMP * NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[2 * NUM_POINTS] = {0.2, 0.1, 0.1, 0.3};
++    CeedScalar u_array[NUM_COMP * P]   = {1.0, 3.0, 4.0, -2.0, -1.0, -6.0};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++  CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++  CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  {
++    const CeedScalar  expected_interp[NUM_COMP * NUM_POINTS]   = {1.7, 2.1, -2.2, -3.1};
++    const CeedScalar  expected_grad[2 * NUM_COMP * NUM_POINTS] = {2.0, 2.0, 1.0, 1.0, 3.0, 3.0, -4.0, -4.0};
++    const CeedScalar *v_array;
++
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &v_array);
++    Check(v_array, expected_interp, NUM_COMP * NUM_POINTS, "Triangle interp");
++    CeedVectorRestoreArrayRead(v_interp, &v_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &v_array);
++    Check(v_array, expected_grad, 2 * NUM_COMP * NUM_POINTS, "Triangle grad");
++    CeedVectorRestoreArrayRead(v_grad, &v_array);
++  }
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++}
++
++int main(int argc, char **argv) {
++  Ceed ceed;
++
++  CeedInit(argv[1], &ceed);
++  TestLine(ceed);
++  TestTriangle(ceed);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t377-basis.c b/tests/t377-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..73fd0d8c3c7f333274e03834e194d5ba1bed1b87
+--- /dev/null
++++ b/tests/t377-basis.c
+@@ -0,0 +1,111 @@
++/// @file
++/// Test AtPoints dimension checks for independently short input and output vectors
++/// \test Test AtPoints dimension checks for independently short input and output vectors
++#include <ceed.h>
++#include <stdio.h>
++#include <stdlib.h>
++
++#define NUM_ELEM 2
++#define P 2
++#define Q 2
++
++static void ExpectError(Ceed ceed, int ierr, const char *label) {
++  const char *message;
++
++  if (!ierr) printf("Expected dimension error for %s\n", label);
++  CeedGetErrorMessage(ceed, &message);
++  CeedResetErrorMessage(ceed, &message);
++}
++
++static void CheckPseudoinverseOverflow(Ceed ceed) {
++  const CeedInt q = 46341, num_points = 1;
++  CeedBasis     basis;
++  CeedVector    x_points, u, v;
++  CeedScalar   *q_ref = calloc(q, sizeof(*q_ref)), *q_weight = calloc(q, sizeof(*q_weight)), *interp = calloc(q, sizeof(*interp)),
++             *grad = calloc(q, sizeof(*grad));
++
++  if (!q_ref || !q_weight || !interp || !grad) {
++    printf("Unable to allocate pseudoinverse overflow test data\n");
++    free(q_ref);
++    free(q_weight);
++    free(interp);
++    free(grad);
++    return;
++  }
++  for (CeedInt i = 0; i < q; i++) {
++    q_weight[i] = 1.0;
++    interp[i]   = 1.0;
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, q, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, 1, &x_points);
++  CeedVectorCreate(ceed, 1, &u);
++  CeedVectorCreate(ceed, 1, &v);
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v),
++              "pseudoinverse workspace overflow");
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++  free(q_ref);
++  free(q_weight);
++  free(interp);
++  free(grad);
++}
++
++int main(int argc, char **argv) {
++  const CeedInt num_points[NUM_ELEM] = {1, 1};
++  Ceed          ceed;
++  CeedBasis     basis;
++  CeedVector    x_points, oversized_x_points, padded_x_points, short_nodes, full_nodes, short_points, full_points, padded_points;
++  CeedScalar    q_ref[Q] = {-1.0, 1.0}, q_weight[Q] = {1.0, 1.0};
++  CeedScalar    interp[Q * P] = {1.0, 0.0, 0.0, 1.0};
++  CeedScalar    grad[Q * P]   = {-0.5, 0.5, -0.5, 0.5};
++
++  CeedInit(argv[1], &ceed);
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, NUM_ELEM, &x_points);
++  CeedVectorCreate(ceed, NUM_ELEM + 1, &oversized_x_points);
++  CeedVectorCreate(ceed, 2 * NUM_ELEM, &padded_x_points);
++  CeedVectorCreate(ceed, NUM_ELEM * P - 1, &short_nodes);
++  CeedVectorCreate(ceed, NUM_ELEM * P, &full_nodes);
++  CeedVectorCreate(ceed, NUM_ELEM - 1, &short_points);
++  CeedVectorCreate(ceed, NUM_ELEM, &full_points);
++  CeedVectorCreate(ceed, 2 * NUM_ELEM, &padded_points);
++
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, short_nodes, full_points),
++              "short NOTRANSPOSE input");
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, full_nodes, short_points),
++              "short NOTRANSPOSE output");
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, short_points, full_nodes),
++              "short TRANSPOSE input");
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_points, full_points, short_nodes),
++              "short TRANSPOSE output");
++  ExpectError(ceed,
++              CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, oversized_x_points, full_nodes, full_points),
++              "ambiguous oversized coordinates");
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, padded_x_points, full_nodes, full_points),
++              "mismatched compact point values");
++  ExpectError(ceed, CeedBasisApplyAtPoints(basis, NUM_ELEM, num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, full_nodes, padded_points),
++              "mismatched padded point values");
++  {
++    const CeedInt invalid_num_points[NUM_ELEM] = {1, -1};
++
++    ExpectError(ceed,
++                CeedBasisApplyAtPoints(basis, NUM_ELEM, invalid_num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, full_nodes, full_points),
++                "negative point count");
++  }
++
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&oversized_x_points);
++  CeedVectorDestroy(&padded_x_points);
++  CeedVectorDestroy(&short_nodes);
++  CeedVectorDestroy(&full_nodes);
++  CeedVectorDestroy(&short_points);
++  CeedVectorDestroy(&full_points);
++  CeedVectorDestroy(&padded_points);
++  CeedBasisDestroy(&basis);
++  CheckPseudoinverseOverflow(ceed);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t378-operator.c b/tests/t378-operator.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..551f634155e82ca2b646f0f4175ad207c856469c
+--- /dev/null
++++ b/tests/t378-operator.c
+@@ -0,0 +1,193 @@
++/// @file
++/// Test non-tensor mass operator at heterogeneous points per element
++/// \test Test non-tensor mass operator at heterogeneous points per element
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <stdlib.h>
++
++#include "t500-operator.h"
++
++int main(int argc, char **argv) {
++  Ceed                ceed;
++  CeedInt             num_elem = 3, dim = 1, p = 3, q = 5;
++  CeedInt             num_nodes_x = num_elem + 1, num_nodes_u = num_elem * (p - 1) + 1, num_points_per_elem = 4, num_points = 2 * num_points_per_elem;
++  CeedInt             ind_x[num_elem * 2], ind_u[num_elem * p], ind_x_points[num_elem + 1 + num_points];
++  CeedScalar          x_array_mesh[num_nodes_x], x_array_points[num_points];
++  CeedVector          x_points = NULL, x_elem = NULL, q_data = NULL, u = NULL, v = NULL;
++  CeedElemRestriction elem_restriction_x_points, elem_restriction_q_data, elem_restriction_x, elem_restriction_u;
++  CeedBasis           basis_x, basis_u;
++  CeedQFunction       qf_setup, qf_mass;
++  CeedOperator        op_setup, op_mass;
++  bool                is_at_points;
++
++  CeedInit(argv[1], &ceed);
++
++  // Nonuniform mesh coordinates make point ownership observable in the mass result.
++  x_array_mesh[0] = 0.0;
++  x_array_mesh[1] = 0.2;
++  x_array_mesh[2] = 0.5;
++  x_array_mesh[3] = 1.0;
++  for (CeedInt i = 0; i < num_elem; i++) {
++    ind_x[2 * i + 0] = i;
++    ind_x[2 * i + 1] = i + 1;
++  }
++  CeedElemRestrictionCreate(ceed, num_elem, 2, 1, 1, num_nodes_x, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restriction_x);
++  CeedVectorCreate(ceed, num_nodes_x, &x_elem);
++  CeedVectorSetArray(x_elem, CEED_MEM_HOST, CEED_USE_POINTER, x_array_mesh);
++
++  // U mesh
++  for (CeedInt i = 0; i < num_elem; i++) {
++    for (CeedInt j = 0; j < p; j++) {
++      ind_u[p * i + j] = i * (p - 1) + j;
++    }
++  }
++  CeedElemRestrictionCreate(ceed, num_elem, p, 1, 1, num_nodes_u, CEED_MEM_HOST, CEED_USE_POINTER, ind_u, &elem_restriction_u);
++
++  // Point reference coordinates
++  {
++    CeedScalar weight_tmp[num_points_per_elem + 1];
++    CeedInt    current_index = 0;
++
++    // Use num_points_per_elem + 1 to test non-uniform quadrature
++    CeedGaussQuadrature(num_points_per_elem + 1, x_array_points, weight_tmp);
++    ind_x_points[0] = num_elem + 1;
++    for (CeedInt p = 0; p < num_points_per_elem + 1; p++, current_index++) {
++      ind_x_points[num_elem + 1 + current_index] = current_index;
++    }
++    // Use zero points for middle elements
++    for (CeedInt e = 1; e < num_elem - 1; e++) ind_x_points[e] = num_elem + 1 + current_index;
++    // Use num_points_per_elem - 1 to test non-uniform quadrature
++    CeedGaussQuadrature(num_points_per_elem - 1, &x_array_points[current_index], weight_tmp);
++    ind_x_points[num_elem - 1] = num_elem + 1 + current_index;
++    for (CeedInt p = 0; p < num_points_per_elem - 1; p++, current_index++) {
++      ind_x_points[num_elem + 1 + current_index] = current_index;
++    }
++    ind_x_points[num_elem] = num_elem + 1 + current_index;
++
++    CeedVectorCreate(ceed, num_points, &x_points);
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_USE_POINTER, x_array_points);
++    CeedElemRestrictionCreateAtPoints(ceed, num_elem, num_points, 1, num_points, CEED_MEM_HOST, CEED_COPY_VALUES, ind_x_points,
++                                      &elem_restriction_x_points);
++    CeedElemRestrictionCreateAtPoints(ceed, num_elem, num_points, 1, num_points, CEED_MEM_HOST, CEED_COPY_VALUES, ind_x_points,
++                                      &elem_restriction_q_data);
++
++    // Q data
++    CeedVectorCreate(ceed, num_points, &q_data);
++  }
++
++  // Basis creation
++  {
++    CeedScalar q_ref[q], q_weight[q], interp_x[q * 2], grad_x[q * 2], interp_u[q * p], grad_u[q * p];
++
++    CeedGaussQuadrature(q, q_ref, q_weight);
++    for (CeedInt i = 0; i < q; i++) {
++      const CeedScalar x = q_ref[i];
++
++      interp_x[i * 2 + 0] = 0.5 * (1.0 - x);
++      interp_x[i * 2 + 1] = 0.5 * (1.0 + x);
++      grad_x[i * 2 + 0]   = -0.5;
++      grad_x[i * 2 + 1]   = 0.5;
++      interp_u[i * p + 0] = 0.5 * x * (x - 1.0);
++      interp_u[i * p + 1] = 1.0 - x * x;
++      interp_u[i * p + 2] = 0.5 * x * (x + 1.0);
++      grad_u[i * p + 0]   = x - 0.5;
++      grad_u[i * p + 1]   = -2.0 * x;
++      grad_u[i * p + 2]   = x + 0.5;
++    }
++    CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, dim, 2, q, interp_x, grad_x, q_ref, q_weight, &basis_x);
++    CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, p, q, interp_u, grad_u, q_ref, q_weight, &basis_u);
++  }
++
++  // Setup geometric scaling
++  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
++  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
++  CeedQFunctionAddInput(qf_setup, "x", dim * dim, CEED_EVAL_GRAD);
++  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
++
++  CeedOperatorCreateAtPoints(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
++  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
++  CeedOperatorSetField(op_setup, "x", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
++  CeedOperatorSetField(op_setup, "rho", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
++  CeedOperatorAtPointsSetPoints(op_setup, elem_restriction_x_points, x_points);
++
++  CeedOperatorApply(op_setup, x_elem, q_data, CEED_REQUEST_IMMEDIATE);
++
++  // Mass operator
++  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
++  CeedQFunctionAddInput(qf_mass, "u", 1, CEED_EVAL_INTERP);
++  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
++  CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
++
++  CeedOperatorCreateAtPoints(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass);
++  CeedOperatorSetField(op_mass, "u", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
++  CeedOperatorSetField(op_mass, "rho", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
++  CeedOperatorSetField(op_mass, "v", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
++  CeedOperatorAtPointsSetPoints(op_mass, elem_restriction_x_points, x_points);
++
++  CeedOperatorIsAtPoints(op_mass, &is_at_points);
++  if (!is_at_points) printf("Error: Operator should be at points\n");
++
++  CeedVectorCreate(ceed, num_nodes_u, &u);
++  {
++    CeedScalar u_array[num_nodes_u];
++
++    for (CeedInt i = 0; i < num_nodes_u; i++) u_array[i] = 1.0 + 0.25 * i + 0.1 * i * i;
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++  CeedVectorCreate(ceed, num_nodes_u, &v);
++
++  // Assemble QFunction
++  CeedOperatorApply(op_mass, u, v, CEED_REQUEST_IMMEDIATE);
++
++  // Independently assemble every output entry. This detects wrong point ownership,
++  // compact/padded indexing, or reference-coordinate reads.
++  {
++    CeedScalar        expected[num_nodes_u], u_array[num_nodes_u];
++    const CeedScalar *v_array;
++
++    for (CeedInt i = 0; i < num_nodes_u; i++) {
++      expected[i] = 0.0;
++      u_array[i]  = 1.0 + 0.25 * i + 0.1 * i * i;
++    }
++    for (CeedInt elem = 0; elem < num_elem; elem++) {
++      const CeedInt    point_start = ind_x_points[elem] - (num_elem + 1);
++      const CeedInt    point_end   = ind_x_points[elem + 1] - (num_elem + 1);
++      const CeedScalar jacobian    = 0.5 * (x_array_mesh[elem + 1] - x_array_mesh[elem]);
++
++      for (CeedInt point = point_start; point < point_end; point++) {
++        const CeedScalar x        = x_array_points[point];
++        const CeedScalar shape[3] = {0.5 * x * (x - 1.0), 1.0 - x * x, 0.5 * x * (x + 1.0)};
++        CeedScalar       value    = 0.0;
++
++        for (CeedInt node = 0; node < p; node++) value += shape[node] * u_array[ind_u[p * elem + node]];
++        for (CeedInt node = 0; node < p; node++) expected[ind_u[p * elem + node]] += shape[node] * jacobian * value;
++      }
++    }
++    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
++    for (CeedInt i = 0; i < num_nodes_u; i++) {
++      if (fabs(v_array[i] - expected[i]) > 1000. * CEED_EPSILON)
++        printf("Incorrect non-tensor AtPoints operator entry %" CeedInt_FMT ": %g != %g\n", i, v_array[i], expected[i]);
++    }
++    CeedVectorRestoreArrayRead(v, &v_array);
++  }
++
++  // Cleanup
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&q_data);
++  CeedVectorDestroy(&x_elem);
++  CeedElemRestrictionDestroy(&elem_restriction_q_data);
++  CeedElemRestrictionDestroy(&elem_restriction_x);
++  CeedElemRestrictionDestroy(&elem_restriction_x_points);
++  CeedElemRestrictionDestroy(&elem_restriction_u);
++  CeedBasisDestroy(&basis_x);
++  CeedBasisDestroy(&basis_u);
++  CeedQFunctionDestroy(&qf_setup);
++  CeedQFunctionDestroy(&qf_mass);
++  CeedOperatorDestroy(&op_setup);
++  CeedOperatorDestroy(&op_mass);
++  CeedDestroy(&ceed);
++  return 0;
++}
+diff --git a/tests/t379-basis.c b/tests/t379-basis.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..b4d3ea8509ae1807fa174d6728c3aa649a1bcf45
+--- /dev/null
++++ b/tests/t379-basis.c
+@@ -0,0 +1,155 @@
++/// @file
++/// Test higher-order non-tensor AtPoints reconstruction and incompatible H^1 tabulation
++/// \test Test higher-order non-tensor AtPoints reconstruction and incompatible H^1 tabulation
++#include <ceed.h>
++#include <math.h>
++#include <stdio.h>
++#include <string.h>
++
++#define P 5
++#define Q 6
++#define NUM_POINTS 3
++
++static CeedScalar PowInt(CeedScalar x, CeedInt p) {
++  CeedScalar value = 1.0;
++
++  for (CeedInt i = 0; i < p; i++) value *= x;
++  return value;
++}
++
++static void CheckHigherOrder(Ceed ceed) {
++  CeedBasis  basis;
++  CeedVector x_points, u, v_interp, v_grad;
++  CeedScalar q_ref[Q] = {-1.0, -0.7, -0.2, 0.2, 0.7, 1.0}, q_weight[Q] = {1., 1., 1., 1., 1., 1.};
++  CeedScalar interp[Q * P], grad[Q * P];
++
++  for (CeedInt q = 0; q < Q; q++) {
++    for (CeedInt node = 0; node < P; node++) {
++      interp[q * P + node] = PowInt(q_ref[q], node);
++      grad[q * P + node]   = node ? node * PowInt(q_ref[q], node - 1) : 0.0;
++    }
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, P, Q, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, NUM_POINTS, &x_points);
++  CeedVectorCreate(ceed, P, &u);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_interp);
++  CeedVectorCreate(ceed, NUM_POINTS, &v_grad);
++  {
++    CeedScalar x_array[NUM_POINTS] = {-0.8, 0.1, 0.9};
++    CeedScalar u_array[P]          = {1.0, -2.0, 3.0, -4.0, 5.0};
++
++    CeedVectorSetArray(x_points, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
++    CeedVectorSetArray(u, CEED_MEM_HOST, CEED_COPY_VALUES, u_array);
++  }
++  {
++    const CeedInt num_points = NUM_POINTS;
++
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v_interp);
++    CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v_grad);
++  }
++  {
++    const CeedScalar *x_array, *interp_array, *grad_array;
++    const CeedScalar  coefficients[P] = {1.0, -2.0, 3.0, -4.0, 5.0};
++
++    CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
++    CeedVectorGetArrayRead(v_interp, CEED_MEM_HOST, &interp_array);
++    CeedVectorGetArrayRead(v_grad, CEED_MEM_HOST, &grad_array);
++    for (CeedInt point = 0; point < NUM_POINTS; point++) {
++      CeedScalar expected_interp = 0.0, expected_grad = 0.0;
++
++      for (CeedInt mode = 0; mode < P; mode++) {
++        expected_interp += coefficients[mode] * PowInt(x_array[point], mode);
++        if (mode) expected_grad += mode * coefficients[mode] * PowInt(x_array[point], mode - 1);
++      }
++      if (fabs(interp_array[point] - expected_interp) > 5000. * CEED_EPSILON)
++        printf("Higher-order interpolation mismatch at point %" CeedInt_FMT "\n", point);
++      if (fabs(grad_array[point] - expected_grad) > 5000. * CEED_EPSILON) printf("Higher-order gradient mismatch at point %" CeedInt_FMT "\n", point);
++    }
++    CeedVectorRestoreArrayRead(x_points, &x_array);
++    CeedVectorRestoreArrayRead(v_interp, &interp_array);
++    CeedVectorRestoreArrayRead(v_grad, &grad_array);
++  }
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v_interp);
++  CeedVectorDestroy(&v_grad);
++  CeedBasisDestroy(&basis);
++}
++
++static void CheckIncompatibleInterpolation(Ceed ceed) {
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++  CeedScalar q_ref[4] = {-1.0, -0.4, 0.3, 1.0}, q_weight[4] = {1.0, 1.0, 1.0, 1.0};
++  CeedScalar interp[12], grad[12];
++
++  for (CeedInt q = 0; q < 4; q++) {
++    interp[q * 3 + 0] = 1.0;
++    interp[q * 3 + 1] = q_ref[q];
++    interp[q * 3 + 2] = q_ref[q] * q_ref[q] * q_ref[q];
++    grad[q * 3 + 0]   = 0.0;
++    grad[q * 3 + 1]   = 1.0;
++    grad[q * 3 + 2]   = 3.0 * q_ref[q] * q_ref[q];
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 3, 4, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, 1, &x_points);
++  CeedVectorCreate(ceed, 3, &u);
++  CeedVectorCreate(ceed, 1, &v);
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  {
++    const CeedInt num_points = 1;
++    const int     ierr       = CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, x_points, u, v);
++    const char   *error_message;
++
++    if (!ierr) printf("Expected incompatible H^1 interpolation tabulation error\n");
++    CeedGetErrorMessage(ceed, &error_message);
++    if (!strstr(error_message, "consistent with the tabulation")) printf("Unexpected error message: %s\n", error_message);
++    CeedResetErrorMessage(ceed, &error_message);
++  }
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++}
++
++static void CheckIncompatibleGradient(Ceed ceed) {
++  CeedBasis  basis;
++  CeedVector x_points, u, v;
++  CeedScalar q_ref[3] = {-1.0, 0.0, 1.0}, q_weight[3] = {1.0, 1.0, 1.0};
++  CeedScalar interp[9], grad[9]                       = {0.0};
++
++  for (CeedInt q = 0; q < 3; q++) {
++    interp[q * 3 + 0] = 1.0;
++    interp[q * 3 + 1] = q_ref[q];
++    interp[q * 3 + 2] = q_ref[q] * q_ref[q];
++  }
++  CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 3, 3, interp, grad, q_ref, q_weight, &basis);
++  CeedVectorCreate(ceed, 1, &x_points);
++  CeedVectorCreate(ceed, 3, &u);
++  CeedVectorCreate(ceed, 1, &v);
++  CeedSetErrorHandler(ceed, CeedErrorStore);
++  {
++    const CeedInt num_points = 1;
++    const int     ierr       = CeedBasisApplyAtPoints(basis, 1, &num_points, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, x_points, u, v);
++    const char   *error_message;
++
++    if (!ierr) printf("Expected incompatible H^1 gradient tabulation error\n");
++    CeedGetErrorMessage(ceed, &error_message);
++    if (!strstr(error_message, "gradient tabulation consistent")) printf("Unexpected error message: %s\n", error_message);
++    CeedResetErrorMessage(ceed, &error_message);
++  }
++  CeedVectorDestroy(&x_points);
++  CeedVectorDestroy(&u);
++  CeedVectorDestroy(&v);
++  CeedBasisDestroy(&basis);
++}
++
++int main(int argc, char **argv) {
++  Ceed ceed;
++
++  CeedInit(argv[1], &ceed);
++  CheckHigherOrder(ceed);
++  CheckIncompatibleInterpolation(ceed);
++  CheckIncompatibleGradient(ceed);
++  CeedDestroy(&ceed);
++  return 0;
++}

--- a/spack_repo/local/packages/libceed/libceed-v0.8-hip.patch
+++ b/spack_repo/local/packages/libceed/libceed-v0.8-hip.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 4f1737ee..3f1811f2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -403,6 +403,9 @@ ifneq ($(HIP_LIB_DIR),)
+     CPPFLAGS += $(subst =,,$(shell $(HIP_DIR)/bin/hipconfig -C))
+   endif
+   $(libceeds) : CPPFLAGS += -I$(HIP_DIR)/include
++  ifneq ($(HIPBLAS_DIR),)
++    PKG_LIBS += -L$(HIPBLAS_DIR)/lib
++  endif
+   PKG_LIBS += -L$(abspath $(HIP_LIB_DIR)) -lamdhip64 -lhipblas
+   LIBCEED_CONTAINS_CXX = 1
+   libceed.c   += interface/ceed-hip.c

--- a/spack_repo/local/packages/libceed/occaFree-0.2.diff
+++ b/spack_repo/local/packages/libceed/occaFree-0.2.diff
@@ -1,0 +1,41 @@
+diff --git a/backends/occa/ceed-occa-basis.c b/backends/occa/ceed-occa-basis.c
+index 85ec292..86a46ee 100644
+--- a/backends/occa/ceed-occa-basis.c
++++ b/backends/occa/ceed-occa-basis.c
+@@ -293,10 +293,6 @@ static int CeedBasisDestroy_Occa(CeedBasis basis) {
+   const Ceed ceed = basis->ceed;
+   CeedBasis_Occa *data = basis->data;
+   dbg("[CeedBasis][Destroy]");
+-  occaFree(data->kZero);
+-  occaFree(data->kInterp);
+-  occaFree(data->kGrad);
+-  occaFree(data->kWeight);
+   occaFree(data->qref1d);
+   occaFree(data->qweight1d);
+   occaFree(data->interp1d);
+diff --git a/backends/occa/ceed-occa-qfunction.c b/backends/occa/ceed-occa-qfunction.c
+index a2776c3..abf7de0 100644
+--- a/backends/occa/ceed-occa-qfunction.c
++++ b/backends/occa/ceed-occa-qfunction.c
+@@ -154,7 +154,6 @@ static int CeedQFunctionDestroy_Occa(CeedQFunction qf) {
+   CeedQFunction_Occa *data=qf->data;
+   free(data->oklPath);
+   dbg("[CeedQFunction][Destroy]");
+-  occaFree(data->kQFunctionApply);
+   if (data->ready) {
+     if (!data->op) occaFree(data->d_q);
+     occaFree(data->d_u);
+diff --git a/backends/occa/ceed-occa-restrict.c b/backends/occa/ceed-occa-restrict.c
+index 6b7786c..c5360dc 100644
+--- a/backends/occa/ceed-occa-restrict.c
++++ b/backends/occa/ceed-occa-restrict.c
+@@ -95,9 +95,6 @@ static int CeedElemRestrictionDestroy_Occa(CeedElemRestriction r) {
+   const Ceed ceed = r->ceed;
+   CeedElemRestriction_Occa *data = r->data;
+   dbg("[CeedElemRestriction][Destroy]");
+-  for (int i=0; i<9; i++) {
+-    occaFree(data->kRestrict[i]);
+-  }
+   ierr = CeedFree(&data); CeedChk(ierr);
+   return 0;
+ }

--- a/spack_repo/local/packages/libceed/package.py
+++ b/spack_repo/local/packages/libceed/package.py
@@ -1,0 +1,191 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
+from spack.package import *
+
+
+class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
+    """The CEED API Library: Code for Efficient Extensible Discretizations."""
+
+    homepage = "https://github.com/CEED/libCEED"
+    git = "https://github.com/CEED/libCEED.git"
+
+    maintainers("jedbrown", "v-dobrev", "tzanio", "jeremylt")
+
+    license("BSD-2-Clause")
+
+    # Palace's develop build carries a libCEED patch, so keep Spack aligned with the
+    # reproducible superbuild revision in cmake/ExternalGitTags.cmake.
+    version("develop", commit="64e0491369518e158481079ef966c29e2fa4f8fd")
+    version("0.12.0", tag="v0.12.0", commit="4018a20a98d451fac24765d3ddb936861647ce8d")
+    version("0.11.0", tag="v0.11.0", commit="8ec64e9ae9d5df169dba8c8ee61d8ec8907b8f80")
+    version("0.10.1", tag="v0.10.1", commit="74532b27052d94e943eb8bc76257fbd710103614")
+    version("0.9", tag="v0.9.0", commit="d66340f5aae79e564186ab7514a1cd08b3a1b06b")
+    version("0.8", tag="v0.8", commit="e8f234590eddcce2220edb1d6e979af7a3c35f82")
+    version("0.7", tag="v0.7", commit="0bc92be5158efcbeb80d3d59240233bf5b2f748c")
+    version(
+        "0.6", commit="c7f533e01e2f3f6720fbf37aac2af2ffed225f60"
+    )  # tag v0.6 + small portability fixes
+    version("0.5", tag="v0.5", commit="12804ff7ea2ac608ae5494437379e4f626cf5cb7")
+    version("0.4", tag="v0.4", commit="40b9dad77dea06a1608fa8b93a0d8b9c993ee43d")
+    version("0.2", tag="v0.2", commit="113004cb41757b819325a4b3a8a7dfcea5156531")
+    version("0.1", tag="v0.1", commit="74e0540e2478136394f75869675056eb6aba67cc")
+
+    variant("occa", default=False, description="Enable OCCA backends")
+    variant("debug", default=False, description="Enable debug build")
+    variant("libxsmm", default=False, description="Enable LIBXSMM backend", when="@0.3:")
+    variant("magma", default=False, description="Enable MAGMA backend", when="@0.6:")
+
+    variant("openmp", default=False, description="Enable OpenMP support")
+
+    variant("shared", default=True, description="Build shared libraries")
+
+    conflicts("+rocm", when="@:0.7")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    with when("+rocm"):
+        depends_on("hip@3.8.0:", when="@0.8:")
+        depends_on("hipblas@3.8.0:", when="@0.8:")
+
+    conflicts("+occa", when="@0.9:")
+
+    with when("+occa"):
+        depends_on("occa@1.1.0", when="@0.7:")
+        depends_on("occa@1.0.8:", when="@0.4")
+        depends_on("occa@1.0.0-alpha.5,develop", when="@:0.2")
+        depends_on("occa+cuda", when="+cuda")
+        depends_on("occa~cuda", when="~cuda")
+
+    depends_on("libxsmm~shared", when="+libxsmm~shared")
+    depends_on("libxsmm+shared", when="+libxsmm+shared")
+    depends_on("blas", when="+libxsmm", type="link")
+
+    depends_on("magma~shared", when="+magma~shared")
+    depends_on("magma+shared", when="+magma+shared")
+
+    patch("libceed-v0.8-hip.patch", when="@0.8+rocm")
+    patch("pkgconfig-version-0.4.diff", when="@0.4")
+
+    # occa: do not occaFree kernels
+    # Repeated creation and freeing of kernels appears to expose a caching
+    # bug in Occa.
+    patch("occaFree-0.2.diff", when="@0.2")
+
+    @property
+    def common_make_opts(self):
+        spec = self.spec
+        compiler = self.compiler
+        # Note: The occa package exports OCCA_DIR in the environment
+
+        # Use verbose building output
+        makeopts = ["V=1"]
+
+        if spec.satisfies("@:0.2"):
+            makeopts += ["NDEBUG=%s" % ("" if spec.satisfies("+debug") else "1")]
+
+        elif spec.satisfies("@0.4:0.12"):
+            # Determine options based on the compiler:
+            if spec.satisfies("+debug"):
+                opt = "-g"
+            elif compiler.name == "gcc":
+                opt = "-O3 -g -ffp-contract=fast"
+                if compiler.version >= ver(4.9):
+                    opt += " -fopenmp-simd"
+                if self.spec.target.family in ["x86_64", "aarch64"]:
+                    opt += " -march=native"
+            elif compiler.name == "apple-clang":
+                opt = "-O3 -g -march=native -ffp-contract=fast"
+                if compiler.version >= ver(10):
+                    opt += " -fopenmp-simd"
+            elif compiler.name == "clang":
+                opt = "-O3 -g -march=native -ffp-contract=fast"
+                if compiler.version >= ver(6):
+                    opt += " -fopenmp-simd"
+            elif compiler.name in ["xl", "xl_r"]:
+                opt = "-O -g -qsimd=auto"
+            elif compiler.name == "intel":
+                opt = "-O3 -g"
+                makeopts += ["CC_VENDOR=icc"]
+            else:
+                opt = "-O -g"
+            # Note: spack will inject additional target-specific flags through
+            # the compiler wrapper.
+            makeopts += ["OPT=%s" % opt]
+
+            if spec.satisfies("@0.7") and compiler.name in ["xl", "xl_r"]:
+                makeopts += ["CXXFLAGS.XL=-qpic -std=c++11 -MMD"]
+
+            if spec.satisfies("@:0.7") and "avx" in self.spec.target:
+                makeopts.append("AVX=1")
+
+        if spec.satisfies("@0.4:"):
+            if spec.satisfies("+cuda"):
+                makeopts += ["CUDA_DIR=%s" % spec["cuda"].prefix]
+                makeopts += ["CUDA_ARCH=sm_%s" % spec.variants["cuda_arch"].value]
+                if spec.satisfies("@:0.4"):
+                    nvccflags = [
+                        '-ccbin %s -Xcompiler "%s" -Xcompiler %s'
+                        % (compiler.cxx, opt, compiler.cc_pic_flag)
+                    ]
+                    nvccflags = " ".join(nvccflags)
+                    makeopts += ["NVCCFLAGS=%s" % nvccflags]
+            else:
+                # Disable CUDA auto-detection:
+                makeopts += ["CUDA_DIR=/disable-cuda"]
+
+            if spec.satisfies("+rocm"):
+                makeopts += ["HIP_DIR=%s" % spec["hip"].prefix]
+                amdgpu_target = ",".join(spec.variants["amdgpu_target"].value)
+                makeopts += ["HIP_ARCH=%s" % amdgpu_target]
+                if spec.satisfies("@0.8"):
+                    makeopts += ["HIPBLAS_DIR=%s" % spec["hipblas"].prefix]
+
+            if spec.satisfies("+libxsmm"):
+                makeopts += ["XSMM_DIR=%s" % spec["libxsmm"].prefix]
+                makeopts += ["BLAS_LIB=%s" % spec["blas"].libs]
+
+            if spec.satisfies("+magma"):
+                makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
+
+            if spec.satisfies("+openmp"):
+                makeopts += ["OPENMP=1"]
+
+            if spec.satisfies("~shared"):
+                makeopts += ["STATIC=1"]
+
+        return makeopts
+
+    def edit(self, spec, prefix):
+        make("info", *self.common_make_opts)
+
+    @property
+    def build_targets(self):
+        return self.common_make_opts
+
+    @property
+    def install_targets(self):
+        return ["install", "prefix={0}".format(self.prefix)] + self.common_make_opts
+
+    def check(self):
+        make("prove", *self.common_make_opts, parallel=False)
+
+    @when("@0.1")
+    def install(self, spec, prefix):
+        mkdirp(prefix.include)
+        install("ceed.h", prefix.include)
+        mkdirp(prefix.lib)
+        install("libceed.%s" % dso_suffix, prefix.lib)
+        filter_file(r"^prefix=.*$", "prefix=%s" % prefix, "ceed.pc")
+        filter_file(r"^includedir=\$\{prefix\}$", "includedir=${prefix}/include", "ceed.pc")
+        filter_file(r"^libdir=\$\{prefix\}$", "libdir=${prefix}/lib", "ceed.pc")
+        filter_file(r"Version:.*$", "Version: 0.1", "ceed.pc")
+        mkdirp(prefix.lib.pkgconfig)
+        install("ceed.pc", prefix.lib.pkgconfig)

--- a/spack_repo/local/packages/libceed/pkgconfig-version-0.4.diff
+++ b/spack_repo/local/packages/libceed/pkgconfig-version-0.4.diff
@@ -1,0 +1,12 @@
+diff --git c/ceed.pc.template w/ceed.pc.template
+index 3216f08..5ada754 100644
+--- c/ceed.pc.template
++++ w/ceed.pc.template
+@@ -4,6 +4,6 @@ libdir=${prefix}/lib
+
+ Name: CEED
+ Description: Code for Efficient Extensible Discretization
+-Version: 0.2.1
++Version: 0.4
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lceed

--- a/spack_repo/local/packages/palace/libceed_nontensor_atpoints_cuda.diff
+++ b/spack_repo/local/packages/palace/libceed_nontensor_atpoints_cuda.diff
@@ -1,0 +1,1 @@
+../../../../extern/patch/libCEED/libceed_nontensor_atpoints_cuda.diff

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -245,7 +245,12 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libxsmm+shared")
 
     with when("@0.14:"):
-        depends_on("libceed@0.13:")
+        depends_on("libceed@0.13:", when="@:0.17")
+        depends_on(
+            "libceed@0.13:",
+            patches=["libceed_nontensor_atpoints_cuda.diff"],
+            when="@0.18:",
+        )
         depends_on("libceed+openmp", when="+openmp")
         depends_on("libceed~openmp", when="~openmp")
         depends_on("libceed+shared", when="+shared")


### PR DESCRIPTION
This is **1/10** in a stacked replacement for [#824](https://github.com/awslabs/palace/pull/824) and [#825](https://github.com/awslabs/palace/pull/825), split into smaller, dependency-ordered chunks that can be reviewed independently. The final non-changelog tree is unchanged from #825.

This PR pins libCEED to the reviewed revision, carries the non-tensor AtPoints CPU/GPU patch through both the superbuild and Spack, and forwards the selected CUDA host compiler.

**Reviewer guidance:** Review the small Palace dependency-plumbing changes first. The generated libCEED patch is intentionally isolated here so it does not obscure the Palace implementation in later PRs.

**Deferred:** Palace point evaluation and all postprocessing adoption begin in the next PR.

**Validation:** Spack build passed with libCEED commit `64e0491`, `patches:=f6d86d0`; patch SHA256 is `f6d86d0b80860e8659d29b5589ca97c60c07abdaa5aab56cc363a763f3c6488d`.
