### PR TITLE
Add parallel sampled face-neighbor field exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Added distributed sampled face-neighbor field exchange for parallel device
+    postprocessing.
   - Added reusable libCEED point-evaluation infrastructure and device-backed
     probe interpolation.
   - Added non-tensor libCEED AtPoints dependency support for CPU and GPU

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ceed_group_operator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/facenbrexchange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/gridfunction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integrator.cpp

--- a/palace/fem/ceed_group_operator.cpp
+++ b/palace/fem/ceed_group_operator.cpp
@@ -21,6 +21,7 @@ void DestroyGroupOperators(std::vector<CeedGroupOperator> &groups)
       PalaceCeedCall(group.ceed, CeedVectorDestroy(&field_vec));
     }
     group.field_vec_sources.clear();
+    group.field_vectors_detached = false;
     for (auto &mesh_nodes_vec : group.mesh_node_vecs)
     {
       if (mesh_nodes_vec)
@@ -81,8 +82,33 @@ void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group)
   }
 }
 
+void DetachGroupOperatorFieldVectors(const std::vector<CeedGroupOperator> &groups)
+{
+  for (const auto &group : groups)
+  {
+    CacheGroupOperatorFieldVectors(group);
+    if (group.field_vec_sources.empty() || group.field_vectors_detached)
+    {
+      continue;
+    }
+    CeedMemType mem;
+    PalaceCeedCall(group.ceed, CeedGetPreferredMemType(group.ceed, &mem));
+    if (!mfem::Device::Allows(mfem::Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
+    {
+      mem = CEED_MEM_HOST;
+    }
+    for (auto &[field_vec, source] : group.field_vec_sources)
+    {
+      (void)source;
+      PalaceCeedCall(group.ceed, CeedVectorTakeArray(field_vec, mem, nullptr));
+    }
+    group.field_vectors_detached = true;
+  }
+}
+
 void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
-                            const std::array<const Vector *, 4> &srcs, const Vector &out)
+                            const std::array<const Vector *, 4> &srcs, const Vector &out,
+                            const Vector *imported)
 {
   if (groups.empty())
   {
@@ -115,11 +141,15 @@ void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
     }
     for (auto &[field_vec, source] : group.field_vec_sources)
     {
-      MFEM_ASSERT(source >= 0 && source < static_cast<int>(srcs.size()),
-                  "Invalid source index for libCEED field input!");
-      MFEM_ASSERT(srcs[source], "Missing source vector for libCEED field input!");
-      ceed::InitCeedVector(*srcs[source], group.ceed, &field_vec, false);
+      // Source index 4 selects an optional imported vector containing sampled
+      // face-neighbor field values. The operator's
+      // restriction slices and transposes the shared vector to the per-element layout.
+      const Vector *sv = (source < 4) ? srcs[source] : imported;
+      MFEM_ASSERT(sv, "Missing source vector for libCEED field input!");
+      ceed::InitCeedVector(*sv, group.ceed, &field_vec, false,
+                           !group.field_vectors_detached);
     }
+    group.field_vectors_detached = false;
     if (!group.out_vec || group.out_size != out_size)
     {
       if (group.out_vec)

--- a/palace/fem/ceed_group_operator.hpp
+++ b/palace/fem/ceed_group_operator.hpp
@@ -33,6 +33,9 @@ struct CeedGroupOperator
   // Cached passive field vectors for field_sources, populated on first apply to avoid
   // repeated string lookups during pointwise libCEED operator application.
   mutable std::vector<std::pair<CeedVector, int>> field_vec_sources;
+  // True after construction storage has been detached from the cached vectors. The next
+  // apply sets arrays directly instead of first taking a nonexistent borrowed array.
+  mutable bool field_vectors_detached = false;
   // Reusable output vector wrapper. The pointed-to MFEM Vector data is supplied at
   // apply time, but the libCEED vector object itself can be retained across repeated
   // postprocessing evaluations instead of being created/destroyed for every group apply.
@@ -46,10 +49,18 @@ struct CeedGroupOperator
 // older call sites or any groups assembled without explicit caching.
 void CacheGroupOperatorFieldVectors(const CeedGroupOperator &group);
 
+// Detach borrowed arrays from cached passive field vectors before releasing their
+// construction storage. The next apply reattaches caller-owned arrays.
+void DetachGroupOperatorFieldVectors(const std::vector<CeedGroupOperator> &groups);
+
 // Re-point the passive field inputs of each group operator at the given source vectors
-// and accumulate into the output vector with CeedOperatorApplyAdd.
+// and accumulate into the output vector with CeedOperatorApplyAdd. A field source index
+// of 4 (out of the srcs range) selects the optional imported vector instead, used to
+// feed face-neighbor (ghost) field values exchanged for two-sided interior boundaries on
+// parallel interfaces.
 void ApplyAddGroupOperators(const std::vector<CeedGroupOperator> &groups,
-                            const std::array<const Vector *, 4> &srcs, const Vector &out);
+                            const std::array<const Vector *, 4> &srcs, const Vector &out,
+                            const Vector *imported = nullptr);
 
 // Destroy the libCEED references owned by a group-operator vector and clear it. The Ceed
 // context itself is borrowed and is not destroyed here.

--- a/palace/fem/facenbrexchange.cpp
+++ b/palace/fem/facenbrexchange.cpp
@@ -1,0 +1,646 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "facenbrexchange.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include "fem/fespace.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/ceed.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/mesh.hpp"
+#include "utils/communication.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/22/eval_22_qf.h"
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
+
+namespace palace
+{
+
+namespace
+{
+
+// Key identifying one export point-evaluator group. The request supplies an
+// integer/topological point_key (reference-face topology/orientation/subface identity),
+// so normal grouping never depends on rounded physical or reference point coordinates.
+// Ad-hoc requests with an empty point_key use exact coordinate bits.
+using PointConfigKey = std::vector<long long>;
+
+// Message tags for the setup (payload size, payload) and evaluation exchanges. A
+// single evaluation tag is sufficient: all processes perform the evaluation calls of
+// every exchange object in the same order, so per-pair messages match in order (MPI
+// non-overtaking guarantee).
+constexpr int TAG_SETUP_SIZE = 1741, TAG_SETUP_PAYLOAD = 1742, TAG_EVAL = 1743;
+
+void VerifyRegisteredIr(const mfem::IntegrationRule &ir,
+                        const std::vector<mfem::IntegrationPoint> &pts)
+{
+  MFEM_VERIFY(ir.GetNPoints() == static_cast<int>(pts.size()),
+              "Face-neighbor point key reused with a different point count!");
+  for (int q = 0; q < ir.GetNPoints(); q++)
+  {
+    const auto &a = ir.IntPoint(q);
+    const auto &b = pts[static_cast<std::size_t>(q)];
+    const double err = std::max({std::abs(a.x - b.x), std::abs(a.y - b.y),
+                                 std::abs(a.z - b.z), std::abs(a.weight - b.weight)});
+    MFEM_VERIFY(err <= 1.0e-12,
+                "Face-neighbor point key reused for different reference points!");
+  }
+}
+
+long long EncodePointCoordinate(double x)
+{
+  static_assert(sizeof(long long) == sizeof(double));
+  long long bits;
+  std::memcpy(&bits, &x, sizeof(bits));
+  return bits;
+}
+
+// Registry of evaluation point integration rules with application lifetime (as in
+// output_functionals.cpp): mfem::FiniteElement::GetDofToQuad caches tabulations keyed by
+// the IntegrationRule pointer inside the (global, shared) FiniteElement objects, so
+// destroying an IntegrationRule which was used for tabulation would leave a dangling
+// cache entry.
+const mfem::IntegrationRule *GetRegisteredIr(const PointConfigKey &key,
+                                             const std::vector<mfem::IntegrationPoint> &pts)
+{
+  static std::map<PointConfigKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::mutex registry_mutex;
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  auto it = registry.find(key);
+  if (it == registry.end())
+  {
+    auto ir = std::make_unique<mfem::IntegrationRule>(static_cast<int>(pts.size()));
+    for (std::size_t q = 0; q < pts.size(); q++)
+    {
+      ir->IntPoint(static_cast<int>(q)) = pts[q];
+    }
+    it = registry.emplace(key, std::move(ir)).first;
+  }
+  else
+  {
+    VerifyRegisteredIr(*it->second, pts);
+  }
+  return it->second.get();
+}
+
+bool CeedSupportsNonTensorAtPoints(Ceed ceed)
+{
+  const char *resource;
+  PalaceCeedCall(ceed, CeedGetResource(ceed, &resource));
+  return std::strstr(resource, "/cpu/self") || std::strstr(resource, "/gpu/cuda/ref") ||
+         std::strstr(resource, "/gpu/cuda/magma");
+}
+
+int FieldValueDim(const mfem::ParFiniteElementSpace &fespace, int space_dim)
+{
+  const auto map_type = fespace.FEColl()->GetMapType(fespace.GetParMesh()->Dimension());
+  if (map_type == mfem::FiniteElement::H_CURL || map_type == mfem::FiniteElement::H_DIV)
+  {
+    return space_dim;
+  }
+  if (map_type == mfem::FiniteElement::VALUE || map_type == mfem::FiniteElement::INTEGRAL)
+  {
+    MFEM_VERIFY(fespace.GetVDim() == 1,
+                "FaceNbrFieldExchange scalar source spaces must have one component!");
+    return 1;
+  }
+  MFEM_ABORT("FaceNbrFieldExchange requires H(curl), H(div), or scalar VALUE/INTEGRAL "
+             "source spaces (map type = "
+             << map_type << ")!");
+  return 0;
+}
+
+void CreateSequentialPointRestriction(Ceed ceed, std::size_t num_elem, int nq, int num_comp,
+                                      CeedSize l_size, CeedElemRestriction *restr)
+{
+  const CeedInt total_pts = static_cast<CeedInt>(num_elem * nq);
+  std::vector<CeedInt> offsets(num_elem + 1 + total_pts);
+  for (std::size_t e = 0; e <= num_elem; e++)
+  {
+    offsets[e] = static_cast<CeedInt>(num_elem + 1 + e * nq);
+  }
+  for (CeedInt i = 0; i < total_pts; i++)
+  {
+    offsets[num_elem + 1 + i] = i;
+  }
+  PalaceCeedCall(ceed, CeedElemRestrictionCreateAtPoints(
+                           ceed, static_cast<CeedInt>(num_elem), total_pts, num_comp,
+                           l_size, CEED_MEM_HOST, CEED_COPY_VALUES, offsets.data(), restr));
+}
+
+}  // namespace
+
+FaceNbrFieldExchange::FaceNbrFieldExchange(
+    const Mesh &mesh,
+    const std::array<const mfem::ParFiniteElementSpace *, MaxSources> &fespaces,
+    const std::vector<Request> &requests)
+  : comm(mesh.GetComm())
+{
+  const mfem::ParMesh &pmesh = mesh.Get();
+  const int num_nbr = pmesh.GetNFaceNeighbors();
+  const int mesh_dim = pmesh.Dimension();
+  const int space_dim = pmesh.SpaceDimension();
+  MFEM_VERIFY((mesh_dim == 2 || mesh_dim == 3) && (space_dim == 2 || space_dim == 3),
+              "FaceNbrFieldExchange requires a 2D or 3D mesh and physical space!");
+  source_num_comp.fill(0);
+  for (int s = 0; s < MaxSources; s++)
+  {
+    if (fespaces[s])
+    {
+      source_num_comp[s] = FieldValueDim(*fespaces[s], space_dim);
+    }
+  }
+  MFEM_VERIFY(requests.empty() || num_nbr > 0,
+              "FaceNbrFieldExchange requires face neighbor data "
+              "(ParMesh::ExchangeFaceNbrData)!");
+
+  // Route each request to its face neighbor process: ghost element index fn falls in
+  // the contiguous block [offset[i], offset[i+1]) of face neighbor i, and the ghost at
+  // position p = fn - offset[i] of the block is the element at position p of the
+  // neighbor's send_face_nbr_elements row for this process. This is the same
+  // correspondence ParMesh::ExchangeFaceNbrData (and the face neighbor dof data of
+  // ParFiniteElementSpace) relies on, for both conformal and nonconforming meshes.
+  const auto &elem_offsets = pmesh.face_nbr_elements_offset;
+  std::vector<std::vector<int>> nbr_reqs(num_nbr);
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const auto &req = requests[r];
+    MFEM_VERIFY(req.face_nbr_elem >= 0 &&
+                    req.face_nbr_elem < pmesh.GetNFaceNeighborElements() &&
+                    req.source_mask != 0 && !req.pts.empty(),
+                "Invalid face neighbor field exchange request!");
+    const int *it =
+        std::upper_bound(elem_offsets.begin(), elem_offsets.end(), req.face_nbr_elem);
+    nbr_reqs[static_cast<int>(it - elem_offsets.begin()) - 1].push_back(
+        static_cast<int>(r));
+  }
+
+  // Serialize the requests per neighbor (as doubles: position in the neighbor's send
+  // element list, number of points, source mask, integer point-key length and entries,
+  // then the point coordinates), and assign the import offsets (per neighbor, in
+  // request construction order, source slots in ascending order; the serving process
+  // lays out the reply values in exactly
+  // this order).
+  import_offsets.resize(requests.size());
+  for (auto &offsets : import_offsets)
+  {
+    offsets.fill(-1);
+  }
+  std::vector<std::vector<double>> send_payload(num_nbr);
+  int import_size = 0;
+  for (int i = 0; i < num_nbr; i++)
+  {
+    if (nbr_reqs[i].empty())
+    {
+      continue;
+    }
+    auto &payload = send_payload[i];
+    const int block_start = import_size;
+    for (const int r : nbr_reqs[i])
+    {
+      const auto &req = requests[r];
+      const int nq = static_cast<int>(req.pts.size());
+      payload.push_back(static_cast<double>(req.face_nbr_elem - elem_offsets[i]));
+      payload.push_back(static_cast<double>(nq));
+      payload.push_back(static_cast<double>(req.source_mask));
+      payload.push_back(static_cast<double>(req.point_key.size()));
+      for (auto v : req.point_key)
+      {
+        payload.push_back(static_cast<double>(v));
+      }
+      for (const auto &ip : req.pts)
+      {
+        payload.push_back(ip.x);
+        payload.push_back(ip.y);
+        payload.push_back(ip.z);
+      }
+      for (int s = 0; s < MaxSources; s++)
+      {
+        if (req.source_mask & (1u << s))
+        {
+          MFEM_VERIFY(fespaces[s],
+                      "Missing finite element space for requested source slot!");
+          import_offsets[r][s] = import_size;
+          import_size += source_num_comp[s] * nq;
+        }
+      }
+    }
+    recv_msgs.push_back({pmesh.GetFaceNbrRank(i), block_start, import_size - block_start});
+  }
+
+  // Symmetric setup exchange with all face neighbors (every pair exchanges, possibly
+  // empty): payload sizes, then the payloads.
+  std::vector<int> send_len(num_nbr), recv_len(num_nbr);
+  {
+    std::vector<MPI_Request> mpi_reqs(2 * num_nbr);
+    for (int i = 0; i < num_nbr; i++)
+    {
+      send_len[i] = static_cast<int>(send_payload[i].size());
+      MPI_Irecv(&recv_len[i], 1, MPI_INT, pmesh.GetFaceNbrRank(i), TAG_SETUP_SIZE, comm,
+                &mpi_reqs[2 * i]);
+      MPI_Isend(&send_len[i], 1, MPI_INT, pmesh.GetFaceNbrRank(i), TAG_SETUP_SIZE, comm,
+                &mpi_reqs[2 * i + 1]);
+    }
+    MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+  }
+  std::vector<std::vector<double>> recv_payload(num_nbr);
+  {
+    std::vector<MPI_Request> mpi_reqs;
+    mpi_reqs.reserve(2 * num_nbr);
+    for (int i = 0; i < num_nbr; i++)
+    {
+      if (recv_len[i] > 0)
+      {
+        recv_payload[i].resize(recv_len[i]);
+        MPI_Irecv(recv_payload[i].data(), recv_len[i], MPI_DOUBLE, pmesh.GetFaceNbrRank(i),
+                  TAG_SETUP_PAYLOAD, comm, &mpi_reqs.emplace_back());
+      }
+      if (send_len[i] > 0)
+      {
+        MPI_Isend(send_payload[i].data(), send_len[i], MPI_DOUBLE, pmesh.GetFaceNbrRank(i),
+                  TAG_SETUP_PAYLOAD, comm, &mpi_reqs.emplace_back());
+      }
+    }
+    MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+  }
+
+  Ceed ceed = ceed::internal::GetCeedObjects()[0];
+  const bool use_at_points = CeedSupportsNonTensorAtPoints(ceed);
+
+  // Parse the received requests, assigning export offsets with the same layout rules
+  // as the import offsets above. On AtPoints-capable libCEED backends, simplex export
+  // evaluators use runtime point coordinates so requests with the same
+  // source/geometry/point count can share one operator even when their finite NC trace
+  // maps differ. Other backends keep the mapped-integration-rule grouping by
+  // integer/topological point-key data; empty keys use exact serialized point bits.
+  struct ExportGroup
+  {
+    bool at_points = false;
+    std::vector<mfem::IntegrationPoint> pts;  // Representative IR or concatenated AtPoints
+    std::vector<int> elems;
+    std::vector<int> bases;  // Export vector base offset per element entry
+  };
+  std::map<PointConfigKey, ExportGroup> export_map;
+  int export_size = 0;
+  for (int i = 0; i < num_nbr; i++)
+  {
+    const auto &payload = recv_payload[i];
+    const int block_start = export_size;
+    std::size_t k = 0;
+    while (k < payload.size())
+    {
+      const int p = static_cast<int>(std::llround(payload[k++]));
+      const int nq = static_cast<int>(std::llround(payload[k++]));
+      const auto mask = static_cast<unsigned int>(std::llround(payload[k++]));
+      const int point_key_size = static_cast<int>(std::llround(payload[k++]));
+      MFEM_VERIFY(point_key_size >= 0,
+                  "Invalid face neighbor point-key size in received field exchange "
+                  "request!");
+      std::vector<long long> point_key(point_key_size);
+      for (int q = 0; q < point_key_size; q++)
+      {
+        point_key[q] = std::llround(payload[k++]);
+      }
+      MFEM_VERIFY(p >= 0 && p < pmesh.send_face_nbr_elements.RowSize(i),
+                  "Invalid face neighbor element position in received field exchange "
+                  "request!");
+      const int elem = pmesh.send_face_nbr_elements.GetRow(i)[p];
+      std::vector<mfem::IntegrationPoint> pts(nq);
+      for (int q = 0; q < nq; q++)
+      {
+        pts[q].Set3(payload[k], payload[k + 1], payload[k + 2]);
+        pts[q].weight = 1.0;
+        k += 3;
+      }
+      const auto geom = pmesh.GetElementGeometry(elem);
+      for (int s = 0; s < MaxSources; s++)
+      {
+        if (mask & (1u << s))
+        {
+          MFEM_VERIFY(fespaces[s],
+                      "Missing finite element space for received source slot!");
+          const bool at_points_group =
+              use_at_points &&
+              (geom == mfem::Geometry::TRIANGLE || geom == mfem::Geometry::TETRAHEDRON);
+          PointConfigKey key;
+          key.reserve(5 + point_key.size() + (point_key.empty() ? 3 * pts.size() : 0));
+          key.push_back(s);
+          key.push_back(static_cast<long long>(geom));
+          key.push_back(nq);
+          key.push_back(static_cast<long long>(at_points_group));
+          if (!at_points_group)
+          {
+            key.push_back(point_key.empty() ? 0 : 1);
+            if (point_key.empty())
+            {
+              // Ad-hoc requests have no topological key. Use the exact serialized point
+              // bits so distinct requests cannot alias in the application-lifetime rule
+              // registry, while repeated identical requests still reuse their rule.
+              for (const auto &ip : pts)
+              {
+                key.push_back(EncodePointCoordinate(ip.x));
+                key.push_back(EncodePointCoordinate(ip.y));
+                key.push_back(EncodePointCoordinate(ip.z));
+              }
+            }
+            else
+            {
+              key.insert(key.end(), point_key.begin(), point_key.end());
+            }
+          }
+          auto &group = export_map[key];
+          group.at_points = at_points_group;
+          if (at_points_group)
+          {
+            group.pts.insert(group.pts.end(), pts.begin(), pts.end());
+          }
+          else if (group.pts.empty())
+          {
+            group.pts = pts;
+          }
+          group.elems.push_back(elem);
+          group.bases.push_back(export_size);
+          export_size += source_num_comp[s] * nq;
+        }
+      }
+    }
+    if (export_size > block_start)
+    {
+      send_msgs.push_back(
+          {pmesh.GetFaceNbrRank(i), block_start, export_size - block_start});
+    }
+  }
+
+  imported.SetSize(import_size);
+  imported.UseDevice(true);
+  imported = 0.0;
+  exported.SetSize(export_size);
+  exported.UseDevice(true);
+  if (export_size == 0)
+  {
+    return;
+  }
+
+  // Assemble a libCEED point evaluator for each export group, writing point-major
+  // values into the exported vector at the assigned offsets. H(curl)/H(div) sources are
+  // physical-space vectors; VALUE sources are scalar fields.
+  int max_vsize = 0;
+  for (const auto *fespace : fespaces)
+  {
+    max_vsize = std::max(max_vsize, fespace ? fespace->GetVSize() : 0);
+  }
+  field_staging.SetSize(max_vsize);
+  field_staging.UseDevice(true);
+  field_staging = 0.0;
+  const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
+  for (const auto &[key, group] : export_map)
+  {
+    const int s = static_cast<int>(key[0]);
+    const auto geom = static_cast<mfem::Geometry::Type>(key[1]);
+    const int nq = static_cast<int>(key[2]);
+    const int value_dim = source_num_comp[s];
+    const std::size_t num_elem = group.elems.size();
+    const auto &fespace = *fespaces[s];
+    MFEM_VERIFY(!group.at_points ||
+                    group.pts.size() == num_elem * static_cast<std::size_t>(nq),
+                "Invalid AtPoints export point layout for face neighbor exchange!");
+    const mfem::IntegrationRule *ir =
+        group.at_points ? nullptr : GetRegisteredIr(key, group.pts);
+
+    // Inputs: mesh node gradients (on-the-fly geometry for the Piola transformations)
+    // and the field, both evaluated at the points.
+    std::vector<ceed::CeedFunctionalFieldInput> inputs;
+    std::vector<std::pair<std::string, int>> field_sources;
+    CeedElemRestriction points_restr = nullptr;
+    CeedVector points_vec = nullptr;
+    if (group.at_points)
+    {
+      // libCEED's AtPoints coordinates have the basis's topological dimension, not the
+      // fixed three-component layout used to serialize IntegrationPoint requests.
+      auto &points = export_attrs.emplace_back(mesh_dim * num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int q = 0; q < nq; q++)
+        {
+          const auto &ip = group.pts[e * nq + q];
+          const std::size_t off = mesh_dim * (e * nq + q);
+          points[off + 0] = ip.x;
+          points[off + 1] = ip.y;
+          if (mesh_dim == 3)
+          {
+            points[off + 2] = ip.z;
+          }
+        }
+      }
+      CreateSequentialPointRestriction(ceed, num_elem, nq, mesh_dim, points.Size(),
+                                       &points_restr);
+      ceed::InitCeedVector(points, ceed, &points_vec);
+    }
+    CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+        mesh_fespace, ceed, geom, group.elems, /*is_interp*/ true);
+    const mfem::FiniteElement *mesh_fe =
+        mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+    CeedBasis mesh_basis;
+    if (group.at_points)
+    {
+      ceed::InitSimplexBasisAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(),
+                                     ceed, &mesh_basis);
+    }
+    else
+    {
+      ceed::InitBasisAtPoints(*mesh_fe, *ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+    }
+    CeedVector mesh_nodes_vec;
+    ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+    inputs.push_back({"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+    CeedElemRestriction field_restr;
+    ceed::InitRestriction(fespace, group.elems, false, /*is_interp*/ true, false, ceed,
+                          &field_restr);
+    const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+    MFEM_VERIFY(fe, "Unable to get field finite element for face neighbor exchange!");
+    CeedBasis field_basis;
+    if (group.at_points)
+    {
+      ceed::InitSimplexBasisAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
+                                     &field_basis);
+    }
+    else
+    {
+      ceed::InitBasisAtPoints(*fe, *ir, fespace.GetVDim(), ceed, &field_basis);
+    }
+    CeedVector field_vec;
+    ceed::InitCeedVector(field_staging, ceed, &field_vec);
+    inputs.push_back({"u_1", field_vec, field_restr, field_basis, ceed::EvalMode::Interp});
+    field_sources.emplace_back("u_1", s);
+
+    // Output restriction: one physical-space vector per point at the assigned export
+    // offsets.
+    std::vector<CeedInt> offsets(num_elem * nq);
+    for (std::size_t e = 0; e < num_elem; e++)
+    {
+      for (int j = 0; j < nq; j++)
+      {
+        offsets[e * nq + j] = group.bases[e] + value_dim * j;
+      }
+    }
+    CeedElemRestriction out_restr;
+    PalaceCeedCall(ceed, CeedElemRestrictionCreate(ceed, static_cast<CeedInt>(num_elem), nq,
+                                                   value_dim, 1, (CeedSize)export_size,
+                                                   CEED_MEM_HOST, CEED_COPY_VALUES,
+                                                   offsets.data(), &out_restr));
+
+    // The reply contains physical-space field values for Piola-mapped spaces, and scalar
+    // values for H1/L2 spaces. The requester needs no neighbor element geometry.
+    const auto map_type = fespace.FEColl()->GetMapType(pmesh.Dimension());
+    ceed::CeedQFunctionInfo info;
+    if (map_type == mfem::FiniteElement::VALUE)
+    {
+      MFEM_VERIFY(value_dim == 1, "Scalar face neighbor fields must have one component!");
+      if (space_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_l2_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_l2_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_l2_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_l2_33_loc);
+      }
+    }
+    else if (map_type == mfem::FiniteElement::INTEGRAL)
+    {
+      MFEM_VERIFY(space_dim == 2 && value_dim == 1,
+                  "Only scalar 2D INTEGRAL face neighbor fields are supported!");
+      info.apply_qf = f_eval_probe_integral_22;
+      info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_integral_22_loc);
+    }
+    else if (map_type == mfem::FiniteElement::H_CURL)
+    {
+      if (space_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_hcurl_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_hcurl_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+      }
+    }
+    else if (map_type == mfem::FiniteElement::H_DIV)
+    {
+      if (space_dim == 2)
+      {
+        info.apply_qf = f_eval_probe_hdiv_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_22_loc);
+      }
+      else
+      {
+        info.apply_qf = f_eval_probe_hdiv_33;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+      }
+    }
+    else
+    {
+      MFEM_ABORT("Unsupported face neighbor field map type!");
+    }
+    CeedOperator op;
+    if (group.at_points)
+    {
+      ceed::AssembleCeedPointEvaluatorAtPoints(info, nullptr, 0, ceed, inputs, points_restr,
+                                               points_vec, value_dim, out_restr, &op);
+    }
+    else
+    {
+      ceed::AssembleCeedPointEvaluator(info, nullptr, 0, ceed, inputs, value_dim, out_restr,
+                                       &op);
+    }
+    export_groups.push_back({ceed, op, std::move(field_sources)});
+    export_groups.back().mesh_nodes = pmesh.GetNodes();
+    export_groups.back().mesh_node_fields = {"grad_x"};
+    fem::CacheGroupOperatorFieldVectors(export_groups.back());
+
+    // Cleanup (the assembled operator holds its own references).
+    if (points_vec)
+    {
+      PalaceCeedCall(ceed, CeedVectorDestroy(&points_vec));
+    }
+    if (points_restr)
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&points_restr));
+    }
+    PalaceCeedCall(ceed, CeedVectorDestroy(&mesh_nodes_vec));
+    PalaceCeedCall(ceed, CeedVectorDestroy(&field_vec));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&mesh_restr));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&field_restr));
+    PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&out_restr));
+    PalaceCeedCall(ceed, CeedBasisDestroy(&mesh_basis));
+    PalaceCeedCall(ceed, CeedBasisDestroy(&field_basis));
+  }
+
+  // Export operators cache their passive field-vector handles and re-point them on each
+  // exchange. Detach the borrowed arrays before releasing the construction buffer, which
+  // would otherwise add another full device FE vector to every boundary evaluator.
+  DetachFieldVectors();
+  field_staging.Destroy();
+  MFEM_ASSERT(field_staging.Capacity() == 0,
+              "Face-neighbor staging allocation was not released!");
+}
+
+FaceNbrFieldExchange::~FaceNbrFieldExchange()
+{
+  fem::DestroyGroupOperators(export_groups);
+}
+
+void FaceNbrFieldExchange::DetachFieldVectors() const
+{
+  fem::DetachGroupOperatorFieldVectors(export_groups);
+}
+
+void FaceNbrFieldExchange::Exchange(
+    const std::array<const Vector *, MaxSources> &srcs) const
+{
+  // Evaluate the values requested by the neighbors (on the device).
+  if (exported.Size() > 0)
+  {
+    exported = 0.0;
+    fem::ApplyAddGroupOperators(export_groups, srcs, exported);
+  }
+  if (recv_msgs.empty() && send_msgs.empty())
+  {
+    return;
+  }
+
+  // Exchange: receive directly into the imported vector (contiguous per neighbor by
+  // construction), send directly from the exported vector.
+  std::vector<MPI_Request> mpi_reqs;
+  mpi_reqs.reserve(recv_msgs.size() + send_msgs.size());
+  double *dst = (imported.Size() > 0) ? imported.HostWrite() : nullptr;
+  for (const auto &msg : recv_msgs)
+  {
+    MPI_Irecv(dst + msg.start, msg.size, MPI_DOUBLE, msg.rank, TAG_EVAL, comm,
+              &mpi_reqs.emplace_back());
+  }
+  const double *src = (exported.Size() > 0) ? exported.HostRead() : nullptr;
+  for (const auto &msg : send_msgs)
+  {
+    MPI_Isend(src + msg.start, msg.size, MPI_DOUBLE, msg.rank, TAG_EVAL, comm,
+              &mpi_reqs.emplace_back());
+  }
+  MPI_Waitall(static_cast<int>(mpi_reqs.size()), mpi_reqs.data(), MPI_STATUSES_IGNORE);
+}
+
+}  // namespace palace

--- a/palace/fem/facenbrexchange.hpp
+++ b/palace/fem/facenbrexchange.hpp
@@ -1,0 +1,147 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_FACE_NBR_EXCHANGE_HPP
+#define PALACE_FEM_FACE_NBR_EXCHANGE_HPP
+
+#include <array>
+#include <deque>
+#include <vector>
+#include <mfem.hpp>
+#include "fem/ceed_group_operator.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+class Mesh;
+
+//
+// Exchanges field values evaluated at prescribed reference points of face neighbor
+// (ghost) elements between processes. This enables pointwise libCEED consumers to
+// evaluate two-sided data on interior boundaries crossing parallel interfaces
+// without exchanging field dofs (the legacy approach of
+// ParGridFunction::ExchangeFaceNbrData): each process posts requests against ghost
+// elements (by face neighbor index, with evaluation points in the neighbor element's
+// reference space, e.g. mapped through FaceElementTransformations::Loc2). At setup, the
+// requests are routed to the owning processes through the pairwise face neighbor
+// communication structure of the ParMesh (the same correspondence
+// ParMesh::ExchangeFaceNbrData relies on, valid for conformal and nonconforming
+// meshes). At evaluation, the owning process evaluates the requested fields at the
+// points with libCEED point evaluators (on the device) and replies with physical-space
+// field values (Piola transformations applied by the evaluating process for H(curl) and
+// H(div) sources, scalar VALUE/INTEGRAL sources copied directly), so the requester needs
+// no neighbor element geometry; material properties are applied by the requester using
+// the ghost element attributes).
+//
+class FaceNbrFieldExchange
+{
+public:
+  // Number of source field slots matching the caller-provided source vectors.
+  static constexpr int MaxSources = 4;
+
+  struct Request
+  {
+    // Face neighbor (ghost) element index, in [0, ParMesh::GetNFaceNeighborElements()),
+    // e.g. FaceElementTransformations::Elem2No - ParMesh::GetNE() for a shared
+    // interior face.
+    int face_nbr_elem;
+
+    // Bitmask over the source field slots to evaluate (bit s set: source slot s).
+    unsigned int source_mask;
+
+    // Integer/topological identity of the point set, independent of physical or
+    // floating-point coordinates. Callers fill this with the topology, orientation,
+    // and subface key used to generate pts. Requests with the same
+    // point_key, source slot, element geometry, and point count can share one libCEED
+    // point evaluator. Empty keys are allowed for ad-hoc requests and force a unique
+    // evaluator group.
+    std::vector<long long> point_key;
+
+    // Evaluation points in the neighbor element's reference space (the ghost element
+    // reference space coincides with the owning process' local element reference
+    // space, as the ghost elements preserve the neighbor's vertex ordering). These
+    // coordinates are used only to evaluate the requested points, not to decide point
+    // identity/grouping.
+    std::vector<mfem::IntegrationPoint> pts;
+  };
+
+private:
+  MPI_Comm comm;
+
+  // Pairwise evaluation-time messages with face neighbor ranks. Receives fill
+  // [start, start + size) of the imported vector; sends read [start, start + size) of
+  // the exported vector (both contiguous per neighbor by construction).
+  struct Message
+  {
+    int rank;
+    int start, size;
+  };
+  std::vector<Message> recv_msgs, send_msgs;
+
+  // Number of imported components for each source slot. H(curl)/H(div) fields use the
+  // mesh space dimension; scalar VALUE/INTEGRAL fields use one component.
+  std::array<int, MaxSources> source_num_comp;
+
+  // For request r (construction order), base offset of the values for source slot s in
+  // the imported vector (-1 when not requested). Values are point-major with
+  // source_num_comp[s] components per point.
+  std::vector<std::array<int, MaxSources>> import_offsets;
+
+  // Assembled libCEED point evaluators serving the requests of neighboring processes,
+  // writing into the exported vector.
+  std::vector<fem::CeedGroupOperator> export_groups;
+
+  // Staging vector used to initialize the field input CeedVectors at construction (the
+  // field CeedVectors are re-pointed at the caller's data on each Exchange() call), and
+  // the exported / imported value vectors. export_attrs holds persistent AtPoints
+  // coordinate buffers referenced by export operators.
+  mutable Vector field_staging, exported, imported;
+  std::deque<Vector> export_attrs;
+
+public:
+  // Construct the exchange for the given requests against ghost elements of the mesh.
+  // fespaces[s] provides the evaluation space for source slot s (may be nullptr for
+  // unused slots; all processes must pass the same spaces). Collective on the mesh
+  // communicator: the requests are routed to the owning processes following the face
+  // neighbor communication structure of ParMesh::ExchangeFaceNbrData (which must have
+  // been called for the mesh already, see fem/mesh.cpp).
+  FaceNbrFieldExchange(
+      const Mesh &mesh,
+      const std::array<const mfem::ParFiniteElementSpace *, MaxSources> &fespaces,
+      const std::vector<Request> &requests);
+  ~FaceNbrFieldExchange();
+
+  FaceNbrFieldExchange(const FaceNbrFieldExchange &) = delete;
+  FaceNbrFieldExchange &operator=(const FaceNbrFieldExchange &) = delete;
+
+  // Size of the imported values vector.
+  int ImportSize() const { return imported.Size(); }
+
+  // Number of point-major components imported for source slot s.
+  int ImportNumComp(int s) const { return source_num_comp[s]; }
+
+  // Base offset in the imported vector of the values of source slot s for request r
+  // (construction order), or -1 when source s was not requested. Layout per request
+  // and source: ImportNumComp(s) components per point, point-major.
+  int ImportOffset(int r, int s) const { return import_offsets[r][s]; }
+
+  // The imported values vector (filled by Exchange()).
+  const Vector &Imported() const { return imported; }
+
+  // Detach borrowed source arrays from the export operators before caller-owned warm-up
+  // storage is released. The next Exchange() reattaches its source arrays directly.
+  void DetachFieldVectors() const;
+
+  // Evaluate the exported field values for the neighbors' requests from the given
+  // source vectors (L-vectors of the corresponding source spaces), exchange with the
+  // face neighbor processes, and fill the imported vector with this process' requested
+  // values. All processes must call in the same order with the corresponding sources
+  // (point-to-point communication with the face neighbor ranks; processes with no
+  // requests and no exports perform no communication).
+  void Exchange(const std::array<const Vector *, MaxSources> &srcs) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_FACE_NBR_EXCHANGE_HPP

--- a/palace/fem/libceed/basis.cpp
+++ b/palace/fem/libceed/basis.cpp
@@ -3,6 +3,9 @@
 
 #include "basis.hpp"
 
+#include <map>
+#include <memory>
+#include <mutex>
 #include <mfem.hpp>
 #include "utils/diagnostic.hpp"
 
@@ -11,6 +14,78 @@ namespace palace::ceed
 
 namespace
 {
+
+int SimplexNumModes(mfem::Geometry::Type geom, int degree)
+{
+  if (geom == mfem::Geometry::TRIANGLE)
+  {
+    return (degree + 1) * (degree + 2) / 2;
+  }
+  MFEM_VERIFY(geom == mfem::Geometry::TETRAHEDRON,
+              "AtPoints lattice requested for a non-simplex element!");
+  return (degree + 1) * (degree + 2) * (degree + 3) / 6;
+}
+
+const mfem::IntegrationRule &GetRegisteredSimplexLatticeRule(mfem::Geometry::Type geom,
+                                                             int degree)
+{
+  using RuleKey = std::pair<int, int>;
+  static std::map<RuleKey, std::unique_ptr<mfem::IntegrationRule>> registry;
+  static std::mutex registry_mutex;
+  const RuleKey key{static_cast<int>(geom), degree};
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  auto it = registry.find(key);
+  if (it == registry.end())
+  {
+    auto ir = std::make_unique<mfem::IntegrationRule>(SimplexNumModes(geom, degree));
+    int q = 0;
+    if (degree == 0)
+    {
+      if (geom == mfem::Geometry::TRIANGLE)
+      {
+        ir->IntPoint(q).Set2(1.0 / 3.0, 1.0 / 3.0);
+      }
+      else
+      {
+        ir->IntPoint(q).Set3(0.25, 0.25, 0.25);
+      }
+      ir->IntPoint(q++).weight = 1.0;
+    }
+    else if (geom == mfem::Geometry::TRIANGLE)
+    {
+      for (int total = 0; total <= degree; total++)
+      {
+        for (int i = 0; i <= total; i++)
+        {
+          const int j = total - i;
+          ir->IntPoint(q).Set2(static_cast<double>(i) / degree,
+                               static_cast<double>(j) / degree);
+          ir->IntPoint(q++).weight = 1.0;
+        }
+      }
+    }
+    else
+    {
+      for (int total = 0; total <= degree; total++)
+      {
+        for (int i = 0; i <= total; i++)
+        {
+          for (int j = 0; j <= total - i; j++)
+          {
+            const int k = total - i - j;
+            ir->IntPoint(q).Set3(static_cast<double>(i) / degree,
+                                 static_cast<double>(j) / degree,
+                                 static_cast<double>(k) / degree);
+            ir->IntPoint(q++).weight = 1.0;
+          }
+        }
+      }
+    }
+    MFEM_ASSERT(q == ir->GetNPoints(), "Invalid simplex lattice rule size!");
+    it = registry.emplace(key, std::move(ir)).first;
+  }
+  return *it->second;
+}
 
 void InitTensorBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
                      CeedInt num_comp, Ceed ceed, CeedBasis *basis)
@@ -197,6 +272,29 @@ void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRul
   // corresponding element restriction must use native dof ordering. The caller must
   // keep ir alive while the finite element can retain its pointer-keyed DofToQuad cache.
   InitNonTensorBasis(fe, ir, num_comp, ceed, basis);
+}
+
+void InitSimplexBasisAtPoints(const mfem::FiniteElement &fe, bool grad_only,
+                              CeedInt num_comp, Ceed ceed, CeedBasis *basis)
+{
+  const auto geom = fe.GetGeomType();
+  MFEM_VERIFY(geom == mfem::Geometry::TRIANGLE || geom == mfem::Geometry::TETRAHEDRON,
+              "Simplex AtPoints basis requested for a non-simplex element!");
+  // MAGMA's non-tensor AtPoints basis construction requires tabulation points that
+  // overdetermine the complete polynomial space. One extra lattice degree provides a
+  // deterministic overdetermined reconstruction. The registered rule has application
+  // lifetime to satisfy MFEM's pointer-keyed DofToQuad cache.
+  const int degree = std::max(0, fe.GetOrder() - (grad_only ? 1 : 0) + 1);
+  InitBasisAtPoints(fe, GetRegisteredSimplexLatticeRule(geom, degree), num_comp, ceed,
+                    basis);
+}
+
+void InitTetBasisAtPoints(const mfem::FiniteElement &fe, bool grad_only, CeedInt num_comp,
+                          Ceed ceed, CeedBasis *basis)
+{
+  MFEM_VERIFY(fe.GetGeomType() == mfem::Geometry::TETRAHEDRON,
+              "Tetrahedral AtPoints basis requested for a non-tetrahedral element!");
+  InitSimplexBasisAtPoints(fe, grad_only, num_comp, ceed, basis);
 }
 
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,

--- a/palace/fem/libceed/basis.hpp
+++ b/palace/fem/libceed/basis.hpp
@@ -28,6 +28,16 @@ void InitBasis(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir, i
 void InitBasisAtPoints(const mfem::FiniteElement &fe, const mfem::IntegrationRule &ir,
                        int num_comp, Ceed ceed, CeedBasis *basis);
 
+// Initialize a simplex AtPoints basis using an overdetermined polynomial lattice. The
+// registered lattice rules have application lifetime because MFEM caches DofToQuad
+// tabulations by IntegrationRule pointer inside shared finite elements.
+void InitSimplexBasisAtPoints(const mfem::FiniteElement &fe, bool grad_only, int num_comp,
+                              Ceed ceed, CeedBasis *basis);
+
+// Compatibility wrapper for three-dimensional callers.
+void InitTetBasisAtPoints(const mfem::FiniteElement &fe, bool grad_only, int num_comp,
+                          Ceed ceed, CeedBasis *basis);
+
 void InitInterpolatorBasis(const mfem::FiniteElement &trial_fe,
                            const mfem::FiniteElement &test_fe, int trial_num_comp,
                            int test_num_comp, Ceed ceed, CeedBasis *basis);

--- a/palace/fem/libceed/functional.cpp
+++ b/palace/fem/libceed/functional.cpp
@@ -135,4 +135,28 @@ void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
   PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
 }
 
+void AssembleCeedPointEvaluatorAtPoints(const CeedQFunctionInfo &info, void *ctx,
+                                        std::size_t ctx_size, Ceed ceed,
+                                        const std::vector<CeedFunctionalFieldInput> &inputs,
+                                        CeedElemRestriction points_restr,
+                                        CeedVector points_vec, CeedInt num_out_comp,
+                                        CeedElemRestriction out_restr, CeedOperator *op)
+{
+  CeedQFunction apply_qf;
+  CreatePointEvaluatorQFunction(info, ctx, ctx_size, ceed, inputs, num_out_comp, &apply_qf);
+
+  PalaceCeedCall(ceed, CeedOperatorCreateAtPoints(ceed, apply_qf, nullptr, nullptr, op));
+  PalaceCeedCall(ceed, CeedQFunctionDestroy(&apply_qf));
+
+  for (const auto &input : inputs)
+  {
+    AddOperatorFieldInput(input, ceed, *op);
+  }
+  PalaceCeedCall(
+      ceed, CeedOperatorSetField(*op, "v", out_restr, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+  PalaceCeedCall(ceed, CeedOperatorAtPointsSetPoints(*op, points_restr, points_vec));
+
+  PalaceCeedCall(ceed, CeedOperatorCheckReady(*op));
+}
+
 }  // namespace palace::ceed

--- a/palace/fem/libceed/functional.hpp
+++ b/palace/fem/libceed/functional.hpp
@@ -47,6 +47,17 @@ void AssembleCeedPointEvaluator(const CeedQFunctionInfo &info, void *ctx,
                                 CeedInt num_out_comp, CeedElemRestriction out_restr,
                                 CeedOperator *op);
 
+// Variant of AssembleCeedPointEvaluator for libCEED AtPoints operators: basis inputs
+// are evaluated at runtime reference coordinates described by points_restr/points_vec,
+// while CEED_EVAL_NONE inputs/outputs use point restrictions compatible with
+// points_restr. This keeps arbitrary mapped face points out of the basis/JIT key.
+void AssembleCeedPointEvaluatorAtPoints(const CeedQFunctionInfo &info, void *ctx,
+                                        std::size_t ctx_size, Ceed ceed,
+                                        const std::vector<CeedFunctionalFieldInput> &inputs,
+                                        CeedElemRestriction points_restr,
+                                        CeedVector points_vec, CeedInt num_out_comp,
+                                        CeedElemRestriction out_restr, CeedOperator *op);
+
 }  // namespace palace::ceed
 
 #endif  // PALACE_LIBCEED_FUNCTIONAL_HPP

--- a/palace/fem/qfunctions/22/eval_22_qf.h
+++ b/palace/fem/qfunctions/22/eval_22_qf.h
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_LIBCEED_EVAL_22_QF_H
+#define PALACE_LIBCEED_EVAL_22_QF_H
+
+#include "utils_22_qf.h"
+
+// QFunctions for pointwise evaluation at arbitrary points of 2D volume elements.
+
+CEED_QFUNCTION(f_eval_probe_hcurl_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, u_loc, E);
+    v[i + Q * 0] = E[0] / detJ;
+    v[i + Q * 1] = E[1] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise scalar L2 field value. Inputs: grad_x, u. The geometry input is unused but
+// kept so this probe has the same field list as the vector-valued domain probes.
+CEED_QFUNCTION(f_eval_probe_l2_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                   CeedScalar *const *out)
+{
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = u[i];
+  }
+  return 0;
+}
+
+// Pointwise scalar INTEGRAL field value: v = u / |detJ|. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_integral_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = IntegralMap22(i, Q, J, u);
+  }
+  return 0;
+}
+
+// Pointwise H(div) field value: v = J/detJ u. Inputs: grad_x, u.
+CEED_QFUNCTION(f_eval_probe_hdiv_22)(void *, CeedInt Q, const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+  const CeedScalar *J = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], B[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = DetJ22(J_loc);
+    MultBx22(J_loc, u_loc, B);
+    v[i + Q * 0] = B[0] / detJ;
+    v[i + Q * 1] = B[1] / detJ;
+  }
+  return 0;
+}
+
+#endif  // PALACE_LIBCEED_EVAL_22_QF_H

--- a/palace/fem/qfunctions/22/utils_22_qf.h
+++ b/palace/fem/qfunctions/22/utils_22_qf.h
@@ -37,6 +37,16 @@ CEED_QFUNCTION_HELPER void MatUnpack22(const CeedScalar *A, const CeedInt A_stri
   A_loc[3] = A[A_stride * 3];
 }
 
+// Map a scalar INTEGRAL finite-element value to physical space. Unlike scalar VALUE
+// elements, INTEGRAL elements transform by the inverse element-transformation weight.
+CEED_QFUNCTION_HELPER CeedScalar IntegralMap22(CeedInt i, CeedInt Q, const CeedScalar *J,
+                                               const CeedScalar *u)
+{
+  CeedScalar J_loc[4];
+  MatUnpack22(J + i, Q, J_loc);
+  return u[i] / fabs(DetJ22(J_loc));
+}
+
 CEED_QFUNCTION_HELPER void MultBx22(const CeedScalar B[4], const CeedScalar x[2],
                                     CeedScalar y[2])
 {

--- a/palace/fem/qfunctions/33/eval_33_qf.h
+++ b/palace/fem/qfunctions/33/eval_33_qf.h
@@ -6,10 +6,8 @@
 
 #include "utils_33_qf.h"
 
-// Pointwise probes at arbitrary reference points of 3D volume elements. No quadrature
-// weighting is applied.
+// QFunctions for pointwise evaluation at arbitrary points of 3D volume elements.
 
-// Pointwise H(curl) field value: v = adj(J)ᵀ/detJ u. Inputs: grad_x, u.
 CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const *in,
                                       CeedScalar *const *out)
 {
@@ -26,6 +24,21 @@ CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const
     v[i + Q * 0] = E[0] / detJ;
     v[i + Q * 1] = E[1] / detJ;
     v[i + Q * 2] = E[2] / detJ;
+  }
+  return 0;
+}
+
+// Pointwise scalar H1/L2 field value. Inputs: grad_x, u. The geometry input is unused
+// but kept so this probe has the same field list as the vector-valued probes.
+CEED_QFUNCTION(f_eval_probe_l2_33)(void *, CeedInt Q, const CeedScalar *const *in,
+                                   CeedScalar *const *out)
+{
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = u[i];
   }
   return 0;
 }

--- a/test/unit/test-pointevaluation.cpp
+++ b/test/unit/test-pointevaluation.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include "fem/facenbrexchange.hpp"
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
 #include "fem/integrator.hpp"
@@ -29,6 +30,47 @@ std::unique_ptr<Mesh> MakeProbeMesh(MPI_Comm comm, mfem::Element::Type elem_type
 {
   mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
   smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+std::unique_ptr<Mesh> MakeFaceExchangeMesh2D(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian2D(2, 2, elem_type);
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+std::unique_ptr<Mesh> MakeFaceExchangeMesh(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
+  smesh.EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
+  auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
+  return std::make_unique<Mesh>(std::move(pmesh));
+}
+
+// Nonconformally refine one half of a Cartesian mesh to exercise ghost
+// master/slave elements without introducing boundary-element fixtures.
+std::unique_ptr<Mesh> MakeNCFaceExchangeMesh(MPI_Comm comm, mfem::Element::Type elem_type)
+{
+  mfem::Mesh smesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, elem_type);
+  smesh.EnsureNodes();
+  smesh.EnsureNCMesh(true);
+  mfem::Array<int> refs;
+  for (int e = 0; e < smesh.GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh.GetElementCenter(e, center);
+    if (center(0) < 0.5)
+    {
+      refs.Append(e);
+    }
+  }
+  smesh.GeneralRefinement(refs, 1);
   REQUIRE(Mpi::Size(comm) <= smesh.GetNE());
   auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
   return std::make_unique<Mesh>(std::move(pmesh));
@@ -135,5 +177,175 @@ TEST_CASE("InterpolationOperator Ceed Probes", "[interpolator][Serial][Parallel]
   CheckProbes(pts_2);
 }
 #endif
+
+TEST_CASE("FaceNbrFieldExchange 2D", "[facenbrexchange][Serial][Parallel]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto mesh = MakeFaceExchangeMesh2D(comm, mfem::Element::TRIANGLE);
+  auto &pmesh = mesh->Get();
+
+  constexpr int order = 2;
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec);
+  mfem::ParGridFunction E(&nd_fespace.Get());
+  mfem::VectorFunctionCoefficient field(2,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = std::sin(x(1)) + 0.25 * x(0);
+                                          v(1) = std::cos(x(0)) + x(0) * x(1);
+                                        });
+  E.ProjectCoefficient(field);
+
+  const int num_ghost = pmesh.GetNFaceNeighborElements();
+  std::vector<FaceNbrFieldExchange::Request> requests;
+  for (int fn = 0; fn < num_ghost; fn++)
+  {
+    auto &req = requests.emplace_back();
+    req.face_nbr_elem = fn;
+    req.source_mask = 0b01u;
+    req.point_key = {mfem::Element::TRIANGLE, order, 3};
+    req.pts.resize(3);
+    req.pts[0].Set2(0.1, 0.2);
+    req.pts[1].Set2(0.2, 0.1);
+    req.pts[2].Set2(0.25, 0.25);
+  }
+  FaceNbrFieldExchange exchange(*mesh, {&nd_fespace.Get(), nullptr, nullptr, nullptr},
+                                requests);
+  exchange.Exchange({&E, nullptr, nullptr, nullptr});
+
+  E.ExchangeFaceNbrData();
+  const double *values = exchange.Imported().HostRead();
+  mfem::Vector ref(2);
+  int num_checked = 0;
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const auto &req = requests[r];
+    const int offset = exchange.ImportOffset(static_cast<int>(r), 0);
+    REQUIRE(offset >= 0);
+    for (std::size_t j = 0; j < req.pts.size(); j++)
+    {
+      E.GetVectorValue(pmesh.GetNE() + req.face_nbr_elem, req.pts[j], ref);
+      for (int c = 0; c < 2; c++)
+      {
+        CAPTURE(r, j, c);
+        CHECK(values[offset + 2 * j + c] == Catch::Approx(ref(c)).margin(1.0e-12));
+        num_checked++;
+      }
+    }
+  }
+  int num_global = num_checked;
+  Mpi::GlobalSum(1, &num_global, comm);
+  CHECK((Mpi::Size(comm) == 1 || num_global > 0));
+}
+
+TEST_CASE("FaceNbrFieldExchange", "[facenbrexchange][Serial][Parallel]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal);
+
+  auto mesh = nonconformal ? MakeNCFaceExchangeMesh(comm, elem_type)
+                           : MakeFaceExchangeMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  mfem::ND_FECollection nd_fec(order, pmesh.Dimension());
+  mfem::RT_FECollection rt_fec(order - 1, pmesh.Dimension());
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  // Project non-trivial smooth fields. The reference values are computed from the same
+  // projected grid functions through the legacy mfem face neighbor dof exchange, so the
+  // comparison is exact up to roundoff (not projection error).
+  mfem::ParGridFunction E(&nd_fespace.Get()), B(&rt_fespace.Get());
+  mfem::VectorFunctionCoefficient fe(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(x(1)) + x(2) * x(2);
+                                       v(1) = std::cos(x(2)) + x(0);
+                                       v(2) = x(0) * x(1) + 1.0;
+                                     });
+  mfem::VectorFunctionCoefficient fb(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) * x(2) - 0.5;
+                                       v(1) = std::sin(x(0)) - x(2);
+                                       v(2) = std::cos(x(1)) + x(0) * x(0);
+                                     });
+  E.ProjectCoefficient(fe);
+  B.ProjectCoefficient(fb);
+
+  // Request E (slot 0) at a few reference points of every ghost element, and both E
+  // and B (slot 1) for every other ghost element (exercising the value layouts). The
+  // points are valid reference coordinates for both tetrahedra and hexahedra.
+  const int num_ghost = pmesh.GetNFaceNeighborElements();
+  std::vector<FaceNbrFieldExchange::Request> requests;
+  for (int fn = 0; fn < num_ghost; fn++)
+  {
+    auto &req = requests.emplace_back();
+    req.face_nbr_elem = fn;
+    req.source_mask = (fn % 2 == 0) ? 0b01u : 0b11u;
+    req.point_key = {static_cast<long long>(elem_type), static_cast<long long>(order), 4};
+    req.pts.resize(4);
+    req.pts[0].Set3(0.1, 0.2, 0.3);
+    req.pts[1].Set3(0.25, 0.25, 0.25);
+    req.pts[2].Set3(0.05, 0.1, 0.7);
+    req.pts[3].Set3(0.3, 0.05, 0.05);
+  }
+  FaceNbrFieldExchange exchange(
+      *mesh, {&nd_fespace.Get(), &rt_fespace.Get(), nullptr, nullptr}, requests);
+  exchange.Exchange({&E, &B, nullptr, nullptr});
+
+  // Reference: evaluate the ghost elements through the legacy dof exchange.
+  E.ExchangeFaceNbrData();
+  B.ExchangeFaceNbrData();
+  std::vector<double> vals(exchange.Imported().HostRead(),
+                           exchange.Imported().HostRead() + exchange.ImportSize());
+  mfem::Vector ref(3);
+  int num_checked = 0;
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const auto &req = requests[r];
+    for (int s = 0; s < 2; s++)
+    {
+      const int offset = exchange.ImportOffset(static_cast<int>(r), s);
+      if (!(req.source_mask & (1u << s)))
+      {
+        CHECK(offset < 0);
+        continue;
+      }
+      const auto &U = (s == 0) ? E : B;
+      for (std::size_t j = 0; j < req.pts.size(); j++)
+      {
+        U.GetVectorValue(pmesh.GetNE() + req.face_nbr_elem, req.pts[j], ref);
+        for (int c = 0; c < 3; c++)
+        {
+          CAPTURE(r, s, j, c);
+          CHECK(vals[offset + 3 * j + c] == Catch::Approx(ref(c)).margin(1.0e-12));
+          num_checked++;
+        }
+      }
+    }
+  }
+  // With more than one process, the partition must produce at least one ghost element
+  // somewhere (the exchange is the point of the test).
+  int num_global = num_checked;
+  Mpi::GlobalSum(1, &num_global, comm);
+  CHECK((Mpi::Size(comm) == 1 || num_global > 0));
+
+  // The field inputs are re-pointed at the sources on each call: scaling the field
+  // scales the exchanged values.
+  E *= 2.0;
+  exchange.Exchange({&E, &B, nullptr, nullptr});
+  const double *vals2 = exchange.Imported().HostRead();
+  for (std::size_t r = 0; r < requests.size(); r++)
+  {
+    const int offset = exchange.ImportOffset(static_cast<int>(r), 0);
+    for (std::size_t j = 0; j < 3 * requests[r].pts.size(); j++)
+    {
+      CHECK(vals2[offset + j] == Catch::Approx(2.0 * vals[offset + j]).margin(1.0e-12));
+    }
+  }
+}
 
 }  // namespace palace


### PR DESCRIPTION
This is **3/10** in the stacked replacement for #824/#825 and depends on [#851](https://github.com/awslabs/palace/pull/851). Please review only the diff against that PR.

This adds variable-point simplex evaluation and `FaceNbrFieldExchange`, which exchanges sampled physical field values instead of face-neighbor DOFs for parallel two-sided consumers.

**Reviewer guidance:** Focus on request routing and the point-major import/export layout in `facenbrexchange.*`, especially all-rank collective participation, source masks, and conforming/nonconforming ghost elements. The libCEED changes are the minimum variable-point support needed by that exchange.

**Deferred:** No physics reduction or boundary-field policy is introduced here.

**Validation:** Face-neighbor tests pass with 18 serial and 2,644 MPI-2 assertions.
