### PR TITLE
Add boundary point-field evaluators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Added device-backed boundary point-field evaluators for field traces,
+    charge, current, energy, and Poynting quantities.
   - Added device-backed domain point-field evaluators for primary and derived
     visualization quantities.
   - Routed surface, port, and far-field postprocessing through device-backed

--- a/palace/fem/CMakeLists.txt
+++ b/palace/fem/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${LIB_TARGET_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/lumpedelement.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/output_functionals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/point_field_evaluator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/curlcurlmass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/integ/diffusion.cpp

--- a/palace/fem/output_functionals.cpp
+++ b/palace/fem/output_functionals.cpp
@@ -116,6 +116,10 @@ struct FaceGroup
   // the FaceNbrFieldExchange request index (filled when the exchange is built).
   bool ghost_a = false, ghost_b = false;
   bool at_points = false;
+  // Split two-sided boundary-visualization groups into one-sided AtPoints operators.
+  // ApplyAdd accumulation combines the side contributions in the shared output buffer;
+  // side_scale handles averages, normal_scale handles signed jump quantities.
+  double side_scale = 1.0;
   double normal_scale = 1.0;
   std::vector<int> face_nbr, ghost_attr, req_idx;
   std::vector<std::vector<long long>> face_nbr_point_keys;
@@ -208,11 +212,11 @@ void FoldNormalScaleIntoFaceJacobian(const mfem::DenseMatrix &J, double normal_s
   // and the oriented normal by s, including flipping the normal direction for s < 0.
   // Split local two-sided SURFACE_FLUX AtPoints groups use this to carry the per-entry
   // signed jump/average convention in geometry while sharing one operator across sides.
-  for (int d = 0; d < 2; d++)
+  for (int d = 0; d < J.Width(); d++)
   {
-    for (int c = 0; c < 3; c++)
+    for (int c = 0; c < J.Height(); c++)
     {
-      Jf[c + 3 * d] = (d == 0 ? normal_scale : 1.0) * J(c, d);
+      Jf[c + J.Height() * d] = (d == 0 ? normal_scale : 1.0) * J(c, d);
     }
   }
 }
@@ -295,6 +299,32 @@ SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(Kind kind)
   MFEM_ABORT("Unknown surface functional kind!");
 }
 
+SurfaceFunctional::KernelKind SurfaceFunctional::ToKernelKind(PointFieldKind kind)
+{
+  switch (kind)
+  {
+    case PointFieldKind::FIELD_E:
+      return KernelKind::BDR_FIELD_E;
+    case PointFieldKind::FIELD_B:
+      return KernelKind::BDR_FIELD_B;
+    case PointFieldKind::FIELD_H1:
+      return KernelKind::BDR_FIELD_H1;
+    case PointFieldKind::FLUX_Q:
+      return KernelKind::BDR_FLUX_Q;
+    case PointFieldKind::CURRENT_J:
+      return KernelKind::BDR_CURRENT_J;
+    case PointFieldKind::ENERGY_E:
+      return KernelKind::BDR_ENERGY_E;
+    case PointFieldKind::ENERGY_M:
+      return KernelKind::BDR_ENERGY_M;
+    case PointFieldKind::POYNTING:
+      return KernelKind::BDR_POYNTING;
+    case PointFieldKind::MODE_SN:
+      MFEM_ABORT("Boundary-mode Sn is a domain point field, not a boundary field!");
+  }
+  MFEM_ABORT("Unknown point field kind!");
+}
+
 const char *SurfaceFunctional::KindName(KernelKind kind)
 {
   switch (kind)
@@ -311,6 +341,22 @@ const char *SurfaceFunctional::KindName(KernelKind kind)
       return "FARFIELD";
     case KernelKind::MODE_OVERLAP:
       return "MODE_OVERLAP";
+    case KernelKind::BDR_FIELD_E:
+      return "BDR_FIELD_E";
+    case KernelKind::BDR_FIELD_B:
+      return "BDR_FIELD_B";
+    case KernelKind::BDR_FIELD_H1:
+      return "BDR_FIELD_H1";
+    case KernelKind::BDR_FLUX_Q:
+      return "BDR_FLUX_Q";
+    case KernelKind::BDR_CURRENT_J:
+      return "BDR_CURRENT_J";
+    case KernelKind::BDR_ENERGY_E:
+      return "BDR_ENERGY_E";
+    case KernelKind::BDR_ENERGY_M:
+      return "BDR_ENERGY_M";
+    case KernelKind::BDR_POYNTING:
+      return "BDR_POYNTING";
   }
   return "UNKNOWN";
 }
@@ -327,6 +373,59 @@ SurfaceFunctional::SurfaceFunctional(Kind kind, const Mesh &mesh,
               "SurfaceFunctional requires a field finite element space for functionals "
               "with field inputs!");
   Assemble(mesh, bdr_attr_marker);
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &fespace, int lod)
+  : kind(ToKernelKind(kind)),
+    nd_fespace((kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_H1)
+                   ? &fespace
+                   : nullptr),
+    rt_fespace(kind == PointFieldKind::FIELD_B ? &fespace : nullptr), mat_op(nullptr),
+    comm(mesh.GetComm()), viz_lod(lod)
+{
+  MFEM_VERIFY(kind == PointFieldKind::FIELD_E || kind == PointFieldKind::FIELD_B ||
+                  kind == PointFieldKind::FIELD_H1,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &fespace,
+                                     const MaterialOperator &mat_op, int lod,
+                                     double scaling)
+  : kind(ToKernelKind(kind)),
+    nd_fespace((kind == PointFieldKind::FLUX_Q || kind == PointFieldKind::ENERGY_E)
+                   ? &fespace
+                   : nullptr),
+    rt_fespace((kind == PointFieldKind::CURRENT_J || kind == PointFieldKind::ENERGY_M)
+                   ? &fespace
+                   : nullptr),
+    mat_op(&mat_op), comm(mesh.GetComm()), viz_lod(lod), viz_scaling(scaling)
+{
+  MFEM_VERIFY(kind == PointFieldKind::FLUX_Q || kind == PointFieldKind::CURRENT_J ||
+                  kind == PointFieldKind::ENERGY_E || kind == PointFieldKind::ENERGY_M,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
+}
+
+SurfaceFunctional::SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                                     const mfem::Array<int> &bdr_attr_marker,
+                                     const mfem::ParFiniteElementSpace &nd_fespace,
+                                     const mfem::ParFiniteElementSpace &rt_fespace,
+                                     const MaterialOperator &mat_op, int lod,
+                                     double scaling)
+  : kind(ToKernelKind(kind)), nd_fespace(&nd_fespace), rt_fespace(&rt_fespace),
+    mat_op(&mat_op), comm(mesh.GetComm()), viz_lod(lod), viz_scaling(scaling)
+{
+  MFEM_VERIFY(kind == PointFieldKind::POYNTING,
+              "Invalid SurfaceFunctional point-field backend constructor!");
+  Assemble(mesh, bdr_attr_marker);
+  WarmUpBufferOperators();
 }
 
 SurfaceFunctional::SurfaceFunctional(const Mesh &mesh,
@@ -406,8 +505,8 @@ void SurfaceFunctional::Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_a
   // The validity decision must be globally consistent: a rank may locally encounter an
   // unsupported configuration while others do not. All ranks must agree on whether the
   // libCEED path is valid so that collective evaluation calls match; model-level callers
-  // decide whether invalid means an explicit unsupported-case legacy path or an error for
-  // a supported path.
+  // then report the unsupported configuration directly instead of hiding it behind an
+  // alternate writer.
   bool global_valid = valid;
   Mpi::GlobalAnd(1, &global_valid, comm);
   if (!global_valid)
@@ -417,10 +516,21 @@ void SurfaceFunctional::Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_a
     fem::DestroyGroupOperators(groups);
     face_nbr_exchange.reset();
     elem_attrs.clear();
-    field_staging.SetSize(0);
+    field_staging.Destroy();
     local_out.SetSize(0);
     local_out_attrs.clear();
+    buffer_bases.clear();
+    buffer_size = 0;
     valid = false;
+  }
+  if (!IsBufferKind(kind))
+  {
+    // Field CeedVectors have cached handles and are re-pointed on every apply. Detach
+    // their borrowed arrays before releasing the construction storage.
+    fem::DetachGroupOperatorFieldVectors(groups);
+    field_staging.Destroy();
+    MFEM_ASSERT(field_staging.Capacity() == 0,
+                "Surface functional staging allocation was not released!");
   }
 }
 
@@ -436,12 +546,13 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     valid = false;
     return;
   }
-  if (is_2d && kind != KernelKind::AREA && kind != KernelKind::HCURL_NORM2 &&
-      kind != KernelKind::INTERFACE_EPR)
+  if (IsBufferKind(kind))
   {
-    // Initial 2D support covers line integrals needed by interface dielectric
-    // postprocessing. Other boundary-output, surface-flux, and mode-overlap kinds still
-    // use the legacy paths until their 2D scalar/vector conventions are implemented.
+    buffer_num_comp = BufferNumComp(kind, sdim);
+  }
+  if (is_2d && kind != KernelKind::AREA && kind != KernelKind::HCURL_NORM2 &&
+      kind != KernelKind::INTERFACE_EPR && !IsBufferKind(kind))
+  {
     valid = false;
     return;
   }
@@ -450,7 +561,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
   const mfem::FiniteElementSpace &mesh_fespace = *pmesh.GetNodes()->FESpace();
   const bool need_field = (kind != KernelKind::AREA);
   Ceed ceed = ceed::internal::GetCeedObjects()[0];
-  const bool use_at_points = is_3d && CeedSupportsNonTensorAtPoints(ceed);
+  const bool use_at_points = CeedSupportsNonTensorAtPoints(ceed);
 
   // Plan the evaluation for each marked boundary element and group the elements by
   // their face configuration. AtPoints groups share tabulated bases and carry mapped
@@ -485,8 +596,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       const bool has_elem2 = (FET.Elem2 != nullptr);
       const bool elem2_local = has_elem2 && (FET.Elem2No < pmesh.GetNE());
 
-      // Decide which side(s) the field is evaluated from following the conventions of
-      // the legacy coefficients (see InterfaceDielectricCoefficient and
+      // Decide which side(s) the field is evaluated from following the established
+      // coefficient semantics (see InterfaceDielectricCoefficient and
       // BdrSurfaceFluxCoefficient).
       ElemPlan plan;
       plan.bdr_elem = i;
@@ -511,7 +622,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         }
         plan.elem_a = FET.Elem1No;
       }
-      else if (kind == KernelKind::SURFACE_FLUX ||
+      else if (kind == KernelKind::SURFACE_FLUX || IsBufferKind(kind) ||
                (kind == KernelKind::INTERFACE_EPR &&
                 epr_type == InterfaceDielectric::DEFAULT))
       {
@@ -579,8 +690,11 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       // (TransformBdrElementToFace with the boundary element to face orientation) ->
       // element 1/2 reference coordinates (FET.Loc1/Loc2).
       const auto bdr_geom = pmesh.GetBdrElementGeometry(i);
+      const bool buffer_kind = IsBufferKind(kind);
       const mfem::IntegrationRule &face_ir =
-          mfem::IntRules.Get(bdr_geom, fem::DefaultIntegrationOrder::Get(pmesh, bdr_geom));
+          buffer_kind ? mfem::GlobGeometryRefiner.Refine(bdr_geom, viz_lod, 1)->RefPts
+                      : mfem::IntRules.Get(
+                            bdr_geom, fem::DefaultIntegrationOrder::Get(pmesh, bdr_geom));
       const int nq = face_ir.GetNPoints();
       int f, o;
       pmesh.GetBdrElementFace(i, &f, &o);
@@ -631,6 +745,11 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         plan.point_key_b = MakeTraceMapTopologyKey(face_info, side, vol_geom_b, bdr_geom,
                                                    face_ir, o, FET.Loc2);
       }
+      auto IsAtPointsSimplex = [&](mfem::Geometry::Type geom)
+      {
+        return (is_3d && geom == mfem::Geometry::TETRAHEDRON) ||
+               (is_2d && geom == mfem::Geometry::TRIANGLE);
+      };
       const bool can_surface_flux_at_points_a =
           use_at_points && kind == KernelKind::SURFACE_FLUX && plan.elem_a >= 0 &&
           !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
@@ -639,19 +758,41 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           !plan.ghost_b && vol_geom_b == mfem::Geometry::TETRAHEDRON;
       const bool can_epr_at_points = use_at_points && kind == KernelKind::INTERFACE_EPR &&
                                      plan.elem_a >= 0 && plan.elem_b < 0 && !plan.ghost_a &&
-                                     vol_geom_a == mfem::Geometry::TETRAHEDRON;
+                                     IsAtPointsSimplex(vol_geom_a);
       const bool can_farfield_at_points =
           use_at_points && kind == KernelKind::FARFIELD && plan.elem_a >= 0 &&
           plan.elem_b < 0 && !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
       const bool can_mode_overlap_at_points =
           use_at_points && kind == KernelKind::MODE_OVERLAP && plan.elem_a >= 0 &&
           plan.elem_b < 0 && !plan.ghost_a && vol_geom_a == mfem::Geometry::TETRAHEDRON;
-      const bool can_at_points_a = can_surface_flux_at_points_a || can_epr_at_points ||
-                                   can_farfield_at_points || can_mode_overlap_at_points;
-      const bool can_at_points_b = can_surface_flux_at_points_b;
+      const bool can_at_points_a =
+          (use_at_points && buffer_kind && plan.elem_a >= 0 && !plan.ghost_a &&
+           vol_geom_a == mfem::Geometry::TETRAHEDRON) ||
+          can_surface_flux_at_points_a || can_epr_at_points || can_farfield_at_points ||
+          can_mode_overlap_at_points;
+      const bool can_at_points_b =
+          (use_at_points && buffer_kind && plan.elem_b >= 0 && !plan.ghost_b &&
+           vol_geom_b == mfem::Geometry::TETRAHEDRON) ||
+          can_surface_flux_at_points_b;
 
-      const int out_slot = num_marked++;
-      local_out_attrs.push_back(attr);
+      int out_slot;
+      if (IsBufferKind(kind))
+      {
+        if (buffer_bases.empty())
+        {
+          buffer_bases.resize(pmesh.GetNBE(), -1);
+        }
+        const int nc = buffer_num_comp;
+        out_slot = buffer_size / nc;
+        buffer_bases[i] = out_slot;
+        buffer_size += nq * nc;
+        num_marked++;
+      }
+      else
+      {
+        out_slot = num_marked++;
+        local_out_attrs.push_back(attr);
+      }
 
       auto AddGroup = [&](int elem_a, bool ghost_a, mfem::Geometry::Type geom_a,
                           const std::vector<mfem::IntegrationPoint> &pts_a,
@@ -659,7 +800,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
                           bool ghost_b, mfem::Geometry::Type geom_b,
                           const std::vector<mfem::IntegrationPoint> &pts_b,
                           const std::vector<long long> &point_key_b, bool at_points_group,
-                          double normal_scale)
+                          double side_scale, double normal_scale)
       {
         FaceConfigKey key;
         key.reserve(12);
@@ -672,9 +813,10 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         key.push_back(static_cast<long long>(ghost_b));
         key.push_back(static_cast<long long>(nq));
         key.push_back(static_cast<long long>(at_points_group));
-        // Normal scales are exact multiples of 1/2 from the split-side conventions.
-        // Encode those discrete states directly rather than carrying a floating-point
-        // grouping key.
+        // Current side/normal scales are exact multiples of 1/2 from the split-side
+        // conventions. Encode those discrete states directly rather than carrying a
+        // floating-point grouping key.
+        key.push_back(static_cast<long long>(std::llround(2.0 * side_scale)));
         key.push_back(
             static_cast<long long>((at_points_group && kind == KernelKind::SURFACE_FLUX)
                                        ? 0
@@ -715,6 +857,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           group.ghost_a = ghost_a;
           group.ghost_b = ghost_b;
           group.at_points = at_points_group;
+          group.side_scale = side_scale;
           group.normal_scale = normal_scale;
           if (!at_points_group && elem_a >= 0)
           {
@@ -795,16 +938,51 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         const double scale_a = flux_two_sided ? 1.0 : 0.5;
         const double scale_b = flux_two_sided ? -1.0 : 0.5;
         AddGroup(plan.elem_a, false, vol_geom_a, plan.pts_a, plan.point_key_a, -1, false,
-                 mfem::Geometry::INVALID, {}, {}, true, scale_a);
+                 mfem::Geometry::INVALID, {}, {}, true, 1.0, scale_a);
         AddGroup(plan.elem_b, false, vol_geom_b, plan.pts_b, plan.point_key_b, -1, false,
-                 mfem::Geometry::INVALID, {}, {}, true, scale_b);
+                 mfem::Geometry::INVALID, {}, {}, true, 1.0, scale_b);
+      }
+      else if (buffer_kind && can_at_points_a && can_at_points_b)
+      {
+        // Split two-sided boundary visualization into two one-sided AtPoints operators
+        // that accumulate into the same output slot. One AtPoints operator can only own
+        // one point-coordinate set; the two sides generally use different mapped
+        // reference coordinates, so preserving the two-sided kernels would reintroduce
+        // mapped-point specialization.
+        const bool average_quantity =
+            kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+            kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_ENERGY_E ||
+            kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
+        const double side_weight = average_quantity ? 0.5 : 1.0;
+        AddGroup(plan.elem_a, false, vol_geom_a, plan.pts_a, plan.point_key_a, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, side_weight, 1.0);
+        AddGroup(plan.elem_b, false, vol_geom_b, plan.pts_b, plan.point_key_b, -1, false,
+                 mfem::Geometry::INVALID, {}, {}, true, side_weight, -1.0);
+      }
+      else if (buffer_kind && plan.elem_a >= 0 && plan.elem_b >= 0 &&
+               ((can_at_points_a && plan.ghost_b) || (can_at_points_b && plan.ghost_a)))
+      {
+        // For shared NC faces, only the local side can use libCEED AtPoints; the ghost
+        // side must first be imported through FaceNbrFieldExchange. Split the trace so
+        // the local contribution still batches with other AtPoints boundary fields, and
+        // only the ghost contribution uses the finite mapped trace key.
+        const bool average_quantity =
+            kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+            kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_ENERGY_E ||
+            kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
+        const double side_weight = average_quantity ? 0.5 : 1.0;
+        AddGroup(plan.elem_a, plan.ghost_a, vol_geom_a, plan.pts_a, plan.point_key_a, -1,
+                 false, mfem::Geometry::INVALID, {}, {}, can_at_points_a, side_weight, 1.0);
+        AddGroup(plan.elem_b, plan.ghost_b, vol_geom_b, plan.pts_b, plan.point_key_b, -1,
+                 false, mfem::Geometry::INVALID, {}, {}, can_at_points_b, side_weight,
+                 -1.0);
       }
       else
       {
         const bool at_points_group = can_at_points_a && plan.elem_b < 0;
         AddGroup(plan.elem_a, plan.ghost_a, vol_geom_a, plan.pts_a, plan.point_key_a,
                  plan.elem_b, plan.ghost_b, vol_geom_b, plan.pts_b, plan.point_key_b,
-                 at_points_group, 1.0);
+                 at_points_group, 1.0, 1.0);
       }
     }
   }
@@ -813,7 +991,9 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
   // produce 6 values (Re/Im of a 3-vector) per direction per element.
   const int num_out =
       (kind == KernelKind::FARFIELD) ? 6 * static_cast<int>(farfield_dirs.size()) : 1;
-  local_out.SetSize(num_marked * num_out);
+  local_out.SetSize((kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+                        ? 0
+                        : num_marked * num_out);
   local_out.UseDevice(true);
   if (need_field)
   {
@@ -887,6 +1067,45 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
     }
   }
+  else if (kind == KernelKind::BDR_FLUX_Q || kind == KernelKind::BDR_CURRENT_J)
+  {
+    base_ctx.resize(2);
+    base_ctx[0].second = 1.0;  // Normal sign, set per group
+    base_ctx[1].second = viz_scaling;
+    const bool magnetic = (kind == KernelKind::BDR_CURRENT_J);
+    MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
+                                           magnetic ? mat_op->GetCurlCurlInvPermeability()
+                                                    : mat_op->GetPermittivityReal());
+    auto mat_ctx =
+        ceed::PopulateCoefficientContext(magnetic && is_2d ? 1 : dim, &coeff_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else if (kind == KernelKind::BDR_POYNTING)
+  {
+    // Pointwise S = scale * E x (mu^-1 B). For split two-sided AtPoints groups,
+    // group.side_scale folds in the legacy 1/2 side average.
+    base_ctx.resize(1);
+    base_ctx[0].second = viz_scaling;
+    MaterialPropertyCoefficient invmu_func(mat_op->GetAttributeToMaterial(),
+                                           mat_op->GetCurlCurlInvPermeability());
+    auto mat_ctx = ceed::PopulateCoefficientContext(is_2d ? 1 : dim, &invmu_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
+  else if (kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M)
+  {
+    // Shared energy kernel: [0].first = piola (0 = ND/E, 1 = RT/B), [1].second = scaling,
+    // material table at +2.
+    base_ctx.resize(2);
+    base_ctx[0].first = (kind == KernelKind::BDR_ENERGY_M) ? 1 : 0;
+    base_ctx[1].second = viz_scaling;
+    const bool magnetic = (kind == KernelKind::BDR_ENERGY_M);
+    MaterialPropertyCoefficient coeff_func(mat_op->GetAttributeToMaterial(),
+                                           magnetic ? mat_op->GetCurlCurlInvPermeability()
+                                                    : mat_op->GetPermittivityReal());
+    auto mat_ctx =
+        ceed::PopulateCoefficientContext(magnetic && is_2d ? 1 : dim, &coeff_func);
+    base_ctx.insert(base_ctx.end(), mat_ctx.begin(), mat_ctx.end());
+  }
   else if (kind == KernelKind::MODE_OVERLAP)
   {
     // Group-specific entries are filled after selecting the boundary attribute:
@@ -924,6 +1143,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     base_ctx.resize(2);
     base_ctx[0].second = 0.0;
     base_ctx[1].second = 1.0;
+    if (kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B)
+    {
+      // Shared vector field kernel: [0].first = piola (0 = ND/E, 1 = RT/B),
+      // [1].second = output scale (used when split AtPoints sides accumulate).
+      base_ctx[0].first = (kind == KernelKind::BDR_FIELD_B) ? 1 : 0;
+    }
   }
 
   // Build the face neighbor field exchange for any ghost (face neighbor) sides of
@@ -956,6 +1181,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         source_mask = (flux_type == SurfaceFlux::ELECTRIC)   ? 0b01u
                       : (flux_type == SurfaceFlux::MAGNETIC) ? 0b10u
                                                              : 0b11u;
+      }
+      else if (kind == KernelKind::BDR_POYNTING)
+      {
+        ex_fes[0] = nd_fespace;
+        ex_fes[1] = rt_fespace;
+        source_mask = 0b11u;
       }
       else
       {
@@ -1031,8 +1262,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         profile_counts[7]++;
       }
     }
-    const mfem::IntegrationRule &face_ir = mfem::IntRules.Get(
-        group.bdr_geom, fem::DefaultIntegrationOrder::Get(pmesh, group.bdr_geom));
+    const bool buffer_kind = IsBufferKind(kind);
+    const mfem::IntegrationRule &face_ir =
+        buffer_kind
+            ? mfem::GlobGeometryRefiner.Refine(group.bdr_geom, viz_lod, 1)->RefPts
+            : mfem::IntRules.Get(group.bdr_geom,
+                                 fem::DefaultIntegrationOrder::Get(pmesh, group.bdr_geom));
 
     // Objects are owned by the assembled operator; scratch destroys our references.
     CeedAssemblyScratch scratch(ceed);
@@ -1043,19 +1278,25 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       const int nq = face_ir.GetNPoints();
       MFEM_VERIFY(group.mapped_pts_a.size() == num_elem * static_cast<std::size_t>(nq),
                   "Invalid AtPoints coordinate data for surface output group!");
-      auto &points = elem_attrs.emplace_back(3 * num_elem * nq);
+      // libCEED's AtPoints coordinates have the basis's topological dimension, not a
+      // fixed three-component IntegrationPoint layout.
+      auto &points = elem_attrs.emplace_back(dim * num_elem * nq);
       for (std::size_t e = 0; e < num_elem; e++)
       {
         for (int q = 0; q < nq; q++)
         {
           const auto &ip = group.mapped_pts_a[e * nq + q];
-          const std::size_t off = 3 * (e * nq + q);
+          const std::size_t off = dim * (e * nq + q);
           points[off + 0] = ip.x;
           points[off + 1] = ip.y;
-          points[off + 2] = ip.z;
+          if (dim == 3)
+          {
+            points[off + 2] = ip.z;
+          }
         }
       }
-      CreateSequentialPointRestriction(ceed, num_elem, nq, 3, points.Size(), &points_restr);
+      CreateSequentialPointRestriction(ceed, num_elem, nq, dim, points.Size(),
+                                       &points_restr);
       ceed::InitCeedVector(points, ceed, &points_vec);
       scratch.restrs.push_back(points_restr);
       scratch.vecs.push_back(points_vec);
@@ -1069,6 +1310,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     // in the QFunctions (no stored geometry factor data).
     std::vector<ceed::CeedFunctionalFieldInput> inputs;
     std::vector<std::pair<std::string, int>> field_sources;
+    std::vector<std::string> mesh_node_fields;
     const mfem::FiniteElement *face_mesh_fe =
         mesh_fespace.FEColl()->FiniteElementForGeometry(group.bdr_geom);
     if (!face_mesh_fe)
@@ -1089,21 +1331,25 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     auto AddFaceGeomInputAtPoints = [&]()
     {
       const int nq = face_ir.GetNPoints();
-      auto &qw = elem_attrs.emplace_back(num_elem * nq);
-      for (std::size_t e = 0; e < num_elem; e++)
+      if (!buffer_kind)
       {
-        for (int q = 0; q < nq; q++)
+        auto &qw = elem_attrs.emplace_back(num_elem * nq);
+        for (std::size_t e = 0; e < num_elem; e++)
         {
-          qw[e * nq + q] = face_ir.IntPoint(q).weight;
+          for (int q = 0; q < nq; q++)
+          {
+            qw[e * nq + q] = face_ir.IntPoint(q).weight;
+          }
         }
+        AddSequentialPointInput("qw", qw, 1);
       }
-      AddSequentialPointInput("qw", qw, 1);
       if (kind == KernelKind::SURFACE_FLUX && !group.normal_scales.empty())
       {
         MFEM_VERIFY(group.normal_scales.size() == num_elem,
                     "SURFACE_FLUX AtPoints normal scales must be entry-indexed!");
       }
-      auto &face_geom = elem_attrs.emplace_back(num_elem * nq * 6);
+      const int face_jac_size = sdim * (dim - 1);
+      auto &face_geom = elem_attrs.emplace_back(num_elem * nq * face_jac_size);
       face_geom = 0.0;
       for (std::size_t e = 0; e < num_elem; e++)
       {
@@ -1118,32 +1364,46 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
               (kind == KernelKind::SURFACE_FLUX && !group.normal_scales.empty())
                   ? group.normal_scales[e]
                   : 1.0;
-          const std::size_t off = 6 * (e * nq + q);
+          const std::size_t off = face_jac_size * (e * nq + q);
           FoldNormalScaleIntoFaceJacobian(J, normal_scale, face_geom.HostReadWrite() + off);
         }
       }
-      AddSequentialPointInput("grad_x_f", face_geom, 6);
+      AddSequentialPointInput("grad_x_f", face_geom, face_jac_size);
     };
-    const bool needs_elem_attr = kind != KernelKind::MODE_OVERLAP;
-    if (group.at_points)
+    const bool field_value_kind = kind == KernelKind::BDR_FIELD_E ||
+                                  kind == KernelKind::BDR_FIELD_B ||
+                                  kind == KernelKind::BDR_FIELD_H1;
+    const bool needs_face_geom = !field_value_kind && kind != KernelKind::BDR_ENERGY_E &&
+                                 kind != KernelKind::BDR_ENERGY_M &&
+                                 kind != KernelKind::BDR_POYNTING;
+    const bool needs_elem_attr = !field_value_kind && kind != KernelKind::MODE_OVERLAP;
+    if (needs_face_geom)
     {
-      AddFaceGeomInputAtPoints();
-    }
-    else
-    {
-      CeedBasis face_mesh_basis;
-      ceed::InitBasisAtPoints(*face_mesh_fe, face_ir, mesh_fespace.GetVDim(), ceed,
-                              &face_mesh_basis);
-      CeedElemRestriction face_mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
-          mesh_fespace, ceed, group.bdr_geom, group.bdr_indices, /*is_interp*/ true);
-      CeedVector mesh_nodes_vec;
-      ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
-      inputs.push_back({"qw", nullptr, nullptr, face_mesh_basis, ceed::EvalMode::Weight});
-      inputs.push_back(
-          {"x_f", mesh_nodes_vec, face_mesh_restr, face_mesh_basis, ceed::EvalMode::Grad});
-      scratch.vecs.push_back(mesh_nodes_vec);
-      scratch.restrs.push_back(face_mesh_restr);
-      scratch.bases.push_back(face_mesh_basis);
+      if (group.at_points)
+      {
+        AddFaceGeomInputAtPoints();
+      }
+      else
+      {
+        CeedBasis face_mesh_basis;
+        ceed::InitBasisAtPoints(*face_mesh_fe, face_ir, mesh_fespace.GetVDim(), ceed,
+                                &face_mesh_basis);
+        CeedElemRestriction face_mesh_restr = FiniteElementSpace::BuildCeedElemRestriction(
+            mesh_fespace, ceed, group.bdr_geom, group.bdr_indices, /*is_interp*/ true);
+        CeedVector mesh_nodes_vec;
+        ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
+        if (!buffer_kind)
+        {
+          inputs.push_back(
+              {"qw", nullptr, nullptr, face_mesh_basis, ceed::EvalMode::Weight});
+        }
+        inputs.push_back({"x_f", mesh_nodes_vec, face_mesh_restr, face_mesh_basis,
+                          ceed::EvalMode::Grad});
+        mesh_node_fields.push_back("grad_x_f");
+        scratch.vecs.push_back(mesh_nodes_vec);
+        scratch.restrs.push_back(face_mesh_restr);
+        scratch.bases.push_back(face_mesh_basis);
+      }
     }
     auto AddVolGeomInputs = [&](const std::string &suffix, const std::vector<int> &indices,
                                 mfem::Geometry::Type geom, const mfem::IntegrationRule &ir)
@@ -1171,12 +1431,13 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         const mfem::FiniteElement *mesh_fe =
             mesh_fespace.FEColl()->FiniteElementForGeometry(geom);
         CeedBasis mesh_basis;
-        ceed::InitTetBasisAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(),
-                                   ceed, &mesh_basis);
+        ceed::InitSimplexBasisAtPoints(*mesh_fe, /*grad_only*/ true, mesh_fespace.GetVDim(),
+                                       ceed, &mesh_basis);
         CeedVector mesh_nodes_vec;
         ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
         inputs.push_back(
             {"x_" + suffix, mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+        mesh_node_fields.push_back("grad_x_" + suffix);
         scratch.vecs.push_back(mesh_nodes_vec);
         scratch.restrs.push_back(mesh_restr);
         scratch.bases.push_back(mesh_basis);
@@ -1222,6 +1483,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &mesh_nodes_vec);
       inputs.push_back(
           {"x_" + suffix, mesh_nodes_vec, mesh_restr, mesh_basis, ceed::EvalMode::Grad});
+      mesh_node_fields.push_back("grad_x_" + suffix);
       if (needs_elem_attr)
       {
         scratch.vecs.push_back(attr_vec);
@@ -1371,6 +1633,7 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         CeedVector x_vec;
         ceed::InitCeedVector(*mesh_fespace.GetMesh()->GetNodes(), ceed, &x_vec);
         inputs.push_back({"x", x_vec, x_restr, x_basis, ceed::EvalMode::Interp});
+        mesh_node_fields.push_back("x");
         scratch.vecs.push_back(x_vec);
         scratch.restrs.push_back(x_restr);
         scratch.bases.push_back(x_basis);
@@ -1390,8 +1653,8 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       MFEM_VERIFY(fe, "Unable to get field finite element for surface functional!");
       if (group.at_points)
       {
-        ceed::InitTetBasisAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
-                                   &basis);
+        ceed::InitSimplexBasisAtPoints(*fe, /*grad_only*/ false, fespace.GetVDim(), ceed,
+                                       &basis);
       }
       else
       {
@@ -1414,18 +1677,19 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
         [&](const std::string &name, int slot, const mfem::IntegrationRule &ir)
     {
       const int nq = ir.GetNPoints();
+      const int num_comp = face_nbr_exchange->ImportNumComp(slot);
       std::vector<CeedInt> offsets(num_elem * nq);
       for (std::size_t e = 0; e < num_elem; e++)
       {
         const int base = face_nbr_exchange->ImportOffset(group.req_idx[e], slot);
         for (int i = 0; i < nq; i++)
         {
-          offsets[e * nq + i] = base + sdim * i;
+          offsets[e * nq + i] = base + num_comp * i;
         }
       }
       CeedElemRestriction restr;
       PalaceCeedCall(ceed, CeedElemRestrictionCreate(
-                               ceed, static_cast<CeedInt>(num_elem), nq, sdim, 1,
+                               ceed, static_cast<CeedInt>(num_elem), nq, num_comp, 1,
                                (CeedSize)face_nbr_exchange->ImportSize(), CEED_MEM_HOST,
                                CEED_COPY_VALUES, offsets.data(), &restr));
       CeedVector vec;
@@ -1435,8 +1699,35 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       scratch.vecs.push_back(vec);
       scratch.restrs.push_back(restr);
     };
-    if (kind == KernelKind::HCURL_NORM2 || kind == KernelKind::INTERFACE_EPR ||
-        kind == KernelKind::MODE_OVERLAP)
+    if (kind == KernelKind::BDR_POYNTING)
+    {
+      auto AddPoyntingSide = [&](const std::string &suffix, const std::vector<int> &indices,
+                                 mfem::Geometry::Type geom, const mfem::IntegrationRule &ir,
+                                 bool ghost)
+      {
+        const std::string e_name = "u_e_" + suffix;
+        const std::string b_name = "u_b_" + suffix;
+        if (ghost)
+        {
+          AddFieldInputGhost(e_name, 0, ir);
+          AddFieldInputGhost(b_name, 1, ir);
+        }
+        else
+        {
+          AddFieldInput(e_name, 0, *nd_fespace, indices, geom, ir);
+          AddFieldInput(b_name, 1, *rt_fespace, indices, geom, ir);
+        }
+      };
+      AddPoyntingSide("1", group.vol_indices_a, group.vol_geom_a,
+                      group.at_points ? face_ir : *group.mapped_ir_a, group.ghost_a);
+      if (has_b)
+      {
+        AddPoyntingSide("2", group.vol_indices_b, group.vol_geom_b,
+                        group.at_points ? face_ir : *group.mapped_ir_b, group.ghost_b);
+      }
+    }
+    else if (kind == KernelKind::HCURL_NORM2 || kind == KernelKind::INTERFACE_EPR ||
+             kind == KernelKind::MODE_OVERLAP || buffer_kind)
     {
       const auto &field_fespace = rt_fespace ? *rt_fespace : *nd_fespace;
       if (group.ghost_a)
@@ -1509,10 +1800,34 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
       }
     }
 
-    // Output restriction: num_out slots per boundary element in the local output vector
-    // (component stride num_marked).
+    // Output restriction: for integral kinds, num_out slots per boundary element in
+    // the local output vector (component stride num_marked); for the boundary
+    // visualization field kinds, component-major lanes over all lattice points scatter
+    // into the output buffer at the per-element point-base offsets.
     CeedElemRestriction out_restr;
-    if (group.at_points)
+    if (buffer_kind)
+    {
+      const int nq = face_ir.GetNPoints();
+      const int nc = buffer_num_comp;
+      const int component_stride = buffer_size / nc;
+      std::vector<CeedInt> offsets(num_elem * nq);
+      for (std::size_t e = 0; e < num_elem; e++)
+      {
+        for (int j = 0; j < nq; j++)
+        {
+          offsets[e * nq + j] = group.out_slots[e] + j;
+        }
+      }
+      // Even for AtPoints operators, keep the output as an ordinary EVAL_NONE
+      // restriction. libCEED requires all AtPoints restrictions on the same operator to
+      // use identical point-offset layouts; the output buffer is intentionally scattered
+      // by boundary-element slot and should not constrain the point-coordinate layout.
+      PalaceCeedCall(ceed, CeedElemRestrictionCreate(
+                               ceed, static_cast<CeedInt>(num_elem), nq, nc,
+                               component_stride, (CeedSize)buffer_size, CEED_MEM_HOST,
+                               CEED_COPY_VALUES, offsets.data(), &out_restr));
+    }
+    else if (group.at_points)
     {
       const int nq = face_ir.GetNPoints();
       std::vector<CeedInt> offsets(num_elem * nq);
@@ -1564,6 +1879,73 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
                                                       : f_integ_surf_epr_1_21_loc)
                   : PalaceQFunctionRelativePath(has_b ? f_integ_surf_epr_2_32_loc
                                                       : f_integ_surf_epr_1_32_loc);
+        break;
+      case KernelKind::BDR_FIELD_E:
+      case KernelKind::BDR_FIELD_B:
+        // Shared vector field kernel; the ND/RT Piola is set in base_ctx[0].first.
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_field_2_21 : f_eval_bdr_field_1_21)
+                              : (has_b ? f_eval_bdr_field_2_32 : f_eval_bdr_field_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_21_loc
+                                                      : f_eval_bdr_field_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_2_32_loc
+                                                      : f_eval_bdr_field_1_32_loc);
+        break;
+      case KernelKind::BDR_FIELD_H1:
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = is_2d
+                            ? (has_b ? f_eval_bdr_field_h1_2_21 : f_eval_bdr_field_h1_1_21)
+                            : (has_b ? f_eval_bdr_field_h1_2_32 : f_eval_bdr_field_h1_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_h1_2_21_loc
+                                                      : f_eval_bdr_field_h1_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_field_h1_2_32_loc
+                                                      : f_eval_bdr_field_h1_1_32_loc);
+        break;
+      case KernelKind::BDR_FLUX_Q:
+        ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_flux_q_2_21 : f_eval_bdr_flux_q_1_21)
+                              : (has_b ? f_eval_bdr_flux_q_2_32 : f_eval_bdr_flux_q_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_flux_q_2_21_loc
+                                                      : f_eval_bdr_flux_q_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_flux_q_2_32_loc
+                                                      : f_eval_bdr_flux_q_1_32_loc);
+        break;
+      case KernelKind::BDR_CURRENT_J:
+        ctx[0].second = (group.flip_normal ? -1.0 : 1.0) * group.normal_scale;
+        info.apply_qf =
+            is_2d ? (has_b ? f_eval_bdr_current_j_2_21 : f_eval_bdr_current_j_1_21)
+                  : (has_b ? f_eval_bdr_current_j_2_32 : f_eval_bdr_current_j_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_current_j_2_21_loc
+                                                      : f_eval_bdr_current_j_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_current_j_2_32_loc
+                                                      : f_eval_bdr_current_j_1_32_loc);
+        break;
+      case KernelKind::BDR_ENERGY_E:
+      case KernelKind::BDR_ENERGY_M:
+        // Shared kernel; the ND/RT Piola is set in base_ctx[0].first.
+        ctx[1].second *= group.side_scale;
+        info.apply_qf = is_2d ? (has_b ? f_eval_bdr_energy_2_21 : f_eval_bdr_energy_1_21)
+                              : (has_b ? f_eval_bdr_energy_2_32 : f_eval_bdr_energy_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_energy_2_21_loc
+                                                      : f_eval_bdr_energy_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_energy_2_32_loc
+                                                      : f_eval_bdr_energy_1_32_loc);
+        break;
+      case KernelKind::BDR_POYNTING:
+        ctx[0].second *= group.side_scale;
+        info.apply_qf = is_2d
+                            ? (has_b ? f_eval_bdr_poynting_2_21 : f_eval_bdr_poynting_1_21)
+                            : (has_b ? f_eval_bdr_poynting_2_32 : f_eval_bdr_poynting_1_32);
+        info.apply_qf_path =
+            is_2d ? PalaceQFunctionRelativePath(has_b ? f_eval_bdr_poynting_2_21_loc
+                                                      : f_eval_bdr_poynting_1_21_loc)
+                  : PalaceQFunctionRelativePath(has_b ? f_eval_bdr_poynting_2_32_loc
+                                                      : f_eval_bdr_poynting_1_32_loc);
         break;
       case KernelKind::FARFIELD:
         ctx[0].second = group.flip_normal ? -1.0 : 1.0;
@@ -1621,7 +2003,22 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
     // Assemble the operator.
     CeedOperator op;
     CeedQFunctionContext op_ctx = nullptr;
-    if (group.at_points)
+    if (buffer_kind)
+    {
+      if (group.at_points)
+      {
+        ceed::AssembleCeedPointEvaluatorAtPoints(
+            info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+            points_restr, points_vec, buffer_num_comp, out_restr, &op);
+      }
+      else
+      {
+        ceed::AssembleCeedPointEvaluator(info, ctx.data(),
+                                         ctx.size() * sizeof(CeedIntScalar), ceed, inputs,
+                                         buffer_num_comp, out_restr, &op);
+      }
+    }
+    else if (group.at_points)
     {
       ceed::AssembleCeedPointEvaluatorAtPoints(
           info, ctx.data(), ctx.size() * sizeof(CeedIntScalar), ceed, inputs, points_restr,
@@ -1635,6 +2032,12 @@ void SurfaceFunctional::AssembleLocal(const Mesh &mesh,
           out_restr, &op, (kind == KernelKind::FARFIELD) ? &op_ctx : nullptr);
     }
     groups.push_back({ceed, op, std::move(field_sources), op_ctx});
+    if (!mesh_node_fields.empty())
+    {
+      groups.back().mesh_nodes = pmesh.GetNodes();
+      groups.back().mesh_node_fields = std::move(mesh_node_fields);
+    }
+    fem::CacheGroupOperatorFieldVectors(groups.back());
   }
   if (profile)
   {
@@ -1797,6 +2200,58 @@ std::vector<std::complex<double>> SurfaceFunctional::EvalModeOverlapByAttribute(
   return result;
 }
 
+void SurfaceFunctional::WarmUpBufferOperators() const
+{
+  if (!valid || !IsBufferKind(kind))
+  {
+    field_staging.Destroy();
+    return;
+  }
+  // Do not return early on ranks with no local groups. Face-neighbor exchange is
+  // collective and another rank may have a marked interface face even when this rank has
+  // no output entries.
+  // Force libCEED/CUDA lazy initialization for boundary point-field operators while the
+  // output backend is being configured instead of during the first VTU payload write.
+  // This does not remove any output fields or payload bytes; secondary timers track the
+  // shifted setup cost in the full application run.
+  Vector buffer(buffer_size);
+  buffer.UseDevice(true);
+  buffer = 0.0;
+  if (kind == KernelKind::BDR_POYNTING)
+  {
+    if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&field_staging, &field_staging});
+      fem::ApplyAddGroupOperators(groups, {&field_staging, &field_staging}, buffer,
+                                  &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&field_staging, &field_staging}, buffer);
+    }
+  }
+  else if (face_nbr_exchange)
+  {
+    face_nbr_exchange->Exchange({&field_staging});
+    fem::ApplyAddGroupOperators(groups, {&field_staging}, buffer,
+                                &face_nbr_exchange->Imported());
+  }
+  else
+  {
+    fem::ApplyAddGroupOperators(groups, {&field_staging}, buffer);
+  }
+  // Normal evaluations re-point the cached passive vectors to caller-owned field data.
+  // Detach every operator which borrowed this warm-up vector before releasing it.
+  if (face_nbr_exchange)
+  {
+    face_nbr_exchange->DetachFieldVectors();
+  }
+  fem::DetachGroupOperatorFieldVectors(groups);
+  field_staging.Destroy();
+  MFEM_ASSERT(field_staging.Capacity() == 0,
+              "Surface functional staging allocation was not released!");
+}
+
 std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
                                                  const GridFunction *B) const
 {
@@ -1828,6 +2283,79 @@ std::complex<double> SurfaceFunctional::EvalFlux(const GridFunction *E,
   }
   Mpi::GlobalSum(1, &dot, comm);
   return dot;
+}
+
+void SurfaceFunctional::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(
+      valid && IsBufferKind(kind) && kind != KernelKind::BDR_POYNTING,
+      "EvalBuffer requires a valid single-field boundary visualization functional!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  if (face_nbr_exchange)
+  {
+    face_nbr_exchange->Exchange({&u});
+    fem::ApplyAddGroupOperators(groups, {&u}, buffer, &face_nbr_exchange->Imported());
+  }
+  else
+  {
+    fem::ApplyAddGroupOperators(groups, {&u}, buffer);
+  }
+}
+
+void SurfaceFunctional::EvalBuffer(const GridFunction &u, Vector &buffer) const
+{
+  MFEM_VERIFY(
+      valid && IsBufferKind(kind) && kind != KernelKind::BDR_POYNTING,
+      "EvalBuffer requires a valid single-field boundary visualization functional!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  auto Apply = [&](const Vector &v)
+  {
+    if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&v});
+      fem::ApplyAddGroupOperators(groups, {&v}, buffer, &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&v}, buffer);
+    }
+  };
+  Apply(u.Real());
+  if (u.HasImag())
+  {
+    Apply(u.Imag());
+  }
+}
+
+void SurfaceFunctional::EvalBuffer(const GridFunction &E, const GridFunction &B,
+                                   Vector &buffer) const
+{
+  MFEM_VERIFY(valid && kind == KernelKind::BDR_POYNTING,
+              "EvalBuffer requires a valid boundary Poynting visualization functional!");
+  MFEM_VERIFY(E.HasImag() == B.HasImag(),
+              "Mismatch between real- and complex-valued E and B fields in boundary "
+              "Poynting visualization!");
+  MFEM_ASSERT(buffer.Size() == buffer_size, "Invalid buffer size for EvalBuffer!");
+  buffer = 0.0;
+  auto Apply = [&](const Vector &e, const Vector &b)
+  {
+    if (face_nbr_exchange)
+    {
+      face_nbr_exchange->Exchange({&e, &b});
+      fem::ApplyAddGroupOperators(groups, {&e, &b}, buffer, &face_nbr_exchange->Imported());
+    }
+    else
+    {
+      fem::ApplyAddGroupOperators(groups, {&e, &b}, buffer);
+    }
+  };
+  Apply(E.Real(), B.Real());
+  if (E.HasImag())
+  {
+    Apply(E.Imag(), B.Imag());
+  }
 }
 
 std::vector<std::array<std::complex<double>, 3>>

--- a/palace/fem/output_functionals.hpp
+++ b/palace/fem/output_functionals.hpp
@@ -21,6 +21,7 @@ namespace palace
 class GridFunction;
 class MaterialOperator;
 class Mesh;
+class PointFieldEvaluator;
 class FaceNbrFieldExchange;
 
 // Description of a real vector-valued mode coefficient on a marked boundary surface.
@@ -44,18 +45,19 @@ struct SurfaceModeCoefficient
 //
 // Class to compute reducing output functionals (integrals of functions of solution
 // fields) over boundary element sets using libCEED, supporting full (non-trace)
-// evaluation of volume fields at boundary element quadrature points. This enables
-// postprocessing measurements (interface dielectric energy participation, surface
-// fluxes, port powers, etc.) to execute on the device, in contrast to the legacy
-// mfem::Coefficient-based paths which are host-only.
+// evaluation of volume fields at boundary element quadrature points. Non-reducing
+// visualization point fields are exposed through PointFieldEvaluator, which uses private
+// boundary point-field assembly hooks here. This enables postprocessing measurements
+// (interface dielectric energy participation, surface fluxes, port powers, etc.) to
+// execute on the device instead of using host-only mfem::Coefficient evaluation for
+// supported paths.
 //
 // The key construction: for each boundary element, the field is evaluated from an
 // attached volume element (or both, with averaging or differencing, for interior
 // boundaries, following the conventions of BdrGridFunctionCoefficient and its derived
-// coefficients). AtPoints-capable groups keep mapped reference points as runtime data;
-// mapped-integration-rule groups use per-assembly registry identities plus finite
-// MFEM/NCMesh topology keys rather than rounded point-cloud keys. Processor-boundary
-// ghost values are requested through
+// coefficient semantics). AtPoints-capable groups keep mapped reference points as runtime
+// data; mapped-integration-rule groups use per-assembly integer identities rather than
+// rounded coordinate keys. Processor-boundary ghost values are requested through
 // FaceNbrFieldExchange with integer/topological reference-face orientation keys so point
 // identity never depends on fuzzy coordinate matching.
 //
@@ -72,6 +74,11 @@ public:
   };
 
 private:
+  friend class PointFieldEvaluator;
+
+  // Internal backend selector. Public SurfaceFunctional::Kind is reduction-only;
+  // non-reducing boundary visualization entries are reachable only through
+  // PointFieldEvaluator's private backend hooks.
   enum class KernelKind
   {
     AREA,
@@ -79,11 +86,46 @@ private:
     INTERFACE_EPR,
     SURFACE_FLUX,
     FARFIELD,
-    MODE_OVERLAP
+    MODE_OVERLAP,
+    BDR_FIELD_E,
+    BDR_FIELD_B,
+    BDR_FIELD_H1,
+    BDR_FLUX_Q,
+    BDR_CURRENT_J,
+    BDR_ENERGY_E,
+    BDR_ENERGY_M,
+    BDR_POYNTING
   };
 
   static KernelKind ToKernelKind(Kind kind);
+  static KernelKind ToKernelKind(PointFieldKind kind);
   static const char *KindName(KernelKind kind);
+
+  // Whether the backend kind fills a per-point visualization buffer (vs. computing
+  // reductions).
+  static bool IsBufferKind(KernelKind kind)
+  {
+    return kind == KernelKind::BDR_FIELD_E || kind == KernelKind::BDR_FIELD_B ||
+           kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_FLUX_Q ||
+           kind == KernelKind::BDR_CURRENT_J || kind == KernelKind::BDR_ENERGY_E ||
+           kind == KernelKind::BDR_ENERGY_M || kind == KernelKind::BDR_POYNTING;
+  }
+
+  // Number of components per visualization point for buffer kinds.
+  static int BufferNumComp(KernelKind kind, int sdim)
+  {
+    return (kind == KernelKind::BDR_FIELD_H1 || kind == KernelKind::BDR_FLUX_Q ||
+            kind == KernelKind::BDR_ENERGY_E || kind == KernelKind::BDR_ENERGY_M)
+               ? 1
+               : sdim;
+  }
+
+  // Total buffer size (all boundary elements, lattice points, components) and
+  // per-element point-base offsets for the boundary visualization field kinds. Vector
+  // buffers are component-major: x[points], y[points], (z[points] in 3D).
+  int BufferSize() const { return buffer_size; }
+  int BufferNumComp() const { return buffer_num_comp; }
+  const std::vector<int> &BufferBases() const { return buffer_bases; }
 
   // Computation kind and integrand parameters.
   KernelKind kind;
@@ -96,18 +138,26 @@ private:
   std::complex<double> farfield_omega = 0.0;
   std::map<int, SurfaceModeCoefficient> mode_coeff_by_attr;
 
-  // Field finite element spaces (not owned): nd_fespace for H(curl) fields (source index
-  // 0), rt_fespace for H(div) fields (source index 1). Either may be nullptr depending
-  // on the functional kind. Material operator (not owned) for material property lookups
-  // and side selection.
+  // Boundary visualization field kinds: lattice refinement level, output scaling,
+  // total output buffer size, and per-boundary-element point-base offsets into the
+  // component-major buffer.
+  int viz_lod = 0;
+  double viz_scaling = 1.0;
+  int buffer_size = 0;
+  int buffer_num_comp = 0;
+  std::vector<int> buffer_bases;
+
+  // Field finite element spaces (not owned): nd_fespace for H(curl)/H1 fields (source
+  // index 0), rt_fespace for H(div) fields (source index 1). Either may be nullptr
+  // depending on the functional kind. Material operator (not owned) for material property
+  // lookups and side selection.
   const mfem::ParFiniteElementSpace *nd_fespace;
   const mfem::ParFiniteElementSpace *rt_fespace;
   const MaterialOperator *mat_op;
 
   // Whether the functional could be assembled. False means the configuration is outside
-  // the current support matrix; model-level callers may explicitly use legacy code for
-  // those cases, but supported cases should treat invalid assembly as an error rather
-  // than silently falling back.
+  // the current support matrix; supported model-level paths treat invalid assembly as an
+  // error rather than silently selecting a different implementation.
   bool valid = true;
 
   // MPI communicator from the mesh.
@@ -138,6 +188,7 @@ private:
 
   void Assemble(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
   void AssembleLocal(const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker);
+  void WarmUpBufferOperators() const;
 
   // Apply all group operators with the field inputs pointed at the given source
   // vectors, accumulating into the local output vector.
@@ -149,6 +200,28 @@ private:
   // Add the current local_out element slots into per-attribute bins.
   void BinLocalOutByAttribute(const mfem::Array<int> &attr_to_bin, int num_bins,
                               std::vector<double> &bins, double scale) const;
+
+  // Construct boundary point-field evaluators. These are intentionally private to keep
+  // SurfaceFunctional reduction-oriented at call sites; PointFieldEvaluator owns the
+  // non-reducing visualization API.
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &fespace, int lod);
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &fespace,
+                    const MaterialOperator &mat_op, int lod, double scaling);
+  SurfaceFunctional(PointFieldKind kind, const Mesh &mesh,
+                    const mfem::Array<int> &bdr_attr_marker,
+                    const mfem::ParFiniteElementSpace &nd_fespace,
+                    const mfem::ParFiniteElementSpace &rt_fespace,
+                    const MaterialOperator &mat_op, int lod, double scaling);
+
+  // Fill boundary visualization buffers. Friend-only; non-reducing callers use
+  // PointFieldEvaluator.
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &E, const GridFunction &B, Vector &buffer) const;
 
 public:
   // Construct a functional over the boundary elements with marked attributes (marker
@@ -193,9 +266,8 @@ public:
   SurfaceFunctional &operator=(const SurfaceFunctional &) = delete;
 
   // Whether the functional was successfully assembled. When false, evaluation is not
-  // possible. Supported model-level paths should error rather than silently falling back;
-  // explicit legacy/oracle paths remain available for unsupported configurations and
-  // validation.
+  // possible; supported model-level paths should error rather than silently selecting a
+  // different implementation.
   bool IsValid() const { return valid; }
 
   // Evaluate the functional for the given field (L-vector, e.g. the local vector of a

--- a/palace/fem/point_field_evaluator.cpp
+++ b/palace/fem/point_field_evaluator.cpp
@@ -1,0 +1,180 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fem/point_field_evaluator.hpp"
+
+#include "fem/domain_point_field_evaluator.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/output_functionals.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+DomainPointFieldEvaluator::Kind ToDomainKind(PointFieldEvaluator::Kind kind)
+{
+  switch (kind)
+  {
+    case PointFieldEvaluator::Kind::FIELD_E:
+      return DomainPointFieldEvaluator::Kind::FIELD_E;
+    case PointFieldEvaluator::Kind::FIELD_B:
+      return DomainPointFieldEvaluator::Kind::FIELD_B;
+    case PointFieldEvaluator::Kind::FIELD_H1:
+      return DomainPointFieldEvaluator::Kind::FIELD_H1;
+    case PointFieldEvaluator::Kind::ENERGY_E:
+      return DomainPointFieldEvaluator::Kind::ENERGY_E;
+    case PointFieldEvaluator::Kind::ENERGY_M:
+      return DomainPointFieldEvaluator::Kind::ENERGY_M;
+    case PointFieldEvaluator::Kind::POYNTING:
+      return DomainPointFieldEvaluator::Kind::POYNTING;
+    case PointFieldEvaluator::Kind::MODE_SN:
+      return DomainPointFieldEvaluator::Kind::MODE_SN;
+    default:
+      MFEM_ABORT("Unsupported domain point field kind!");
+  }
+}
+
+}  // namespace
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const MaterialOperator &mat_op,
+                                         const mfem::ParFiniteElementSpace *nd_fespace,
+                                         const mfem::ParFiniteElementSpace *rt_fespace,
+                                         const mfem::ParFiniteElementSpace &target_fespace,
+                                         double scaling, bool build_gridfunction,
+                                         bool build_buffer)
+  : location(MeshEntityType::Domain), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1 ||
+                  kind == Kind::ENERGY_E || kind == Kind::ENERGY_M ||
+                  kind == Kind::POYNTING || kind == Kind::MODE_SN,
+              "Unsupported domain point field kind!");
+  domain_eval = std::make_unique<DomainPointFieldEvaluator>(
+      ToDomainKind(kind), mesh, mat_op, nd_fespace, rt_fespace, target_fespace, scaling,
+      build_gridfunction, build_buffer);
+  valid = domain_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &fespace,
+                                         int lod)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FIELD_E || kind == Kind::FIELD_B || kind == Kind::FIELD_H1,
+              "Unsupported boundary field point kind!");
+  boundary_eval.reset(new SurfaceFunctional(kind, mesh, bdr_attr_marker, fespace, lod));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &fespace,
+                                         const MaterialOperator &mat_op, int lod,
+                                         double scaling)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::FLUX_Q || kind == Kind::CURRENT_J || kind == Kind::ENERGY_E ||
+                  kind == Kind::ENERGY_M,
+              "Unsupported boundary material point field kind!");
+  boundary_eval.reset(
+      new SurfaceFunctional(kind, mesh, bdr_attr_marker, fespace, mat_op, lod, scaling));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::PointFieldEvaluator(Kind kind, const Mesh &mesh,
+                                         const mfem::Array<int> &bdr_attr_marker,
+                                         const mfem::ParFiniteElementSpace &nd_fespace,
+                                         const mfem::ParFiniteElementSpace &rt_fespace,
+                                         const MaterialOperator &mat_op, int lod,
+                                         double scaling)
+  : location(MeshEntityType::Boundary), kind(kind)
+{
+  MFEM_VERIFY(kind == Kind::POYNTING, "Unsupported two-field boundary point kind!");
+  boundary_eval.reset(new SurfaceFunctional(kind, mesh, bdr_attr_marker, nd_fespace,
+                                            rt_fespace, mat_op, lod, scaling));
+  valid = boundary_eval->IsValid();
+}
+
+PointFieldEvaluator::~PointFieldEvaluator() = default;
+
+bool PointFieldEvaluator::IsValid() const
+{
+  return valid;
+}
+
+int PointFieldEvaluator::BufferSize() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferSize()
+                                            : boundary_eval->BufferSize();
+}
+
+int PointFieldEvaluator::BufferNumComp() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferNumComp()
+                                            : boundary_eval->BufferNumComp();
+}
+
+const std::vector<int> &PointFieldEvaluator::BufferBases() const
+{
+  return location == MeshEntityType::Domain ? domain_eval->BufferBases()
+                                            : boundary_eval->BufferBases();
+}
+
+void PointFieldEvaluator::Eval(const GridFunction *E, const GridFunction *B,
+                               Vector &out) const
+{
+  MFEM_VERIFY(location == MeshEntityType::Domain && domain_eval,
+              "GridFunction output is only supported for domain point fields!");
+  domain_eval->Eval(E, B, out);
+}
+
+void PointFieldEvaluator::EvalBuffer(const Vector &u, Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid() && kind != Kind::POYNTING,
+              "Vector EvalBuffer is only valid for single-field point fields!");
+  if (location == MeshEntityType::Domain)
+  {
+    domain_eval->EvalBuffer(u, buffer);
+  }
+  else
+  {
+    boundary_eval->EvalBuffer(u, buffer);
+  }
+}
+
+void PointFieldEvaluator::EvalBuffer(const GridFunction &u, Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid() && location == MeshEntityType::Boundary && kind != Kind::POYNTING,
+              "GridFunction EvalBuffer is only valid for single-field boundary point "
+              "fields!");
+  boundary_eval->EvalBuffer(u, buffer);
+}
+
+void PointFieldEvaluator::EvalBuffer(const GridFunction *E, const GridFunction *B,
+                                     Vector &buffer) const
+{
+  MFEM_VERIFY(IsValid(), "EvalBuffer called on an invalid point field evaluator!");
+  if (location == MeshEntityType::Domain)
+  {
+    domain_eval->EvalBuffer(E, B, buffer);
+    return;
+  }
+
+  MFEM_VERIFY(boundary_eval, "Missing boundary point field evaluator!");
+  if (kind == Kind::POYNTING)
+  {
+    MFEM_VERIFY(E && B, "Boundary Poynting point field requires E and B fields!");
+    boundary_eval->EvalBuffer(*E, *B, buffer);
+  }
+  else
+  {
+    const GridFunction *u = E ? E : B;
+    MFEM_VERIFY(u, "Boundary point field requires a source field!");
+    boundary_eval->EvalBuffer(*u, buffer);
+  }
+}
+
+}  // namespace palace

--- a/palace/fem/point_field_evaluator.hpp
+++ b/palace/fem/point_field_evaluator.hpp
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PALACE_FEM_POINT_FIELD_EVALUATOR_HPP
+#define PALACE_FEM_POINT_FIELD_EVALUATOR_HPP
+
+#include <memory>
+#include <vector>
+#include <mfem.hpp>
+#include "linalg/vector.hpp"
+#include "utils/labels.hpp"
+
+namespace palace
+{
+
+class DomainPointFieldEvaluator;
+class GridFunction;
+class MaterialOperator;
+class Mesh;
+class SurfaceFunctional;
+
+// Non-reducing libCEED evaluator for visualization point fields. Unlike reduction
+// functionals, this produces one value per local visualization point and is intended to
+// feed ParaView point data. Domain direct-VTU buffers are point-major; boundary buffers
+// use the existing component-major writer path. The mesh entity location selects domain
+// elements or boundary elements; the operation remains pointwise, not an MPI-reduced
+// functional.
+class PointFieldEvaluator
+{
+public:
+  using Kind = PointFieldKind;
+
+private:
+  MeshEntityType location;
+  Kind kind;
+  bool valid = false;
+  std::unique_ptr<DomainPointFieldEvaluator> domain_eval;
+  std::unique_ptr<SurfaceFunctional> boundary_eval;
+
+public:
+  // Domain pointwise evaluator for U_e, U_m, or S at VTU visualization points. The
+  // target space is retained only to preserve the existing GridFunction export path.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const MaterialOperator &mat_op,
+                      const mfem::ParFiniteElementSpace *nd_fespace,
+                      const mfem::ParFiniteElementSpace *rt_fespace,
+                      const mfem::ParFiniteElementSpace &target_fespace, double scaling,
+                      bool build_gridfunction = true, bool build_buffer = true);
+
+  // Boundary field evaluator for E or B at boundary VTU visualization points.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &fespace, int lod);
+
+  // Boundary material-dependent evaluator for Q_s, J_s, U_e, or U_m.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &fespace,
+                      const MaterialOperator &mat_op, int lod, double scaling);
+
+  // Boundary Poynting vector evaluator.
+  PointFieldEvaluator(Kind kind, const Mesh &mesh, const mfem::Array<int> &bdr_attr_marker,
+                      const mfem::ParFiniteElementSpace &nd_fespace,
+                      const mfem::ParFiniteElementSpace &rt_fespace,
+                      const MaterialOperator &mat_op, int lod, double scaling);
+  ~PointFieldEvaluator();
+
+  PointFieldEvaluator(const PointFieldEvaluator &) = delete;
+  PointFieldEvaluator &operator=(const PointFieldEvaluator &) = delete;
+
+  bool IsValid() const;
+  MeshEntityType Location() const { return location; }
+  Kind GetKind() const { return kind; }
+
+  int BufferSize() const;
+  int BufferNumComp() const;
+  const std::vector<int> &BufferBases() const;
+
+  // Domain-only compatibility path for grid-function output.
+  void Eval(const GridFunction *E, const GridFunction *B, Vector &out) const;
+
+  // Fill the visualization buffer. Domain buffers are point-major for direct VTU output;
+  // boundary buffers are component-major. The Vector overload is for already split
+  // real/imaginary fields; the GridFunction overload accumulates real and imaginary
+  // contributions for quadratic single-field quantities. For POYNTING pass E and B to
+  // the two-field overload.
+  void EvalBuffer(const Vector &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction &u, Vector &buffer) const;
+  void EvalBuffer(const GridFunction *E, const GridFunction *B, Vector &buffer) const;
+};
+
+}  // namespace palace
+
+#endif  // PALACE_FEM_POINT_FIELD_EVALUATOR_HPP

--- a/palace/fem/qfunctions/21/surf_21_qf.h
+++ b/palace/fem/qfunctions/21/surf_21_qf.h
@@ -5,6 +5,7 @@
 #define PALACE_LIBCEED_SURF_21_QF_H
 
 #include "../22/utils_22_qf.h"
+#include "../coeff/coeff_1_qf.h"
 #include "../coeff/coeff_2_qf.h"
 #include "utils_21_qf.h"
 
@@ -47,6 +48,96 @@ SurfHcurlField2Avg21(CeedInt i, CeedInt Q, const CeedScalar *J_v1, const CeedSca
   SurfHcurlField21(i, Q, J_v2, u_2, E_2);
   E[0] = 0.5 * (E[0] + E_2[0]);
   E[1] = 0.5 * (E[1] + E_2[1]);
+}
+
+// Runtime-selected 2D field value for boundary visualization. H(curl) fields are full
+// in-plane physical vectors. The H(div) branch is not used for Palace's scalar 2D B
+// boundary output, but keeps the shared enum path well-defined.
+CEED_QFUNCTION_HELPER void SurfField21(CeedInt piola, CeedInt i, CeedInt Q,
+                                       const CeedScalar *J_v, const CeedScalar *u,
+                                       CeedScalar V[2])
+{
+  if (piola)
+  {
+    V[0] = IntegralMap22(i, Q, J_v, u);
+    V[1] = 0.0;
+  }
+  else
+  {
+    SurfHcurlField21(i, Q, J_v, u, V);
+  }
+}
+
+// Pointwise boundary vector field values (no quadrature weighting; for visualization
+// output at the boundary element lattice points), following BdrFieldVectorCoefficient:
+// the full field from the attached volume element, averaged over both sides for interior
+// boundaries. Inputs match the 3D field kernels. Output: 2 components per point.
+CEED_QFUNCTION(f_eval_bdr_field_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[2];
+    SurfField21(ctx[0].first, i, Q, J_v, u, V);
+    v[i + Q * 0] = ctx[1].second * V[0];
+    v[i + Q * 1] = ctx[1].second * V[1];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v1 = in[0], *J_v2 = in[1], *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[2], V_2[2];
+    SurfField21(ctx[0].first, i, Q, J_v1, u_1, V);
+    SurfField21(ctx[0].first, i, Q, J_v2, u_2, V_2);
+    v[i + Q * 0] = ctx[1].second * 0.5 * (V[0] + V_2[0]);
+    v[i + Q * 1] = ctx[1].second * 0.5 * (V[1] + V_2[1]);
+  }
+  return 0;
+}
+
+// Pointwise scalar H1 boundary field values. Inputs: grad_x_1, u_1; or grad_x_1,
+// grad_x_2, u_1, u_2. The geometry inputs keep the operator shape shared with other
+// boundary field kernels; the scalar VALUE basis already evaluates the physical value.
+CEED_QFUNCTION(f_eval_bdr_field_h1_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * u[i];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_h1_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * 0.5 * (u_1[i] + u_2[i]);
+  }
+  return 0;
 }
 
 // Line measure: v = qw * |J_f|. Inputs: qw, grad_x_f.
@@ -166,6 +257,207 @@ CEED_QFUNCTION(f_integ_surf_epr_2_21)(void *__restrict__ ctx_, CeedInt Q,
     const CeedScalar wdetJ = qw[i] * SurfMeasure21(J_f_loc, n);
     SurfHcurlField2Avg21(i, Q, J_v1, J_v2, u_1, u_2, E);
     v[i] = wdetJ * SurfEpr21(ctx, (CeedInt)attr[i], n, E);
+  }
+  return 0;
+}
+
+// Pointwise boundary surface charge, surface current, energy density, and Poynting
+// values at visualization lattice points for 2D line boundaries. These mirror the 3D
+// boundary visualization kernels in surf_32_qf.h using Palace's 2D field convention:
+// E is an in-plane H(curl) vector and B is the scalar out-of-plane magnetic flux B_z.
+// Vector outputs have two in-plane components to preserve MFEM's 2D ParaView field
+// shape. Context layouts match the 3D kernels, except material tables for magnetic
+// quantities use the scalar 1x1 out-of-plane inverse permeability.
+CEED_QFUNCTION(f_eval_bdr_flux_q_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2], eps[4], D[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    SurfHcurlField21(i, Q, J_v, u, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr[i], eps);
+    MultBx22(eps, E, D);
+    v[i] = ctx[0].second * ctx[1].second * (D[0] * n[0] + D[1] * n[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_flux_q_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2], E[2], eps[4], D[2], D_2[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    SurfHcurlField21(i, Q, J_v1, u_1, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr_1[i], eps);
+    MultBx22(eps, E, D);
+    SurfHcurlField21(i, Q, J_v2, u_2, E);
+    CoeffUnpack2(ctx + 2, (CeedInt)attr_2[i], eps);
+    MultBx22(eps, E, D_2);
+    // Two-sided: contributions from opposite sides add with opposite normals.
+    v[i] =
+        ctx[0].second * ctx[1].second * ((D[0] - D_2[0]) * n[0] + (D[1] - D_2[1]) * n[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    const CeedScalar Bz = IntegralMap22(i, Q, J_v, u);
+    const CeedScalar Hz = CoeffUnpack1(ctx + 2, (CeedInt)attr[i]) * Bz;
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * Hz * n[1];
+    v[i + Q * 1] = -s * Hz * n[0];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[2], n[2];
+    MatUnpack21(J_f + i, Q, J_f_loc);
+    SurfMeasure21(J_f_loc, n);
+    const CeedScalar Bz_1 = IntegralMap22(i, Q, J_v1, u_1);
+    const CeedScalar Bz_2 = IntegralMap22(i, Q, J_v2, u_2);
+    const CeedScalar Hz_1 = CoeffUnpack1(ctx + 2, (CeedInt)attr_1[i]) * Bz_1;
+    const CeedScalar Hz_2 = CoeffUnpack1(ctx + 2, (CeedInt)attr_2[i]) * Bz_2;
+    const CeedScalar Hz = Hz_1 - Hz_2;
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * Hz * n[1];
+    v[i + Q * 1] = -s * Hz * n[0];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION_HELPER void SurfPoynting21(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                          CeedInt attr, const CeedScalar *J_v,
+                                          const CeedScalar *u_e, const CeedScalar *u_b,
+                                          CeedScalar S[2])
+{
+  CeedScalar E[2];
+  SurfHcurlField21(i, Q, J_v, u_e, E);
+  const CeedScalar Bz = IntegralMap22(i, Q, J_v, u_b);
+  const CeedScalar Hz = CoeffUnpack1(ctx + 1, attr) * Bz;
+  S[0] = E[1] * Hz;
+  S[1] = -E[0] * Hz;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[2];
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr[i], J_v, u_e, u_b, S);
+    const CeedScalar s = ctx[0].second;
+    v[i + Q * 0] = s * S[0];
+    v[i + Q * 1] = s * S[1];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_e_1 = in[4], *u_b_1 = in[5], *u_e_2 = in[6], *u_b_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[2], S_2[2];
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_e_1, u_b_1, S);
+    SurfPoynting21(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_e_2, u_b_2, S_2);
+    const CeedScalar s = 0.5 * ctx[0].second;
+    v[i + Q * 0] = s * (S[0] + S_2[0]);
+    v[i + Q * 1] = s * (S[1] + S_2[1]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION_HELPER CeedScalar SurfEnergy21(const CeedIntScalar *ctx, CeedInt i,
+                                              CeedInt Q, CeedInt attr,
+                                              const CeedScalar *J_v, const CeedScalar *u)
+{
+  if (ctx[0].first)
+  {
+    const CeedScalar Bz = IntegralMap22(i, Q, J_v, u);
+    return CoeffUnpack1(ctx + 2, attr) * Bz * Bz;
+  }
+  CeedScalar E[2], eps[4], D[2];
+  SurfHcurlField21(i, Q, J_v, u, E);
+  CoeffUnpack2(ctx + 2, attr, eps);
+  MultBx22(eps, E, D);
+  return D[0] * E[0] + D[1] * E[1];
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_1_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = 0.5 * ctx[1].second * SurfEnergy21(ctx, i, Q, (CeedInt)attr[i], J_v, u);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_2_21)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_1 = in[4], *u_2 = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    const CeedScalar U_1 = SurfEnergy21(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_1);
+    const CeedScalar U_2 = SurfEnergy21(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_2);
+    v[i] = 0.25 * ctx[1].second * (U_1 + U_2);
   }
   return 0;
 }

--- a/palace/fem/qfunctions/32/surf_32_qf.h
+++ b/palace/fem/qfunctions/32/surf_32_qf.h
@@ -562,4 +562,313 @@ CEED_QFUNCTION(f_integ_surf_farfield_32)(void *__restrict__ ctx_, CeedInt Q,
   return 0;
 }
 
+// Combined Piola transform selected at runtime by piola: H(curl) (0, E = adj(J)^T u /
+// detJ) or H(div) (1, B = J u / detJ). Lets the field and energy boundary-viz kernels
+// share one compiled kernel across the ND and RT field spaces.
+CEED_QFUNCTION_HELPER void SurfField32(CeedInt piola, CeedInt i, CeedInt Q,
+                                       const CeedScalar *J_v, const CeedScalar *u,
+                                       CeedScalar V[3])
+{
+  if (piola)
+  {
+    SurfHdivField32(i, Q, J_v, u, V);
+  }
+  else
+  {
+    SurfHcurlField32(i, Q, J_v, u, V);
+  }
+}
+
+// Pointwise boundary field values (no quadrature weighting; for visualization output at
+// the boundary element lattice points), following BdrFieldVectorCoefficient: the field
+// from the attached volume element, averaged over both sides for interior boundaries.
+// The H(curl)/H(div) space is selected at runtime from ctx[0].first, so the E (ND) and
+// B (RT) boundary fields share one kernel. Inputs ("_1"): grad_x_1, u_1; ("_2"):
+// grad_x_1, grad_x_2, u_1, u_2. Output: 3 components per point.
+CEED_QFUNCTION(f_eval_bdr_field_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[3];
+    SurfField32(ctx[0].first, i, Q, J_v, u, V);
+    v[i + Q * 0] = ctx[1].second * V[0];
+    v[i + Q * 1] = ctx[1].second * V[1];
+    v[i + Q * 2] = ctx[1].second * V[2];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                      const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_v1 = in[0], *J_v2 = in[1], *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar V[3], V_2[3];
+    SurfField32(ctx[0].first, i, Q, J_v1, u_1, V);
+    SurfField32(ctx[0].first, i, Q, J_v2, u_2, V_2);
+    v[i + Q * 0] = ctx[1].second * 0.5 * (V[0] + V_2[0]);
+    v[i + Q * 1] = ctx[1].second * 0.5 * (V[1] + V_2[1]);
+    v[i + Q * 2] = ctx[1].second * 0.5 * (V[2] + V_2[2]);
+  }
+  return 0;
+}
+
+// Pointwise scalar H1 boundary field values. Inputs: grad_x_1, u_1; or grad_x_1,
+// grad_x_2, u_1, u_2. The geometry inputs keep the operator shape shared with other
+// boundary field kernels; the scalar VALUE basis already evaluates the physical value.
+CEED_QFUNCTION(f_eval_bdr_field_h1_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u = in[1];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * u[i];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_field_h1_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *u_1 = in[2], *u_2 = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    v[i] = ctx[1].second * 0.5 * (u_1[i] + u_2[i]);
+  }
+  return 0;
+}
+
+// Pointwise boundary surface charge, surface current, and energy density values at the
+// visualization lattice points, following BdrSurfaceFluxCoefficient<ELECTRIC>
+// (two-sided), BdrSurfaceCurrentVectorCoefficient, and EnergyDensityCoefficient
+// (boundary branch: per-side energies averaged). Context: [0].second = normal sign,
+// [1].second = scaling, material table at +2. Inputs ("_1"): grad_x_f, attr_1,
+// grad_x_1, u_1; ("_2"): grad_x_f, attr_1, grad_x_1, attr_2, grad_x_2, u_1, u_2.
+CEED_QFUNCTION(f_eval_bdr_flux_q_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3], eps[9], D[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHcurlField32(i, Q, J_v, u, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], eps);
+    MultAx33(eps, E, D);
+    v[i] = ctx[0].second * ctx[1].second * (D[0] * n[0] + D[1] * n[1] + D[2] * n[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_flux_q_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], E[3], eps[9], D[3], D_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHcurlField32(i, Q, J_v1, u_1, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], eps);
+    MultAx33(eps, E, D);
+    SurfHcurlField32(i, Q, J_v2, u_2, E);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], eps);
+    MultAx33(eps, E, D_2);
+    // Two-sided: contributions from opposite sides add with opposite normals.
+    v[i] = ctx[0].second * ctx[1].second *
+           ((D[0] - D_2[0]) * n[0] + (D[1] - D_2[1]) * n[1] + (D[2] - D_2[2]) * n[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr = in[1], *J_v = in[2], *u = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3], invmu[9], H[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v, u, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], invmu);
+    MultAx33(invmu, B, H);
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * (n[1] * H[2] - n[2] * H[1]);
+    v[i + Q * 1] = s * (n[2] * H[0] - n[0] * H[2]);
+    v[i + Q * 2] = s * (n[0] * H[1] - n[1] * H[0]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_current_j_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *J_f = in[0], *attr_1 = in[1], *J_v1 = in[2], *attr_2 = in[3],
+                   *J_v2 = in[4], *u_1 = in[5], *u_2 = in[6];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar J_f_loc[6], n[3], B[3], invmu[9], H[3], H_2[3];
+    MatUnpack32(J_f + i, Q, J_f_loc);
+    SurfMeasure32(J_f_loc, n);
+    SurfHdivField32(i, Q, J_v1, u_1, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], invmu);
+    MultAx33(invmu, B, H);
+    SurfHdivField32(i, Q, J_v2, u_2, B);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], invmu);
+    MultAx33(invmu, B, H_2);
+    H[0] -= H_2[0];
+    H[1] -= H_2[1];
+    H[2] -= H_2[2];
+    const CeedScalar s = ctx[0].second * ctx[1].second;
+    v[i + Q * 0] = s * (n[1] * H[2] - n[2] * H[1]);
+    v[i + Q * 1] = s * (n[2] * H[0] - n[0] * H[2]);
+    v[i + Q * 2] = s * (n[0] * H[1] - n[1] * H[0]);
+  }
+  return 0;
+}
+
+// Boundary Poynting vector: per-side S = scale * E x (mu^-1 B), averaged over both
+// sides for interior boundaries. This matches PoyntingVectorCoefficient's boundary
+// branch: full vector, no n-dot, no 1/2 time-average factor. Context: [0].second =
+// scaling, material table at +1. Inputs ("_1"): attr_1, grad_x_1, u_e_1, u_b_1;
+// ("_2"): attr_1, grad_x_1, attr_2, grad_x_2, u_e_1, u_b_1, u_e_2, u_b_2.
+CEED_QFUNCTION_HELPER void SurfPoynting32(const CeedIntScalar *ctx, CeedInt i, CeedInt Q,
+                                          CeedInt attr, const CeedScalar *J_v,
+                                          const CeedScalar *u_e, const CeedScalar *u_b,
+                                          CeedScalar S[3])
+{
+  CeedScalar E[3], B[3], invmu[9], H[3];
+  SurfHcurlField32(i, Q, J_v, u_e, E);
+  SurfHdivField32(i, Q, J_v, u_b, B);
+  CoeffUnpack3(ctx + 1, attr, invmu);
+  MultAx33(invmu, B, H);
+  S[0] = E[1] * H[2] - E[2] * H[1];
+  S[1] = E[2] * H[0] - E[0] * H[2];
+  S[2] = E[0] * H[1] - E[1] * H[0];
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u_e = in[2], *u_b = in[3];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[3];
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr[i], J_v, u_e, u_b, S);
+    const CeedScalar s = ctx[0].second;
+    v[i + Q * 0] = s * S[0];
+    v[i + Q * 1] = s * S[1];
+    v[i + Q * 2] = s * S[2];
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_poynting_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_e_1 = in[4], *u_b_1 = in[5], *u_e_2 = in[6], *u_b_2 = in[7];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar S[3], S_2[3];
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr_1[i], J_v1, u_e_1, u_b_1, S);
+    SurfPoynting32(ctx, i, Q, (CeedInt)attr_2[i], J_v2, u_e_2, u_b_2, S_2);
+    const CeedScalar s = 0.5 * ctx[0].second;
+    v[i + Q * 0] = s * (S[0] + S_2[0]);
+    v[i + Q * 1] = s * (S[1] + S_2[1]);
+    v[i + Q * 2] = s * (S[2] + S_2[2]);
+  }
+  return 0;
+}
+
+// Boundary energy densities: per-side 1/2 (mat F).F with the side attribute, averaged
+// over both sides for interior boundaries. The H(curl)/H(div) space is selected at
+// runtime from ctx[0].first; ctx[1].second = scaling, material table at +2. Inputs
+// ("_1"): attr_1, grad_x_1, u_1; ("_2"): attr_1, grad_x_1, attr_2, grad_x_2, u_1,
+// u_2.
+CEED_QFUNCTION(f_eval_bdr_energy_1_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr = in[0], *J_v = in[1], *u = in[2];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar F[3], mat[9], G[3];
+    SurfField32(ctx[0].first, i, Q, J_v, u, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr[i], mat);
+    MultAx33(mat, F, G);
+    v[i] = 0.5 * ctx[1].second * (G[0] * F[0] + G[1] * F[1] + G[2] * F[2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(f_eval_bdr_energy_2_32)(void *__restrict__ ctx_, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+  const CeedIntScalar *ctx = (const CeedIntScalar *)ctx_;
+  const CeedScalar *attr_1 = in[0], *J_v1 = in[1], *attr_2 = in[2], *J_v2 = in[3],
+                   *u_1 = in[4], *u_2 = in[5];
+  CeedScalar *v = out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+  {
+    CeedScalar F[3], mat[9], G[3];
+    SurfField32(ctx[0].first, i, Q, J_v1, u_1, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_1[i], mat);
+    MultAx33(mat, F, G);
+    CeedScalar U = G[0] * F[0] + G[1] * F[1] + G[2] * F[2];
+    SurfField32(ctx[0].first, i, Q, J_v2, u_2, F);
+    CoeffUnpack3(ctx + 2, (CeedInt)attr_2[i], mat);
+    MultAx33(mat, F, G);
+    U = 0.5 * (U + G[0] * F[0] + G[1] * F[1] + G[2] * F[2]);
+    v[i] = 0.5 * ctx[1].second * U;
+  }
+  return 0;
+}
+
 #endif  // PALACE_LIBCEED_SURF_32_QF_H

--- a/palace/utils/labels.hpp
+++ b/palace/utils/labels.hpp
@@ -62,6 +62,28 @@ enum class InterfaceDielectric : char
   SA
 };
 
+// Mesh entity location: domain/volume elements or boundary/surface elements.
+enum class MeshEntityType : char
+{
+  Domain,
+  Boundary
+};
+
+// Non-reducing point field outputs for visualization. These produce one value per
+// sampled mesh point rather than a globally reduced scalar/array.
+enum class PointFieldKind : char
+{
+  FIELD_E,    // H(curl) vector field values
+  FIELD_B,    // H(div)/L2 magnetic flux values
+  FIELD_H1,   // H1 scalar field values
+  FLUX_Q,     // Surface charge (eps E) . n
+  CURRENT_J,  // Surface current n x (mu^-1 B)
+  ENERGY_E,   // Electric energy density
+  ENERGY_M,   // Magnetic energy density
+  POYNTING,   // Poynting vector E x (mu^-1 B)
+  MODE_SN     // Boundary-mode z-directed Poynting density
+};
+
 // Frequency sampling schemes.
 enum class FrequencySampling : char
 {

--- a/test/unit/test-surfacefunctional.cpp
+++ b/test/unit/test-surfacefunctional.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include "fem/coefficient.hpp"
-#include "fem/domain_point_field_evaluator.hpp"
 #include "fem/facenbrexchange.hpp"
 #include "fem/fespace.hpp"
 #include "fem/gridfunction.hpp"
@@ -19,6 +18,7 @@
 #include "fem/interpolator.hpp"
 #include "fem/mesh.hpp"
 #include "fem/output_functionals.hpp"
+#include "fem/point_field_evaluator.hpp"
 #include "fixtures.hpp"
 #include "models/boundarymodeoperator.hpp"
 #include "models/domainpostoperator.hpp"
@@ -1632,8 +1632,7 @@ TEST_CASE("SurfaceFunctional Nonconformal Parallel", "[surfacefunctional][Parall
   }
 }
 
-TEST_CASE("DomainPointFieldEvaluator Domain Fields",
-          "[surfacefunctional][Serial][Parallel][GPU]")
+TEST_CASE("PointFieldEvaluator Domain Fields", "[surfacefunctional][Serial][Parallel][GPU]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
@@ -1727,8 +1726,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields",
 
   SECTION("Electric energy density")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_E, *mesh, mat_op,
-                                   E.ParFESpace(), nullptr, viz_scalar, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_E, *mesh, mat_op,
+                             E.ParFESpace(), nullptr, viz_scalar, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
     eval.Eval(&E, nullptr, val);
@@ -1739,8 +1738,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields",
 
   SECTION("Magnetic energy density")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_M, *mesh, mat_op,
-                                   nullptr, B.ParFESpace(), viz_scalar, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_M, *mesh, mat_op, nullptr,
+                             B.ParFESpace(), viz_scalar, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
     eval.Eval(nullptr, &B, val);
@@ -1751,8 +1750,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields",
 
   SECTION("Poynting vector")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::POYNTING, *mesh, mat_op,
-                                   E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::POYNTING, *mesh, mat_op,
+                             E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
     eval.Eval(&E, &B, val);
@@ -1762,7 +1761,7 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields",
   }
 }
 
-TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
+TEST_CASE("PointFieldEvaluator Domain Fields 2D",
           "[surfacefunctional][Serial][Parallel][GPU]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
@@ -1844,8 +1843,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
 
   SECTION("Electric energy density")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_E, mesh, mat_op,
-                                   E.ParFESpace(), nullptr, viz_scalar, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_E, mesh, mat_op,
+                             E.ParFESpace(), nullptr, viz_scalar, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
     eval.Eval(&E, nullptr, val);
@@ -1856,8 +1855,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
 
   SECTION("Magnetic flux density")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::FIELD_B, mesh, mat_op,
-                                   nullptr, B.ParFESpace(), viz_scalar, 1.0);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::FIELD_B, mesh, mat_op, nullptr,
+                             B.ParFESpace(), viz_scalar, 1.0);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
     eval.Eval(nullptr, &B, val);
@@ -1875,8 +1874,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
 
   SECTION("Magnetic energy density")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::ENERGY_M, mesh, mat_op,
-                                   nullptr, B.ParFESpace(), viz_scalar, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::ENERGY_M, mesh, mat_op, nullptr,
+                             B.ParFESpace(), viz_scalar, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_scalar), ref(&viz_scalar);
     eval.Eval(nullptr, &B, val);
@@ -1887,8 +1886,8 @@ TEST_CASE("DomainPointFieldEvaluator Domain Fields 2D",
 
   SECTION("Poynting vector")
   {
-    DomainPointFieldEvaluator eval(DomainPointFieldEvaluator::Kind::POYNTING, mesh, mat_op,
-                                   E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
+    PointFieldEvaluator eval(PointFieldEvaluator::Kind::POYNTING, mesh, mat_op,
+                             E.ParFESpace(), B.ParFESpace(), viz_vector, scaling);
     REQUIRE(eval.IsValid());
     mfem::ParGridFunction val(&viz_vector), ref(&viz_vector);
     eval.Eval(&E, &B, val);
@@ -2048,7 +2047,7 @@ TEST_CASE("SurfaceFunctional FarField", "[surfacefunctional][Serial][Parallel][G
 }
 
 #if defined(MFEM_USE_GSLIB)
-TEST_CASE("InterpolationOperator Ceed Probes", "[interpolator][Serial][Parallel][GPU]")
+TEST_CASE("InterpolationOperator Ceed Probes", "[surfacefunctional][Serial][Parallel][GPU]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
@@ -2147,7 +2146,197 @@ TEST_CASE("InterpolationOperator Ceed Probes", "[interpolator][Serial][Parallel]
 }
 #endif
 
-TEST_CASE("FaceNbrFieldExchange 2D", "[facenbrexchange][Serial][Parallel]")
+TEST_CASE("PointFieldEvaluator Boundary Viz Fields",
+          "[surfacefunctional][Serial][Parallel][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  auto order = GENERATE(1, 2);
+  auto nonconformal = GENERATE(false, true);
+  CAPTURE(elem_type, order, nonconformal);
+  fem::DefaultIntegrationOrder::p_trial = order;
+  fem::DefaultIntegrationOrder::q_order_jac = true;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = 0;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = 0;
+
+  auto mesh = nonconformal ? MakeNCInterfaceMesh(comm, elem_type)
+                           : MakeInterfaceMesh(comm, elem_type);
+  auto &pmesh = mesh->Get();
+
+  config::MaterialData vacuum, dielectric;
+  vacuum.attributes = {1};
+  dielectric.attributes = {2};
+  dielectric.epsilon_r.s[0] = 11.7;
+  dielectric.epsilon_r.s[1] = 11.7;
+  dielectric.epsilon_r.s[2] = 11.7;
+  dielectric.mu_r.s[0] = 1.4;
+  dielectric.mu_r.s[1] = 1.4;
+  dielectric.mu_r.s[2] = 1.4;
+  config::PeriodicBoundaryData periodic;
+  MaterialOperator mat_op({vacuum, dielectric}, periodic, ProblemType::DRIVEN, *mesh);
+
+  mfem::ND_FECollection nd_fec(order, 3);
+  mfem::RT_FECollection rt_fec(order - 1, 3);
+  FiniteElementSpace nd_fespace(*mesh, &nd_fec), rt_fespace(*mesh, &rt_fec);
+
+  GridFunction E(nd_fespace, false), B(rt_fespace, false);
+  mfem::VectorFunctionCoefficient fer(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = std::sin(x(1)) + x(2) * x(2);
+                                        v(1) = std::cos(x(2)) + x(0);
+                                        v(2) = x(0) * x(1) + 1.0;
+                                      });
+  mfem::VectorFunctionCoefficient fbr(3,
+                                      [](const mfem::Vector &x, mfem::Vector &v)
+                                      {
+                                        v(0) = x(1) - 0.3 * x(2);
+                                        v(1) = std::sin(x(2)) + 0.5;
+                                        v(2) = std::cos(x(0)) - x(1) * x(2);
+                                      });
+  E.Real().ProjectCoefficient(fer);
+  B.Real().ProjectCoefficient(fbr);
+  E.Real().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+
+  const int lod = order;
+  const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+  mfem::Array<int> marker(bdr_attr_max);
+  marker = 1;
+
+  auto TestKind = [&](PointFieldEvaluator::Kind kind,
+                      const mfem::ParFiniteElementSpace &fes,
+                      const mfem::ParGridFunction &U)
+  {
+    PointFieldEvaluator viz(kind, *mesh, marker, fes, lod);
+
+    // The validity decision must be identical on all ranks; interior surfaces split
+    // across processes fall back (consistently).
+    bool valid = viz.IsValid();
+    bool valid_and = valid, valid_or = valid;
+    Mpi::GlobalAnd(1, &valid_and, comm);
+    Mpi::GlobalOr(1, &valid_or, comm);
+    REQUIRE(valid_and == valid_or);
+    if (!valid)
+    {
+      return;
+    }
+
+    Vector buffer(viz.BufferSize());
+    buffer.UseDevice(true);
+    // Constructor warm-up releases its source storage. Two evaluations exercise both
+    // the first direct reattachment and the later take-and-repoint path, including MPI
+    // face-neighbor exporters on partition interfaces.
+    viz.EvalBuffer(U, buffer);
+    viz.EvalBuffer(U, buffer);
+    const double *buf = buffer.HostRead();
+    const auto &bases = viz.BufferBases();
+    const int component_stride = viz.BufferSize() / 3;
+
+    BdrFieldVectorCoefficient legacy(U);
+    mfem::Vector V(3);
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const auto &RefG =
+          *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), lod, 1);
+      auto *T = pmesh.GetBdrElementTransformation(i);
+      for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+      {
+        const auto &ip = RefG.RefPts.IntPoint(j);
+        T->SetIntPoint(&ip);
+        legacy.Eval(V, *T, ip);
+        for (int c = 0; c < 3; c++)
+        {
+          const double val = buf[bases[i] + j + c * component_stride];
+          CAPTURE(i, j, c, V(c), val);
+          CHECK(val == Catch::Approx(V(c)).epsilon(1.0e-10).margin(1.0e-13));
+        }
+      }
+    }
+  };
+
+  TestKind(PointFieldEvaluator::Kind::FIELD_E, nd_fespace, E.Real());
+  TestKind(PointFieldEvaluator::Kind::FIELD_B, rt_fespace, B.Real());
+
+  // Material-dependent boundary visualization kinds (surface charge, surface current,
+  // boundary energy densities) against the corresponding legacy coefficients.
+  const double scaling = 1.7;
+  auto TestKindCoeff = [&](PointFieldEvaluator::Kind kind,
+                           const mfem::ParFiniteElementSpace &fes,
+                           mfem::Coefficient *legacy_s, mfem::VectorCoefficient *legacy_v)
+  {
+    PointFieldEvaluator viz(kind, *mesh, marker, fes, mat_op, lod, scaling);
+    const int nc = viz.BufferNumComp();
+    bool valid = viz.IsValid();
+    bool valid_and = valid, valid_or = valid;
+    Mpi::GlobalAnd(1, &valid_and, comm);
+    Mpi::GlobalOr(1, &valid_or, comm);
+    REQUIRE(valid_and == valid_or);
+    if (!valid)
+    {
+      return;
+    }
+    Vector buffer(viz.BufferSize());
+    buffer.UseDevice(true);
+    const auto &u = kind == PointFieldEvaluator::Kind::CURRENT_J ||
+                            kind == PointFieldEvaluator::Kind::ENERGY_M
+                        ? B.Real()
+                        : E.Real();
+    viz.EvalBuffer(u, buffer);
+    viz.EvalBuffer(u, buffer);
+    const double *buf = buffer.HostRead();
+    const auto &bases = viz.BufferBases();
+    const int component_stride = viz.BufferSize() / nc;
+    mfem::Vector V(3);
+    for (int i = 0; i < pmesh.GetNBE(); i++)
+    {
+      const auto &RefG =
+          *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementGeometry(i), lod, 1);
+      auto *T = pmesh.GetBdrElementTransformation(i);
+      for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+      {
+        const auto &ip = RefG.RefPts.IntPoint(j);
+        T->SetIntPoint(&ip);
+        if (nc == 1)
+        {
+          const double ref = legacy_s->Eval(*T, ip);
+          const double val = buf[bases[i] + j];
+          CAPTURE(i, j, ref, val);
+          CHECK(val == Catch::Approx(ref).epsilon(1.0e-10).margin(1.0e-13));
+        }
+        else
+        {
+          legacy_v->Eval(V, *T, ip);
+          for (int c = 0; c < 3; c++)
+          {
+            const double val = buf[bases[i] + j + c * component_stride];
+            CAPTURE(i, j, c, V(c), val);
+            CHECK(val == Catch::Approx(V(c)).epsilon(1.0e-10).margin(1.0e-13));
+          }
+        }
+      }
+    }
+  };
+  {
+    BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> q_legacy(
+        &E.Real(), nullptr, mat_op, true, mfem::Vector(), scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::FLUX_Q, nd_fespace, &q_legacy, nullptr);
+  }
+  {
+    BdrSurfaceCurrentVectorCoefficient j_legacy(B.Real(), mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::CURRENT_J, rt_fespace, nullptr, &j_legacy);
+  }
+  {
+    EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> ue_legacy(E, mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::ENERGY_E, nd_fespace, &ue_legacy, nullptr);
+  }
+  {
+    EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> um_legacy(B, mat_op, scaling);
+    TestKindCoeff(PointFieldEvaluator::Kind::ENERGY_M, rt_fespace, &um_legacy, nullptr);
+  }
+}
+
+TEST_CASE("FaceNbrFieldExchange 2D", "[surfacefunctional][Serial][Parallel]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   auto mesh = MakeInterfaceMesh2D(comm, mfem::Element::TRIANGLE);
@@ -2207,7 +2396,7 @@ TEST_CASE("FaceNbrFieldExchange 2D", "[facenbrexchange][Serial][Parallel]")
   CHECK((Mpi::Size(comm) == 1 || num_global > 0));
 }
 
-TEST_CASE("FaceNbrFieldExchange", "[facenbrexchange][Serial][Parallel]")
+TEST_CASE("FaceNbrFieldExchange", "[surfacefunctional][Serial][Parallel]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   auto elem_type = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);


### PR DESCRIPTION
This is **7/10** in the stacked replacement for #824/#825 and depends on [#855](https://github.com/awslabs/palace/pull/855). Please review only the diff against that PR.

This adds the shared point-field facade and device-backed boundary evaluation for field traces, charge, current, energy, and Poynting quantities.

**Reviewer guidance:** Focus on boundary semantics: primary and derived traces are averaged, while charge/current use oriented jumps. Also check local/ghost-side composition, discontinuous output ownership, and point-major buffer layout. No writer is involved yet.

**Deferred:** VTU/PVTU serialization and `PostOperator` registration follow in PRs 8 and 9.

**Validation:** Boundary evaluator tests pass with 36,512 serial and 19,052 MPI-2 assertions.
