### PR TITLE
Add domain point-field evaluators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Added device-backed domain point-field evaluators for primary and derived
+    visualization quantities.
   - Routed surface, port, and far-field postprocessing through device-backed
     reductions with batched ports and corrected 2D magnetic-energy references.
   - Added libCEED surface reduction functionals for energy, flux, power,

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/bilinearform.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficient.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ceed_group_operator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/domain_point_field_evaluator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/errorindicator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/facenbrexchange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fespace.cpp

--- a/palace/fem/domain_point_field_evaluator.cpp
+++ b/palace/fem/domain_point_field_evaluator.cpp
@@ -1,0 +1,496 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "domain_point_field_evaluator.hpp"
+
+#include <algorithm>
+#include <map>
+#include "fem/coefficient.hpp"
+#include "fem/fespace.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/libceed/basis.hpp"
+#include "fem/libceed/coefficient.hpp"
+#include "fem/libceed/functional.hpp"
+#include "fem/libceed/integrator.hpp"
+#include "fem/libceed/restriction.hpp"
+#include "fem/mesh.hpp"
+#include "models/materialoperator.hpp"
+#include "utils/diagnostic.hpp"
+
+PalacePragmaDiagnosticPush
+PalacePragmaDiagnosticDisableUnused
+
+#include "fem/qfunctions/22/eval_22_qf.h"
+#include "fem/qfunctions/33/eval_33_qf.h"
+
+PalacePragmaDiagnosticPop
+
+namespace palace
+{
+
+namespace
+{
+
+// Holds libCEED object references created during operator assembly for destruction once
+// the assembled operator owns them.
+struct CeedAssemblyScratch
+{
+  Ceed ceed;
+  std::vector<CeedVector> vecs;
+  std::vector<CeedElemRestriction> restrs;
+  std::vector<CeedBasis> bases;
+
+  CeedAssemblyScratch(Ceed ceed) : ceed(ceed) {}
+  CeedAssemblyScratch(const CeedAssemblyScratch &) = delete;
+  CeedAssemblyScratch &operator=(const CeedAssemblyScratch &) = delete;
+
+  ~CeedAssemblyScratch()
+  {
+    for (auto &v : vecs)
+    {
+      PalaceCeedCall(ceed, CeedVectorDestroy(&v));
+    }
+    for (auto &r : restrs)
+    {
+      PalaceCeedCall(ceed, CeedElemRestrictionDestroy(&r));
+    }
+    for (auto &b : bases)
+    {
+      PalaceCeedCall(ceed, CeedBasisDestroy(&b));
+    }
+  }
+};
+
+}  // namespace
+
+DomainPointFieldEvaluator::DomainPointFieldEvaluator(
+    Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+    const mfem::ParFiniteElementSpace *nd_fespace,
+    const mfem::ParFiniteElementSpace *rt_fespace,
+    const mfem::ParFiniteElementSpace &target_fespace, double scaling,
+    bool build_gridfunction, bool build_buffer)
+  : kind(kind), nd_fespace(nd_fespace), rt_fespace(rt_fespace)
+{
+  const bool needs_nd = kind == Kind::FIELD_E || kind == Kind::FIELD_H1 ||
+                        kind == Kind::ENERGY_E || kind == Kind::POYNTING ||
+                        kind == Kind::MODE_SN;
+  const bool needs_rt = kind == Kind::FIELD_B || kind == Kind::ENERGY_M ||
+                        kind == Kind::POYNTING || kind == Kind::MODE_SN;
+  MFEM_VERIFY((!needs_nd || nd_fespace) && (!needs_rt || rt_fespace),
+              "Missing finite element space for domain field evaluator!");
+  MFEM_VERIFY(build_gridfunction || build_buffer,
+              "Domain point evaluator has no requested output path!");
+  Assemble(mesh, mat_op, target_fespace, scaling, build_gridfunction, build_buffer);
+}
+
+DomainPointFieldEvaluator::~DomainPointFieldEvaluator()
+{
+  fem::DestroyGroupOperators(groups);
+  fem::DestroyGroupOperators(buffer_groups);
+}
+
+void DomainPointFieldEvaluator::Assemble(const Mesh &mesh, const MaterialOperator &mat_op,
+                                         const mfem::ParFiniteElementSpace &target_fespace,
+                                         double scaling, bool build_gridfunction,
+                                         bool build_buffer)
+{
+  const int dim = mesh.Dimension();
+  const int sdim = mesh.SpaceDimension();
+  if (!((dim == 2 && sdim == 2) || (dim == 3 && sdim == 3)))
+  {
+    valid = false;
+    return;
+  }
+  const bool scalar_magnetic_field = (dim == 2);
+  const mfem::ParMesh &pmesh = mesh.Get();
+  const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
+
+  // Point-major buffer layout matching VTK tuple order and MFEM's domain VTU point
+  // order (element order, then refined/nodal points within each element). The output
+  // restriction scatters each point tuple contiguously so CeedParaViewDataCollection can
+  // write the payload without repacking.
+  buffer_num_comp = target_fespace.GetVDim();
+  buffer_bases.assign(pmesh.GetNE(), -1);
+  int buffer_points = 0;
+  const int vtu_lod = target_fespace.GetMaxElementOrder();
+  for (int e = 0; e < pmesh.GetNE(); e++)
+  {
+    const auto *RefG =
+        mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(e), vtu_lod, 1);
+    buffer_bases[e] = buffer_points;
+    buffer_points += RefG->RefPts.GetNPoints();
+  }
+  buffer_size = buffer_points * buffer_num_comp;
+
+  // Group the elements by geometry type.
+  std::map<mfem::Geometry::Type, std::vector<int>> geom_elems;
+  for (int e = 0; e < pmesh.GetNE(); e++)
+  {
+    geom_elems[pmesh.GetElementGeometry(e)].push_back(e);
+  }
+
+  // QFunction context: derived quantities need a scaling factor followed by the material
+  // property table. Plain field probes only need geometry and field values.
+  const bool field_value_kind =
+      (kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1);
+  std::vector<CeedIntScalar> ctx;
+  if (!field_value_kind)
+  {
+    ctx.resize(1);
+    ctx[0].second = scaling;
+    const auto &coeff = (kind == Kind::ENERGY_E)
+                            ? mat_op.GetPermittivityReal()
+                            : ((scalar_magnetic_field || kind == Kind::MODE_SN)
+                                   ? mat_op.GetCurlCurlInvPermeability()
+                                   : mat_op.GetInvPermeability());
+    MaterialPropertyCoefficient coeff_func(mat_op.GetAttributeToMaterial(), coeff);
+    auto mat_ctx = ceed::PopulateCoefficientContext(
+        ((scalar_magnetic_field && kind != Kind::ENERGY_E) || kind == Kind::MODE_SN) ? 1
+                                                                                     : dim,
+        &coeff_func);
+    ctx.insert(ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+
+  field_staging.SetSize(std::max(nd_fespace ? nd_fespace->GetVSize() : 0,
+                                 rt_fespace ? rt_fespace->GetVSize() : 0));
+  field_staging.UseDevice(true);
+  field_staging = 0.0;
+
+  Ceed ceed = ceed::internal::GetCeedObjects()[0];
+  for (const auto &geom_indices : geom_elems)
+  {
+    const mfem::Geometry::Type geom = geom_indices.first;
+    const auto &indices = geom_indices.second;
+    CeedAssemblyScratch scratch(ceed);
+
+    // Evaluation points are the nodal points of the (interpolatory) target space.
+    const mfem::FiniteElement *target_fe =
+        target_fespace.FEColl()->FiniteElementForGeometry(geom);
+    MFEM_VERIFY(target_fe, "Unable to get target finite element for field evaluator!");
+    const mfem::IntegrationRule &nodes_ir = target_fe->GetNodes();
+    const int num_pts = nodes_ir.GetNPoints();
+
+    // Element attributes (libCEED local, for material lookup) and mesh node gradients
+    // (for on the fly geometry evaluation at the points).
+    std::vector<ceed::CeedFunctionalFieldInput> inputs;
+    std::vector<std::pair<std::string, int>> field_sources;
+    if (!field_value_kind && build_gridfunction)
+    {
+      auto &elem_attr = elem_attrs.emplace_back(indices.size());
+      const auto &loc_attr = mesh.GetCeedAttributes();
+      for (std::size_t k = 0; k < indices.size(); k++)
+      {
+        elem_attr[k] = loc_attr.at(pmesh.GetAttribute(indices[k]));
+      }
+      CeedElemRestriction attr_restr;
+      CeedBasis attr_basis;
+      CeedVector attr_vec;
+      PalaceCeedCall(
+          ceed, CeedElemRestrictionCreateStrided(ceed, indices.size(), 1, 1, indices.size(),
+                                                 CEED_STRIDES_BACKEND, &attr_restr));
+      {
+        // Note: ceed::GetCeedTopology(CEED_TOPOLOGY_LINE) == 1.
+        mfem::Vector Bt(num_pts), Gt(num_pts), qX(num_pts), qW(num_pts);
+        Bt = 1.0;
+        Gt = 0.0;
+        qX = 0.0;
+        qW = 0.0;
+        PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_pts,
+                                               Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                               qW.GetData(), &attr_basis));
+      }
+      ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+      inputs.push_back({"attr", attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      scratch.vecs.push_back(attr_vec);
+      scratch.restrs.push_back(attr_restr);
+      scratch.bases.push_back(attr_basis);
+    }
+    {
+      CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+          mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+      const mfem::FiniteElement *mesh_fe =
+          mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+      CeedBasis mesh_basis;
+      ceed::InitBasisAtPoints(*mesh_fe, nodes_ir, mesh_fespace.GetVDim(), ceed,
+                              &mesh_basis);
+      CeedVector mesh_nodes_vec;
+      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+      inputs.push_back({"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      scratch.vecs.push_back(mesh_nodes_vec);
+      scratch.restrs.push_back(mesh_restr);
+      scratch.bases.push_back(mesh_basis);
+    }
+
+    // Field inputs evaluated at the nodal points.
+    auto AddFieldInput =
+        [&](const std::string &name, int source, const mfem::ParFiniteElementSpace &fespace)
+    {
+      CeedElemRestriction restr;
+      CeedBasis basis;
+      CeedVector vec;
+      ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                            &restr);
+      const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+      ceed::InitBasisAtPoints(*fe, nodes_ir, fespace.GetVDim(), ceed, &basis);
+      ceed::InitCeedVector(field_staging, ceed, &vec);
+      inputs.push_back({name, vec, restr, basis, ceed::EvalMode::Interp});
+      field_sources.emplace_back(name, source);
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+      scratch.bases.push_back(basis);
+    };
+    if (kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E ||
+        kind == Kind::POYNTING || kind == Kind::MODE_SN)
+    {
+      AddFieldInput("u_1", 0, *nd_fespace);
+    }
+    if (kind == Kind::FIELD_B || kind == Kind::ENERGY_M || kind == Kind::POYNTING ||
+        kind == Kind::MODE_SN)
+    {
+      AddFieldInput((kind == Kind::POYNTING || kind == Kind::MODE_SN) ? "u_2" : "u_1", 1,
+                    *rt_fespace);
+    }
+
+    // Output restriction scattering nodal values into the target grid function.
+    CeedElemRestriction out_restr;
+    ceed::InitRestriction(target_fespace, indices, false, /*is_interp*/ true, false, ceed,
+                          &out_restr);
+    scratch.restrs.push_back(out_restr);
+
+    ceed::CeedQFunctionInfo info;
+    switch (kind)
+    {
+      case Kind::FIELD_E:
+        info.apply_qf = (dim == 2) ? f_eval_probe_hcurl_22 : f_eval_probe_hcurl_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_hcurl_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_hcurl_33_loc);
+        break;
+      case Kind::FIELD_B:
+        info.apply_qf =
+            scalar_magnetic_field ? f_eval_probe_integral_22 : f_eval_probe_hdiv_33;
+        info.apply_qf_path = scalar_magnetic_field
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_integral_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_hdiv_33_loc);
+        break;
+      case Kind::FIELD_H1:
+        info.apply_qf = (dim == 2) ? f_eval_probe_l2_22 : f_eval_probe_l2_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_probe_l2_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_probe_l2_33_loc);
+        break;
+      case Kind::ENERGY_E:
+        info.apply_qf = (dim == 2) ? f_eval_energy_e_22 : f_eval_energy_e_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_energy_e_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_energy_e_33_loc);
+        break;
+      case Kind::ENERGY_M:
+        info.apply_qf = (dim == 2) ? f_eval_energy_m_22 : f_eval_energy_m_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_energy_m_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_energy_m_33_loc);
+        break;
+      case Kind::POYNTING:
+        info.apply_qf = (dim == 2) ? f_eval_poynting_22 : f_eval_poynting_33;
+        info.apply_qf_path = (dim == 2)
+                                 ? PalaceQFunctionRelativePath(f_eval_poynting_22_loc)
+                                 : PalaceQFunctionRelativePath(f_eval_poynting_33_loc);
+        break;
+      case Kind::MODE_SN:
+        MFEM_VERIFY(dim == 2, "Boundary-mode Sn output requires a 2D mesh!");
+        info.apply_qf = f_eval_mode_sn_22;
+        info.apply_qf_path = PalaceQFunctionRelativePath(f_eval_mode_sn_22_loc);
+        break;
+    }
+
+    if (build_gridfunction)
+    {
+      CeedOperator op;
+      ceed::AssembleCeedPointEvaluator(info, ctx.empty() ? nullptr : ctx.data(),
+                                       ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+                                       target_fespace.GetVDim(), out_restr, &op);
+      groups.push_back({ceed, op, std::move(field_sources)});
+      groups.back().mesh_nodes = pmesh.GetNodes();
+      groups.back().mesh_node_fields = {"grad_x"};
+      fem::CacheGroupOperatorFieldVectors(groups.back());
+    }
+
+    // Assemble a second operator for the direct VTU point-buffer path. This evaluates at
+    // MFEM's refined VTU points (not necessarily the same order as the target L2 nodes)
+    // and scatters into point-major tuples consumed by CeedParaViewDataCollection.
+    const mfem::IntegrationRule &vtu_ir =
+        mfem::GlobGeometryRefiner.Refine(geom, vtu_lod, 1)->RefPts;
+    const int num_vtu_pts = vtu_ir.GetNPoints();
+    std::vector<ceed::CeedFunctionalFieldInput> buffer_inputs;
+    std::vector<std::pair<std::string, int>> buffer_field_sources;
+    if (!field_value_kind && build_buffer)
+    {
+      auto &elem_attr = elem_attrs.emplace_back(indices.size());
+      const auto &loc_attr = mesh.GetCeedAttributes();
+      for (std::size_t k = 0; k < indices.size(); k++)
+      {
+        elem_attr[k] = loc_attr.at(pmesh.GetAttribute(indices[k]));
+      }
+      CeedElemRestriction attr_restr;
+      CeedBasis attr_basis;
+      CeedVector attr_vec;
+      PalaceCeedCall(
+          ceed, CeedElemRestrictionCreateStrided(ceed, indices.size(), 1, 1, indices.size(),
+                                                 CEED_STRIDES_BACKEND, &attr_restr));
+      {
+        mfem::Vector Bt(num_vtu_pts), Gt(num_vtu_pts), qX(num_vtu_pts), qW(num_vtu_pts);
+        Bt = 1.0;
+        Gt = 0.0;
+        qX = 0.0;
+        qW = 0.0;
+        PalaceCeedCall(ceed, CeedBasisCreateH1(ceed, CEED_TOPOLOGY_LINE, 1, 1, num_vtu_pts,
+                                               Bt.GetData(), Gt.GetData(), qX.GetData(),
+                                               qW.GetData(), &attr_basis));
+      }
+      ceed::InitCeedVector(elem_attr, ceed, &attr_vec);
+      buffer_inputs.push_back(
+          {"attr", attr_vec, attr_restr, attr_basis, ceed::EvalMode::Interp});
+      scratch.vecs.push_back(attr_vec);
+      scratch.restrs.push_back(attr_restr);
+      scratch.bases.push_back(attr_basis);
+    }
+    {
+      CeedElemRestriction mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+          mesh_fespace, ceed, geom, indices, /*is_interp*/ true);
+      const mfem::FiniteElement *mesh_fe =
+          mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
+      CeedBasis mesh_basis;
+      ceed::InitBasisAtPoints(*mesh_fe, vtu_ir, mesh_fespace.GetVDim(), ceed, &mesh_basis);
+      CeedVector mesh_nodes_vec;
+      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+      buffer_inputs.push_back(
+          {"x", mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      scratch.vecs.push_back(mesh_nodes_vec);
+      scratch.restrs.push_back(mesh_restr);
+      scratch.bases.push_back(mesh_basis);
+    }
+    auto AddBufferFieldInput =
+        [&](const std::string &name, int source, const mfem::ParFiniteElementSpace &fespace)
+    {
+      CeedElemRestriction restr;
+      CeedBasis basis;
+      CeedVector vec;
+      ceed::InitRestriction(fespace, indices, false, /*is_interp*/ true, false, ceed,
+                            &restr);
+      const mfem::FiniteElement *fe = fespace.FEColl()->FiniteElementForGeometry(geom);
+      ceed::InitBasisAtPoints(*fe, vtu_ir, fespace.GetVDim(), ceed, &basis);
+      ceed::InitCeedVector(field_staging, ceed, &vec);
+      buffer_inputs.push_back({name, vec, restr, basis, ceed::EvalMode::Interp});
+      buffer_field_sources.emplace_back(name, source);
+      scratch.vecs.push_back(vec);
+      scratch.restrs.push_back(restr);
+      scratch.bases.push_back(basis);
+    };
+    if (kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E ||
+        kind == Kind::POYNTING || kind == Kind::MODE_SN)
+    {
+      AddBufferFieldInput("u_1", 0, *nd_fespace);
+    }
+    if (kind == Kind::FIELD_B || kind == Kind::ENERGY_M || kind == Kind::POYNTING ||
+        kind == Kind::MODE_SN)
+    {
+      AddBufferFieldInput((kind == Kind::POYNTING || kind == Kind::MODE_SN) ? "u_2" : "u_1",
+                          1, *rt_fespace);
+    }
+    CeedElemRestriction buffer_out_restr;
+    {
+      std::vector<CeedInt> offsets(indices.size() * num_vtu_pts);
+      for (std::size_t e = 0; e < indices.size(); e++)
+      {
+        const int point_base = buffer_bases[indices[e]];
+        for (int j = 0; j < num_vtu_pts; j++)
+        {
+          offsets[e * num_vtu_pts + j] = (point_base + j) * buffer_num_comp;
+        }
+      }
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(indices.size()), num_vtu_pts,
+                               buffer_num_comp, 1, (CeedSize)buffer_size, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &buffer_out_restr));
+    }
+    scratch.restrs.push_back(buffer_out_restr);
+    if (build_buffer)
+    {
+      CeedOperator buffer_op;
+      ceed::AssembleCeedPointEvaluator(
+          info, ctx.empty() ? nullptr : ctx.data(), ctx.size() * sizeof(CeedIntScalar),
+          ceed, buffer_inputs, buffer_num_comp, buffer_out_restr, &buffer_op);
+      buffer_groups.push_back({ceed, buffer_op, std::move(buffer_field_sources)});
+      buffer_groups.back().mesh_nodes = pmesh.GetNodes();
+      buffer_groups.back().mesh_node_fields = {"grad_x"};
+      fem::CacheGroupOperatorFieldVectors(buffer_groups.back());
+    }
+  }
+
+  // The passive libCEED field vectors are cached and re-pointed to caller-owned data on
+  // every apply. Detach their borrowed arrays before actually releasing the construction
+  // buffer, so no full device FE vector remains per evaluator through subsequent solves.
+  fem::DetachGroupOperatorFieldVectors(groups);
+  fem::DetachGroupOperatorFieldVectors(buffer_groups);
+  field_staging.Destroy();
+  MFEM_ASSERT(field_staging.Capacity() == 0,
+              "Domain evaluator staging allocation was not released!");
+}
+
+void DomainPointFieldEvaluator::Eval(const GridFunction *E, const GridFunction *B,
+                                     Vector &out) const
+{
+  MFEM_VERIFY(valid, "Eval called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(
+      (E || kind == Kind::FIELD_B || kind == Kind::ENERGY_M) &&
+          (B || kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E),
+      "Missing field grid function for domain field evaluator!");
+  out = 0.0;
+  fem::ApplyAddGroupOperators(groups, {E ? &E->Real() : nullptr, B ? &B->Real() : nullptr},
+                              out);
+  if (E ? E->HasImag() : B->HasImag())
+  {
+    fem::ApplyAddGroupOperators(groups,
+                                {E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr}, out);
+  }
+}
+
+void DomainPointFieldEvaluator::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(valid,
+              "EvalBuffer called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1,
+              "Vector EvalBuffer is only valid for linear field evaluators!");
+  MFEM_ASSERT(buffer.Size() == buffer_size,
+              "Invalid buffer size for DomainPointFieldEvaluator::EvalBuffer!");
+  buffer = 0.0;
+  fem::ApplyAddGroupOperators(
+      buffer_groups,
+      {(kind == Kind::FIELD_E || kind == Kind::FIELD_H1) ? &u : nullptr,
+       kind == Kind::FIELD_B ? &u : nullptr, nullptr, nullptr},
+      buffer);
+}
+
+void DomainPointFieldEvaluator::EvalBuffer(const GridFunction *E, const GridFunction *B,
+                                           Vector &buffer) const
+{
+  MFEM_VERIFY(valid,
+              "EvalBuffer called on an invalid (unassembled) DomainPointFieldEvaluator!");
+  MFEM_VERIFY(
+      (E || kind == Kind::FIELD_B || kind == Kind::ENERGY_M) &&
+          (B || kind == Kind::FIELD_E || kind == Kind::FIELD_H1 || kind == Kind::ENERGY_E),
+      "Missing field grid function for domain field evaluator!");
+  MFEM_ASSERT(buffer.Size() == buffer_size,
+              "Invalid buffer size for DomainPointFieldEvaluator::EvalBuffer!");
+  buffer = 0.0;
+  fem::ApplyAddGroupOperators(buffer_groups,
+                              {E ? &E->Real() : nullptr, B ? &B->Real() : nullptr}, buffer);
+  if (E ? E->HasImag() : B->HasImag())
+  {
+    fem::ApplyAddGroupOperators(
+        buffer_groups, {E ? &E->Imag() : nullptr, B ? &B->Imag() : nullptr}, buffer);
+  }
+}
+
+}  // namespace palace

--- a/palace/fem/domain_point_field_evaluator.hpp
+++ b/palace/fem/domain_point_field_evaluator.hpp
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP
+#define PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP
+
+#include <deque>
+#include <vector>
+#include <mfem.hpp>
+#include "fem/ceed_group_operator.hpp"
+#include "linalg/vector.hpp"
+
+namespace palace
+{
+
+class GridFunction;
+class MaterialOperator;
+class Mesh;
+
+//
+// Class to evaluate derived field quantities (energy densities, Poynting vector) at the
+// nodal points of an interpolatory output space using libCEED, filling a grid function
+// for visualization output without per-point host coefficient evaluation. Follows the
+// conventions of EnergyDensityCoefficient and PoyntingVectorCoefficient.
+//
+class DomainPointFieldEvaluator
+{
+public:
+  enum class Kind
+  {
+    FIELD_E,   // H(curl) vector field value
+    FIELD_B,   // Magnetic flux value, scalar in 2D and vector in 3D
+    FIELD_H1,  // H1 scalar field value
+    ENERGY_E,  // 1/2 (ε E)ᴴ E, scalar output
+    ENERGY_M,  // 1/2 (μ⁻¹ B)ᴴ B, scalar output
+    POYNTING,  // Re{E x (μ⁻¹ B)⥁}, vector output
+    MODE_SN    // Boundary-mode Re{Eₜ x (μ⁻¹Bₜ)⋆} ⋅ z, scalar output
+  };
+
+private:
+  Kind kind;
+
+  // Source field finite element spaces (not owned): nd_fespace for H(curl), rt_fespace
+  // for H(div)/L2 B; either may be nullptr depending on the kind.
+  const mfem::ParFiniteElementSpace *nd_fespace;
+  const mfem::ParFiniteElementSpace *rt_fespace;
+
+  // Whether the evaluator could be assembled.
+  bool valid = true;
+
+  // Per-geometry assembled libCEED operators, evaluating at the target space nodal
+  // points and scattering directly into the output grid function or into a point-major
+  // ParaView point buffer. The element attribute vectors are operator inputs and must
+  // outlive the operators.
+  std::vector<fem::CeedGroupOperator> groups, buffer_groups;
+  std::deque<Vector> elem_attrs;
+
+  // Point-major buffer layout for domain visualization fields. Buffer bases are point
+  // offsets in the same element/refined-point order used by MFEM's VTU writer.
+  int buffer_size = 0, buffer_num_comp = 0;
+  std::vector<int> buffer_bases;
+
+  // Staging vector used to initialize the field input CeedVectors at construction.
+  mutable Vector field_staging;
+
+  void Assemble(const Mesh &mesh, const MaterialOperator &mat_op,
+                const mfem::ParFiniteElementSpace &target_fespace, double scaling,
+                bool build_gridfunction, bool build_buffer);
+
+public:
+  // Construct an evaluator filling grid functions on target_fespace (an interpolatory
+  // L2 space). The scaling multiplies the output as for the legacy coefficients.
+  DomainPointFieldEvaluator(Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+                            const mfem::ParFiniteElementSpace *nd_fespace,
+                            const mfem::ParFiniteElementSpace *rt_fespace,
+                            const mfem::ParFiniteElementSpace &target_fespace,
+                            double scaling, bool build_gridfunction = true,
+                            bool build_buffer = true);
+  ~DomainPointFieldEvaluator();
+
+  DomainPointFieldEvaluator(const DomainPointFieldEvaluator &) = delete;
+  DomainPointFieldEvaluator &operator=(const DomainPointFieldEvaluator &) = delete;
+
+  // Whether the evaluator was successfully assembled.
+  bool IsValid() const { return valid; }
+
+  // Total buffer size (all elements, lattice points, components), number of components,
+  // and per-element point-base offsets for the domain visualization field. Vector
+  // buffers are point-major: xyzxyz... in VTK tuple order.
+  int BufferSize() const { return buffer_size; }
+  int BufferNumComp() const { return buffer_num_comp; }
+  const std::vector<int> &BufferBases() const { return buffer_bases; }
+
+  // Fill the output vector (L-vector of the target space, e.g. a GridFunction) with
+  // the pointwise quantity. Real and imaginary field contributions add. Local
+  // operation (no MPI communication).
+  void Eval(const GridFunction *E, const GridFunction *B, Vector &out) const;
+
+  // Fill the point-major domain visualization point buffer for a single linear field.
+  // Local operation (no MPI communication).
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+
+  // Fill the point-major domain visualization point buffer. Real and imaginary field
+  // contributions add. Local operation (no MPI communication).
+  void EvalBuffer(const GridFunction *E, const GridFunction *B, Vector &buffer) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_DOMAIN_POINT_FIELD_EVALUATOR_HPP

--- a/palace/fem/qfunctions/22/eval_22_qf.h
+++ b/palace/fem/qfunctions/22/eval_22_qf.h
@@ -4,10 +4,106 @@
 #ifndef PALACE_LIBCEED_EVAL_22_QF_H
 #define PALACE_LIBCEED_EVAL_22_QF_H
 
+#include "../coeff/coeff_1_qf.h"
+#include "../coeff/coeff_2_qf.h"
 #include "utils_22_qf.h"
 
-// QFunctions for pointwise evaluation at arbitrary points of 2D volume elements.
+// QFunctions for pointwise evaluation of derived field quantities at arbitrary points
+// of 2D volume elements. No quadrature weighting is applied. H(curl):
+// E = adj(J)^T / detJ u. The 2D magnetic flux density B is scalar-valued (out of
+// plane), with H_z = mu^{-1}_{zz} B_z supplied through a scalar coefficient context.
 
+// Electric energy density: v = 0.5 * scale * (eps_r E) . E.
+CEED_QFUNCTION(f_eval_energy_e_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[2] = {u[i + Q * 0], u[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2], eps[4], D[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, u_loc, E);
+    CoeffUnpack2(ctx + 1, (CeedInt)attr[i], eps);
+    MultBx22(eps, E, D);
+    v[i] = 0.5 * ctx[0].second * (D[0] * E[0] + D[1] * E[1]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Magnetic energy density: v = 0.5 * scale * mu^{-1}_{zz} B_z^2.
+CEED_QFUNCTION(f_eval_energy_m_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar invmu_zz = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]);
+    const CeedScalar B_z = IntegralMap22(i, Q, J, u);
+    v[i] = 0.5 * ctx[0].second * invmu_zz * B_z * B_z;
+  }
+  return 0;
+}
+
+// Poynting vector: v = scale * E x (H_z zhat) = scale * H_z * (E_y, -E_x).
+CEED_QFUNCTION(f_eval_poynting_22)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[2] = {u_e[i + Q * 0], u_e[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, ue_loc, E);
+    const CeedScalar B_z = IntegralMap22(i, Q, J, u_b);
+    const CeedScalar H_z = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]) * B_z;
+    const CeedScalar s = ctx[0].second * H_z / detJ;
+    v[i + Q * 0] = s * E[1];
+    v[i + Q * 1] = -s * E[0];
+  }
+  return 0;
+}
+
+// Boundary-mode normal Poynting density on a 2D cross-section, matching
+// ModeSnCoefficient's sign convention: v = scale * Re{-Ex Hy* + Ey Hx*}, with
+// Ht = mu^{-1}_{zz} Bt. This qfunction is applied separately to real and imaginary
+// parts and accumulated.
+CEED_QFUNCTION(f_eval_mode_sn_22)(void *__restrict__ ctx_, CeedInt Q,
+                                  const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[2] = {u_e[i + Q * 0], u_e[i + Q * 1]};
+    const CeedScalar ub_loc[2] = {u_b[i + Q * 0], u_b[i + Q * 1]};
+    CeedScalar J_loc[4], adjJt_loc[4], E[2], B[2];
+    MatUnpack22(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt22<true>(J_loc, adjJt_loc);
+    MultBx22(adjJt_loc, ue_loc, E);
+    MultBx22(adjJt_loc, ub_loc, B);
+    const CeedScalar invmu = CoeffUnpack1(ctx + 1, (CeedInt)attr[i]);
+    const CeedScalar s = ctx[0].second * invmu / (detJ * detJ);
+    v[i] = s * (-E[0] * B[1] + E[1] * B[0]);
+  }
+  return 0;
+}
+
+// Pointwise H(curl) field value: v = adj(J)^T/detJ u. Inputs: grad_x, u.
 CEED_QFUNCTION(f_eval_probe_hcurl_22)(void *, CeedInt Q, const CeedScalar *const *in,
                                       CeedScalar *const *out)
 {

--- a/palace/fem/qfunctions/33/eval_33_qf.h
+++ b/palace/fem/qfunctions/33/eval_33_qf.h
@@ -4,10 +4,95 @@
 #ifndef PALACE_LIBCEED_EVAL_33_QF_H
 #define PALACE_LIBCEED_EVAL_33_QF_H
 
+#include "../coeff/coeff_3_qf.h"
 #include "utils_33_qf.h"
 
-// QFunctions for pointwise evaluation at arbitrary points of 3D volume elements.
+// QFunctions for pointwise evaluation of derived field quantities at arbitrary points
+// of 3D volume elements (for example the nodal points of an interpolatory output space
+// for visualization). No quadrature weighting is applied; the element geometry is
+// computed on the fly from the mesh nodes gradient (as in geom_qf.h) instead of stored
+// geometry factor data. Contributions of repeated applications accumulate at the output
+// L-vector (CeedOperatorApplyAdd), which implements the real/imaginary part sums of the
+// quadratic quantities.
+//
+// Inputs: in[0] is element attributes, shape [Q]
+//         in[1] is mesh node Jacobians, shape [qcomp=dim, ncomp=space_dim, Q]
+//         in[2], in[3] are field inputs (reference components at the points)
+// The context is a CeedIntScalar array: [0].second = scale, followed by a material
+// property coefficient context. H(curl): E = adj(J)ᵀ/detJ u, H(div): B = J/detJ u.
 
+// Electric energy density: v = 0.5 * scale * (eps_r E) . E.
+CEED_QFUNCTION(f_eval_energy_e_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3], eps[9], D[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, u_loc, E);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], eps);
+    MultAx33(eps, E, D);
+    v[i] = 0.5 * ctx[0].second * (D[0] * E[0] + D[1] * E[1] + D[2] * E[2]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Magnetic energy density: v = 0.5 * scale * (mu⁻¹ B) . B.
+CEED_QFUNCTION(f_eval_energy_m_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar u_loc[3] = {u[i + Q * 0], u[i + Q * 1], u[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], B[3], invmu[9], H[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(J_loc, u_loc, B);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    v[i] = 0.5 * ctx[0].second * (H[0] * B[0] + H[1] * B[1] + H[2] * B[2]) / (detJ * detJ);
+  }
+  return 0;
+}
+
+// Poynting vector: v = scale * E x (mu⁻¹ B).
+CEED_QFUNCTION(f_eval_poynting_33)(void *__restrict__ ctx_, CeedInt Q,
+                                   const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar ue_loc[3] = {u_e[i + Q * 0], u_e[i + Q * 1], u_e[i + Q * 2]};
+    const CeedScalar ub_loc[3] = {u_b[i + Q * 0], u_b[i + Q * 1], u_b[i + Q * 2]};
+    CeedScalar J_loc[9], adjJt_loc[9], E[3], B[3], invmu[9], H[3];
+    MatUnpack33(J + i, Q, J_loc);
+    const CeedScalar detJ = AdjJt33<true>(J_loc, adjJt_loc);
+    MultAx33(adjJt_loc, ue_loc, E);
+    MultAx33(J_loc, ub_loc, B);
+    CoeffUnpack3(ctx + 1, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    const CeedScalar s = ctx[0].second / (detJ * detJ);
+    v[i + Q * 0] = s * (E[1] * H[2] - E[2] * H[1]);
+    v[i + Q * 1] = s * (E[2] * H[0] - E[0] * H[2]);
+    v[i + Q * 2] = s * (E[0] * H[1] - E[1] * H[0]);
+  }
+  return 0;
+}
+
+// Pointwise H(curl) field value: v = adj(J)ᵀ/detJ u. Inputs: grad_x, u.
 CEED_QFUNCTION(f_eval_probe_hcurl_33)(void *, CeedInt Q, const CeedScalar *const *in,
                                       CeedScalar *const *out)
 {

--- a/test/unit/test-surfacefunctional.cpp
+++ b/test/unit/test-surfacefunctional.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include "fem/coefficient.hpp"
+#include "fem/domain_point_field_evaluator.hpp"
 #include "fem/facenbrexchange.hpp"
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
@@ -1628,6 +1629,272 @@ TEST_CASE("SurfaceFunctional Nonconformal Parallel", "[surfacefunctional][Parall
     CAPTURE(ref.real(), val.real(), val.imag());
     CheckPart(val.real(), ref.real());
     CheckPart(val.imag(), 0.0);
+  }
+}
+
+TEST_CASE("DomainPointFieldEvaluator Domain Fields",
+          "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = nonconformal ? MakeNCInterfaceMesh(comm, elem_type)
+                           : MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, complex), B(rt_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(1) * x(2) - 0.5;
+                                          v(1) = std::sin(x(0)) - x(2);
+                                          v(2) = std::cos(x(1)) + x(0) * x(0);
+                                        });
+    mfem::VectorFunctionCoefficient fbi(3,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = std::cos(x(2)) - 0.2;
+                                          v(1) = x(0) * x(2) + 0.1;
+                                          v(2) = std::sin(x(1)) - x(0);
+                                        });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  // Interpolatory L2 output spaces (legacy ProjectCoefficient on these spaces evaluates
+  // the coefficient at the nodal points, which is exactly the libCEED evaluator
+  // semantics, at any order).
+  mfem::L2_FECollection viz_fec(order, 3);
+  mfem::ParFiniteElementSpace viz_scalar(&pmesh, &viz_fec), viz_vector(&pmesh, &viz_fec, 3);
+
+  const double scaling = 2.5;
+  auto CheckField = [](const mfem::ParGridFunction &val, const mfem::ParGridFunction &ref)
+  {
+    // HostRead to sync from device (the evaluator fills on device).
+    const double *v = val.HostRead();
+    const double *r = ref.HostRead();
+    double max_diff = 0.0, max_ref = 0.0;
+    for (int i = 0; i < ref.Size(); i++)
+    {
+      max_diff = std::max(max_diff, std::abs(v[i] - r[i]));
+      max_ref = std::max(max_ref, std::abs(r[i]));
+    }
+    CAPTURE(max_diff, max_ref);
+    CHECK(max_diff <= 1.0e-11 * std::max(max_ref, 1.0));
+  };
+
+  SECTION("Electric energy density")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_E, *mesh, mat_op,
+                                   E.ParFESpace(), nullptr, viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(&E, nullptr, val);
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> legacy(E, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Magnetic energy density")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_M, *mesh, mat_op,
+                                   nullptr, B.ParFESpace(), viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(nullptr, &B, val);
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> legacy(B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Poynting vector")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::POYNTING, *mesh, mat_op,
+                                   E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
+    eval.Eval(&E, &B, val);
+    PoyntingVectorCoefficient legacy(E, B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+}
+
+TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
+          "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TRIANGLE, mfem::Element::QUADRILATERAL);
+  auto order = GENERATE(1, 2);
+  auto complex = GENERATE(false, true);
+  CAPTURE(elem_type, order, complex);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian2D(3, 2, elem_type, false, 1.2, 0.7));
+  smesh->EnsureNodes();
+  REQUIRE(Mpi::Size(comm) <= smesh->GetNE());
+  auto pmesh_ptr = std::make_unique<mfem::ParMesh>(comm, *smesh);
+  Mesh mesh(std::move(pmesh_ptr));
+  auto &pmesh = mesh.Get();
+
+  config::MaterialData material;
+  material.attributes = {1};
+  material.epsilon_r.s[0] = 2.0;
+  material.epsilon_r.s[1] = 3.0;
+  material.epsilon_r.s[2] = 4.0;
+  material.mu_r.s[0] = 1.0;
+  material.mu_r.s[1] = 1.5;
+  material.mu_r.s[2] = 2.0;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({material}, periodic, ProblemType::DRIVEN, mesh);
+
+  mfem::ND_FECollection nd_fec(order, 2);
+  mfem::L2_FECollection l2_fec(order - 1, 2, mfem::BasisType::GaussLegendre,
+                               mfem::FiniteElement::INTEGRAL);
+  FiniteElementSpace nd_fespace(mesh, &nd_fec), l2_fespace(mesh, &l2_fec);
+
+  GridFunction E(nd_fespace, complex), B(l2_fespace, complex);
+  mfem::VectorFunctionCoefficient fer(2,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + 0.2 * x(0);
+                                        v(1) = std::cos(x(0)) + x(1) * x(1);
+                                      });
+  mfem::FunctionCoefficient fbr([](const mfem::Vector &x)
+                                { return 0.3 + x(0) - 0.7 * x(1); });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  if (complex)
+  {
+    mfem::VectorFunctionCoefficient fei(2,
+                                        [](const mfem::Vector &x, mfem::Vector &v)
+                                        {
+                                          v(0) = x(0) * x(1) - 0.1;
+                                          v(1) = std::sin(x(0) + x(1));
+                                        });
+    mfem::FunctionCoefficient fbi([](const mfem::Vector &x)
+                                  { return std::cos(x(0)) + 0.4 * x(1); });
+    E.Imag().ProjectCoefficient(fei);
+    B.Imag().ProjectCoefficient(fbi);
+  }
+
+  mfem::L2_FECollection viz_fec(order, 2);
+  mfem::ParFiniteElementSpace viz_scalar(&pmesh, &viz_fec), viz_vector(&pmesh, &viz_fec, 2);
+
+  const double scaling = 1.7;
+  auto CheckField = [](const mfem::ParGridFunction &val, const mfem::ParGridFunction &ref)
+  {
+    const double *v = val.HostRead();
+    const double *r = ref.HostRead();
+    double max_diff = 0.0, max_ref = 0.0;
+    for (int i = 0; i < ref.Size(); i++)
+    {
+      max_diff = std::max(max_diff, std::abs(v[i] - r[i]));
+      max_ref = std::max(max_ref, std::abs(r[i]));
+    }
+    CAPTURE(max_diff, max_ref);
+    CHECK(max_diff <= 1.0e-11 * std::max(max_ref, 1.0));
+  };
+
+  SECTION("Electric energy density")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_E, mesh, mat_op,
+                                   E.ParFESpace(), nullptr, viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(&E, nullptr, val);
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> legacy(E, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Magnetic flux density")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::FIELD_B, mesh, mat_op,
+                                   nullptr, B.ParFESpace(), viz_scalar, 1.0);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(nullptr, &B, val);
+    mfem::GridFunctionCoefficient legacy_real(&B.Real());
+    ref.ProjectCoefficient(legacy_real);
+    if (complex)
+    {
+      mfem::ParGridFunction ref_imag(&viz_scalar);
+      mfem::GridFunctionCoefficient legacy_imag(&B.Imag());
+      ref_imag.ProjectCoefficient(legacy_imag);
+      ref += ref_imag;
+    }
+    CheckField(val, ref);
+  }
+
+  SECTION("Magnetic energy density")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_M, mesh, mat_op,
+                                   nullptr, B.ParFESpace(), viz_scalar, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
+    eval.Eval(nullptr, &B, val);
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> legacy(B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
+  }
+
+  SECTION("Poynting vector")
+  {
+    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::POYNTING, mesh, mat_op,
+                                   E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    REQUIRE(eval.IsValid());
+    mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
+    eval.Eval(&E, &B, val);
+    PoyntingVectorCoefficient legacy(E, B, mat_op, scaling);
+    ref.ProjectCoefficient(legacy);
+    CheckField(val, ref);
   }
 }
 


### PR DESCRIPTION
This is **6/10** in the stacked replacement for #824/#825 and depends on [#854](https://github.com/awslabs/palace/pull/854). Please review only the diff against that PR.

This adds an in-memory, device-backed evaluator for domain primary and derived fields at GridFunction and VTU refinement points.

**Reviewer guidance:** Review `domain_point_field_evaluator.*` as a self-contained domain abstraction. The important contracts are component/tuple layout, FE-space mapping, 2D versus 3D quantities, and shared lifetime of cached integration rules.

**Deferred:** Boundary traces, surface charge/current, and serialization are intentionally absent.

**Validation:** Domain evaluator tests pass with 240 assertions in both serial and MPI-2.
