### PR TITLE
Route model postprocessing through libCEED reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Routed surface, port, and far-field postprocessing through device-backed
+    reductions with batched ports and corrected 2D magnetic-energy references.
   - Added libCEED surface reduction functionals for energy, flux, power,
     mode-overlap, and far-field calculations with device-friendly element reductions.
   - Added distributed sampled face-neighbor field exchange for parallel device

--- a/palace/fem/coefficient.hpp
+++ b/palace/fem/coefficient.hpp
@@ -596,18 +596,20 @@ template <>
 inline double EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>::GetLocalEnergyDensity(
     mfem::ElementTransformation &T) const
 {
-  if (T.GetSpaceDim() == 2)
+  if (T.GetSpaceDim() == 2 && U.Real().VectorDim() == 1)
   {
-    // In 2D, B is the scalar out-of-plane component Bz (L2). The magnetic energy density
-    // is 1/2 μ⁻¹_zz |Bz|², matching the integrated domain energy.
+    // In 2D, B is scalar-valued and represents the out-of-plane flux density B_z.
+    // Magnetic energy density is therefore 1/2 * mu^{-1}_{zz} * |B_z|^2, matching
+    // the integrated domain energy.
+    const double invmu_zz = mat_op.GetInvPermeabilityZZ(T.Attribute);
     double Bz = U.Real().GetValue(T, T.GetIntPoint());
-    double dot = Bz * Bz;
+    double dot = invmu_zz * Bz * Bz;
     if (U.HasImag())
     {
       Bz = U.Imag().GetValue(T, T.GetIntPoint());
-      dot += Bz * Bz;
+      dot += invmu_zz * Bz * Bz;
     }
-    return 0.5 * mat_op.GetInvPermeabilityZZ(T.Attribute) * dot * scaling;
+    return 0.5 * dot * scaling;
   }
   double V_data[3];
   mfem::Vector V(V_data, T.GetSpaceDim());

--- a/palace/fem/lumpedelement.hpp
+++ b/palace/fem/lumpedelement.hpp
@@ -49,6 +49,7 @@ public:
 
   double GetGeometryLength() const override { return l; }
   double GetGeometryWidth() const override { return w; }
+  const mfem::Vector &GetDirection() const { return direction; }
 
   std::unique_ptr<mfem::VectorCoefficient>
   GetModeCoefficient(double coeff = 1.0) const override;
@@ -72,6 +73,8 @@ public:
 
   double GetGeometryLength() const override { return std::log(r_outer / r_inner); }
   double GetGeometryWidth() const override { return 2.0 * M_PI; }
+  double GetDirection() const { return direction; }
+  const mfem::Vector &GetOrigin() const { return origin; }
 
   std::unique_ptr<mfem::VectorCoefficient>
   GetModeCoefficient(double coeff = 1.0) const override;

--- a/palace/fem/output_functionals.cpp
+++ b/palace/fem/output_functionals.cpp
@@ -1681,6 +1681,29 @@ double SurfaceFunctional::EvalLocal(const std::array<const Vector *, 4> &srcs) c
   return (local_out.Size() > 0) ? linalg::LocalSum(local_out) : 0.0;
 }
 
+void SurfaceFunctional::BinLocalOutByAttribute(const mfem::Array<int> &attr_to_bin,
+                                               int num_bins, std::vector<double> &bins,
+                                               double scale) const
+{
+  if (local_out.Size() == 0)
+  {
+    return;
+  }
+  MFEM_VERIFY(local_out_attrs.size() == static_cast<std::size_t>(local_out.Size()),
+              "SurfaceFunctional attribute bins require one output slot per element!");
+  const double *vals = local_out.HostRead();
+  for (int i = 0; i < local_out.Size(); i++)
+  {
+    const int attr = local_out_attrs[i];
+    const int bin = (attr > 0 && attr <= attr_to_bin.Size()) ? attr_to_bin[attr - 1] : -1;
+    if (bin >= 0)
+    {
+      MFEM_VERIFY(bin < num_bins, "SurfaceFunctional attribute bin out of range!");
+      bins[bin] += scale * vals[i];
+    }
+  }
+}
+
 double SurfaceFunctional::Eval(const Vector *u) const
 {
   MFEM_VERIFY(kind == KernelKind::AREA || u,
@@ -1730,6 +1753,48 @@ std::complex<double> SurfaceFunctional::EvalModeOverlap(const GridFunction &E) c
   }
   Mpi::GlobalSum(1, &dot, comm);
   return dot;
+}
+
+std::vector<std::complex<double>> SurfaceFunctional::EvalModeOverlapByAttribute(
+    const GridFunction &E, const mfem::Array<int> &attr_to_bin, int num_bins) const
+{
+  MFEM_VERIFY(kind == KernelKind::MODE_OVERLAP,
+              "SurfaceFunctional::EvalModeOverlapByAttribute is only valid for "
+              "mode-overlap functionals!");
+  MFEM_VERIFY(num_bins >= 0, "Invalid number of output bins!");
+  auto AccumulateBins = [&](const Vector &u, std::vector<double> &bins)
+  {
+    if (local_out.Size() > 0)
+    {
+      local_out = 0.0;
+    }
+    // Keep the apply collective even on ranks with no local marked elements, matching
+    // the per-port EvalModeOverlap path and the binned power evaluator.
+    ApplyAdd({&u, nullptr});
+    BinLocalOutByAttribute(attr_to_bin, num_bins, bins, 1.0);
+  };
+
+  std::vector<double> real(num_bins, 0.0), imag(num_bins, 0.0);
+  AccumulateBins(E.Real(), real);
+  if (E.HasImag())
+  {
+    AccumulateBins(E.Imag(), imag);
+  }
+
+  std::vector<double> packed(2 * num_bins, 0.0);
+  for (int i = 0; i < num_bins; i++)
+  {
+    packed[2 * i + 0] = real[i];
+    packed[2 * i + 1] = imag[i];
+  }
+  Mpi::GlobalSum(static_cast<int>(packed.size()), packed.data(), comm);
+
+  std::vector<std::complex<double>> result(num_bins);
+  for (int i = 0; i < num_bins; i++)
+  {
+    result[i] = {packed[2 * i + 0], packed[2 * i + 1]};
+  }
+  return result;
 }
 
 std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
@@ -1876,9 +1941,6 @@ SurfaceFunctional::EvalComplexPowerByAttribute(const GridFunction &E, const Grid
               "Mismatch between real- and complex-valued E and B fields in batched "
               "port power calculation!");
   MFEM_VERIFY(num_bins >= 0, "Invalid number of output bins!");
-  MFEM_VERIFY(local_out_attrs.size() == static_cast<std::size_t>(local_out.Size()),
-              "SurfaceFunctional attribute bins require one output slot per element!");
-
   auto AccumulateBins = [&](const std::array<const Vector *, 4> &srcs,
                             std::vector<double> &bins, double scale)
   {
@@ -1890,21 +1952,7 @@ SurfaceFunctional::EvalComplexPowerByAttribute(const GridFunction &E, const Grid
     // face-neighbor exchange may need this rank to export field data for another rank's
     // processor-boundary side.
     ApplyAdd(srcs);
-    if (local_out.Size() == 0)
-    {
-      return;
-    }
-    const double *vals = local_out.HostRead();
-    for (int i = 0; i < local_out.Size(); i++)
-    {
-      const int attr = local_out_attrs[i];
-      const int bin = (attr > 0 && attr <= attr_to_bin.Size()) ? attr_to_bin[attr - 1] : -1;
-      if (bin >= 0)
-      {
-        MFEM_VERIFY(bin < num_bins, "SurfaceFunctional attribute bin out of range!");
-        bins[bin] += scale * vals[i];
-      }
-    }
+    BinLocalOutByAttribute(attr_to_bin, num_bins, bins, scale);
   };
 
   std::vector<double> real(num_bins, 0.0), imag(num_bins, 0.0);

--- a/palace/fem/output_functionals.hpp
+++ b/palace/fem/output_functionals.hpp
@@ -146,6 +146,10 @@ private:
   // Zero the local output vector, apply, and return the local sum (no MPI reduction).
   double EvalLocal(const std::array<const Vector *, 4> &srcs) const;
 
+  // Add the current local_out element slots into per-attribute bins.
+  void BinLocalOutByAttribute(const mfem::Array<int> &attr_to_bin, int num_bins,
+                              std::vector<double> &bins, double scale) const;
+
 public:
   // Construct a functional over the boundary elements with marked attributes (marker
   // over global mfem boundary attributes). For field-less functionals (AREA), fespace
@@ -233,6 +237,13 @@ public:
   // Evaluate the linear mode-overlap functional, returning the complex integral when the
   // supplied field has real and imaginary parts.
   std::complex<double> EvalModeOverlap(const GridFunction &E) const;
+
+  // Same mode-overlap convention as EvalModeOverlap, but return one result per
+  // boundary-attribute bin. attr_to_bin is indexed by boundary attribute - 1 and uses -1
+  // for attributes not assigned to an output bin. Collective on the mesh communicator.
+  std::vector<std::complex<double>>
+  EvalModeOverlapByAttribute(const GridFunction &E, const mfem::Array<int> &attr_to_bin,
+                             int num_bins) const;
 };
 
 }  // namespace palace

--- a/palace/models/lumpedportoperator.cpp
+++ b/palace/models/lumpedportoperator.cpp
@@ -3,6 +3,7 @@
 
 #include "lumpedportoperator.hpp"
 
+#include <set>
 #include <fmt/ranges.h>
 #include "fem/coefficient.hpp"
 #include "fem/gridfunction.hpp"
@@ -164,6 +165,38 @@ double LumpedPortData::GetExcitationVoltage() const
   }
 }
 
+SurfaceModeCoefficient LumpedPortData::GetModeCoefficient(const LumpedElementData &elem,
+                                                          double coeff) const
+{
+  SurfaceModeCoefficient mode;
+  mode.attr_list = elem.GetAttrList();
+  mode.scale = coeff;
+  if (const auto *uniform = dynamic_cast<const UniformElementData *>(&elem))
+  {
+    mode.type = SurfaceModeCoefficient::Type::UNIFORM;
+    const auto &dir = uniform->GetDirection();
+    for (int d = 0; d < 3; d++)
+    {
+      mode.direction[d] = (d < dir.Size()) ? dir(d) : 0.0;
+    }
+  }
+  else if (const auto *coax = dynamic_cast<const CoaxialElementData *>(&elem))
+  {
+    mode.type = SurfaceModeCoefficient::Type::COAXIAL;
+    mode.scale *= coax->GetDirection();
+    const auto &origin = coax->GetOrigin();
+    for (int d = 0; d < 3; d++)
+    {
+      mode.origin[d] = (d < origin.Size()) ? origin(d) : 0.0;
+    }
+  }
+  else
+  {
+    MFEM_ABORT("Unknown lumped element type for mode-overlap coefficient!");
+  }
+  return mode;
+}
+
 void LumpedPortData::InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespace) const
 {
   const auto &mesh = *nd_fespace.GetParMesh();
@@ -244,6 +277,48 @@ std::complex<double> LumpedPortData::GetPower(GridFunction &E, GridFunction &B) 
   const bool has_imag = E.HasImag();
   auto &nd_fespace = *E.ParFESpace();
   const auto &mesh = *nd_fespace.GetParMesh();
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  if (!power_func)
+  {
+    mfem::Array<int> attr_list;
+    for (const auto &elem : elems)
+    {
+      attr_list.Append(elem->GetAttrList());
+    }
+    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+    mfem::Vector x0(mesh.SpaceDimension());
+    x0 = 0.0;
+    power_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), mat_op,
+        SurfaceFlux::POWER, /*two_sided*/ true, x0);
+  }
+  if (power_func && power_func->IsValid())
+  {
+    return power_func->EvalComplexPower(E, B);
+  }
+  if (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(power_func && power_func->IsValid(),
+                "libCEED lumped-port power postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+  return GetPowerLegacy(E, B);
+}
+
+std::complex<double> LumpedPortData::GetPowerLegacy(GridFunction &E, GridFunction &B) const
+{
+  // MFEM coefficient/linear-form implementation used for unsupported dimensions and as
+  // an independent numerical reference in tests.
+  MFEM_VERIFY((E.HasImag() && B.HasImag()) || (!E.HasImag() && !B.HasImag()),
+              "Mismatch between real- and complex-valued E and B fields in port power "
+              "calculation!");
+  const bool has_imag = E.HasImag();
+  auto &nd_fespace = *E.ParFESpace();
+  const auto &mesh = *nd_fespace.GetParMesh();
+
   SumVectorCoefficient fbr(mesh.SpaceDimension()), fbi(mesh.SpaceDimension());
   mfem::Array<int> attr_list;
   for (const auto &elem : elems)
@@ -293,20 +368,40 @@ std::complex<double> LumpedPortData::GetPower(GridFunction &E, GridFunction &B) 
 
 std::complex<double> LumpedPortData::GetSParameter(GridFunction &E) const
 {
-  // Compute port S-parameter, or the projection of the field onto the port mode.
-  InitializeLinearForms(*E.ParFESpace());
-  std::complex<double> dot((*s) * E.Real(), 0.0);
-  if (E.HasImag())
-  {
-    dot.imag((*s) * E.Imag());
-  }
-  Mpi::GlobalSum(1, &dot, E.GetComm());
-  return dot;
+  // The S-parameter mode coefficient is the voltage coefficient scaled by
+  // 1/sqrt(R_ref): H_inc = 1 / sqrt((R_ref W/L n) W L n) =
+  // 1 / (W n sqrt(R_ref)). For purely reactive ports, use the same unit reference
+  // resistance as the excitation source.
+  return GetVoltage(E) / std::sqrt(GetExcitationRefResistance());
 }
 
 std::complex<double> LumpedPortData::GetVoltage(GridFunction &E) const
 {
-  // Compute the average voltage across the port.
+  // Compute the average voltage across the port using the same mode-overlap machinery as
+  // S-parameters, with the voltage normalization coefficient.
+  if (!v_func)
+  {
+    std::vector<SurfaceModeCoefficient> modes;
+    modes.reserve(elems.size());
+    for (const auto &elem : elems)
+    {
+      modes.push_back(
+          GetModeCoefficient(*elem, 1.0 / (elem->GetGeometryWidth() * elems.size())));
+    }
+    v_func = std::make_unique<SurfaceFunctional>(mat_op.GetMesh(), *E.ParFESpace(), modes);
+  }
+  if (v_func && v_func->IsValid())
+  {
+    return v_func->EvalModeOverlap(E);
+  }
+  const auto &mesh = *E.ParFESpace()->GetParMesh();
+  if (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(v_func && v_func->IsValid(),
+                "libCEED lumped-port voltage postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+
   InitializeLinearForms(*E.ParFESpace());
   std::complex<double> dot((*v) * E.Real(), 0.0);
   if (E.HasImag())
@@ -480,6 +575,215 @@ const LumpedPortData &LumpedPortOperator::GetPort(int idx) const
   auto it = ports.find(idx);
   MFEM_VERIFY(it != ports.end(), "Unknown lumped port index requested!");
   return it->second;
+}
+
+std::map<int, std::complex<double>> LumpedPortOperator::GetPowers(GridFunction &E,
+                                                                  GridFunction &B) const
+{
+  std::map<int, std::complex<double>> powers;
+  if (ports.empty())
+  {
+    return powers;
+  }
+  // Assemble one union-surface POWER functional for all disjoint lumped ports. The
+  // SurfaceFunctional still accumulates per-boundary-element slots;
+  // EvalComplexPowerByAttribute bins those slots back to the port indices, so no
+  // processor-boundary or ghost-side behavior is weakened relative to the per-port path.
+  if (!batched_power_bins.unavailable)
+  {
+    if (!batched_power_func)
+    {
+      auto &nd_fespace = *E.ParFESpace();
+      const auto &mesh = *nd_fespace.GetParMesh();
+      const int bdr_attr_max = mesh::GetMaxBdrAttribute(mesh);
+      batched_power_bins.attr_to_port.SetSize(bdr_attr_max);
+      for (int i = 0; i < batched_power_bins.attr_to_port.Size(); i++)
+      {
+        batched_power_bins.attr_to_port[i] = -1;
+      }
+      batched_power_bins.port_indices.clear();
+
+      mfem::Array<int> attr_list;
+      std::set<int> seen_attrs;
+      bool can_batch = true;
+      int bin = 0;
+      for (const auto &[idx, data] : ports)
+      {
+        batched_power_bins.port_indices.push_back(idx);
+        for (const auto &elem : data.elems)
+        {
+          for (int attr : elem->GetAttrList())
+          {
+            if (attr <= 0 || attr > bdr_attr_max || !seen_attrs.insert(attr).second)
+            {
+              can_batch = false;
+              break;
+            }
+            attr_list.Append(attr);
+            batched_power_bins.attr_to_port[attr - 1] = bin;
+          }
+          if (!can_batch)
+          {
+            break;
+          }
+        }
+        if (!can_batch)
+        {
+          break;
+        }
+        bin++;
+      }
+
+      Mpi::GlobalAnd(1, &can_batch, nd_fespace.GetComm());
+
+      if (can_batch && attr_list.Size() > 0)
+      {
+        const auto &data0 = ports.begin()->second;
+        mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+
+        mfem::Vector x0(mesh.SpaceDimension());
+        x0 = 0.0;
+        batched_power_func = std::make_unique<SurfaceFunctional>(
+            data0.mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), data0.mat_op,
+            SurfaceFlux::POWER, /*two_sided*/ true, x0);
+      }
+      else
+      {
+        batched_power_bins.unavailable = true;
+      }
+    }
+
+    if (batched_power_func && batched_power_func->IsValid())
+    {
+      auto values = batched_power_func->EvalComplexPowerByAttribute(
+          E, B, batched_power_bins.attr_to_port,
+          static_cast<int>(batched_power_bins.port_indices.size()));
+      for (std::size_t i = 0; i < batched_power_bins.port_indices.size(); i++)
+      {
+        powers.emplace(batched_power_bins.port_indices[i], values[i]);
+      }
+      return powers;
+    }
+    if (batched_power_func)
+    {
+      if (E.ParFESpace()->GetParMesh()->Dimension() == 3 &&
+          E.ParFESpace()->GetParMesh()->SpaceDimension() == 3)
+      {
+        MFEM_VERIFY(batched_power_func->IsValid(),
+                    "libCEED batched lumped-port power postprocessing could not assemble "
+                    "for supported 3D port surfaces!");
+      }
+      batched_power_bins.unavailable = true;
+    }
+  }
+
+  for (const auto &[idx, data] : ports)
+  {
+    powers.emplace(idx, data.GetPower(E, B));
+  }
+  return powers;
+}
+
+std::map<int, std::complex<double>> LumpedPortOperator::GetVoltages(GridFunction &E) const
+{
+  std::map<int, std::complex<double>> voltages;
+  if (ports.empty())
+  {
+    return voltages;
+  }
+  // Assemble one union-surface mode-overlap functional for all disjoint lumped ports.
+  // EvalModeOverlapByAttribute bins per-boundary-element slots back to port indices,
+  // avoiding one separate mode-overlap apply per port while preserving per-port values.
+  if (!batched_voltage_bins.unavailable)
+  {
+    if (!batched_voltage_func)
+    {
+      auto &nd_fespace = *E.ParFESpace();
+      const auto &mesh = *nd_fespace.GetParMesh();
+      const int bdr_attr_max = mesh::GetMaxBdrAttribute(mesh);
+      batched_voltage_bins.attr_to_port.SetSize(bdr_attr_max);
+      for (int i = 0; i < batched_voltage_bins.attr_to_port.Size(); i++)
+      {
+        batched_voltage_bins.attr_to_port[i] = -1;
+      }
+      batched_voltage_bins.port_indices.clear();
+
+      std::vector<SurfaceModeCoefficient> modes;
+      std::set<int> seen_attrs;
+      bool can_batch = true;
+      int bin = 0;
+      for (const auto &[idx, data] : ports)
+      {
+        batched_voltage_bins.port_indices.push_back(idx);
+        for (const auto &elem : data.elems)
+        {
+          SurfaceModeCoefficient mode = data.GetModeCoefficient(
+              *elem, 1.0 / (elem->GetGeometryWidth() * data.elems.size()));
+          for (int attr : mode.attr_list)
+          {
+            if (attr <= 0 || attr > bdr_attr_max || !seen_attrs.insert(attr).second)
+            {
+              can_batch = false;
+              break;
+            }
+            batched_voltage_bins.attr_to_port[attr - 1] = bin;
+          }
+          if (!can_batch)
+          {
+            break;
+          }
+          modes.push_back(std::move(mode));
+        }
+        if (!can_batch)
+        {
+          break;
+        }
+        bin++;
+      }
+
+      Mpi::GlobalAnd(1, &can_batch, nd_fespace.GetComm());
+
+      if (can_batch && !modes.empty())
+      {
+        const auto &data0 = ports.begin()->second;
+        batched_voltage_func =
+            std::make_unique<SurfaceFunctional>(data0.mat_op.GetMesh(), nd_fespace, modes);
+      }
+      else
+      {
+        batched_voltage_bins.unavailable = true;
+      }
+    }
+
+    if (batched_voltage_func && batched_voltage_func->IsValid())
+    {
+      auto values = batched_voltage_func->EvalModeOverlapByAttribute(
+          E, batched_voltage_bins.attr_to_port,
+          static_cast<int>(batched_voltage_bins.port_indices.size()));
+      for (std::size_t i = 0; i < batched_voltage_bins.port_indices.size(); i++)
+      {
+        voltages.emplace(batched_voltage_bins.port_indices[i], values[i]);
+      }
+      return voltages;
+    }
+    if (batched_voltage_func)
+    {
+      if (E.ParFESpace()->GetParMesh()->Dimension() == 3 &&
+          E.ParFESpace()->GetParMesh()->SpaceDimension() == 3)
+      {
+        MFEM_VERIFY(batched_voltage_func->IsValid(),
+                    "libCEED batched lumped-port voltage postprocessing could not "
+                    "assemble for supported 3D port surfaces!");
+      }
+      batched_voltage_bins.unavailable = true;
+    }
+  }
+
+  for (const auto &[idx, data] : ports)
+  {
+    voltages.emplace(idx, data.GetVoltage(E));
+  }
+  return voltages;
 }
 
 mfem::Array<int> LumpedPortOperator::GetAttrList() const

--- a/palace/models/lumpedportoperator.hpp
+++ b/palace/models/lumpedportoperator.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <mfem.hpp>
 #include "fem/lumpedelement.hpp"
+#include "fem/output_functionals.hpp"
 
 namespace palace
 {
@@ -33,6 +34,8 @@ struct LumpedPortData;
 //
 class LumpedPortData
 {
+  friend class LumpedPortOperator;
+
 public:
   // Reference to material property data (not owned).
   const MaterialOperator &mat_op;
@@ -51,7 +54,12 @@ protected:
   // Linear forms for postprocessing integrated quantities on the port.
   mutable std::unique_ptr<mfem::LinearForm> s, v;
 
+  // Per-port libCEED evaluators for port power and voltage.
+  mutable std::unique_ptr<SurfaceFunctional> power_func, v_func;
+
   void InitializeLinearForms(mfem::ParFiniteElementSpace &nd_fespace) const;
+  SurfaceModeCoefficient GetModeCoefficient(const LumpedElementData &elem,
+                                            double coeff) const;
 
 public:
   LumpedPortData(const config::LumpedPortData &data, const MaterialOperator &mat_op,
@@ -113,7 +121,10 @@ public:
   double GetExcitationPower() const;
   double GetExcitationVoltage() const;
 
+  // Per-port evaluation used by LumpedPortOperator when a batched functional is not
+  // available for the requested port set.
   std::complex<double> GetPower(GridFunction &E, GridFunction &B) const;
+  std::complex<double> GetPowerLegacy(GridFunction &E, GridFunction &B) const;
   std::complex<double> GetSParameter(GridFunction &E) const;
   std::complex<double> GetVoltage(GridFunction &E) const;
 };
@@ -128,6 +139,20 @@ private:
   // calculate circuit properties like voltage and current on lumped or multielement lumped
   // ports.
   std::map<int, LumpedPortData> ports;
+
+  struct PortAttributeBins
+  {
+    mfem::Array<int> attr_to_port;
+    std::vector<int> port_indices;
+    bool unavailable = false;
+  };
+
+  // Batched libCEED surface functionals for lumped-port power and voltage. Individual
+  // LumpedPortData evaluation remains available for port sets that cannot be batched.
+  mutable std::unique_ptr<SurfaceFunctional> batched_power_func;
+  mutable PortAttributeBins batched_power_bins;
+  mutable std::unique_ptr<SurfaceFunctional> batched_voltage_func;
+  mutable PortAttributeBins batched_voltage_bins;
 
   void SetUpBoundaryProperties(const std::map<int, config::LumpedPortData> &lumpedport,
                                const MaterialOperator &mat_op, const mfem::ParMesh &mesh);
@@ -147,6 +172,14 @@ public:
   auto rbegin() const { return ports.rbegin(); }
   auto rend() const { return ports.rend(); }
   auto Size() const { return ports.size(); }
+
+  // Compute port powers, batching disjoint libCEED surface-functional evaluations when
+  // possible while preserving per-port scalar outputs.
+  std::map<int, std::complex<double>> GetPowers(GridFunction &E, GridFunction &B) const;
+
+  // Compute port voltages, batching disjoint libCEED mode-overlap evaluations when
+  // possible while preserving per-port scalar outputs.
+  std::map<int, std::complex<double>> GetVoltages(GridFunction &E) const;
 
   // Returns array of lumped port attributes.
   mfem::Array<int> GetAttrList() const;

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -5,8 +5,11 @@
 
 #include <algorithm>
 #include <complex>
+#include <map>
 #include <set>
 #include <string>
+#include <tuple>
+#include <vector>
 #include "drivers/boundarymodesolver.hpp"
 #include "fem/coefficient.hpp"
 #include "fem/errorindicator.hpp"
@@ -1093,11 +1096,13 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
   if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN ||
                 solver_t == ProblemType::TRANSIENT)
   {
+    const auto port_powers = fem_op->GetLumpedPortOp().GetPowers(*E, *B);
+    const auto port_voltages = fem_op->GetLumpedPortOp().GetVoltages(*E);
     for (const auto &[idx, data] : fem_op->GetLumpedPortOp())
     {
       auto &vi = measurement_cache.lumped_port_vi[idx];
-      vi.P = data.GetPower(*E, *B);
-      vi.V = data.GetVoltage(*E);
+      vi.P = port_powers.at(idx);
+      vi.V = port_voltages.at(idx);
       if constexpr (solver_t == ProblemType::EIGENMODE || solver_t == ProblemType::DRIVEN)
       {
         // Compute current from the port impedance, separate contributions for R, L, C
@@ -1123,7 +1128,9 @@ void PostOperator<solver_t>::MeasureLumpedPorts() const
                 : 0.0;
         vi.I = std::accumulate(vi.I_RLC.begin(), vi.I_RLC.end(),
                                std::complex<double>{0.0, 0.0});
-        vi.S = data.GetSParameter(*E);
+        // S-parameter mode coefficient uses the same real reference resistance as the
+        // excitation source, including the unit reference for purely reactive ports.
+        vi.S = vi.V / std::sqrt(data.GetExcitationRefResistance());
 
         // Add contribution due to all inductive lumped boundaries in the model:
         //                      E_ind = ∑_j 1/2 L_j I_mj².
@@ -1220,10 +1227,13 @@ void PostOperator<solver_t>::MeasureWavePorts() const
       MFEM_VERIFY(freq_re > 0.0,
                   "Frequency domain wave port postprocessing requires nonzero frequency!");
       auto &vi = measurement_cache.wave_port_vi[idx];
-      vi.P = data.GetPower(*E, *B);
       vi.S = data.GetSParameter(*E);
-      vi.V = data.GetVoltage(*E);
-      vi.Z_PV = data.GetCharacteristicImpedance();
+      if (data.HasVoltageCoords())
+      {
+        vi.P = data.GetPower(*E, *B);
+        vi.V = data.GetVoltage(*E);
+        vi.Z_PV = data.GetCharacteristicImpedance();
+      }
     }
   }
 }
@@ -1434,8 +1444,7 @@ void PostOperator<solver_t>::MeasureFarField() const
 
     // NOTE: measurement_cache.freq is omega (it has a factor of 2pi).
     measurement_cache.farfield.E_field = surf_post_op.GetFarFieldrE(
-        measurement_cache.farfield.thetaphis, *E, *B, measurement_cache.freq.real(),
-        measurement_cache.freq.imag());
+        measurement_cache.farfield.thetaphis, *E, *B, measurement_cache.freq);
   }
 }
 
@@ -1830,11 +1839,60 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
   measurement_cache.mode_data.kn = kn;
   measurement_cache.mode_data.n_eff = n_eff;
 
-  // Helper: compute voltage V = ∫ E · dl via coordinate path or boundary attributes.
-  auto ComputeVoltage = [this](const std::vector<mfem::Vector> &path, bool has_coords,
-                               mfem::Array<int> marker, int quad_order,
-                               const GridFunction &field) -> std::complex<double>
+  struct LineIntegralKey
   {
+    bool has_coords = false;
+    int quad_order = 0;
+    std::vector<double> path_data;
+    std::vector<int> marker_data;
+
+    bool operator<(const LineIntegralKey &other) const
+    {
+      return std::tie(has_coords, quad_order, path_data, marker_data) <
+             std::tie(other.has_coords, other.quad_order, other.path_data,
+                      other.marker_data);
+    }
+  };
+  auto MakeLineIntegralKey = [](const std::vector<mfem::Vector> &path, bool has_coords,
+                                const mfem::Array<int> &marker, int quad_order)
+  {
+    LineIntegralKey key;
+    key.has_coords = has_coords;
+    key.quad_order = quad_order;
+    if (has_coords)
+    {
+      for (const auto &pt : path)
+      {
+        for (int d = 0; d < pt.Size(); d++)
+        {
+          key.path_data.push_back(pt(d));
+        }
+      }
+    }
+    else
+    {
+      key.marker_data.reserve(marker.Size());
+      for (int i = 0; i < marker.Size(); i++)
+      {
+        key.marker_data.push_back(marker[i]);
+      }
+    }
+    return key;
+  };
+  std::map<LineIntegralKey, std::complex<double>> voltage_cache, current_cache;
+
+  // Helper: compute voltage V = ∫ E · dl via coordinate path or boundary attributes.
+  auto ComputeVoltage = [this, &MakeLineIntegralKey, &voltage_cache](
+                            const std::vector<mfem::Vector> &path, bool has_coords,
+                            mfem::Array<int> marker, int quad_order,
+                            const GridFunction &field) -> std::complex<double>
+  {
+    auto key = MakeLineIntegralKey(path, has_coords, marker, quad_order);
+    if (auto it = voltage_cache.find(key); it != voltage_cache.end())
+    {
+      return it->second;
+    }
+
     std::complex<double> V(0.0, 0.0);
     if (has_coords)
     {
@@ -1863,14 +1921,22 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
       V.real(linalg::Dot(nd_fespace.GetComm(), v_lf_tdof, fr));
       V.imag(linalg::Dot(nd_fespace.GetComm(), v_lf_tdof, fi));
     }
+    voltage_cache.emplace(std::move(key), V);
     return V;
   };
 
   // Helper: compute current I = ∮ H · t dl via coordinate path or boundary attributes.
-  auto ComputeCurrent = [this](const std::vector<mfem::Vector> &path, bool has_path,
-                               mfem::Array<int> marker, int quad_order,
-                               const GridFunction &field) -> std::complex<double>
+  auto ComputeCurrent = [this, &MakeLineIntegralKey, &current_cache](
+                            const std::vector<mfem::Vector> &path, bool has_path,
+                            mfem::Array<int> marker, int quad_order,
+                            const GridFunction &field) -> std::complex<double>
   {
+    auto key = MakeLineIntegralKey(path, has_path, marker, quad_order);
+    if (auto it = current_cache.find(key); it != current_cache.end())
+    {
+      return it->second;
+    }
+
     std::complex<double> I(0.0, 0.0);
     if (has_path)
     {
@@ -1899,8 +1965,57 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
       I.real(linalg::Dot(nd_fespace.GetComm(), i_lf_tdof, fr));
       I.imag(linalg::Dot(nd_fespace.GetComm(), i_lf_tdof, fi));
     }
+    current_cache.emplace(std::move(key), I);
     return I;
   };
+
+  auto SameMarker = [](const mfem::Array<int> &a, const mfem::Array<int> &b)
+  {
+    if (a.Size() != b.Size())
+    {
+      return false;
+    }
+    for (int i = 0; i < a.Size(); i++)
+    {
+      if (a[i] != b[i])
+      {
+        return false;
+      }
+    }
+    return true;
+  };
+  auto SamePath = [](const std::vector<mfem::Vector> &a, const std::vector<mfem::Vector> &b)
+  {
+    if (a.size() != b.size())
+    {
+      return false;
+    }
+    for (std::size_t i = 0; i < a.size(); i++)
+    {
+      if (a[i].Size() != b[i].Size())
+      {
+        return false;
+      }
+      for (int d = 0; d < a[i].Size(); d++)
+      {
+        if (a[i](d) != b[i](d))
+        {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+  auto SameVoltageConfig =
+      [&](const ImpedancePostproConfig &imp, const VoltagePostproConfig &vol)
+  {
+    return imp.n_samples == vol.n_samples &&
+           imp.has_voltage_coordinates == vol.has_coordinates &&
+           (imp.has_voltage_coordinates
+                ? SamePath(imp.voltage_path, vol.voltage_path)
+                : SameMarker(imp.voltage_marker, vol.voltage_marker));
+  };
+  std::set<int> filled_voltage_postpro;
 
   // Compute impedance for each configured entry. P is the Poynting power of the
   // power-normalized mode (|P| ≈ 1), computed by the caller on the mode eigensolver.
@@ -1909,6 +2024,12 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     auto V = ComputeVoltage(cfg.voltage_path, cfg.has_voltage_coordinates,
                             cfg.voltage_marker, cfg.n_samples, *E);
     auto &result = measurement_cache.mode_data.impedance[idx];
+    if (auto vol_it = voltage_postpro.find(idx);
+        vol_it != voltage_postpro.end() && SameVoltageConfig(cfg, vol_it->second))
+    {
+      measurement_cache.mode_data.voltage[idx] = {V};
+      filled_voltage_postpro.insert(idx);
+    }
 
     // Power-voltage impedance: Z_PV = |V|^2 / (2P).
     if (std::abs(P) > 1e-30)
@@ -1919,18 +2040,25 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     }
 
     // V/I impedance: Z_VI = |V| / |I|.
-    auto I = ComputeCurrent(cfg.current_path, cfg.has_current_path, cfg.current_marker,
-                            cfg.n_samples, *Bt_inplane);
-    if (std::abs(I) > 1e-30)
+    if (cfg.has_current)
     {
-      result.Z_VI = std::abs(V) / std::abs(I);
-      result.has_vi_impedance = true;
+      auto I = ComputeCurrent(cfg.current_path, cfg.has_current_path, cfg.current_marker,
+                              cfg.n_samples, *Bt_inplane);
+      if (std::abs(I) > 1e-30)
+      {
+        result.Z_VI = std::abs(V) / std::abs(I);
+        result.has_vi_impedance = true;
+      }
     }
   }
 
   // Compute voltage for each configured voltage-only entry.
   for (const auto &[idx, cfg] : voltage_postpro)
   {
+    if (filled_voltage_postpro.count(idx))
+    {
+      continue;
+    }
     auto V = ComputeVoltage(cfg.voltage_path, cfg.has_coordinates, cfg.voltage_marker,
                             cfg.n_samples, *E);
     measurement_cache.mode_data.voltage[idx] = {V};

--- a/palace/models/surfacepostoperator.cpp
+++ b/palace/models/surfacepostoperator.cpp
@@ -5,6 +5,7 @@
 
 #include <complex>
 #include <set>
+#include <string>
 #include "fem/gridfunction.hpp"
 #include "fem/integrator.hpp"
 #include "linalg/vector.hpp"
@@ -21,6 +22,26 @@ namespace palace
 
 namespace
 {
+
+bool IsSupportedSurfaceFunctionalDimension(const mfem::ParMesh &mesh)
+{
+  return (mesh.Dimension() == 2 && mesh.SpaceDimension() == 2) ||
+         (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3);
+}
+
+bool IsSupportedSurfaceFluxDimension(const mfem::ParMesh &mesh)
+{
+  // The libCEED surface-flux kernels currently implement 3D surface integrals. 2D line
+  // flux semantics remain on the legacy path explicitly rather than by silent invalid
+  // fallback.
+  return mesh.Dimension() == 3 && mesh.SpaceDimension() == 3;
+}
+
+void RequireCeedSurfaceFunctional(const SurfaceFunctional *func, const std::string &what)
+{
+  MFEM_VERIFY(func && func->IsValid(), "libCEED postprocessing was expected for " + what +
+                                           ", but SurfaceFunctional could not assemble!");
+}
 
 template <typename T>
 mfem::Array<int> SetUpBoundaryProperties(const T &data,
@@ -300,6 +321,26 @@ std::complex<double> SurfacePostOperator::GetSurfaceFlux(int idx, const GridFunc
   const auto &mesh = *h1_fespace.GetParMesh();
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, it->second.attr_list);
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  auto &func = flux_funcs[idx];
+  if (!func)
+  {
+    func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, E ? E->ParFESpace() : nullptr,
+        B ? B->ParFESpace() : nullptr, mat_op, it->second.type, it->second.two_sided,
+        it->second.center);
+  }
+  if (func && func->IsValid())
+  {
+    return func->EvalFlux(E, B);
+  }
+  if (IsSupportedSurfaceFluxDimension(mesh))
+  {
+    RequireCeedSurfaceFunctional(func.get(), "3D surface flux");
+  }
+
   auto f =
       it->second.GetCoefficient(E ? &E->Real() : nullptr, B ? &B->Real() : nullptr, mat_op);
   std::complex<double> dot(GetLocalSurfaceIntegral(*f, attr_marker), 0.0);
@@ -338,6 +379,25 @@ double SurfacePostOperator::GetInterfaceElectricFieldEnergy(int idx,
   const auto &mesh = *h1_fespace.GetParMesh();
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, it->second.attr_list);
+
+  // Use the libCEED surface functional path when supported, avoiding per-call
+  // boundary LinearForm assembly in the legacy coefficient path.
+  auto &func = eps_funcs[idx];
+  if (!func)
+  {
+    func = std::make_unique<SurfaceFunctional>(mat_op.GetMesh(), attr_marker,
+                                               *E.ParFESpace(), mat_op, it->second.type,
+                                               it->second.t, it->second.epsilon);
+  }
+  if (func && func->IsValid())
+  {
+    return func->Eval(E);
+  }
+  if (IsSupportedSurfaceFunctionalDimension(mesh))
+  {
+    RequireCeedSurfaceFunctional(func.get(), "interface dielectric postprocessing");
+  }
+
   auto f = it->second.GetCoefficient(E, mat_op);
   double dot = GetLocalSurfaceIntegral(*f, attr_marker);
   Mpi::GlobalSum(1, &dot, E.GetComm());
@@ -361,7 +421,7 @@ SurfacePostOperator::GetLocalSurfaceIntegral(mfem::Coefficient &f,
 
 std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFieldrE(
     const std::vector<std::pair<double, double>> &theta_phi_pairs, const GridFunction &E,
-    const GridFunction &B, double omega_re, double omega_im) const
+    const GridFunction &B, std::complex<double> omega) const
 {
   if (theta_phi_pairs.empty())
     return {};
@@ -372,8 +432,6 @@ std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFiel
   // Compute target unit vectors from the given theta and phis.
   std::vector<std::array<double, 3>> r_naughts;
   r_naughts.reserve(theta_phi_pairs.size());
-
-  r_naughts.reserve(theta_phi_pairs.size());
   for (const auto &[theta, phi] : theta_phi_pairs)
   {
     r_naughts.emplace_back(std::array<double, 3>{
@@ -383,6 +441,25 @@ std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFiel
   const auto &mesh = *nd_fespace.GetParMesh();
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
   mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, farfield.attr_list);
+
+  // Use the libCEED surface functional path when supported, avoiding per-point host
+  // coefficient evaluation in the MFEM path. Observation directions are part of the
+  // assembled operator and must therefore invalidate the cached functional when changed.
+  const bool use_ceed = E.HasImag() && B.HasImag();
+  if (use_ceed && (!farfield_func || farfield_func_dirs != r_naughts))
+  {
+    farfield_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, *E.ParFESpace(), *B.ParFESpace(), mat_op, r_naughts);
+    farfield_func_dirs = r_naughts;
+  }
+  if (use_ceed && farfield_func && farfield_func->IsValid())
+  {
+    return farfield_func->EvalFarField(E, B, omega);
+  }
+  if (use_ceed)
+  {
+    RequireCeedSurfaceFunctional(farfield_func.get(), "3D far-field postprocessing");
+  }
 
   // Integrate. Each MPI process computes its contribution and we will reduce
   // everything at the end. We make them std::vector<std::array<double, 3>>
@@ -401,8 +478,8 @@ std::vector<std::array<std::complex<double>, 3>> SurfacePostOperator::GetFarFiel
     const auto *ir =
         &mfem::IntRules.Get(fe->GetGeomType(), fem::DefaultIntegrationOrder::Get(*T));
 
-    AddStrattonChuIntegrandAtElement(E, B, mat_op, omega_re, omega_im, r_naughts, *T, *ir,
-                                     integrals_r, integrals_i);
+    AddStrattonChuIntegrandAtElement(E, B, mat_op, omega.real(), omega.imag(), r_naughts,
+                                     *T, *ir, integrals_r, integrals_i);
   }
 
   double *data_r_ptr = integrals_r.data()->data();

--- a/palace/models/surfacepostoperator.hpp
+++ b/palace/models/surfacepostoperator.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <mfem.hpp>
 #include "fem/coefficient.hpp"
+#include "fem/output_functionals.hpp"
 
 namespace palace
 {
@@ -93,6 +94,13 @@ private:
   double GetLocalSurfaceIntegral(mfem::Coefficient &f,
                                  const mfem::Array<int> &attr_marker) const;
 
+  // libCEED surface functionals for flux and interface dielectric postprocessing,
+  // constructed lazily per surface index to replace per-call coefficient evaluation and
+  // boundary LinearForm assembly in the legacy paths when supported.
+  mutable std::map<int, std::unique_ptr<SurfaceFunctional>> flux_funcs, eps_funcs;
+  mutable std::unique_ptr<SurfaceFunctional> farfield_func;
+  mutable std::vector<std::array<double, 3>> farfield_func_dirs;
+
 public:
   // Data structures for postprocessing the surface with the given type.
   std::map<int, SurfaceFluxData> flux_surfs;
@@ -114,8 +122,8 @@ public:
   // Batch version for multiple theta/phi pairs
   std::vector<std::array<std::complex<double>, 3>>
   GetFarFieldrE(const std::vector<std::pair<double, double>> &theta_phi_pairs,
-                const GridFunction &E, const GridFunction &B, double omega_re,
-                double omega_im) const;
+                const GridFunction &E, const GridFunction &B,
+                std::complex<double> omega) const;
 
   // Get surface integrals computing interface dielectric energy.
   double GetInterfaceLossTangent(int idx) const;

--- a/palace/models/waveportoperator.cpp
+++ b/palace/models/waveportoperator.cpp
@@ -19,6 +19,7 @@
 #include "fem/coefficient.hpp"
 #include "fem/integrator.hpp"
 #include "fem/interpolator.hpp"
+#include "fem/output_functionals.hpp"
 #include "linalg/amg.hpp"
 #include "linalg/ams.hpp"
 #include "linalg/arpack.hpp"
@@ -832,15 +833,41 @@ double WavePortData::GetExcitationPower() const
 
 std::complex<double> WavePortData::GetPower(GridFunction &E, GridFunction &B) const
 {
-  // Compute port power, (E x H) ⋅ n = E ⋅ (-n x H), integrated over the port surface using
-  // the computed E and H = μ⁻¹ B fields, where +n is the outward mesh normal. The
-  // BdrSurfaceCurrentVectorCoefficient computes -n x H for the outward normal. The linear
-  // form is reconstructed from scratch each time due to changing H.
+  // Compute the stationary complex power on the port, E ⋅ (-n x H⋆), integrated over the
+  // port surface with +n the outward mesh normal. Use the libCEED surface functional path
+  // when supported to avoid per-call boundary LinearForm assembly in the legacy path.
   MFEM_VERIFY(E.HasImag() && B.HasImag(),
               "Wave ports expect complex-valued E and B fields in port power "
               "calculation!");
   auto &nd_fespace = *E.ParFESpace();
   const auto &mesh = *nd_fespace.GetParMesh();
+
+  // Set two_sided = true even on the exterior port surface so the QFunction uses the
+  // fixed outward normal directly (no x0-based reorientation).
+  if (!power_func)
+  {
+    int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+    mfem::Vector x0(mesh.SpaceDimension());
+    x0 = 0.0;
+    power_func = std::make_unique<SurfaceFunctional>(
+        mat_op.GetMesh(), attr_marker, &nd_fespace, B.ParFESpace(), mat_op,
+        SurfaceFlux::POWER, /*two_sided*/ true, x0);
+  }
+  if (power_func && power_func->IsValid())
+  {
+    // EvalComplexPower returns the complex Poynting integral with the same normal
+    // convention as the legacy BdrSurfaceCurrentVectorCoefficient path (n x H for the
+    // outward normal, contributions negated), matching LumpedPortData::GetPower.
+    return power_func->EvalComplexPower(E, B);
+  }
+  if (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3)
+  {
+    MFEM_VERIFY(power_func && power_func->IsValid(),
+                "libCEED wave-port power postprocessing could not assemble for a "
+                "supported 3D port surface!");
+  }
+
   BdrSurfaceCurrentVectorCoefficient nxHr_func(B.Real(), mat_op);
   BdrSurfaceCurrentVectorCoefficient nxHi_func(B.Imag(), mat_op);
   int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;

--- a/palace/models/waveportoperator.hpp
+++ b/palace/models/waveportoperator.hpp
@@ -30,6 +30,7 @@ class MaterialOperator;
 class MaterialPropertyCoefficient;
 class SumVectorCoefficient;
 class SurfaceConductivityOperator;
+class SurfaceFunctional;
 class SurfaceRationalImpedanceOperator;
 class SurfaceImpedanceOperator;
 class Units;
@@ -103,6 +104,10 @@ private:
   // postprocessing.
   std::unique_ptr<GridFunction> port_E0t, port_E0n, port_S0t, port_E;
   std::unique_ptr<mfem::LinearForm> port_sr, port_si;
+
+  // libCEED surface functional for port power computation, replacing per-call boundary
+  // LinearForm assembly in the legacy path when supported.
+  mutable std::unique_ptr<SurfaceFunctional> power_func;
 
   // Voltage path for line integral (optional, for impedance postprocessing).
   std::vector<mfem::Vector> voltage_path;

--- a/test/unit/test-lumpedportintegration.cpp
+++ b/test/unit/test-lumpedportintegration.cpp
@@ -28,6 +28,10 @@ using namespace Catch::Matchers;
 class LumpedPortDataTest : public LumpedPortData
 {
 public:
+  void InitializeLinearFormsForTest(mfem::ParFiniteElementSpace &nd_fespace) const
+  {
+    InitializeLinearForms(nd_fespace);
+  }
   mfem::LinearForm *GetLinearFormS() const { return s.get(); }
   mfem::LinearForm *GetLinearFormV() const { return v.get(); }
 };
@@ -375,6 +379,7 @@ TEST_CASE("LumpedPort_BasicTests_1ElementPort_Cube321", "[lumped_port][Serial][P
   // layout Test structure from original structure. Done not to populate code with friend
   // functions, but still access private members for testing.
   const auto &port_1_test_cast = reinterpret_cast<const LumpedPortDataTest &>(port_1);
+  port_1_test_cast.InitializeLinearFormsForTest(space_op.GetNDSpace().Get());
   auto *form_s = port_1_test_cast.GetLinearFormS();
   ComplexVector VecFormS;
   VecFormS.SetSize(space_op.GetNDSpace().GetTrueVSize());
@@ -728,6 +733,7 @@ TEST_CASE("LumpedPort_BasicTests_3ElementPort_Cube321", "[lumped_port][Serial][P
   // layout Test structure from original structure. Done not to populate code with friend
   // functions, but still access private members for testing.
   const auto &port_1_test_cast = reinterpret_cast<const LumpedPortDataTest &>(port_1);
+  port_1_test_cast.InitializeLinearFormsForTest(space_op.GetNDSpace().Get());
   auto *form_s = port_1_test_cast.GetLinearFormS();
   ComplexVector VecFormS;
   VecFormS.SetSize(space_op.GetNDSpace().GetTrueVSize());

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -22,6 +22,23 @@ using namespace Catch::Matchers;
 using json = nlohmann::json;
 // Helpers
 
+class DrivenPostOperatorTest : public PostOperator<ProblemType::DRIVEN>
+{
+public:
+  using PostOperator<ProblemType::DRIVEN>::PostOperator;
+
+  Measurement::PortPostData MeasureLumpedPortForTest(int idx, const ComplexVector &e,
+                                                     const ComplexVector &b,
+                                                     std::complex<double> omega)
+  {
+    measurement_cache.freq = omega;
+    SetEGridFunction(e);
+    SetBGridFunction(b);
+    MeasureLumpedPorts();
+    return measurement_cache.lumped_port_vi.at(idx);
+  }
+};
+
 // random integer between 0 and n as a double.
 auto randd(int n)
 {
@@ -488,6 +505,36 @@ TEST_CASE_METHOD(test::SharedTempDir, "GridFunction export",
     const double expected_freq =
         iodata.units.Dimensionalize<Units::ValueType::FREQUENCY>(1.0) / (2.0 * M_PI);
     CHECK_THAT(pvd_time, Catch::Matchers::WithinRel(expected_freq, 1.0e-5));
+  }
+
+  SECTION("Driven reactive lumped port measurement")
+  {
+    // Purely reactive ports use the unit real reference resistance for excitation and
+    // S-parameter normalization. Exercise the batched PostOperator measurement path,
+    // which must agree with LumpedPortData::GetSParameter rather than special-case R = 0.
+    json reactive_boundaries = {{"LumpedPort",
+                                 {{{"Attributes", {2}},
+                                   {"Index", 1},
+                                   {"L", 1.0},
+                                   {"Direction", "+X"},
+                                   {"Excitation", true}}}}};
+    config::BoundaryData reactive_port(reactive_boundaries);
+
+    iodata.problem.type = ProblemType::DRIVEN;
+    iodata.solver.driven.sample_f = {1.0};
+    iodata.boundaries.lumpedport = reactive_port.lumpedport;
+    SpaceOperator space_op(iodata, mesh);
+    DrivenPostOperatorTest post_op(iodata, space_op);
+
+    ComplexVector E(space_op.GetNDSpace().GetTrueVSize()),
+        B(space_op.GetRTSpace().GetTrueVSize());
+    E = 1.0;
+    B = 0.0;
+    const auto vi = post_op.MeasureLumpedPortForTest(1, E, B, 1.0);
+    const auto &port = space_op.GetLumpedPortOp().GetPort(1);
+    REQUIRE(std::abs(vi.V) > 0.0);
+    CHECK_THAT(std::abs(vi.S - vi.V / std::sqrt(port.GetExcitationRefResistance())),
+               Catch::Matchers::WithinAbs(0.0, 1.0e-12 * std::abs(vi.V)));
   }
 
   SECTION("Eigenmode")

--- a/test/unit/test-strattonchu.cpp
+++ b/test/unit/test-strattonchu.cpp
@@ -241,27 +241,34 @@ void runFarFieldTest(double freq_Hz, std::unique_ptr<mfem::Mesh> serial_mesh,
   SurfacePostOperator surf_post_op(postpro, ProblemType::DRIVEN, mat_op, nd_fespace,
                                    nd_fespace);
 
-  auto thetaphis = GenerateSphericalTestPoints();
   double omega_rad_per_time =
       2 * M_PI * units.Nondimensionalize<Units::ValueType::FREQUENCY>(freq_Hz / 1e9);
   constexpr double omega_im = 0.0;
-  auto rE_computed =
-      surf_post_op.GetFarFieldrE(thetaphis, E_field, B_field, omega_rad_per_time, omega_im);
-
-  // Validate computed far-field against analytical solution
-  for (std::size_t i = 0; i < thetaphis.size(); i++)
+  auto CheckFarField = [&](const std::vector<std::pair<double, double>> &thetaphis)
   {
-    const auto &E_phys = units.Dimensionalize<Units::ValueType::VOLTAGE>(rE_computed[i]);
-    const auto &[theta, phi] = thetaphis[i];
-    auto rE_far = ComputeAnalyticalFarFieldrE(theta, phi, p0, freq_Hz);
-
-    for (std::size_t j = 0; j < dim; j++)
+    auto rE_computed = surf_post_op.GetFarFieldrE(thetaphis, E_field, B_field,
+                                                  {omega_rad_per_time, omega_im});
+    REQUIRE(rE_computed.size() == thetaphis.size());
+    for (std::size_t i = 0; i < thetaphis.size(); i++)
     {
-      // The agreement has to be up to a phase, so we compare the absolute values.
-      CHECK_THAT(std::abs(E_phys[j]),
-                 WithinRel(std::abs(rE_far[j]), rtol) || WithinAbs(0.0, atol));
+      const auto &E_phys = units.Dimensionalize<Units::ValueType::VOLTAGE>(rE_computed[i]);
+      const auto &[theta, phi] = thetaphis[i];
+      auto rE_far = ComputeAnalyticalFarFieldrE(theta, phi, p0, freq_Hz);
+
+      for (std::size_t j = 0; j < dim; j++)
+      {
+        // The agreement has to be up to a phase, so we compare the absolute values.
+        CHECK_THAT(std::abs(E_phys[j]),
+                   WithinRel(std::abs(rE_far[j]), rtol) || WithinAbs(0.0, atol));
+      }
     }
-  }
+  };
+
+  CheckFarField(GenerateSphericalTestPoints());
+  // Observation directions are part of the assembled libCEED functional. A second call
+  // with a different-sized set must rebuild the cached functional rather than silently
+  // returning values for the first call's directions.
+  CheckFarField({{0.27, 0.41}, {1.03, 2.17}, {2.35, 5.02}});
 }
 
 TEST_CASE("Dipole field implementation", "[strattonchu][Serial]")

--- a/test/unit/test-surfacefunctional.cpp
+++ b/test/unit/test-surfacefunctional.cpp
@@ -18,7 +18,11 @@
 #include "fem/interpolator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/output_functionals.hpp"
+#include "fixtures.hpp"
+#include "models/boundarymodeoperator.hpp"
+#include "models/domainpostoperator.hpp"
 #include "models/materialoperator.hpp"
+#include "models/postoperator.hpp"
 #include "models/strattonchu.hpp"
 #include "utils/communication.hpp"
 #include "utils/configfile.hpp"
@@ -158,6 +162,13 @@ std::unique_ptr<Mesh> MakeInterfaceMesh2D(MPI_Comm comm, mfem::Element::Type ele
   auto pmesh = std::make_unique<mfem::ParMesh>(comm, smesh);
   return std::make_unique<Mesh>(std::move(pmesh));
 }
+
+class TestBoundaryModePostOperator : public PostOperator<ProblemType::BOUNDARYMODE>
+{
+public:
+  using PostOperator<ProblemType::BOUNDARYMODE>::PostOperator;
+  const Measurement &Cache() const { return measurement_cache; }
+};
 
 // Build a 3D mesh with two material regions (attribute 1: z < 0.5, vacuum; attribute
 // 2: z >= 0.5, dielectric) and interior boundary elements (attribute 7) added on the
@@ -617,6 +628,112 @@ TEST_CASE("SurfaceFunctional Interface Dielectric 2D", "[surfacefunctional][Seri
       TestType(type, marker);
     }
   }
+}
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator boundary mode 2D interface dielectric matches legacy",
+                 "[postoperator][surfacefunctional][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+  constexpr int order = 2;
+
+  IoData iodata(Units(1.0, 1.0));
+  iodata.problem.type = ProblemType::BOUNDARYMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = false;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0;
+  iodata.model.Lc = 1.0;
+  iodata.solver.order = order;
+  iodata.solver.boundary_mode.freq = 1.0;
+  iodata.solver.boundary_mode.n = 1;
+  iodata.solver.boundary_mode.n_post = 1;
+  iodata.solver.linear.tol = 1.0e-8;
+  iodata.solver.linear.max_it = 50;
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 4.0;
+  dielectric.epsilon_r.s[1] = 6.0;
+  dielectric.epsilon_r.s[2] = 8.0;
+  iodata.domains.materials = {vacuum, dielectric};
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4};
+
+  config::InterfaceDielectricData interface;
+  interface.attributes = {7};
+  interface.type = InterfaceDielectric::SA;
+  interface.t = 2.0e-3;
+  interface.epsilon_r = 10.0;
+  interface.tandelta = 3.0e-4;
+  iodata.boundaries.postpro.dielectric.emplace(1, interface);
+
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(MakeInterfaceMesh2D(comm, mfem::Element::TRIANGLE));
+  auto &pmesh = mesh.front()->Get();
+  MaterialOperator mat_op(iodata, *mesh.front());
+  BoundaryModeOperator fem_op(iodata, mesh, mat_op);
+  TestBoundaryModePostOperator post_op(iodata, fem_op);
+
+  GridFunction E(fem_op.GetNDSpace(), true), En(fem_op.GetH1Space(), true);
+  mfem::VectorFunctionCoefficient etr(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + 0.3 * x(0);
+                                        v(1) = std::cos(x(0)) + x(0) * x(1);
+                                      });
+  mfem::VectorFunctionCoefficient eti(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(0) - 0.2 * x(1);
+                                        v(1) = std::sin(x(0) + x(1));
+                                      });
+  mfem::FunctionCoefficient enr([](const mfem::Vector &x) { return 0.5 + x(0) * x(1); });
+  mfem::FunctionCoefficient eni([](const mfem::Vector &x)
+                                { return std::cos(x(0)) - 0.1 * x(1); });
+  E.Real().ProjectCoefficient(etr);
+  E.Imag().ProjectCoefficient(eti);
+  En.Real().ProjectCoefficient(enr);
+  En.Imag().ProjectCoefficient(eni);
+
+  ComplexVector et(fem_op.GetNDTrueVSize()), en(fem_op.GetH1TrueVSize());
+  E.Real().GetTrueDofs(et.Real());
+  E.Imag().GetTrueDofs(et.Imag());
+  En.Real().GetTrueDofs(en.Real());
+  En.Imag().GetTrueDofs(en.Imag());
+
+  // Public PostOperator entry point under test: BoundaryMode computes its derived B
+  // fields internally, then measures configured interface dielectric participation.
+  const double omega = 2.0;
+  const std::complex<double> kn(0.7, 0.05);
+  post_op.MeasureAndPrintAll(0, et, en, kn, omega, 0.0, 0.0, 1);
+
+  mfem::Array<int> marker(pmesh.bdr_attributes.Max());
+  marker = 0;
+  marker[7 - 1] = 1;
+  InterfaceDielectricCoefficient<InterfaceDielectric::SA> legacy(E, mat_op, interface.t,
+                                                                 interface.epsilon_r);
+  const double interface_energy = RefSurfaceCoefficientIntegral(pmesh, legacy, marker);
+  DomainPostOperator domain_post(iodata.domains.postpro, mat_op, fem_op.GetNDSpace(),
+                                 fem_op.GetCurlSpace());
+  const double domain_energy = domain_post.GetElectricFieldEnergy(E);
+  const double participation = interface_energy / domain_energy;
+
+  const auto &cache = post_op.Cache();
+  REQUIRE(cache.interface_eps_i.size() == 1);
+  const auto &measured = cache.interface_eps_i.front();
+  CHECK(measured.idx == 1);
+  CHECK(measured.energy == Catch::Approx(interface_energy).epsilon(1.0e-10));
+  CHECK(measured.energy_participation == Catch::Approx(participation).epsilon(1.0e-10));
+  CHECK(measured.quality_factor ==
+        Catch::Approx(1.0 / (participation * interface.tandelta)).epsilon(1.0e-10));
 }
 
 TEST_CASE("SurfaceFunctional Surface Flux", "[surfacefunctional][Serial][GPU]")

--- a/test/unit/test-waveportimpedance.cpp
+++ b/test/unit/test-waveportimpedance.cpp
@@ -9,7 +9,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include "fem/coefficient.hpp"
 #include "fem/fespace.hpp"
+#include "fem/integrator.hpp"
 #include "fem/mesh.hpp"
 #include "models/materialoperator.hpp"
 #include "models/waveportoperator.hpp"
@@ -22,6 +24,39 @@
 namespace palace
 {
 using namespace Catch::Matchers;
+
+std::complex<double> RefWavePortPower(const MaterialOperator &mat_op,
+                                      const mfem::Array<int> &attr_list, GridFunction &E,
+                                      GridFunction &B)
+{
+  auto &nd_fespace = *E.ParFESpace();
+  const auto &mesh = *nd_fespace.GetParMesh();
+  BdrSurfaceCurrentVectorCoefficient nxHr_func(B.Real(), mat_op);
+  BdrSurfaceCurrentVectorCoefficient nxHi_func(B.Imag(), mat_op);
+  int bdr_attr_max = mesh.bdr_attributes.Size() ? mesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> attr_marker = mesh::AttrToMarker(bdr_attr_max, attr_list);
+  std::complex<double> dot;
+  {
+    mfem::LinearForm pr(&nd_fespace);
+    pr.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(nxHr_func), attr_marker);
+    pr.UseFastAssembly(false);
+    pr.UseDevice(false);
+    pr.Assemble();
+    pr.UseDevice(true);
+    dot = -(pr * E.Real()) - std::complex<double>(0.0, 1.0) * (pr * E.Imag());
+  }
+  {
+    mfem::LinearForm pi(&nd_fespace);
+    pi.AddBoundaryIntegrator(new VectorFEBoundaryLFIntegrator(nxHi_func), attr_marker);
+    pi.UseFastAssembly(false);
+    pi.UseDevice(false);
+    pi.Assemble();
+    pi.UseDevice(true);
+    dot += -(pi * E.Imag()) + std::complex<double>(0.0, 1.0) * (pi * E.Real());
+  }
+  Mpi::GlobalSum(1, &dot, nd_fespace.GetComm());
+  return dot;
+}
 
 // Expose private WavePortOperator::Initialize so tests can drive a single port without
 // needing the full simulation harness (and without const_cast around GetPort()).
@@ -148,6 +183,103 @@ TEST_CASE("WavePort TE10 Z_PV", "[waveportimpedance][Serial]")
 // is +y-aligned, so naming y=0 as "signal" (high) and y=a as "ground" (low) gives a
 // (high → low) direction of +y, matching the field, sign = +1. Swapping the two
 // attribute roles flips the expected sign to -1.
+TEST_CASE("WavePort port power", "[waveportimpedance][Serial][GPU]")
+{
+  MPI_Comm comm = Mpi::World();
+
+  const double a_m = 22.86e-3, b_m = 10.16e-3, L_m = 10.0e-3;
+
+  auto serial_mesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(6, 6, 4, mfem::Element::TETRAHEDRON, L_m, a_m, b_m));
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.model.L0 = 1.0;
+  iodata.model.Lc = 1.0;
+
+  auto &material = iodata.domains.materials.emplace_back();
+  material.attributes = {1};
+  material.epsilon_r.s = {2.5, 1.7, 1.3};
+  material.mu_r.s = {1.1, 1.2, 1.4};
+
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4, 6};
+
+  auto &wave = iodata.boundaries.waveport.try_emplace(1).first->second;
+  wave.attributes = {5};
+  wave.mode_idx = 1;
+  wave.excitation = 0;
+  wave.active = true;
+  wave.eig_tol = 1.0e-8;
+  wave.ksp_tol = 1.0e-8;
+  wave.ksp_max_its = 100;
+  wave.max_size = std::max(2 * wave.mode_idx, wave.mode_idx + 15);
+
+  iodata.solver.order = 2;
+  iodata.solver.linear.tol = 1.0e-8;
+  iodata.solver.linear.max_it = 200;
+  iodata.problem.type = ProblemType::DRIVEN;
+
+  iodata.NondimensionalizeInputs(serial_mesh);
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  iodata.CheckConfiguration();
+  Mesh palace_mesh(std::move(par_mesh));
+
+  auto nd_fec =
+      std::make_unique<mfem::ND_FECollection>(iodata.solver.order, palace_mesh.Dimension());
+  auto rt_fec = std::make_unique<mfem::RT_FECollection>(iodata.solver.order - 1,
+                                                        palace_mesh.Dimension());
+  auto h1_fec =
+      std::make_unique<mfem::H1_FECollection>(iodata.solver.order, palace_mesh.Dimension());
+  FiniteElementSpace nd_fespace_palace(palace_mesh, nd_fec.get());
+  FiniteElementSpace rt_fespace_palace(palace_mesh, rt_fec.get());
+  FiniteElementSpace h1_fespace_palace(palace_mesh, h1_fec.get());
+  MaterialOperator mat_op(iodata, palace_mesh);
+
+  WavePortOperator wave_port_op(iodata, mat_op, nd_fespace_palace.Get(),
+                                h1_fespace_palace.Get());
+  wave_port_op.SetSuppressOutput(true);
+
+  GridFunction E(nd_fespace_palace, true), B(rt_fespace_palace, true);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(2.0 * x(1)) + x(2);
+                                        v(1) = std::cos(x(0) + x(2));
+                                        v(2) = x(0) * x(1) + 0.25;
+                                      });
+  mfem::VectorFunctionCoefficient fei(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) * x(2) - 0.1;
+                                        v(1) = std::sin(1.5 * x(0)) - x(2);
+                                        v(2) = std::cos(x(1)) + x(0) * x(0);
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  mfem::VectorFunctionCoefficient fbi(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = 0.2 + x(0) * x(2);
+                                        v(1) = x(0) - std::cos(x(1));
+                                        v(2) = std::sin(x(0) + x(1));
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  E.Imag().ProjectCoefficient(fei);
+  B.Real().ProjectCoefficient(fbr);
+  B.Imag().ProjectCoefficient(fbi);
+
+  auto ref = RefWavePortPower(mat_op, wave_port_op.GetPort(1).GetAttrList(), E, B);
+  auto val = wave_port_op.GetPort(1).GetPower(E, B);
+  CAPTURE(ref, val);
+  CHECK_THAT(val.real(), WithinRel(ref.real(), 1.0e-10));
+  CHECK_THAT(val.imag(), WithinRel(ref.imag(), 1.0e-10));
+}
+
 TEST_CASE("WavePort TE10 mode polarity sign", "[waveportimpedance][Serial]")
 {
   MPI_Comm comm = Mpi::World();


### PR DESCRIPTION
This is **5/10** in the stacked replacement for #824/#825 and depends on [#853](https://github.com/awslabs/palace/pull/853). Please review only the diff against that PR.

This migrates surface, lumped-port, wave-port, boundary-mode, and far-field measurements to the reduction engine. It also batches compatible port work and fixes the 2D magnetic-energy reference mapping.

**Reviewer guidance:** The numerical engine is unchanged from the previous PR; review this as a call-site and semantics migration. Check that field definitions, normalization, reactive-port behavior, and CSV/cache outputs remain unchanged.

**Deferred:** This PR does not add visualization point fields or serialization.

**Validation:** Model tests pass with 36,112 serial and 16,751 MPI-2 assertions; GridFunction export passes with 53 serial and 103 MPI-2 assertions.
