### PR TITLE
Add reusable libCEED point evaluation substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Added reusable libCEED point-evaluation infrastructure and device-backed
+    probe interpolation.
   - Added non-tensor libCEED AtPoints dependency support for CPU and GPU
     postprocessing and forwarded CUDA host compiler selection through superbuilds.
   - Added a `RationalImpedance` boundary condition: a surface (Robin) impedance boundary

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${LIB_TARGET_NAME}
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/bilinearform.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ceed_group_operator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gridfunction.cpp
@@ -30,6 +31,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/basis.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/ceed.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/coefficient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libceed/functional.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/integrator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/operator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/libceed/restriction.cpp

--- a/palace/fem/ceed_group_operator.cpp
+++ b/palace/fem/ceed_group_operator.cpp
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fem/ceed_group_operator.hpp"
+
+#include <mfem.hpp>
+
+namespace palace
+{
+
+namespace fem
+{
+
+void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups)
+{
+  for (auto &group : groups)
+  {
+    for (auto &[field_vec, source] : group.field_vec_sources)
+    {
+      (void)source;
+      PalaceCeedCall(group.ceed, CeedVectorDestroy(&field_vec));
+    }
+    group.field_vec_sources.clear();
+    for (auto &mesh_nodes_vec : group.mesh_node_vecs)
+    {
+      if (mesh_nodes_vec)
+      {
+        PalaceCeedCall(group.ceed, CeedVectorDestroy(&mesh_nodes_vec));
+      }
+    }
+    group.mesh_node_vecs.clear();
+    group.mesh_node_fields.clear();
+    group.mesh_nodes = nullptr;
+    if (group.out_vec)
+    {
+      PalaceCeedCall(group.ceed, CeedVectorDestroy(&group.out_vec));
+      group.out_size = 0;
+    }
+    if (group.op)
+    {
+      PalaceCeedCall(group.ceed, CeedOperatorDestroy(&group.op));
+    }
+    group.field_sources.clear();
+  }
+  groups.clear();
+}
+
+void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group)
+{
+  if (group.mesh_node_vecs.size() != group.mesh_node_fields.size())
+  {
+    group.mesh_node_vecs.clear();
+    group.mesh_node_vecs.reserve(group.mesh_node_fields.size());
+    for (const auto &name : group.mesh_node_fields)
+    {
+      CeedOperatorField field;
+      CeedVector mesh_nodes_vec = nullptr;
+      PalaceCeedCall(group.ceed,
+                     CeedOperatorGetFieldByName(group.op, name.c_str(), &field));
+      // libCEED may omit a passive input which the selected QFunction does not use.
+      if (field)
+      {
+        PalaceCeedCall(group.ceed, CeedOperatorFieldGetVector(field, &mesh_nodes_vec));
+      }
+      group.mesh_node_vecs.push_back(mesh_nodes_vec);
+    }
+  }
+  if (group.field_vec_sources.size() == group.field_sources.size())
+  {
+    return;
+  }
+  group.field_vec_sources.clear();
+  group.field_vec_sources.reserve(group.field_sources.size());
+  for (const auto &[name, source] : group.field_sources)
+  {
+    CeedOperatorField field;
+    CeedVector field_vec;
+    PalaceCeedCall(group.ceed, CeedOperatorGetFieldByName(group.op, name.c_str(), &field));
+    PalaceCeedCall(group.ceed, CeedOperatorFieldGetVector(field, &field_vec));
+    group.field_vec_sources.emplace_back(field_vec, source);
+  }
+}
+
+void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
+                            const std::array<const Vector *, 4> &srcs, const Vector &out)
+{
+  if (groups.empty())
+  {
+    return;
+  }
+
+  CeedMemType out_mem;
+  PalaceCeedCall(groups.front().ceed,
+                 CeedGetPreferredMemType(groups.front().ceed, &out_mem));
+  if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && out_mem == CEED_MEM_DEVICE)
+  {
+    out_mem = CEED_MEM_HOST;
+  }
+  auto *out_data = const_cast<Vector &>(out).ReadWrite(out_mem == CEED_MEM_DEVICE);
+  const CeedSize out_size = out.Size();
+
+  for (const auto &group : groups)
+  {
+    CacheGroupOperatorFieldVectors(group);
+    if (!group.mesh_node_vecs.empty())
+    {
+      MFEM_ASSERT(group.mesh_nodes, "Missing mesh-node source for libCEED geometry input!");
+      for (auto &mesh_nodes_vec : group.mesh_node_vecs)
+      {
+        if (mesh_nodes_vec)
+        {
+          ceed::InitCeedVector(*group.mesh_nodes, group.ceed, &mesh_nodes_vec, false);
+        }
+      }
+    }
+    for (auto &[field_vec, source] : group.field_vec_sources)
+    {
+      MFEM_ASSERT(source >= 0 && source < static_cast<int>(srcs.size()),
+                  "Invalid source index for libCEED field input!");
+      MFEM_ASSERT(srcs[source], "Missing source vector for libCEED field input!");
+      ceed::InitCeedVector(*srcs[source], group.ceed, &field_vec, false);
+    }
+    if (!group.out_vec || group.out_size != out_size)
+    {
+      if (group.out_vec)
+      {
+        PalaceCeedCall(group.ceed, CeedVectorDestroy(&group.out_vec));
+      }
+      PalaceCeedCall(group.ceed, CeedVectorCreate(group.ceed, out_size, &group.out_vec));
+      group.out_size = out_size;
+    }
+    PalaceCeedCall(group.ceed,
+                   CeedVectorSetArray(group.out_vec, out_mem, CEED_USE_POINTER, out_data));
+    PalaceCeedCall(group.ceed, CeedOperatorApplyAdd(group.op, CEED_VECTOR_NONE,
+                                                    group.out_vec, CEED_REQUEST_IMMEDIATE));
+    PalaceCeedCall(group.ceed, CeedVectorTakeArray(group.out_vec, out_mem, nullptr));
+  }
+}
+
+}  // namespace fem
+
+}  // namespace palace

--- a/palace/fem/ceed_group_operator.hpp
+++ b/palace/fem/ceed_group_operator.hpp
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_CEED_GROUP_OPERATOR_HPP
+#define PALACE_FEM_CEED_GROUP_OPERATOR_HPP
+
+#include <array>
+#include <string>
+#include <utility>
+#include <vector>
+#include "fem/libceed/ceed.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+namespace fem
+{
+
+// An assembled libCEED operator over one group of elements, with the named passive field
+// inputs re-pointed at caller data (by source vector index) on each evaluation.
+struct CeedGroupOperator
+{
+  Ceed ceed = nullptr;
+  CeedOperator op = nullptr;
+  std::vector<std::pair<std::string, int>> field_sources;
+  // Optional mesh-node source and operator input names. Unlike fixed coefficient data,
+  // mesh coordinates may be scaled in place between applies for dimensional output, so
+  // every listed libCEED vector is re-pointed at current MFEM memory on each evaluation.
+  const Vector *mesh_nodes = nullptr;
+  std::vector<std::string> mesh_node_fields;
+  mutable std::vector<CeedVector> mesh_node_vecs;
+  // Cached passive field vectors for field_sources, populated on first apply to avoid
+  // repeated string lookups during pointwise libCEED operator application.
+  mutable std::vector<std::pair<CeedVector, int>> field_vec_sources;
+  // Reusable output vector wrapper. The pointed-to MFEM Vector data is supplied at
+  // apply time, but the libCEED vector object itself can be retained across repeated
+  // postprocessing evaluations instead of being created/destroyed for every group apply.
+  mutable CeedVector out_vec = nullptr;
+  mutable CeedSize out_size = 0;
+};
+
+// Populate cached libCEED vector handles for the named passive fields of a group
+// operator. Calling this right after assembly moves field-name lookup overhead out of
+// the first timed postprocessing apply; ApplyAddGroupOperators also calls it lazily for
+// older call sites or any groups assembled without explicit caching.
+void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group);
+
+// Re-point the passive field inputs of each group operator at the given source vectors
+// and accumulate into the output vector with CeedOperatorApplyAdd.
+void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
+                            const std::array<const Vector *, 4> &srcs, const Vector &out);
+
+// Destroy the libCEED references owned by a group-operator vector and clear it. The Ceed
+// context itself is borrowed and is not destroyed here.
+void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups);
+
+}  // namespace fem
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_CEED_GROUP_OPERATOR_HPP

--- a/palace/fem/interpolator.cpp
+++ b/palace/fem/interpolator.cpp
@@ -3,12 +3,34 @@
 
 #include "interpolator.hpp"
 
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+
 #include <algorithm>
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
 #include "utils/communication.hpp"
 #include "utils/iodata.hpp"
 #include "utils/units.hpp"
+
+#include "fem/ceed_group_operator.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
 
 namespace palace
 {
@@ -19,7 +41,193 @@ namespace
 constexpr auto GSLIB_BB_TOL = 0.01;  // MFEM defaults, slightly reduced bounding box
 constexpr auto GSLIB_NEWTON_TOL = 1.0e-12;
 
+#if defined(MFEM_USE_GSLIB)
+
+using PointRuleKey = std::array<std::uint64_t, 4>;
+
+std::uint64_t EncodePointCoordinate(double x)
+{
+  static_assert(sizeof(std::uint64_t) == sizeof(double));
+  std::uint64_t bits;
+  std::memcpy(&bits, &x, sizeof(bits));
+  return bits;
+}
+
+// MFEM caches DofToQuad tabulations by IntegrationRule pointer in the shared finite
+// elements. Keep every rule passed to InitBasisAtPoints alive for the application
+// lifetime; exact IEEE data, including the weight, makes reuse collision-safe.
+const mfem::IntegrationRule &GetRegisteredPointRule(const mfem::IntegrationPoint &ip)
+{
+  static std::map<PointRuleKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::mutex registry_mutex;
+  const PointRuleKey key = {EncodePointCoordinate(ip.x), EncodePointCoordinate(ip.y),
+                            EncodePointCoordinate(ip.z), EncodePointCoordinate(ip.weight)};
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  auto it = registry.find(key);
+  if (it == registry.end())
+  {
+    auto ir = std::make_unique<mfem::IntegrationRule>(1);
+    ir->IntPoint(0) = ip;
+    it = registry.emplace(key, std::move(ir)).first;
+  }
+  return *it->second;
+}
+
+#endif
+
 }  // namespace
+
+#if defined(MFEM_USE_GSLIB)
+
+// Evaluates fields at the (fixed, located) probe points through libCEED: one small
+// operator per locally owned point (volume element restriction and basis tabulated at
+// the point, geometry on the fly from mesh node gradients). Results for all points are
+// reduced over all processes (unowned and not-found points contribute zero, matching
+// the GSLIB default interpolation value).
+class CeedProbeEvaluator
+{
+private:
+  std::vector<fem::CeedGroupOperator> groups;
+  mutable Vector field_staging, local_out;
+  MPI_Comm comm;
+  bool valid = true;
+
+public:
+  CeedProbeEvaluator(const mfem::FindPointsGSLIB &op,
+                     const mfem::ParFiniteElementSpace &fespace)
+    : comm(fespace.GetComm())
+  {
+    const auto &mesh = *fespace.GetParMesh();
+    const auto map_type = fespace.FEColl()->GetMapType(mesh.Dimension());
+    if (mesh.Dimension() != 3 || mesh.SpaceDimension() != 3 ||
+        (map_type != mfem::FiniteElement::H_CURL && map_type != mfem::FiniteElement::H_DIV))
+    {
+      valid = false;
+      return;
+    }
+    const mfem::FiniteElementSpace &mesh_fespace = *mesh.GetNodes()->FESpace();
+    const int npts = op.GetCode().Size();
+    const int rank = Mpi::Rank(comm);
+    field_staging.SetSize(fespace.GetVSize());
+    field_staging.UseDevice(true);
+    field_staging = 0.0;
+    local_out.SetSize(npts * 3);
+    local_out.UseDevice(true);
+
+    // Claim each point on exactly one process: for points on element borders the GSLIB
+    // ownership may not be consistent across the (all) searching processes, so resolve
+    // ties globally with a minimum reduction.
+    std::vector<int> owner(npts);
+    for (int i = 0; i < npts; i++)
+    {
+      owner[i] =
+          (op.GetCode()[i] != 2 && op.GetProc()[i] == static_cast<unsigned int>(rank))
+              ? rank
+              : std::numeric_limits<int>::max();
+    }
+    Mpi::GlobalMin(npts, owner.data(), comm);
+
+    Ceed ceed = ceed::internal::GetCeedObjects()[0];
+    for (int i = 0; i < npts; i++)
+    {
+      if (owner[i] != rank)
+      {
+        continue;  // Not found (default value 0) or owned by another process
+      }
+      const int elem = op.GetElem()[i];
+      const auto geom = mesh.GetElementGeometry(elem);
+      const int dim = mesh.Dimension();
+
+      // FindPointsGSLIB::GetReferencePosition returns mfem reference coordinates of
+      // the original mesh element (point-major).
+      mfem::IntegrationPoint ip;
+      ip.Set3(op.GetReferencePosition()[i * dim + 0],
+              op.GetReferencePosition()[i * dim + 1],
+              op.GetReferencePosition()[i * dim + 2]);
+      ip.weight = 1.0;
+      const mfem::IntegrationRule &ir = GetRegisteredPointRule(ip);
+      const std::vector<int> indices = {elem};
+
+      std::vector<ceed::CeedFunctionalFieldInput> inputs;
+      std::vector<std::pair<std::string, int>> field_sources;
+      {
+        CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+        const mfem::FiniteElement *mesh_fe =
+            mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+        CeedBasis mesh_basis;
+        ceed::InitBasisAtPoints(*mesh_fe, ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+        CeedVector mesh_nodes_vec;
+        ceed::InitCeedVector(*mesh.GetNodes(), ceed, &mesh_nodes_vec);
+        inputs.push_back(
+            {"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+        CeedElemRestriction field_restr;
+        ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                              &field_restr);
+        const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+        CeedBasis field_basis;
+        ceed::InitBasisAtPoints(*fe, ir, fespace.GetVDim(), ceed, &field_basis);
+        CeedVector field_vec;
+        ceed::InitCeedVector(field_staging, ceed, &field_vec);
+        inputs.push_back(
+            {"u_1", field_vec, field_restr, field_basis, ceed::EvalMode::Interp});
+        field_sources.emplace_back("u_1", 0);
+
+        // Output: 3 components for point i (byVDIM layout).
+        CeedElemRestriction out_restr;
+        const CeedInt offset[1] = {3 * i};
+        PalaceCeedCall(ceed, CeedElemRestrictionCreate(ceed, 1, 1, 3, 1, (CeedSize)npts * 3,
+                                                       CEED_MEM_HOST, CEED_COPY_VALUES,
+                                                       offset, &out_restr));
+
+        ceed::CeedQFunctionInfo info;
+        if (map_type == mfem::FiniteElement::H_CURL)
+        {
+          info.apply_qf = f_eval_probe_hcurl_33;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+        }
+        else
+        {
+          info.apply_qf = f_eval_probe_hdiv_33;
+          info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+        }
+        CeedOperator point_op;
+        ceed::AssembleCeedPointEvaluator(info, nullptr, 0, ceed, inputs, 3, out_restr,
+                                         &point_op);
+        groups.push_back({ceed, point_op, std::move(field_sources)});
+        groups.back().mesh_nodes = mesh.GetNodes();
+        groups.back().mesh_node_fields = {"grad_x"};
+        fem::CacheGroupOperatorFieldVectors(groups.back());
+
+        PalaceCeedCall(ceed, CeedVectorDestroy(&mesh_nodes_vec));
+        PalaceCeedCall(ceed, CeedVectorDestroy(&field_vec));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_restr));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&field_restr));
+        PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&out_restr));
+        PalaceCeedCall(ceed, CeedBasisDestroy(&mesh_basis));
+        PalaceCeedCall(ceed, CeedBasisDestroy(&field_basis));
+      }
+    }
+  }
+
+  ~CeedProbeEvaluator() { fem::DestroyGroupOperators(groups); }
+
+  bool IsValid() const { return valid; }
+
+  // Evaluate the field at all probe points (byVDIM ordering). Collective.
+  std::vector<double> Eval(const mfem::ParGridFunction &U) const
+  {
+    local_out = 0.0;
+    fem::ApplyAddGroupOperators(groups, {&U}, local_out);
+    std::vector<double> vals(local_out.Size());
+    const double *d = local_out.HostRead();
+    std::copy(d, d + local_out.Size(), vals.begin());
+    Mpi::GlobalSum(static_cast<int>(vals.size()), vals.data(), comm);
+    return vals;
+  }
+};
+
+#endif
 
 InterpolationOperator::InterpolationOperator(const std::map<int, config::ProbeData> &probe,
                                              const Units &units,
@@ -78,12 +286,33 @@ InterpolationOperator::InterpolationOperator(const IoData &iodata,
 {
 }
 
+InterpolationOperator::~InterpolationOperator() = default;
+
 std::vector<double> InterpolationOperator::ProbeField(const mfem::ParGridFunction &U)
 {
 #if defined(MFEM_USE_GSLIB)
+  const int npts = op.GetCode().Size();
+
+  // Use the libCEED evaluation path when supported and enough probe points are present
+  // to amortize operator assembly/JIT. Tiny probe sets are cheaper through the existing
+  // GSLIB interpolation path, especially in driven postprocessing where only a few
+  // fixed monitor points are evaluated once or twice.
+  constexpr int ceed_probe_min_points = 8;
+  if (npts >= ceed_probe_min_points)
+  {
+    auto &eval = ceed_probes[U.FESpace()];
+    if (!eval)
+    {
+      eval = std::make_unique<CeedProbeEvaluator>(op, *U.ParFESpace());
+    }
+    if (eval->IsValid())
+    {
+      return eval->Eval(U);
+    }
+  }
+
   // Interpolated vector values are returned from GSLIB interpolator with the same ordering
   // as the source grid function, which we transform to byVDIM for output.
-  const int npts = op.GetCode().Size();
   const int vdim = U.VectorDim();
   std::vector<double> vals(npts * vdim);
   if (U.FESpace()->GetOrdering() == mfem::Ordering::byVDIM)

--- a/palace/fem/interpolator.hpp
+++ b/palace/fem/interpolator.hpp
@@ -6,6 +6,7 @@
 
 #include <complex>
 #include <map>
+#include <memory>
 #include <vector>
 #include <mfem.hpp>
 #include "utils/configfile.hpp"
@@ -24,6 +25,7 @@ class FindPointsGSLIB;
 namespace palace
 {
 
+class CeedProbeEvaluator;
 class GridFunction;
 class IoData;
 class Units;
@@ -37,6 +39,13 @@ class InterpolationOperator
 private:
 #if defined(MFEM_USE_GSLIB)
   mfem::FindPointsGSLIB op;
+
+  // libCEED evaluators at the located probe points, avoiding per-sample GSLIB
+  // interpolation, constructed lazily per source finite element space. The source spaces
+  // outlive this operator and both are rebuilt together after mesh/space reconstruction,
+  // so pointer identity is stable for the lifetime of this cache.
+  mutable std::map<const mfem::FiniteElementSpace *, std::unique_ptr<CeedProbeEvaluator>>
+      ceed_probes;
 #endif
   std::vector<int> op_idx;
 
@@ -48,6 +57,7 @@ public:
   InterpolationOperator(const std::map<int, config::ProbeData> &probe, const Units &units,
                         FiniteElementSpace &nd_space);
   InterpolationOperator(const IoData &iodata, FiniteElementSpace &nd_space);
+  ~InterpolationOperator();
 
   auto GetVDim() const { return v_dim_fes; }
   const auto &GetProbes() const { return op_idx; }

--- a/palace/fem/libceed/basis.cpp
+++ b/palace/fem/libceed/basis.cpp
@@ -44,19 +44,23 @@ void InitNonTensorBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRu
   const int dim = fe.GetDim();
   const int P = maps.ndof;
   const int Q = maps.nqpt;
-  mfem::DenseMatrix qX(dim, Q);
+  // libCEED expects reference coordinates in component-major layout,
+  // q_ref[d * Q + q].  MFEM DenseMatrix is column-major, so store the logical
+  // transpose (points as rows, dimensions as columns): qX(q, d) has exactly the
+  // layout libCEED expects while keeping matrix-style indexing.
+  mfem::DenseMatrix qX(Q, dim);
   mfem::Vector qW(Q);
   for (int i = 0; i < Q; i++)
   {
     const mfem::IntegrationPoint &ip = ir.IntPoint(i);
-    qX(0, i) = ip.x;
+    qX(i, 0) = ip.x;
     if (dim > 1)
     {
-      qX(1, i) = ip.y;
+      qX(i, 1) = ip.y;
     }
     if (dim > 2)
     {
-      qX(2, i) = ip.z;
+      qX(i, 2) = ip.z;
     }
     qW(i) = ip.weight;
   }
@@ -183,6 +187,16 @@ void InitBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
   {
     InitNonTensorBasis(fe, ir, num_comp, ceed, basis);
   }
+}
+
+void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
+                       CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+{
+  // Always use full tabulation: the integration rule points may be arbitrary (not a
+  // tensor-product rule), which the tensor basis construction cannot represent. The
+  // corresponding element restriction must use native dof ordering. The caller must
+  // keep ir alive while the finite element can retain its pointer-keyed DofToQuad cache.
+  InitNonTensorBasis(fe, ir, num_comp, ceed, basis);
 }
 
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,

--- a/palace/fem/libceed/basis.hpp
+++ b/palace/fem/libceed/basis.hpp
@@ -20,6 +20,14 @@ namespace palace::ceed
 void InitBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir, int num_comp,
                Ceed ceed, CeedBasis *basis);
 
+// Initialize a basis tabulated at arbitrary integration rule points (which need not
+// correspond to a tensor-product quadrature rule, for example points lying on a face of
+// the reference element). Always uses full (non-lexicographic, native dof ordering)
+// tabulation, so the corresponding element restriction must also use native ordering
+// (is_interp = true for InitRestriction of scalar tensor-product elements).
+void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
+                       int num_comp, Ceed ceed, CeedBasis *basis);
+
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,
                            const mfem::FiniteElement &test_fe, int trial_num_comp,
                            int test_num_comp, Ceed ceed, CeedBasis *basis);

--- a/palace/fem/libceed/ceed.cpp
+++ b/palace/fem/libceed/ceed.cpp
@@ -81,7 +81,8 @@ std::string Print()
   return std::string(ceed_resource);
 }
 
-void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init)
+void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init,
+                    bool take_array)
 {
   CeedMemType mem;
   PalaceCeedCall(ceed, CeedGetPreferredMemType(ceed, &mem));
@@ -94,7 +95,7 @@ void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init)
   {
     PalaceCeedCall(ceed, CeedVectorCreate(ceed, v.Size(), cv));
   }
-  else
+  else if (take_array)
   {
     PalaceCeedCall(ceed, CeedVectorTakeArray(*cv, mem, nullptr));
   }

--- a/palace/fem/libceed/ceed.hpp
+++ b/palace/fem/libceed/ceed.hpp
@@ -56,7 +56,8 @@ std::string Print();
 
 // Initialize a CeedVector from an mfem::Vector. When init is false, expects the CeedVector
 // has already been initialized and just sets the data pointer.
-void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init = true);
+void InitCeedVector(const mfem::Vector &v, Ceed ceed, CeedVector *cv, bool init = true,
+                    bool take_array = true);
 
 // Convert an MFEM geometry type to a libCEED one.
 CeedElemTopology GetCeedTopology(mfem::Geometry::Type geom);

--- a/palace/fem/libceed/functional.cpp
+++ b/palace/fem/libceed/functional.cpp
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "functional.hpp"
+
+#include <ceed/backend.h>
+#include <mfem.hpp>
+
+namespace palace::ceed
+{
+
+namespace
+{
+
+void AddQFunctionFieldInput(const CeedFunctionalFieldInput &input, Ceed ceed,
+                            CeedQFunction qf)
+{
+  if (input.ops & EvalMode::None)
+  {
+    // EvalMode::None inputs may have no basis (e.g. quadrature point data passed
+    // through directly), so get the component count from the restriction.
+    CeedInt num_comp;
+    PalaceCeedCall(ceed, CeedElemRestrictionGetNumComponents(input.restr, &num_comp));
+    PalaceCeedCall(ceed,
+                   CeedQFunctionAddInput(qf, input.name.c_str(), num_comp, CEED_EVAL_NONE));
+  }
+  if (input.ops & EvalMode::Interp)
+  {
+    CeedInt num_comp, q_comp;
+    PalaceCeedCall(ceed, CeedBasisGetNumComponents(input.basis, &num_comp));
+    PalaceCeedCall(
+        ceed, CeedBasisGetNumQuadratureComponents(input.basis, CEED_EVAL_INTERP, &q_comp));
+    PalaceCeedCall(ceed, CeedQFunctionAddInput(qf, input.name.c_str(), num_comp * q_comp,
+                                               CEED_EVAL_INTERP));
+  }
+  if (input.ops & EvalMode::Grad)
+  {
+    CeedInt num_comp, q_comp;
+    PalaceCeedCall(ceed, CeedBasisGetNumComponents(input.basis, &num_comp));
+    PalaceCeedCall(
+        ceed, CeedBasisGetNumQuadratureComponents(input.basis, CEED_EVAL_GRAD, &q_comp));
+    PalaceCeedCall(ceed, CeedQFunctionAddInput(qf, ("grad_" + input.name).c_str(),
+                                               num_comp * q_comp, CEED_EVAL_GRAD));
+  }
+  if (input.ops & EvalMode::Weight)
+  {
+    PalaceCeedCall(ceed,
+                   CeedQFunctionAddInput(qf, input.name.c_str(), 1, CEED_EVAL_WEIGHT));
+  }
+  MFEM_VERIFY(!(input.ops & (EvalMode::Div | EvalMode::Curl)),
+              "Unsupported evaluation mode for pointwise operator field input '"
+                  << input.name << "'!");
+}
+
+void AddOperatorFieldInput(const CeedFunctionalFieldInput &input, Ceed ceed,
+                           CeedOperator op)
+{
+  if (input.ops & EvalMode::None)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, input.name.c_str(), input.restr,
+                                              CEED_BASIS_NONE, input.vec));
+  }
+  if (input.ops & EvalMode::Interp)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, input.name.c_str(), input.restr,
+                                              input.basis, input.vec));
+  }
+  if (input.ops & EvalMode::Grad)
+  {
+    PalaceCeedCall(ceed, CeedOperatorSetField(op, ("grad_" + input.name).c_str(),
+                                              input.restr, input.basis, input.vec));
+  }
+  if (input.ops & EvalMode::Weight)
+  {
+    PalaceCeedCall(ceed,
+                   CeedOperatorSetField(op, input.name.c_str(), CEED_ELEMRESTRICTION_NONE,
+                                        input.basis, CEED_VECTOR_NONE));
+  }
+}
+
+}  // namespace
+
+namespace
+{
+
+void CreatePointEvaluatorQFunction(const CeedQFunctionInfo &info, void *ctx,
+                                   std::size_t ctx_size, Ceed ceed,
+                                   const std::vector<CeedFunctionalFieldInput> &inputs,
+                                   CeedInt num_out_comp, CeedQFunction *apply_qf)
+{
+  MFEM_VERIFY(!info.assemble_q_data,
+              "Point evaluator does not support quadrature data assembly!");
+  PalaceCeedCall(ceed, CeedQFunctionCreateInterior(ceed, 1, info.apply_qf,
+                                                   info.apply_qf_path.c_str(), apply_qf));
+
+  if (ctx && ctx_size > 0)
+  {
+    CeedQFunctionContext apply_ctx;
+    PalaceCeedCall(ceed, CeedQFunctionContextCreate(ceed, &apply_ctx));
+    PalaceCeedCall(ceed, CeedQFunctionContextSetData(apply_ctx, CEED_MEM_HOST,
+                                                     CEED_COPY_VALUES, ctx_size, ctx));
+    PalaceCeedCall(ceed, CeedQFunctionSetContext(*apply_qf, apply_ctx));
+    PalaceCeedCall(ceed, CeedQFunctionContextDestroy(&apply_ctx));
+  }
+
+  for (const auto &input : inputs)
+  {
+    AddQFunctionFieldInput(input, ceed, *apply_qf);
+  }
+  PalaceCeedCall(ceed,
+                 CeedQFunctionAddOutput(*apply_qf, "v", num_out_comp, CEED_EVAL_NONE));
+}
+
+}  // namespace
+
+void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
+                                std::size_t ctx_size, Ceed ceed,
+                                const std::vector<CeedFunctionalFieldInput> &inputs,
+                                CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                CeedOperator *op)
+{
+  CeedQFunction apply_qf;
+  CreatePointEvaluatorQFunction(info, ctx, ctx_size, ceed, inputs, num_out_comp, &apply_qf);
+
+  PalaceCeedCall(ceed, CeedOperatorCreate(ceed, apply_qf, nullptr, nullptr, op));
+  PalaceCeedCall(ceed, CeedQFunctionDestroy(&apply_qf));
+
+  for (const auto &input : inputs)
+  {
+    AddOperatorFieldInput(input, ceed, *op);
+  }
+  PalaceCeedCall(
+      ceed, CeedOperatorSetField(*op, "v", out_restr, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+
+  PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
+}
+
+}  // namespace palace::ceed

--- a/palace/fem/libceed/functional.hpp
+++ b/palace/fem/libceed/functional.hpp
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_FUNCTIONAL_HPP
+#define PALACE_LIBCEED_FUNCTIONAL_HPP
+
+#include <string>
+#include <vector>
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/integrator.hpp"
+
+namespace palace::ceed
+{
+
+// Description of a passive field input for a libCEED pointwise operator. The field
+// vector is evaluated at the operator points through the provided element restriction
+// and basis.
+struct CeedFunctionalFieldInput
+{
+  // Name of the QFunction input field (QFunction inputs are added in the order the
+  // inputs are provided, after the geometry data inputs).
+  std::string name;
+
+  // Field vector (L-vector layout matching the restriction).
+  CeedVector vec;
+
+  // Element restriction and basis for evaluation at quadrature points.
+  CeedElemRestriction restr;
+  CeedBasis basis;
+
+  // Evaluation modes (ceed::EvalMode) for the field input.
+  unsigned int ops;
+};
+
+// Construct a libCEED operator which evaluates a pointwise function of the provided
+// fields at arbitrary points of each element (for example the nodal points of an
+// interpolatory output space), writing num_out_comp values per point through out_restr
+// (CEED_EVAL_NONE, so the number of "quadrature" points of the operator must match the
+// element size of the output restriction). No quadrature weighting or sum over points
+// is performed, and the element geometry is computed on the fly from a mesh nodes
+// gradient input rather than stored geometry factor data. Apply with
+// CeedOperatorApplyAdd(op, CEED_VECTOR_NONE, output, ...) (contributions accumulate,
+// e.g. for the real and imaginary part applications of quadratic quantities).
+void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
+                                std::size_t ctx_size, Ceed ceed,
+                                const std::vector<CeedFunctionalFieldInput> &inputs,
+                                CeedInt num_out_comp, CeedElemRestriction out_restr,
+                                CeedOperator *op);
+
+}  // namespace palace::ceed
+
+#endif  // PALACE_LIBCEED_FUNCTIONAL_HPP

--- a/palace/fem/qfunctions/33/eval_33_qf.h
+++ b/palace/fem/qfunctions/33/eval_33_qf.h
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_EVAL_33_QF_H
+#define PALACE_LIBCEED_EVAL_33_QF_H
+
+#include "utils_33_qf.h"
+
+// Pointwise probes at arbitrary reference points of 3D volume elements. No quadrature
+// weighting is applied.
+
+// Pointwise H(curl) field value: v = adj(J)ᵀ/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, u_loc, E);
+    v[i + Q * 0] = E[0] / detJ;
+    v[i + Q * 1] = E[1] / detJ;
+    v[i + Q * 2] = E[2] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise H(div) field value: v = J/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hdiv_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], B[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(J_loc, u_loc, B);
+    v[i + Q * 0] = B[0] / detJ;
+    v[i + Q * 1] = B[1] / detJ;
+    v[i + Q * 2] = B[2] / detJ;
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_EVAL_33_QF_H

--- a/palace/fem/qfunctions/33/utils_33_qf.h
+++ b/palace/fem/qfunctions/33/utils_33_qf.h
@@ -36,6 +36,15 @@ CEED_QFUNCTION_HELPER CeedScalar AdjJt33(const CeedScalar J[9], CeedScalar adjJt
   return ComputeDet ? (J[0] * adjJt[0] + J[1] * adjJt[1] + J[2] * adjJt[2]) : 0.0;
 }
 
+// Compute y = A x for a 3x3 matrix A stored column-major.
+CEED_QFUNCTION_HELPER void MultAx33(const CeedScalar A[9], const CeedScalar x[3],
+                                    CeedScalar y[3])
+{
+  y[0] = A[0] * x[0] + A[3] * x[1] + A[6] * x[2];
+  y[1] = A[1] * x[0] + A[4] * x[1] + A[7] * x[2];
+  y[2] = A[2] * x[0] + A[5] * x[1] + A[8] * x[2];
+}
+
 CEED_QFUNCTION_HELPER void MatUnpack33(const CeedScalar *A, const CeedInt A_stride,
                                        CeedScalar A_loc[9])
 {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-pointevaluation.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp
@@ -109,7 +110,7 @@ endif()
 # Add JIT source file path definition for libCEED
 set_property(
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-  APPEND PROPERTY COMPILE_DEFINITIONS "PALACE_LIBCEED_JIT_SOURCE_DIR=\"${CMAKE_INSTALL_PREFIX}/include/palace/\""
+  APPEND PROPERTY COMPILE_DEFINITIONS "PALACE_LIBCEED_JIT_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}/fem/\""
 )
 
 # Add path for test data files.

--- a/test/unit/test-pointevaluation.cpp
+++ b/test/unit/test-pointevaluation.cpp
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <mfem.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
+#include "fem/interpolator.hpp"
+#include "fem/mesh.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+// Build a simple Cartesian probe mesh.
+std::unique_ptr<Mesh> MakeProbeMesh(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+}  // namespace
+
+#if defined(MFEM_USE_GSLIB)
+TEST_CASE("InterpolationOperator Ceed Probes", "[interpolator][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  CAPTURE(elem_type, order);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = MakeProbeMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+  GridFunction E(nd_fespace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.5;
+                                        v(1) = std::sin(x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+
+  // Probe points are in element interiors and both material regions. Use enough points
+  // to select the libCEED path, and compare against direct GSLIB interpolation.
+  Units units(1.0, 1.0);
+  auto CheckProbes = [&](const std::array<std::array<double, 3>, 8> &pts)
+  {
+    std::map<int, config::ProbeData> probes;
+    for (std::size_t i = 0; i < pts.size(); i++)
+    {
+      config::ProbeData data;
+      data.center = pts[i];
+      probes.emplace(static_cast<int>(i + 1), data);
+    }
+    InterpolationOperator interp(probes, units, nd_fespace);
+
+    const int npts = static_cast<int>(pts.size());
+    mfem::Vector xyz(npts * 3), vals_r(npts * 3), vals_i(npts * 3);
+    for (int i = 0; i < npts; i++)
+    {
+      for (int d = 0; d < 3; d++)
+      {
+        xyz(d * npts + i) = pts[i][d];
+      }
+    }
+    fem::InterpolateFunction(xyz, E.Real(), vals_r, mfem::Ordering::byNODES);
+    fem::InterpolateFunction(xyz, E.Imag(), vals_i, mfem::Ordering::byNODES);
+
+    auto vals = interp.ProbeField(E);
+    REQUIRE(static_cast<int>(vals.size()) == npts * 3);
+    for (int i = 0; i < npts; i++)
+    {
+      for (int d = 0; d < 3; d++)
+      {
+        // ProbeField returns byVDIM; the reference uses the requested byNODES ordering.
+        const auto val = vals[3 * i + d];
+        const double ref_r = vals_r(d * npts + i), ref_i = vals_i(d * npts + i);
+        CAPTURE(i, d, ref_r, ref_i);
+        CHECK(val.real() == Catch::Approx(ref_r).epsilon(1.0e-9).margin(1.0e-12));
+        CHECK(val.imag() == Catch::Approx(ref_i).epsilon(1.0e-9).margin(1.0e-12));
+      }
+    }
+  };
+
+  const std::array<std::array<double, 3>, 8> pts_1 = {{{0.21, 0.37, 0.23},
+                                                       {0.74, 0.52, 0.81},
+                                                       {0.53, 0.48, 0.52},
+                                                       {0.13, 0.68, 0.34},
+                                                       {0.32, 0.82, 0.67},
+                                                       {0.87, 0.16, 0.42},
+                                                       {0.61, 0.29, 0.73},
+                                                       {0.43, 0.57, 0.89}}};
+  const std::array<std::array<double, 3>, 8> pts_2 = {{{0.17, 0.31, 0.27},
+                                                       {0.78, 0.56, 0.84},
+                                                       {0.58, 0.44, 0.54},
+                                                       {0.11, 0.72, 0.38},
+                                                       {0.36, 0.86, 0.63},
+                                                       {0.83, 0.19, 0.46},
+                                                       {0.66, 0.24, 0.77},
+                                                       {0.47, 0.61, 0.92}}};
+  CheckProbes(pts_1);
+  // CheckProbes destroys its InterpolationOperator. Reconstruct one with different
+  // coordinates while nd_fespace and its MFEM DofToQuad caches remain alive.
+  CheckProbes(pts_2);
+}
+#endif
+
+}  // namespace palace


### PR DESCRIPTION
This is **2/10** in the stacked replacement for #824/#825 and depends on [#850](https://github.com/awslabs/palace/pull/850). Please review only the diff against that PR.

This adds reusable libCEED basis, functional, and grouped-operator infrastructure for evaluating fields at fixed points, then uses it for probe interpolation.

**Reviewer guidance:** Start with `fem/libceed/{basis,functional}.*` and `ceed_group_operator.*`; `interpolator.cpp` is the first concrete consumer. The ownership and cache lifetimes introduced here are the contracts used by the rest of the stack.

**Deferred:** Variable per-element points, face-neighbor exchange, and surface reductions are intentionally later.

**Validation:** Probe tests pass serial and MPI-2: 396 assertions each.
