### PR TITLE
Use device point fields for visualization output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Routed ParaView and GridFunction output through device-backed point-field
+    evaluators while preserving field names, units, and layouts.
   - Added lazy ParaView VTU serialization for device-evaluated point and cell
     fields.
   - Added device-backed boundary point-field evaluators for field traces,

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -134,6 +134,58 @@ but the variable names and corresponding units for various possible postprocesse
   - Magnetic energy density : `U_m` (J/m³)
   - Poynting vector: `S` (W/m²)
 
+### Visualization field spaces and interface values
+
+Domain fields available in both the ParaView and grid function formats are represented in
+different ways. ParaView stores values sampled at visualization points, whereas an MFEM grid
+function stores the finite element space and its degrees of freedom. Primary solution fields
+retain their native finite element spaces in grid function output. Derived fields are
+evaluated directly into discontinuous, interpolatory L2 spaces of the solution order:
+
+| Fields                                           | Grid function space | Continuity represented by the space                                                                        |
+|:------------------------------------------------ |:------------------- |:---------------------------------------------------------------------------------------------------------- |
+| `V`, `En`, and other scalar H1 solution fields   | H1                  | The scalar value is continuous across conforming element interfaces.                                       |
+| `E`, `E_real`, `E_imag`, `A`, `A_real`, `A_imag` | ND (H(curl))        | The tangential trace is continuous; the normal component may differ between the two sides of an interface. |
+| `B`, `B_real`, `B_imag` in 3D                    | RT (H(div))         | The normal trace is continuous; the tangential component may differ between the two sides of an interface. |
+| `B`, `B_real`, `B_imag` in 2D                    | Scalar L2           | Element-local scalar values are retained.                                                                  |
+| `U_e`, `U_m`, `S`, `Sn`                          | Scalar or vector L2 | All element-local values are retained, including both traces at an interface.                              |
+
+The L2 representation of the derived fields is important even when a primary solution field
+belongs to a conforming space. H1, H(curl), and H(div) impose different notions of
+continuity; neither H(curl) nor H(div) makes the complete vector field single-valued at an
+interface. In addition, the constitutive parameters can be discontinuous between materials.
+For example,
+
+```math
+U_e = \frac{1}{2} \bm{E}^{*} \bm{\epsilon} \bm{E}, \qquad
+U_m = \frac{1}{2} \bm{B}^{*} \bm{\mu}^{-1} \bm{B}, \qquad
+\bm{S} = \operatorname{Re}\!\left\{\bm{E} \times
+\left(\bm{\mu}^{-1}\bm{B}\right)^{*}\right\}.
+```
+
+A jump in ``\bm{\epsilon}`` or ``\bm{\mu}^{-1}`` can therefore produce a jump in an energy
+density or the Poynting vector, even where the conforming trace of a primary field is
+continuous. Similarly, at a material interface:
+
+  - H(curl) continuity constrains only the tangential electric field; its normal component
+    can jump.
+  - H(div) continuity constrains only the normal magnetic flux density; its tangential
+    component can jump.
+  - ``\bm{D} = \bm{\epsilon}\bm{E}`` and
+    ``\bm{H} = \bm{\mu}^{-1}\bm{B}`` inherit jumps from both the fields and the material
+    tensors.
+  - Surface charge ``Q_s = \bm{D} \cdot \bm{n}`` and surface current
+    ``\bm{J}_s = \bm{n} \times \bm{H}`` are side-dependent traces when the corresponding
+    interface charge or current is nonzero.
+
+Forcing these quantities into a continuous H1 space would select, average, or smooth values
+across interfaces and would discard the distinction between the two element-side traces.
+The L2 domain fields instead preserve the element-local result. The separate boundary
+visualization has one tuple per geometric interface point: primary fields are the average of
+the two traces, energy density and Poynting output average the corresponding per-side
+quantities, and surface charge/current use their oriented jump definitions. Exterior
+boundaries use the single adjacent element trace.
+
 Also, at the final step of the simulation the following element-wise quantities are written
 for visualization:
 

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <complex>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <tuple>
@@ -30,6 +31,7 @@
 #include "utils/tablecsv.hpp"
 #include "utils/timer.hpp"
 
+#include <mfem/config/config.hpp>
 namespace palace
 {
 
@@ -37,6 +39,34 @@ using namespace std::complex_literals;
 
 namespace
 {
+
+bool IsSupportedDomainOutputDimension(const mfem::ParMesh &mesh)
+{
+  return (mesh.Dimension() == 2 && mesh.SpaceDimension() == 2) ||
+         (mesh.Dimension() == 3 && mesh.SpaceDimension() == 3);
+}
+
+bool IsSupportedBoundaryOutputDimension(const mfem::ParMesh &mesh)
+{
+  return IsSupportedDomainOutputDimension(mesh);
+}
+
+bool UseCeedDomainParaviewPointFields(const mfem::ParMesh &mesh)
+{
+  return IsSupportedDomainOutputDimension(mesh);
+}
+
+bool UseCeedBoundaryParaviewPointFields(const mfem::ParMesh &mesh)
+{
+  return IsSupportedBoundaryOutputDimension(mesh);
+}
+
+void RequireCeedPointFieldEvaluator(const PointFieldEvaluator *eval,
+                                    const std::string &what)
+{
+  MFEM_VERIFY(eval && eval->IsValid(), "libCEED postprocessing was expected for " + what +
+                                           ", but PointFieldEvaluator could not assemble!");
+}
 
 std::string OutputFolderName(const ProblemType solver_t)
 {
@@ -278,16 +308,193 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
   {
     return;
   }
+  // Initialize the (interpolatory L2) output spaces for the libCEED-evaluated
+  // visualization fields. The order matches the ParaView output sampling lattice
+  // (SetLevelsOfDetail below), preserving the existing VTU point layout.
+  // TODO: Revisit the output order choice: order p smooths the (degree 2p) energy
+  // densities slightly relative to the legacy exact-at-lattice sampling (U_e showed
+  // ~2e-3 relative on the CPW example, visualization only). Order 2p reproduces the
+  // legacy values exactly on affine elements at ~3.5x the field storage, which may be
+  // immaterial next to the solver memory high water mark.
+  // All direct VTU point fields and the MFEM mesh writer must use one sampling lattice.
+  // This matters in 2D magnetostatics, where A is ND order p while scalar B is L2 order
+  // p-1. Use the maximum primary-field order rather than whichever field happens to be
+  // initialized first.
+  int paraview_refine_order = 0;
+  for (const auto *field : {E.get(), B.get(), V.get(), A.get()})
+  {
+    if (field)
+    {
+      paraview_refine_order =
+          std::max(paraview_refine_order, field->ParFESpace()->GetMaxElementOrder());
+    }
+  }
+  MFEM_VERIFY(paraview_refine_order > 0, "Unable to determine field output order!");
+  auto InitializeVizSpaces = [&](mfem::ParFiniteElementSpace &src_fespace)
+  {
+    if (viz_fec)
+    {
+      return;
+    }
+    auto *pmesh = src_fespace.GetParMesh();
+    viz_fec =
+        std::make_unique<mfem::L2_FECollection>(paraview_refine_order, pmesh->Dimension());
+    viz_scalar_fespace =
+        std::make_unique<mfem::ParFiniteElementSpace>(pmesh, viz_fec.get());
+    viz_vector_fespace = std::make_unique<mfem::ParFiniteElementSpace>(
+        pmesh, viz_fec.get(), pmesh->SpaceDimension());
+  };
+  const auto &output_mesh = fem_op->GetNDSpace().GetParMesh();
+  const bool use_ceed_domain_paraview_fields =
+      ShouldWriteParaviewFields() && UseCeedDomainParaviewPointFields(output_mesh);
+  const bool use_ceed_domain_fields =
+      ShouldWriteGridFunctionFields() || use_ceed_domain_paraview_fields;
+  const bool use_ceed_boundary_fields =
+      ShouldWriteParaviewFields() && UseCeedBoundaryParaviewPointFields(output_mesh);
 
-  // Set-up grid-functions for the paraview output / measurement.
+  auto MakeFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                mfem::ParFiniteElementSpace *e_fespace,
+                                mfem::ParFiniteElementSpace *b_fespace, double scaling,
+                                std::unique_ptr<PointFieldEvaluator> &eval,
+                                std::unique_ptr<mfem::ParGridFunction> &gf)
+  {
+    InitializeVizSpaces(e_fespace ? *e_fespace : *b_fespace);
+    auto &target = (kind == PointFieldEvaluator::Kind::POYNTING) ? *viz_vector_fespace
+                                                                 : *viz_scalar_fespace;
+    eval = std::make_unique<PointFieldEvaluator>(
+        kind, fem_op->GetMaterialOp().GetMesh(), fem_op->GetMaterialOp(), e_fespace,
+        b_fespace, target, scaling, ShouldWriteGridFunctionFields(),
+        use_ceed_domain_paraview_fields);
+    if (eval->IsValid())
+    {
+      if (ShouldWriteGridFunctionFields())
+      {
+        gf = std::make_unique<mfem::ParGridFunction>(&target);
+        gf->UseDevice(true);
+      }
+    }
+    else
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "domain field visualization");
+    }
+  };
+  auto MakeBaseDomainFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                          mfem::ParFiniteElementSpace &fespace,
+                                          std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    if (!use_ceed_domain_paraview_fields)
+    {
+      return;
+    }
+    InitializeVizSpaces(fespace);
+    const bool scalar_b_field = kind == PointFieldEvaluator::Kind::FIELD_B &&
+                                fespace.GetParMesh()->Dimension() == 2;
+    auto &target = (kind == PointFieldEvaluator::Kind::FIELD_H1 || scalar_b_field)
+                       ? *viz_scalar_fespace
+                       : *viz_vector_fespace;
+    eval = std::make_unique<PointFieldEvaluator>(
+        kind, fem_op->GetMaterialOp().GetMesh(), fem_op->GetMaterialOp(),
+        (kind == PointFieldEvaluator::Kind::FIELD_E ||
+         kind == PointFieldEvaluator::Kind::FIELD_H1)
+            ? &fespace
+            : nullptr,
+        kind == PointFieldEvaluator::Kind::FIELD_B ? &fespace : nullptr, target, 1.0, false,
+        true);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "base domain field visualization");
+    }
+  };
+  auto MakeBdrFieldEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                   mfem::ParFiniteElementSpace &fespace,
+                                   std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(kind, mesh, marker, fespace,
+                                                 paraview_refine_order);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary field visualization");
+    }
+  };
+  auto MakeBdrCoeffEvaluator = [&](PointFieldEvaluator::Kind kind,
+                                   mfem::ParFiniteElementSpace &fespace, double scaling,
+                                   std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(kind, mesh, marker, fespace,
+                                                 fem_op->GetMaterialOp(),
+                                                 paraview_refine_order, scaling);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary coefficient visualization");
+    }
+  };
+  auto MakeBdrPoyntingEvaluator =
+      [&](mfem::ParFiniteElementSpace &e_fespace, mfem::ParFiniteElementSpace &b_fespace,
+          double scaling, std::unique_ptr<PointFieldEvaluator> &eval)
+  {
+    const auto &mesh = fem_op->GetMaterialOp().GetMesh();
+    const auto &pmesh = mesh.Get();
+    const int bdr_attr_max = pmesh.bdr_attributes.Size() ? pmesh.bdr_attributes.Max() : 0;
+    mfem::Array<int> marker(bdr_attr_max);
+    marker = 1;
+    eval = std::make_unique<PointFieldEvaluator>(
+        PointFieldEvaluator::Kind::POYNTING, mesh, marker, e_fespace, b_fespace,
+        fem_op->GetMaterialOp(), paraview_refine_order, scaling);
+    if (!eval->IsValid())
+    {
+      RequireCeedPointFieldEvaluator(eval.get(), "boundary Poynting visualization");
+    }
+  };
+
+  // Set-up evaluators for the paraview output / measurement.
+  if (En)
+  {
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *En->ParFESpace(),
+                                 En_domain_eval);
+  }
+
+  if (Bt_inplane)
+  {
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E,
+                                 *Bt_inplane->ParFESpace(), Bt_domain_eval);
+  }
+
+  if (E && Bt_inplane && use_ceed_domain_fields)
+  {
+    MakeFieldEvaluator(PointFieldEvaluator::Kind::MODE_SN, E->ParFESpace(),
+                       Bt_inplane->ParFESpace(), 1.0, Sn_eval, Sn_gf);
+  }
+
   if constexpr (HasVGridFunction<solver_t>())
   {
-    V_s = std::make_unique<BdrFieldCoefficient>(V->Real());
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *V->ParFESpace(),
+                                 V_domain_eval);
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_H1, *V->ParFESpace(),
+                            V_bdr_eval);
+    }
   }
 
   if constexpr (HasAGridFunction<solver_t>())
   {
-    A_s = std::make_unique<BdrFieldVectorCoefficient>(A->Real());
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *A->ParFESpace(),
+                                 A_domain_eval);
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *A->ParFESpace(),
+                            A_bdr_eval);
+    }
   }
 
   if constexpr (HasEGridFunction<solver_t>())
@@ -305,17 +512,30 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
     // U_e = 1/2 Dᴴ E = 1/2 ε_0 Eᴴ E.
     U_e = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::ELECTRIC>>(
         *E, fem_op->GetMaterialOp(), scaling);
+    if (use_ceed_domain_fields)
+    {
+      MakeFieldEvaluator(PointFieldEvaluator::Kind::ENERGY_E, E->ParFESpace(), nullptr,
+                         scaling, U_e_eval, U_e_gf);
+    }
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::ENERGY_E, *E->ParFESpace(), scaling,
+                            Ue_bdr_eval);
+    }
 
     // Electric Boundary Field & Surface Charge.
-    E_sr = std::make_unique<BdrFieldVectorCoefficient>(E->Real());
-    // Q_s = D ⋅ n = ε_0 E ⋅ n.
-    Q_sr = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
-        &E->Real(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector(), scaling);
-    if constexpr (HasComplexGridFunction<solver_t>())
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *E->ParFESpace(),
+                                 E_domain_eval);
+    if (use_ceed_boundary_fields)
     {
-      E_si = std::make_unique<BdrFieldVectorCoefficient>(E->Imag());
-      Q_si = std::make_unique<BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC>>(
-          &E->Imag(), nullptr, fem_op->GetMaterialOp(), true, mfem::Vector(), scaling);
+      MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_E, *E->ParFESpace(),
+                            E_bdr_eval);
+    }
+    // Q_s = D ⋅ n = ε_0 E ⋅ n.
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::FLUX_Q, *E->ParFESpace(), scaling,
+                            Q_bdr_eval);
     }
   }
 
@@ -334,24 +554,33 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
     // U_m = 1/2 Hᴴ B = 1/2 μ⁻¹ Bᴴ B.
     U_m = std::make_unique<EnergyDensityCoefficient<EnergyDensityType::MAGNETIC>>(
         *B, fem_op->GetMaterialOp(), scaling);
-
-    // Magnetic Boundary Field & Surface Current.
-    // In 2D, B is scalar (L2), so boundary vector coefficients are not applicable.
-    if (B->Real().VectorDim() > 1)
+    if (use_ceed_domain_fields)
     {
-      B_sr = std::make_unique<BdrFieldVectorCoefficient>(B->Real());
-      // J_s = n x H = n x μ⁻¹ B.
-      J_sr = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(
-          B->Real(), fem_op->GetMaterialOp(), scaling);
+      MakeFieldEvaluator(PointFieldEvaluator::Kind::ENERGY_M, nullptr, B->ParFESpace(),
+                         scaling, U_m_eval, U_m_gf);
+    }
+    if (use_ceed_boundary_fields)
+    {
+      MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::ENERGY_M, *B->ParFESpace(), scaling,
+                            Um_bdr_eval);
     }
 
-    if constexpr (HasComplexGridFunction<solver_t>())
+    // Magnetic Field, Boundary Field & Surface Current. In 2D, B is scalar (L2), so the
+    // domain field is scalar while boundary vector B and J_s outputs are not applicable.
+    MakeBaseDomainFieldEvaluator(PointFieldEvaluator::Kind::FIELD_B, *B->ParFESpace(),
+                                 B_domain_eval);
+    if (B->Real().VectorDim() > 1)
     {
-      if (B->Imag().VectorDim() > 1)
+      if (use_ceed_boundary_fields)
       {
-        B_si = std::make_unique<BdrFieldVectorCoefficient>(B->Imag());
-        J_si = std::make_unique<BdrSurfaceCurrentVectorCoefficient>(
-            B->Imag(), fem_op->GetMaterialOp(), scaling);
+        MakeBdrFieldEvaluator(PointFieldEvaluator::Kind::FIELD_B, *B->ParFESpace(),
+                              B_bdr_eval);
+      }
+      // J_s = n x H = n x μ⁻¹ B.
+      if (use_ceed_boundary_fields)
+      {
+        MakeBdrCoeffEvaluator(PointFieldEvaluator::Kind::CURRENT_J, *B->ParFESpace(),
+                              scaling, J_bdr_eval);
       }
     }
   }
@@ -369,9 +598,18 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
                              units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
       S = std::make_unique<PoyntingVectorCoefficient>(*E, *B, fem_op->GetMaterialOp(),
                                                       scaling);
+      if (use_ceed_domain_fields)
+      {
+        MakeFieldEvaluator(PointFieldEvaluator::Kind::POYNTING, E->ParFESpace(),
+                           B->ParFESpace(), scaling, S_eval, S_gf);
+      }
+      if (use_ceed_boundary_fields)
+      {
+        MakeBdrPoyntingEvaluator(*E->ParFESpace(), *B->ParFESpace(), scaling, S_bdr_eval);
+      }
     }
-    // For boundary mode, Sn = Re{Et · (ẑ × Ht*)} is computed after Bt_inplane is
-    // available (in MeasureAndPrintAll), as it requires the in-plane B field.
+    // For boundary mode, Sn = Re{Et · (ẑ × Ht*)} uses the in-plane B field and is
+    // registered below through a domain point evaluator.
   }
 }
 
@@ -401,147 +639,230 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
   paraview_bdr = {paraview_dir_b, &fem_op->GetNDSpace().GetParMesh()};
 
   const mfem::VTKFormat format = mfem::VTKFormat::BINARY32;
-#if defined(MFEM_USE_ZLIB)
-  const int compress = -1;  // Default compression level
-#else
-  const int compress = 0;
-#endif
   const bool use_ho = true;
-  const int refine_ho = HasEGridFunction<solver_t>()
-                            ? E->ParFESpace()->GetMaxElementOrder()
-                            : B->ParFESpace()->GetMaxElementOrder();
+  MFEM_VERIFY(viz_scalar_fespace,
+              "ParaView point-field space must be initialized before the collection!");
+  const int refine_ho = viz_scalar_fespace->GetMaxElementOrder();
+  const bool use_ceed_domain_paraview =
+      UseCeedDomainParaviewPointFields(fem_op->GetNDSpace().GetParMesh());
+  const bool use_ceed_boundary_paraview =
+      UseCeedBoundaryParaviewPointFields(fem_op->GetNDSpace().GetParMesh());
 
   // Output mesh coordinate units same as input.
   paraview->SetCycle(-1);
   paraview->SetDataFormat(format);
-  paraview->SetCompressionLevel(compress);
+  MFEM_VERIFY(use_ceed_domain_paraview,
+              "ParaView domain output requires the libCEED point-field path!");
+  // Direct point fields use appended raw VTU arrays so their payload can be written
+  // without an extra full-field base64 staging buffer.
+  paraview->SetCompressionLevel(0);
   paraview->SetHighOrderOutput(use_ho);
   paraview->SetLevelsOfDetail(refine_ho);
 
   paraview_bdr->SetBoundaryOutput(true);
   paraview_bdr->SetCycle(-1);
   paraview_bdr->SetDataFormat(format);
-  paraview_bdr->SetCompressionLevel(compress);
+  MFEM_VERIFY(use_ceed_boundary_paraview,
+              "ParaView boundary output requires the libCEED point-field path!");
+  paraview_bdr->SetCompressionLevel(0);
   paraview_bdr->SetHighOrderOutput(use_ho);
   paraview_bdr->SetLevelsOfDetail(refine_ho);
 
+  // Register libCEED domain and boundary visualization fields lazily: ParaView Save()
+  // evaluates one field at a time into a reusable device-capable buffer and then writes
+  // that buffer to the VTU file. Domain direct-VTU buffers are point-major to match VTK
+  // tuple order; boundary buffers keep the existing component-major packing path. This
+  // keeps peak memory proportional to one output field instead of the sum of all derived
+  // fields, while still doing the sampling/transforms in libCEED. Nonconforming AMR
+  // meshes use the same point-field path; the static mesh/header caches above avoid
+  // repeating VTU setup across mode saves.
+  auto RegisterDomainEvalField =
+      [&](const std::string &name, const std::unique_ptr<PointFieldEvaluator> &eval,
+          const GridFunction *E_field, const GridFunction *B_field)
+  {
+    const auto *eval_ptr = eval.get();
+    const auto *E_ptr = E_field;
+    const auto *B_ptr = B_field;
+    paraview->RegisterDomainPointEvaluator(
+        name, [eval_ptr, E_ptr, B_ptr](Vector &buffer)
+        { eval_ptr->EvalBuffer(E_ptr, B_ptr, buffer); }, eval_ptr->BufferBases(),
+        eval_ptr->BufferNumComp(), eval_ptr->BufferSize(), true);
+  };
+  auto RegisterDomainBaseEvalField = [&](const std::string &name,
+                                         const std::unique_ptr<PointFieldEvaluator> &eval,
+                                         const mfem::ParGridFunction &field)
+  {
+    RequireCeedPointFieldEvaluator(eval.get(),
+                                   fmt::format("domain {} visualization", name));
+    const auto *eval_ptr = eval.get();
+    const auto *field_ptr = &field;
+    paraview->RegisterDomainPointEvaluator(
+        name,
+        [eval_ptr, field_ptr](Vector &buffer) { eval_ptr->EvalBuffer(*field_ptr, buffer); },
+        eval_ptr->BufferBases(), eval_ptr->BufferNumComp(), eval_ptr->BufferSize(), true);
+  };
+  auto RegisterBdrEvalField = [&](const std::string &name,
+                                  const std::unique_ptr<PointFieldEvaluator> &eval,
+                                  const auto &field)
+  {
+    const auto *eval_ptr = eval.get();
+    const auto *field_ptr = &field;
+    paraview_bdr->RegisterBoundaryPointEvaluator(
+        name,
+        [eval_ptr, field_ptr](Vector &buffer) { eval_ptr->EvalBuffer(*field_ptr, buffer); },
+        eval_ptr->BufferBases(), eval_ptr->BufferNumComp(), eval_ptr->BufferSize());
+  };
+  auto RegisterBdrPoyntingField = [&](const std::string &name)
+  {
+    const auto *eval_ptr = S_bdr_eval.get();
+    const auto *E_ptr = E.get();
+    const auto *B_ptr = B.get();
+    paraview_bdr->RegisterBoundaryPointEvaluator(
+        name, [eval_ptr, E_ptr, B_ptr](Vector &buffer)
+        { eval_ptr->EvalBuffer(E_ptr, B_ptr, buffer); }, eval_ptr->BufferBases(),
+        eval_ptr->BufferNumComp(), eval_ptr->BufferSize());
+  };
+
   // Output fields @ phase = 0 and π/2 for frequency domain (rather than, for example,
-  // peak phasors or magnitude = sqrt(2) * RMS). Also output fields evaluated on mesh
-  // boundaries. For internal boundary surfaces, this takes the field evaluated in the
-  // neighboring element with the larger dielectric permittivity or magnetic
-  // permeability.
+  // peak phasors or magnitude = sqrt(2) * RMS). Boundary fields use the documented
+  // trace averages or oriented jumps on internal interfaces.
   if (E)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("E_real", &E->Real());
-      paraview->RegisterField("E_imag", &E->Imag());
-      paraview_bdr->RegisterVCoeffField("E_real", E_sr.get());
-      paraview_bdr->RegisterVCoeffField("E_imag", E_si.get());
+      RegisterDomainBaseEvalField("E_real", E_domain_eval, E->Real());
+      RegisterDomainBaseEvalField("E_imag", E_domain_eval, E->Imag());
+      RequireCeedPointFieldEvaluator(E_bdr_eval.get(), "boundary E visualization");
+      RegisterBdrEvalField("E_real", E_bdr_eval, E->Real());
+      RegisterBdrEvalField("E_imag", E_bdr_eval, E->Imag());
     }
     else
     {
-      paraview->RegisterField("E", &E->Real());
-      paraview_bdr->RegisterVCoeffField("E", E_sr.get());
+      RegisterDomainBaseEvalField("E", E_domain_eval, E->Real());
+      RequireCeedPointFieldEvaluator(E_bdr_eval.get(), "boundary E visualization");
+      RegisterBdrEvalField("E", E_bdr_eval, E->Real());
     }
   }
   if (En)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("En_real", &En->Real());
-      paraview->RegisterField("En_imag", &En->Imag());
+      RegisterDomainBaseEvalField("En_real", En_domain_eval, En->Real());
+      RegisterDomainBaseEvalField("En_imag", En_domain_eval, En->Imag());
     }
     else
     {
-      paraview->RegisterField("En", &En->Real());
+      RegisterDomainBaseEvalField("En", En_domain_eval, En->Real());
     }
   }
   if (B)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview->RegisterField("B_real", &B->Real());
-      paraview->RegisterField("B_imag", &B->Imag());
-      if (B_sr)
+      RegisterDomainBaseEvalField("B_real", B_domain_eval, B->Real());
+      RegisterDomainBaseEvalField("B_imag", B_domain_eval, B->Imag());
+      if (B_bdr_eval)
       {
-        paraview_bdr->RegisterVCoeffField("B_real", B_sr.get());
-      }
-      if (B_si)
-      {
-        paraview_bdr->RegisterVCoeffField("B_imag", B_si.get());
+        RegisterBdrEvalField("B_real", B_bdr_eval, B->Real());
+        RegisterBdrEvalField("B_imag", B_bdr_eval, B->Imag());
       }
     }
     else
     {
-      paraview->RegisterField("B", &B->Real());
-      if (B_sr)
+      RegisterDomainBaseEvalField("B", B_domain_eval, B->Real());
+      if (B_bdr_eval)
       {
-        paraview_bdr->RegisterVCoeffField("B", B_sr.get());
+        RegisterBdrEvalField("B", B_bdr_eval, B->Real());
       }
     }
   }
   // In-plane B field for mode analysis (2D vector on ND space).
   if (Bt_inplane)
   {
-    paraview->RegisterField("Bt_real", &Bt_inplane->Real());
-    paraview->RegisterField("Bt_imag", &Bt_inplane->Imag());
+    RegisterDomainBaseEvalField("Bt_real", Bt_domain_eval, Bt_inplane->Real());
+    RegisterDomainBaseEvalField("Bt_imag", Bt_domain_eval, Bt_inplane->Imag());
   }
   if (V)
   {
-    paraview->RegisterField("V", &V->Real());
-    paraview_bdr->RegisterCoeffField("V", V_s.get());
+    RegisterDomainBaseEvalField("V", V_domain_eval, V->Real());
+    RequireCeedPointFieldEvaluator(V_bdr_eval.get(), "boundary V visualization");
+    RegisterBdrEvalField("V", V_bdr_eval, V->Real());
   }
   if (A)
   {
-    paraview->RegisterField("A", &A->Real());
-    paraview_bdr->RegisterVCoeffField("A", A_s.get());
+    RegisterDomainBaseEvalField("A", A_domain_eval, A->Real());
+    RequireCeedPointFieldEvaluator(A_bdr_eval.get(), "boundary A visualization");
+    RegisterBdrEvalField("A", A_bdr_eval, A->Real());
   }
 
   // Extract energy density field for electric field energy 1/2 Dᴴ E or magnetic field
   // energy 1/2 Hᴴ B. Also Poynting vector S = E x H⋆.
   if (U_e)
   {
-    paraview->RegisterCoeffField("U_e", U_e.get());
-    paraview_bdr->RegisterCoeffField("U_e", U_e.get());
+    RequireCeedPointFieldEvaluator(U_e_eval.get(), "domain electric energy visualization");
+    RegisterDomainEvalField("U_e", U_e_eval, E.get(), nullptr);
+    RequireCeedPointFieldEvaluator(Ue_bdr_eval.get(),
+                                   "boundary electric energy visualization");
+    RegisterBdrEvalField("U_e", Ue_bdr_eval, *E);
   }
   if (U_m)
   {
-    paraview->RegisterCoeffField("U_m", U_m.get());
-    paraview_bdr->RegisterCoeffField("U_m", U_m.get());
+    RequireCeedPointFieldEvaluator(U_m_eval.get(), "domain magnetic energy visualization");
+    RegisterDomainEvalField("U_m", U_m_eval, nullptr, B.get());
+    RequireCeedPointFieldEvaluator(Um_bdr_eval.get(),
+                                   "boundary magnetic energy visualization");
+    RegisterBdrEvalField("U_m", Um_bdr_eval, *B);
   }
   if (S)
   {
-    paraview->RegisterVCoeffField("S", S.get());
-    paraview_bdr->RegisterVCoeffField("S", S.get());
+    RequireCeedPointFieldEvaluator(S_eval.get(), "domain Poynting visualization");
+    RegisterDomainEvalField("S", S_eval, E.get(), B.get());
+    RequireCeedPointFieldEvaluator(S_bdr_eval.get(), "boundary Poynting visualization");
+    RegisterBdrPoyntingField("S");
   }
 
   // Extract surface charge from normally discontinuous ND E-field. Also extract surface
   // currents from tangentially discontinuous RT B-field The surface charge and surface
   // currents are single-valued at internal boundaries.
-  if (Q_sr)
+  if (Q_bdr_eval)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview_bdr->RegisterCoeffField("Q_s_real", Q_sr.get());
-      paraview_bdr->RegisterCoeffField("Q_s_imag", Q_si.get());
+      RegisterBdrEvalField("Q_s_real", Q_bdr_eval, E->Real());
+      RegisterBdrEvalField("Q_s_imag", Q_bdr_eval, E->Imag());
     }
     else
     {
-      paraview_bdr->RegisterCoeffField("Q_s", Q_sr.get());
+      RegisterBdrEvalField("Q_s", Q_bdr_eval, E->Real());
     }
   }
-  if (J_sr)
+  else if (Q_sr)
+  {
+    MFEM_ABORT(
+        "Boundary surface-charge ParaView output requires a libCEED point evaluator!");
+  }
+  if (J_bdr_eval)
   {
     if (HasComplexGridFunction<solver_t>())
     {
-      paraview_bdr->RegisterVCoeffField("J_s_real", J_sr.get());
-      paraview_bdr->RegisterVCoeffField("J_s_imag", J_si.get());
+      RegisterBdrEvalField("J_s_real", J_bdr_eval, B->Real());
+      RegisterBdrEvalField("J_s_imag", J_bdr_eval, B->Imag());
     }
     else
     {
-      paraview_bdr->RegisterVCoeffField("J_s", J_sr.get());
+      RegisterBdrEvalField("J_s", J_bdr_eval, B->Real());
     }
+  }
+  else if (J_sr)
+  {
+    MFEM_ABORT(
+        "Boundary surface-current ParaView output requires a libCEED point evaluator!");
+  }
+
+  if (Sn_eval)
+  {
+    RequireCeedPointFieldEvaluator(Sn_eval.get(), "boundary-mode Sn visualization");
+    RegisterDomainEvalField("Sn", Sn_eval, E.get(), Bt_inplane.get());
   }
 
   // Add wave port boundary mode postprocessing when available.
@@ -670,12 +991,9 @@ void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
     Bt_inplane->Imag().FaceNbrData() *= mesh_Lc0;
     units.DimensionalizeInPlace<Units::ValueType::FIELD_B>(*Bt_inplane);
   }
-  // Register Sn on first write (created lazily after Bt_inplane is available).
-  if (Sn && !sn_registered)
-  {
-    paraview->RegisterCoeffField("Sn", Sn.get());
-    sn_registered = true;
-  }
+  // libCEED-evaluated derived domain fields are registered as lazy point evaluators;
+  // Save() evaluates them now, after dimensionalization, without materializing
+  // GridFunctions.
   double paraview_time = time;
   if constexpr (solver_t == ProblemType::DRIVEN)
   {
@@ -744,30 +1062,26 @@ void PostOperator<solver_t>::WriteParaviewFieldsFinal(const ErrorIndicator *indi
   {
     paraview->DeregisterVCoeffField(name);
   }
-  mfem::L2_FECollection pwconst_fec(0, mesh.Dimension());
-  mfem::FiniteElementSpace pwconst_fespace(&mesh, &pwconst_fec);
-  std::unique_ptr<mfem::GridFunction> rank, eta;
-  {
-    rank = std::make_unique<mfem::GridFunction>(&pwconst_fespace);
-    *rank = mesh.GetMyRank() + 1;
-    paraview->RegisterField("Rank", rank.get());
-  }
+  Vector rank(mesh.GetNE());
+  rank = mesh.GetMyRank() + 1;
+  paraview->RegisterDomainCellField("Rank", rank);
   if (indicator)
   {
-    eta = std::make_unique<mfem::GridFunction>(&pwconst_fespace);
-    MFEM_VERIFY(eta->Size() == indicator->Local().Size(),
+    MFEM_VERIFY(mesh.GetNE() == indicator->Local().Size(),
                 "Size mismatch for provided ErrorIndicator for postprocessing!");
-    *eta = indicator->Local();
-    paraview->RegisterField("Indicator", eta.get());
+    paraview->RegisterDomainCellField("Indicator", indicator->Local());
+  }
+  for (const char *name :
+       {"E", "E_real", "E_imag", "B", "B_real", "B_imag", "En", "En_real", "En_imag",
+        "Bt_real", "Bt_imag", "V", "A", "U_e", "U_m", "S", "Sn"})
+  {
+    paraview->DeregisterDomainPointField(name);
   }
   paraview->Save();
-  if (rank)
+  paraview->DeregisterDomainCellField("Rank");
+  if (indicator)
   {
-    paraview->DeregisterField("Rank");
-  }
-  if (eta)
-  {
-    paraview->DeregisterField("Indicator");
+    paraview->DeregisterDomainCellField("Indicator");
   }
   for (const auto &[name, gf] : field_map)
   {
@@ -906,29 +1220,54 @@ void PostOperator<solver_t>::WriteMFEMGridFunctions(double time, int step)
 
   if (U_e)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*U_e.get());
-    write_grid_function(gridfunc_scalar, "U_e");
+    if (U_e_eval)
+    {
+      // Device-evaluated (libCEED) energy density into the interpolatory L2 output
+      // space, reusing the ParaView evaluator instead of a host coefficient projection.
+      U_e_eval->Eval(E.get(), nullptr, *U_e_gf);
+      write_grid_function(*U_e_gf, "U_e");
+    }
+    else
+    {
+      gridfunc_scalar = 0.0;
+      gridfunc_scalar.ProjectCoefficient(*U_e.get());
+      write_grid_function(gridfunc_scalar, "U_e");
+    }
   }
 
   if (U_m)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*U_m.get());
-    write_grid_function(gridfunc_scalar, "U_m");
+    if (U_m_eval)
+    {
+      U_m_eval->Eval(nullptr, B.get(), *U_m_gf);
+      write_grid_function(*U_m_gf, "U_m");
+    }
+    else
+    {
+      gridfunc_scalar = 0.0;
+      gridfunc_scalar.ProjectCoefficient(*U_m.get());
+      write_grid_function(gridfunc_scalar, "U_m");
+    }
   }
 
   if (S)
   {
-    gridfunc_vector = 0.0;
-    gridfunc_vector.ProjectCoefficient(*S.get());
-    write_grid_function(gridfunc_vector, "S");
+    if (S_eval)
+    {
+      S_eval->Eval(E.get(), B.get(), *S_gf);
+      write_grid_function(*S_gf, "S");
+    }
+    else
+    {
+      gridfunc_vector = 0.0;
+      gridfunc_vector.ProjectCoefficient(*S.get());
+      write_grid_function(gridfunc_vector, "S");
+    }
   }
-  if (Sn)
+  if (Sn_eval)
   {
-    gridfunc_scalar = 0.0;
-    gridfunc_scalar.ProjectCoefficient(*Sn.get());
-    write_grid_function(gridfunc_scalar, "Sn");
+    Sn_eval->Eval(E.get(), Bt_inplane.get(), *Sn_gf);
+    write_grid_function(*Sn_gf, "Sn");
   }
 
   mesh::NondimensionalizeMesh(mesh, mesh_Lc0);
@@ -1820,14 +2159,6 @@ auto PostOperator<solver_t>::MeasureAndPrintAll(int step, const ComplexVector &e
     Bt_inplane->Imag().ProjectCoefficient(bt_imag_coeff);
     Bt_inplane->Real().ExchangeFaceNbrData();
     Bt_inplane->Imag().ExchangeFaceNbrData();
-  }
-
-  // Create Sn coefficient for boundary mode Poynting visualization.
-  // Sn = Re{Ex Hy* - Ey Hx*}: z-directed power density on the cross-section.
-  if (Bt_inplane && !Sn)
-  {
-    Sn = std::make_unique<ModeSnCoefficient>(E->Real(), E->Imag(), Bt_inplane->Real(),
-                                             Bt_inplane->Imag(), fem_op->GetMaterialOp());
   }
 
   measurement_cache = {};

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -14,12 +14,14 @@
 #include <mfem.hpp>
 #include "fem/gridfunction.hpp"
 #include "fem/interpolator.hpp"
+#include "fem/point_field_evaluator.hpp"
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
 #include "models/domainpostoperator.hpp"
 #include "models/lumpedportoperator.hpp"
 #include "models/postoperatorcsv.hpp"
 #include "models/surfacepostoperator.hpp"
+#include "utils/ceedparaviewdatacollection.hpp"
 #include "utils/configfile.hpp"
 #include "utils/filesystem.hpp"
 #include "utils/units.hpp"
@@ -180,7 +182,8 @@ protected:
   // ParaView data collection: writing fields to disk for visualization.
   // This is an optional, since ParaViewDataCollection has no default (empty) ctor,
   // and we only want initialize it if ShouldWriteParaviewFields() returns true.
-  std::optional<mfem::ParaViewDataCollection> paraview, paraview_bdr;
+  std::optional<CeedParaViewDataCollection> paraview;
+  std::optional<CeedParaViewDataCollection> paraview_bdr;
 
   // MFEM grid function output details.
   std::string gridfunction_output_dir;
@@ -188,16 +191,29 @@ protected:
 
   // Measurements of field solution for ParaView files (full domain or surfaces).
 
-  // Poynting Coefficient (vector for 3D, scalar Sn for boundary mode), Electric Boundary
-  // Field (re+im), Magnetic Boundary Field (re+im), Vector Potential Boundary Field,
-  // Surface Current (re+im).
-  std::unique_ptr<mfem::VectorCoefficient> S, E_sr, E_si, B_sr, B_si, A_s, J_sr, J_si;
-  std::unique_ptr<mfem::Coefficient> Sn;
-  bool sn_registered = false;
+  // Poynting Coefficient (vector for 3D), Electric Boundary Field (re+im), Magnetic
+  // Boundary Field (re+im), Surface Current (re+im).
+  std::unique_ptr<mfem::VectorCoefficient> S, E_sr, E_si, B_sr, B_si, J_sr, J_si;
 
-  // Electric Energy Density, Magnetic Energy Density, Scalar Potential Boundary Field,
-  // Surface Charge (re+im).
-  std::unique_ptr<mfem::Coefficient> U_e, U_m, V_s, Q_sr, Q_si;
+  // Electric Energy Density, Magnetic Energy Density, Surface Charge (re+im).
+  std::unique_ptr<mfem::Coefficient> U_e, U_m, Q_sr, Q_si;
+
+  // libCEED evaluators and optional output grid functions for the domain coefficient
+  // fields (U_e, U_m, S), replacing per-point host coefficient evaluation at ParaView
+  // save time when supported. ParaView output uses lazy component-major point buffers;
+  // gridfunction output still uses the GridFunction path when requested.
+  std::unique_ptr<mfem::L2_FECollection> viz_fec;
+  std::unique_ptr<mfem::ParFiniteElementSpace> viz_scalar_fespace, viz_vector_fespace;
+  std::unique_ptr<mfem::ParGridFunction> U_e_gf, U_m_gf, S_gf, Sn_gf;
+  std::unique_ptr<PointFieldEvaluator> E_domain_eval, B_domain_eval, En_domain_eval,
+      Bt_domain_eval, V_domain_eval, A_domain_eval, U_e_eval, U_m_eval, S_eval, Sn_eval;
+
+  // libCEED evaluators for boundary collection fields (E_s, B_s, Q_s, J_s, U_e, U_m,
+  // S). CeedParaViewDataCollection evaluates these lazily into one temporary buffer per
+  // field in the same integer boundary-element/refined-point order used for writing,
+  // avoiding coefficient adapters or floating-point point lookup at save time.
+  std::unique_ptr<PointFieldEvaluator> E_bdr_eval, B_bdr_eval, V_bdr_eval, A_bdr_eval,
+      Q_bdr_eval, J_bdr_eval, Ue_bdr_eval, Um_bdr_eval, S_bdr_eval;
 
   // Wave port boundary mode field postprocessing.
   struct WavePortFieldData
@@ -206,7 +222,9 @@ protected:
   };
   std::map<int, WavePortFieldData> port_E0;
 
-  // Setup coefficients for field postprocessing.
+  // Setup coefficients/evaluators for field output after the first solution is ready.
+  // Construction-only FE staging is detached and freed immediately; assembled libCEED
+  // operators remain cached for later writes in a frequency or mode sweep.
   void SetupFieldCoefficients();
 
   // Initialize Paraview, register all fields to write.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacefunctional.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-postoperator-boundary-viz.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-tablecsv.cpp
@@ -75,6 +76,13 @@ target_link_libraries(unit-tests
           $<$<BOOL:${PALACE_BUILD_WITH_SANITIZERS}>:sanitizer_flags>
           $<IF:$<BOOL:${PALACE_BUILD_WITH_COVERAGE}>,$<LINK_LIBRARY:WHOLE_ARCHIVE,${LIB_TARGET_NAME}>,${LIB_TARGET_NAME}>
           )
+
+# The PostOperator boundary-viz regression decodes MFEM's compressed binary VTU output
+# when MFEM is built with zlib support.
+find_package(ZLIB QUIET)
+if(ZLIB_FOUND)
+  target_link_libraries(unit-tests PRIVATE ZLIB::ZLIB)
+endif()
 
 # Handle device source code
 set(TARGET_SOURCES_DEVICE

--- a/test/unit/test-postoperator-boundary-viz.cpp
+++ b/test/unit/test-postoperator-boundary-viz.cpp
@@ -1,0 +1,969 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+#include <mfem.hpp>
+#include <mfem/general/binaryio.hpp>
+#ifdef MFEM_USE_ZLIB
+#include <zlib.h>
+#endif
+#include <catch2/catch_test_macros.hpp>
+#include "fem/coefficient.hpp"
+#include "fem/gridfunction.hpp"
+#include "fem/integrator.hpp"
+#include "fem/mesh.hpp"
+#include "fixtures.hpp"
+#include "linalg/vector.hpp"
+#include "models/curlcurloperator.hpp"
+#include "models/postoperator.hpp"
+#include "models/spaceoperator.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/geodata.hpp"
+#include "utils/iodata.hpp"
+#include "utils/labels.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+std::unique_ptr<mfem::Mesh> MakeSmallTetInterfaceSerialMesh()
+{
+  // 2 x 2 x 2 cubes split into tetrahedra: small enough for a unit test, but it has
+  // exterior boundaries, an interior material interface, and enough face orientations to
+  // exercise boundary-normal conventions through PostOperator's boundary ParaView output.
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON));
+  for (int e = 0; e < smesh->GetNE(); e++)
+  {
+    mfem::Vector center(3);
+    smesh->GetElementCenter(e, center);
+    smesh->SetAttribute(e, (center(2) < 0.5) ? 1 : 2);
+  }
+
+  // Add boundary elements on the interior material interface z = 0.5. The public
+  // PostOperator output path should preserve the legacy one-sided exterior and two-sided
+  // interior boundary semantics when its internals are replaced by libCEED kernels.
+  for (int f = 0; f < smesh->GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh->GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh->GetAttribute(e1) != smesh->GetAttribute(e2))
+    {
+      auto *face_elem = smesh->GetFace(f)->Duplicate(smesh.get());
+      face_elem->SetAttribute(7);
+      smesh->AddBdrElement(face_elem);
+    }
+  }
+  smesh->FinalizeTopology();
+  smesh->Finalize();
+  smesh->SetAttributes();
+  smesh->EnsureNodes();
+  return smesh;
+}
+
+std::unique_ptr<mfem::Mesh> MakeSmallTriInterfaceSerialMesh()
+{
+  // 2D companion to MakeSmallTetInterfaceSerialMesh. It has exterior boundaries and an
+  // interior material interface so boundary point fields exercise line-boundary kernels,
+  // scalar out-of-plane B, and two-sided averaging through the public PostOperator path.
+  auto smesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian2D(3, 2, mfem::Element::TRIANGLE, false, 1.0, 1.0));
+  for (int e = 0; e < smesh->GetNE(); e++)
+  {
+    mfem::Vector center(2);
+    smesh->GetElementCenter(e, center);
+    smesh->SetAttribute(e, (center(1) < 0.5) ? 1 : 2);
+  }
+
+  for (int f = 0; f < smesh->GetNumFaces(); f++)
+  {
+    int e1, e2;
+    smesh->GetFaceElements(f, &e1, &e2);
+    if (e1 >= 0 && e2 >= 0 && smesh->GetAttribute(e1) != smesh->GetAttribute(e2))
+    {
+      auto *face_elem = smesh->GetFace(f)->Duplicate(smesh.get());
+      face_elem->SetAttribute(7);
+      smesh->AddBdrElement(face_elem);
+    }
+  }
+  smesh->FinalizeTopology();
+  smesh->Finalize();
+  smesh->SetAttributes();
+  smesh->EnsureNodes();
+  return smesh;
+}
+
+std::vector<config::MaterialData> MakeTwoMaterials()
+{
+  config::MaterialData lower, upper;
+  lower.attributes = {1};
+  upper.attributes = {2};
+
+  // Diagonal anisotropy and different values on each side exercise component ordering and
+  // material lookup, not just identity/isotropic paths.
+  lower.epsilon_r.s = {1.1, 1.2, 1.3};
+  lower.mu_r.s = {0.9, 1.0, 1.1};
+  upper.epsilon_r.s = {11.7, 3.1, 2.4};
+  upper.mu_r.s = {1.4, 1.8, 2.2};
+
+  return {lower, upper};
+}
+
+void ProjectTestFields3D(GridFunction &E, GridFunction &B)
+{
+  mfem::VectorFunctionCoefficient er(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(1.3 * x(1)) + x(2) * x(2) + 0.2;
+                                       v(1) = std::cos(0.7 * x(2)) + 0.4 * x(0);
+                                       v(2) = x(0) * x(1) - 0.3 * x(2) + 1.0;
+                                     });
+  mfem::VectorFunctionCoefficient ei(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) * x(2) - 0.5;
+                                       v(1) = std::sin(x(0)) - 0.25 * x(2);
+                                       v(2) = std::cos(1.1 * x(1)) + x(0) * x(0);
+                                     });
+  mfem::VectorFunctionCoefficient br(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(1) - 0.3 * x(2) + 0.4;
+                                       v(1) = std::sin(0.9 * x(2)) + 0.5;
+                                       v(2) = std::cos(x(0)) - x(1) * x(2);
+                                     });
+  mfem::VectorFunctionCoefficient bi(3,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::cos(x(2)) - 0.2;
+                                       v(1) = x(0) * x(2) + 0.1;
+                                       v(2) = std::sin(x(1)) - 0.4 * x(0);
+                                     });
+
+  E.Real().ProjectCoefficient(er);
+  E.Imag().ProjectCoefficient(ei);
+  B.Real().ProjectCoefficient(br);
+  B.Imag().ProjectCoefficient(bi);
+
+  E.Real().ExchangeFaceNbrData();
+  E.Imag().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+  B.Imag().ExchangeFaceNbrData();
+}
+
+void ProjectTestFields2D(GridFunction &E, GridFunction &B)
+{
+  mfem::VectorFunctionCoefficient er(2,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = std::sin(1.7 * x(1)) + 0.25 * x(0) + 0.1;
+                                       v(1) = std::cos(0.8 * x(0)) - 0.35 * x(1) + 0.2;
+                                     });
+  mfem::VectorFunctionCoefficient ei(2,
+                                     [](const mfem::Vector &x, mfem::Vector &v)
+                                     {
+                                       v(0) = x(0) * x(1) - 0.15;
+                                       v(1) = std::sin(0.9 * x(0)) + 0.4 * x(1);
+                                     });
+  mfem::FunctionCoefficient br([](const mfem::Vector &x)
+                               { return std::cos(1.1 * x(0)) + 0.3 * x(1) + 0.5; });
+  mfem::FunctionCoefficient bi([](const mfem::Vector &x)
+                               { return std::sin(1.4 * x(1)) - 0.2 * x(0) + 0.25; });
+
+  E.Real().ProjectCoefficient(er);
+  E.Imag().ProjectCoefficient(ei);
+  B.Real().ProjectCoefficient(br);
+  B.Imag().ProjectCoefficient(bi);
+
+  E.Real().ExchangeFaceNbrData();
+  E.Imag().ExchangeFaceNbrData();
+  B.Real().ExchangeFaceNbrData();
+  B.Imag().ExchangeFaceNbrData();
+}
+
+void GetTrueDofs(const GridFunction &gf, ComplexVector &x)
+{
+  gf.Real().GetTrueDofs(x.Real());
+  gf.Imag().GetTrueDofs(x.Imag());
+}
+
+void DimensionalizeForPostOperatorOutput(const Units &units, GridFunction &E,
+                                         GridFunction &B)
+{
+  // Reproduce the temporary mesh and Piola scaling performed by WriteParaviewFields so
+  // legacy coefficient references and emitted Points are compared in input coordinates.
+  auto &mesh = *E.ParFESpace()->GetParMesh();
+  const double L = units.GetMeshLengthRelativeScale();
+  mesh::DimensionalizeMesh(mesh, L);
+
+  const double e_scale = L * units.GetScaleFactor<Units::ValueType::FIELD_E>();
+  E *= e_scale;
+  E.Real().FaceNbrData() *= e_scale;
+  E.Imag().FaceNbrData() *= e_scale;
+
+  const double b_scale =
+      std::pow(L, mesh.Dimension() - 1) * units.GetScaleFactor<Units::ValueType::FIELD_B>();
+  B *= b_scale;
+  B.Real().FaceNbrData() *= b_scale;
+  B.Imag().FaceNbrData() *= b_scale;
+}
+
+struct ErrorStats
+{
+  long long count = 0;
+  double max_abs = 0.0;
+  double max_scaled = 0.0;
+  double sum_sq = 0.0;
+
+  void Add(double val, double ref, double rtol, double atol)
+  {
+    const double err = std::abs(val - ref);
+    const double denom = atol + rtol * std::max({1.0, std::abs(val), std::abs(ref)});
+    max_abs = std::max(max_abs, err);
+    max_scaled = std::max(max_scaled, err / denom);
+    sum_sq += err * err;
+    count++;
+  }
+
+  double Rms() const
+  {
+    return count ? std::sqrt(sum_sq / static_cast<double>(count)) : 0.0;
+  }
+};
+
+void CheckStats(const std::string &name, const ErrorStats &stats)
+{
+  INFO("field = " << name);
+  INFO("count = " << stats.count);
+  INFO("max_abs = " << stats.max_abs);
+  INFO("max_scaled = " << stats.max_scaled);
+  INFO("rms = " << stats.Rms());
+  CHECK(stats.count > 0);
+  CHECK(stats.max_scaled <= 1.0);
+}
+
+std::string ReadFile(const fs::path &path)
+{
+  std::ifstream in(path, std::ios::binary);
+  REQUIRE(in.good());
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+std::string RemoveWhitespace(std::string_view text)
+{
+  std::string out;
+  out.reserve(text.size());
+  for (char c : text)
+  {
+    if (!std::isspace(static_cast<unsigned char>(c)))
+    {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+std::vector<char> DecodeBase64(std::string_view encoded)
+{
+  std::vector<char> decoded;
+  const auto clean = RemoveWhitespace(encoded);
+  mfem::bin_io::DecodeBase64(clean.c_str(), clean.size(), decoded);
+  return decoded;
+}
+
+template <typename T>
+T ReadLittleEndian(const char *bytes)
+{
+  T value;
+  std::memcpy(&value, bytes, sizeof(T));
+  return value;
+}
+
+std::vector<char> DecodeVtkBinaryPayload(std::string_view encoded, bool compressed)
+{
+  const auto clean = RemoveWhitespace(encoded);
+  if (!compressed)
+  {
+    const auto decoded = DecodeBase64(clean);
+    REQUIRE(decoded.size() >= sizeof(std::uint32_t));
+    const auto nbytes = ReadLittleEndian<std::uint32_t>(decoded.data());
+    REQUIRE(decoded.size() >= sizeof(std::uint32_t) + nbytes);
+    return {decoded.begin() + sizeof(std::uint32_t),
+            decoded.begin() + sizeof(std::uint32_t) + nbytes};
+  }
+
+  // MFEM writes one compressed VTK block with a 4 * uint32 header encoded separately
+  // from the zlib payload: [num_blocks=1, uncompressed_size, partial_size=0,
+  // compressed_size]. Decode the two base64 chunks independently because the header chunk
+  // carries its own padding.
+  constexpr std::size_t header_bytes = 4 * sizeof(std::uint32_t);
+  const auto header_chars = mfem::bin_io::NumBase64Chars(header_bytes);
+  REQUIRE(clean.size() >= header_chars);
+  const auto header = DecodeBase64(std::string_view(clean).substr(0, header_chars));
+  REQUIRE(header.size() == header_bytes);
+  const auto num_blocks = ReadLittleEndian<std::uint32_t>(header.data());
+  const auto uncompressed_size = ReadLittleEndian<std::uint32_t>(header.data() + 4);
+  const auto partial_size = ReadLittleEndian<std::uint32_t>(header.data() + 8);
+  const auto compressed_size = ReadLittleEndian<std::uint32_t>(header.data() + 12);
+  REQUIRE(num_blocks == 1);
+  REQUIRE(partial_size == 0);
+
+  const auto compressed_payload =
+      DecodeBase64(std::string_view(clean).substr(header_chars));
+  REQUIRE(compressed_payload.size() >= compressed_size);
+  std::vector<char> uncompressed(uncompressed_size);
+#ifdef MFEM_USE_ZLIB
+  uLongf dest_len = uncompressed_size;
+  const int zret = uncompress(reinterpret_cast<Bytef *>(uncompressed.data()), &dest_len,
+                              reinterpret_cast<const Bytef *>(compressed_payload.data()),
+                              compressed_size);
+  REQUIRE(zret == Z_OK);
+  REQUIRE(dest_len == uncompressed_size);
+#else
+  MFEM_ABORT("Cannot decode compressed VTK output without zlib support!");
+#endif
+  return uncompressed;
+}
+
+std::string_view ExtractDataArrayTag(std::string_view xml, const std::string &name)
+{
+  const std::string needle = "Name=\"" + name + "\"";
+  const auto name_pos = xml.find(needle);
+  REQUIRE(name_pos != std::string_view::npos);
+  const auto tag_begin = xml.rfind("<DataArray", name_pos);
+  REQUIRE(tag_begin != std::string_view::npos);
+  const auto tag_end = xml.find('>', name_pos);
+  REQUIRE(tag_end != std::string_view::npos);
+  return xml.substr(tag_begin, tag_end - tag_begin + 1);
+}
+
+std::string_view ExtractDataArrayPayload(std::string_view xml, const std::string &name)
+{
+  const std::string needle = "Name=\"" + name + "\"";
+  const auto name_pos = xml.find(needle);
+  REQUIRE(name_pos != std::string_view::npos);
+  const auto tag_end = xml.find('>', name_pos);
+  REQUIRE(tag_end != std::string_view::npos);
+  const auto close = xml.find("</DataArray>", tag_end);
+  REQUIRE(close != std::string_view::npos);
+  return xml.substr(tag_end + 1, close - tag_end - 1);
+}
+
+std::uint64_t ExtractUnsignedAttribute(std::string_view tag, std::string_view attr)
+{
+  const std::string needle = std::string(attr) + "=\"";
+  const auto begin = tag.find(needle);
+  REQUIRE(begin != std::string_view::npos);
+  const auto value_begin = begin + needle.size();
+  const auto value_end = tag.find('"', value_begin);
+  REQUIRE(value_end != std::string_view::npos);
+  return std::stoull(std::string(tag.substr(value_begin, value_end - value_begin)));
+}
+
+std::vector<char> ExtractAppendedDataArrayPayload(std::string_view xml,
+                                                  std::string_view tag)
+{
+  REQUIRE(tag.find("format=\"appended\"") != std::string_view::npos);
+  const auto offset = ExtractUnsignedAttribute(tag, "offset");
+  const auto appended_begin = xml.find("<AppendedData");
+  REQUIRE(appended_begin != std::string_view::npos);
+  const auto underscore = xml.find('_', appended_begin);
+  REQUIRE(underscore != std::string_view::npos);
+  const auto data_begin = underscore + 1 + offset;
+  REQUIRE(data_begin + sizeof(std::uint32_t) <= xml.size());
+  const auto nbytes = ReadLittleEndian<std::uint32_t>(xml.data() + data_begin);
+  const auto payload_begin = data_begin + sizeof(std::uint32_t);
+  REQUIRE(payload_begin + nbytes <= xml.size());
+  return {xml.begin() + static_cast<std::ptrdiff_t>(payload_begin),
+          xml.begin() + static_cast<std::ptrdiff_t>(payload_begin + nbytes)};
+}
+
+bool VtuUsesCompression(std::string_view xml)
+{
+  return xml.find("compressor=\"vtkZLibDataCompressor\"") != std::string_view::npos;
+}
+
+std::vector<char> ReadDataArrayBytes(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  if (tag.find("format=\"appended\"") != std::string_view::npos)
+  {
+    return ExtractAppendedDataArrayPayload(xml, tag);
+  }
+  return DecodeVtkBinaryPayload(ExtractDataArrayPayload(xml, name),
+                                VtuUsesCompression(xml));
+}
+
+std::vector<double> DecodeFloatDataArray(std::string_view tag,
+                                         const std::vector<char> &bytes)
+{
+  std::vector<double> values;
+  if (tag.find("type=\"Float32\"") != std::string_view::npos)
+  {
+    REQUIRE(bytes.size() % sizeof(float) == 0);
+    values.resize(bytes.size() / sizeof(float));
+    for (std::size_t i = 0; i < values.size(); i++)
+    {
+      values[i] = ReadLittleEndian<float>(bytes.data() + i * sizeof(float));
+    }
+  }
+  else
+  {
+    REQUIRE(tag.find("type=\"Float64\"") != std::string_view::npos);
+    REQUIRE(bytes.size() % sizeof(double) == 0);
+    values.resize(bytes.size() / sizeof(double));
+    for (std::size_t i = 0; i < values.size(); i++)
+    {
+      values[i] = ReadLittleEndian<double>(bytes.data() + i * sizeof(double));
+    }
+  }
+  return values;
+}
+
+std::vector<double> ReadFloatDataArray(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  return DecodeFloatDataArray(tag, ReadDataArrayBytes(xml, name));
+}
+
+std::vector<double> ReadPointsDataArray(std::string_view xml)
+{
+  const auto points_begin = xml.find("<Points>");
+  REQUIRE(points_begin != std::string_view::npos);
+  const auto tag_begin = xml.find("<DataArray", points_begin);
+  REQUIRE(tag_begin != std::string_view::npos);
+  const auto tag_end = xml.find('>', tag_begin);
+  REQUIRE(tag_end != std::string_view::npos);
+  const auto close = xml.find("</DataArray>", tag_end);
+  REQUIRE(close != std::string_view::npos);
+  const auto tag = xml.substr(tag_begin, tag_end - tag_begin + 1);
+  REQUIRE(tag.find("format=\"appended\"") == std::string_view::npos);
+  const auto payload = xml.substr(tag_end + 1, close - tag_end - 1);
+  return DecodeFloatDataArray(tag,
+                              DecodeVtkBinaryPayload(payload, VtuUsesCompression(xml)));
+}
+
+std::vector<int> ReadIntDataArray(std::string_view xml, const std::string &name)
+{
+  const auto bytes = ReadDataArrayBytes(xml, name);
+  REQUIRE(bytes.size() % sizeof(std::int32_t) == 0);
+  std::vector<int> values(bytes.size() / sizeof(std::int32_t));
+  for (std::size_t i = 0; i < values.size(); i++)
+  {
+    values[i] = ReadLittleEndian<std::int32_t>(bytes.data() + i * sizeof(std::int32_t));
+  }
+  return values;
+}
+
+int CountBoundaryVisualizationPoints(const mfem::ParMesh &pmesh, int lod)
+{
+  int count = 0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    count += RefG.RefPts.GetNPoints();
+  }
+  return count;
+}
+
+int CountDomainVisualizationPoints(const mfem::ParMesh &pmesh, int lod)
+{
+  int count = 0;
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    count += RefG.RefPts.GetNPoints();
+  }
+  return count;
+}
+
+ErrorStats CompareMeshPoints(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                             int lod, bool boundary, double rtol, double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  const int num_entity = boundary ? pmesh.GetNBE() : pmesh.GetNE();
+  mfem::Vector x(pmesh.SpaceDimension());
+  for (int i = 0; i < num_entity; i++)
+  {
+    const auto geom =
+        boundary ? pmesh.GetBdrElementBaseGeometry(i) : pmesh.GetElementBaseGeometry(i);
+    const auto &RefG = *mfem::GlobGeometryRefiner.Refine(geom, lod, 1);
+    auto *T =
+        boundary ? pmesh.GetBdrElementTransformation(i) : pmesh.GetElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+    {
+      T->Transform(RefG.RefPts.IntPoint(j), x);
+      for (int c = 0; c < 3; c++, idx++)
+      {
+        stats.Add(values[idx], c < x.Size() ? x(c) : 0.0, rtol, atol);
+      }
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+ErrorStats CompareScalarField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                              int lod, mfem::Coefficient &legacy, double rtol, double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++, idx++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      stats.Add(values[idx], legacy.Eval(*T, ip), rtol, atol);
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+ErrorStats CompareScalarDomainField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                                    int lod, mfem::Coefficient &legacy, double rtol,
+                                    double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++, idx++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      stats.Add(values[idx], legacy.Eval(*T, ip), rtol, atol);
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+ErrorStats CompareVectorField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                              int lod, mfem::VectorCoefficient &legacy, double rtol,
+                              double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  mfem::Vector ref(legacy.GetVDim());
+  for (int i = 0; i < pmesh.GetNBE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetBdrElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetBdrElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      legacy.Eval(ref, *T, ip);
+      for (int c = 0; c < legacy.GetVDim(); c++, idx++)
+      {
+        stats.Add(values[idx], ref(c), rtol, atol);
+      }
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+void RequireInteriorBoundaryWasWritten(std::string_view xml, const mfem::ParMesh &pmesh)
+{
+  const auto attributes = ReadIntDataArray(xml, "attribute");
+  REQUIRE(attributes.size() == static_cast<std::size_t>(pmesh.GetNBE()));
+  CHECK(std::find(attributes.begin(), attributes.end(), 7) != attributes.end());
+}
+
+ErrorStats CompareVectorDomainField(const std::vector<double> &values, mfem::ParMesh &pmesh,
+                                    int lod, mfem::VectorCoefficient &legacy, double rtol,
+                                    double atol)
+{
+  ErrorStats stats;
+  int idx = 0;
+  mfem::Vector ref(legacy.GetVDim());
+  for (int i = 0; i < pmesh.GetNE(); i++)
+  {
+    const auto &RefG =
+        *mfem::GlobGeometryRefiner.Refine(pmesh.GetElementBaseGeometry(i), lod, 1);
+    auto *T = pmesh.GetElementTransformation(i);
+    for (int j = 0; j < RefG.RefPts.GetNPoints(); j++)
+    {
+      const auto &ip = RefG.RefPts.IntPoint(j);
+      T->SetIntPoint(&ip);
+      legacy.Eval(ref, *T, ip);
+      for (int c = 0; c < legacy.GetVDim(); c++, idx++)
+      {
+        stats.Add(values[idx], ref(c), rtol, atol);
+      }
+    }
+  }
+  REQUIRE(idx == static_cast<int>(values.size()));
+  return stats;
+}
+
+void RequirePointFieldUsesAppendedData(std::string_view xml, const std::string &name)
+{
+  const auto tag = ExtractDataArrayTag(xml, name);
+  CHECK(tag.find("format=\"appended\"") != std::string_view::npos);
+  CHECK(xml.find("<AppendedData encoding=\"raw\">") != std::string_view::npos);
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator boundary ParaView fields match legacy coefficients",
+                 "[postoperator][boundary-viz][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+
+  constexpr int order = 2;
+  // PostOperator intentionally writes ParaView files as Float32, so tolerate single
+  // precision roundoff in the file representation while still catching semantic errors.
+  constexpr double rtol = 5.0e-5;
+  constexpr double atol = 5.0e-7;
+
+  auto serial_mesh = MakeSmallTetInterfaceSerialMesh();
+  REQUIRE(serial_mesh->bdr_attributes.Find(7) >= 0);
+
+  IoData iodata(Units(1.0e-4, 2.5e-4));
+  iodata.problem.type = ProblemType::EIGENMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = true;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0e-4;
+  iodata.model.Lc = 2.5;
+  iodata.domains.materials = MakeTwoMaterials();
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4, 5, 6};
+  iodata.solver.order = order;
+  iodata.solver.eigenmode.n_post = 1;
+  iodata.CheckConfiguration();
+  iodata.NondimensionalizeInputs(serial_mesh);
+
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(std::move(par_mesh)));
+  auto &pmesh = mesh.front()->Get();
+  REQUIRE(pmesh.bdr_attributes.Find(7) >= 0);
+
+  SpaceOperator space_op(iodata, mesh);
+  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
+
+  GridFunction E(space_op.GetNDSpace(), true), B(space_op.GetCurlSpace(), true);
+  ProjectTestFields3D(E, B);
+  ComplexVector e_true(space_op.GetNDSpace().GetTrueVSize());
+  ComplexVector b_true(space_op.GetRTSpace().GetTrueVSize());
+  GetTrueDofs(E, e_true);
+  GetTrueDofs(B, b_true);
+
+  // Public API under test: this is the same PostOperator entry point used by the solver.
+  // On origin/main it writes boundary ParaView fields by evaluating legacy coefficients;
+  // this branch replaces selected internals with libCEED buffers while preserving the API
+  // and output contract.
+  post_op.MeasureAndPrintAll(0, e_true, b_true, {1.0, 0.1}, 0.0, 0.0, 1);
+
+  DimensionalizeForPostOperatorOutput(iodata.units, E, B);
+
+  const auto domain_vtu = ReadFile(fs::path(iodata.problem.output) / "paraview" /
+                                   "eigenmode" / "Cycle000001" / "proc000000.vtu");
+  const auto boundary_vtu =
+      ReadFile(fs::path(iodata.problem.output) / "paraview" / "eigenmode_boundary" /
+               "Cycle000001" / "proc000000.vtu");
+  RequireInteriorBoundaryWasWritten(boundary_vtu, pmesh);
+  RequirePointFieldUsesAppendedData(boundary_vtu, "E_real");
+  RequirePointFieldUsesAppendedData(domain_vtu, "U_e");
+
+  const int lod = order;
+  const int n_bdr_pts = CountBoundaryVisualizationPoints(pmesh, lod);
+  const int n_domain_pts = CountDomainVisualizationPoints(pmesh, lod);
+  auto ReadBoundaryChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(boundary_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_bdr_pts * components));
+    return values;
+  };
+  auto ReadDomainChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(domain_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_domain_pts * components));
+    return values;
+  };
+
+  const auto &mat_op = space_op.GetMaterialOp();
+  const double eps_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_D>(1.0) /
+                             iodata.units.Dimensionalize<Units::ValueType::FIELD_E>(1.0);
+  const double invmu_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_H>(1.0) /
+                               iodata.units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
+
+  CheckStats("domain mesh points", CompareMeshPoints(ReadPointsDataArray(domain_vtu), pmesh,
+                                                     lod, false, rtol, atol));
+  CheckStats("boundary mesh points", CompareMeshPoints(ReadPointsDataArray(boundary_vtu),
+                                                       pmesh, lod, true, rtol, atol));
+
+  BdrFieldVectorCoefficient E_real_legacy(E.Real()), E_imag_legacy(E.Imag());
+  BdrFieldVectorCoefficient B_real_legacy(B.Real()), B_imag_legacy(B.Imag());
+  CheckStats("E_real", CompareVectorField(ReadBoundaryChecked("E_real", 3), pmesh, lod,
+                                          E_real_legacy, rtol, atol));
+  CheckStats("E_imag", CompareVectorField(ReadBoundaryChecked("E_imag", 3), pmesh, lod,
+                                          E_imag_legacy, rtol, atol));
+  CheckStats("B_real", CompareVectorField(ReadBoundaryChecked("B_real", 3), pmesh, lod,
+                                          B_real_legacy, rtol, atol));
+  CheckStats("B_imag", CompareVectorField(ReadBoundaryChecked("B_imag", 3), pmesh, lod,
+                                          B_imag_legacy, rtol, atol));
+
+  mfem::Vector unused_x0;
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_real_legacy(
+      &E.Real(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_imag_legacy(
+      &E.Imag(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceCurrentVectorCoefficient J_real_legacy(B.Real(), mat_op, invmu_scaling);
+  BdrSurfaceCurrentVectorCoefficient J_imag_legacy(B.Imag(), mat_op, invmu_scaling);
+  CheckStats("Q_s_real", CompareScalarField(ReadBoundaryChecked("Q_s_real", 1), pmesh, lod,
+                                            Q_real_legacy, rtol, atol));
+  CheckStats("Q_s_imag", CompareScalarField(ReadBoundaryChecked("Q_s_imag", 1), pmesh, lod,
+                                            Q_imag_legacy, rtol, atol));
+  CheckStats("J_s_real", CompareVectorField(ReadBoundaryChecked("J_s_real", 3), pmesh, lod,
+                                            J_real_legacy, rtol, atol));
+  CheckStats("J_s_imag", CompareVectorField(ReadBoundaryChecked("J_s_imag", 3), pmesh, lod,
+                                            J_imag_legacy, rtol, atol));
+
+  EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> Ue_legacy(E, mat_op, eps_scaling);
+  EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> Um_legacy(B, mat_op, invmu_scaling);
+  PoyntingVectorCoefficient S_legacy(E, B, mat_op, invmu_scaling);
+  CheckStats("U_e boundary", CompareScalarField(ReadBoundaryChecked("U_e", 1), pmesh, lod,
+                                                Ue_legacy, rtol, atol));
+  CheckStats("U_m boundary", CompareScalarField(ReadBoundaryChecked("U_m", 1), pmesh, lod,
+                                                Um_legacy, rtol, atol));
+  CheckStats("S boundary", CompareVectorField(ReadBoundaryChecked("S", 3), pmesh, lod,
+                                              S_legacy, rtol, atol));
+  CheckStats("U_e domain", CompareScalarDomainField(ReadDomainChecked("U_e", 1), pmesh, lod,
+                                                    Ue_legacy, rtol, atol));
+  CheckStats("U_m domain", CompareScalarDomainField(ReadDomainChecked("U_m", 1), pmesh, lod,
+                                                    Um_legacy, rtol, atol));
+  CheckStats("S domain", CompareVectorDomainField(ReadDomainChecked("S", 3), pmesh, lod,
+                                                  S_legacy, rtol, atol));
+}
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "PostOperator 2D boundary ParaView fields match legacy coefficients",
+                 "[postoperator][boundary-viz][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+
+  constexpr int order = 2;
+  constexpr double rtol = 5.0e-5;
+  constexpr double atol = 5.0e-7;
+
+  auto serial_mesh = MakeSmallTriInterfaceSerialMesh();
+  REQUIRE(serial_mesh->Dimension() == 2);
+  REQUIRE(serial_mesh->SpaceDimension() == 2);
+  REQUIRE(serial_mesh->bdr_attributes.Find(7) >= 0);
+
+  IoData iodata(Units(1.0e-4, 2.5e-4));
+  iodata.problem.type = ProblemType::EIGENMODE;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = true;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0e-4;
+  iodata.model.Lc = 2.5;
+  iodata.domains.materials = MakeTwoMaterials();
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4};
+  iodata.solver.order = order;
+  iodata.solver.eigenmode.n_post = 1;
+  iodata.CheckConfiguration();
+  iodata.NondimensionalizeInputs(serial_mesh);
+
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(std::move(par_mesh)));
+  auto &pmesh = mesh.front()->Get();
+  REQUIRE(pmesh.bdr_attributes.Find(7) >= 0);
+
+  SpaceOperator space_op(iodata, mesh);
+  PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
+
+  GridFunction E(space_op.GetNDSpace(), true), B(space_op.GetCurlSpace(), true);
+  REQUIRE(E.VectorDim() == 2);
+  REQUIRE(B.VectorDim() == 1);
+  ProjectTestFields2D(E, B);
+  ComplexVector e_true(space_op.GetNDSpace().GetTrueVSize());
+  ComplexVector b_true(space_op.GetCurlSpace().GetTrueVSize());
+  GetTrueDofs(E, e_true);
+  GetTrueDofs(B, b_true);
+
+  post_op.MeasureAndPrintAll(0, e_true, b_true, {1.0, 0.1}, 0.0, 0.0, 1);
+
+  DimensionalizeForPostOperatorOutput(iodata.units, E, B);
+
+  const auto domain_vtu = ReadFile(fs::path(iodata.problem.output) / "paraview" /
+                                   "eigenmode" / "Cycle000001" / "proc000000.vtu");
+  const auto boundary_vtu =
+      ReadFile(fs::path(iodata.problem.output) / "paraview" / "eigenmode_boundary" /
+               "Cycle000001" / "proc000000.vtu");
+  RequireInteriorBoundaryWasWritten(boundary_vtu, pmesh);
+  RequirePointFieldUsesAppendedData(boundary_vtu, "E_real");
+  RequirePointFieldUsesAppendedData(boundary_vtu, "U_m");
+  RequirePointFieldUsesAppendedData(domain_vtu, "B_real");
+
+  const int lod = order;
+  const int n_bdr_pts = CountBoundaryVisualizationPoints(pmesh, lod);
+  const int n_domain_pts = CountDomainVisualizationPoints(pmesh, lod);
+  auto ReadBoundaryChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(boundary_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_bdr_pts * components));
+    return values;
+  };
+  auto ReadDomainChecked = [&](const std::string &name, int components)
+  {
+    auto values = ReadFloatDataArray(domain_vtu, name);
+    REQUIRE(values.size() == static_cast<std::size_t>(n_domain_pts * components));
+    return values;
+  };
+
+  const auto &mat_op = space_op.GetMaterialOp();
+  const double eps_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_D>(1.0) /
+                             iodata.units.Dimensionalize<Units::ValueType::FIELD_E>(1.0);
+  const double invmu_scaling = iodata.units.Dimensionalize<Units::ValueType::FIELD_H>(1.0) /
+                               iodata.units.Dimensionalize<Units::ValueType::FIELD_B>(1.0);
+
+  CheckStats("domain mesh points 2D", CompareMeshPoints(ReadPointsDataArray(domain_vtu),
+                                                        pmesh, lod, false, rtol, atol));
+  CheckStats("boundary mesh points 2D", CompareMeshPoints(ReadPointsDataArray(boundary_vtu),
+                                                          pmesh, lod, true, rtol, atol));
+
+  BdrFieldVectorCoefficient E_real_legacy(E.Real()), E_imag_legacy(E.Imag());
+  CheckStats("E_real boundary 2D",
+             CompareVectorField(ReadBoundaryChecked("E_real", 2), pmesh, lod, E_real_legacy,
+                                rtol, atol));
+  CheckStats("E_imag boundary 2D",
+             CompareVectorField(ReadBoundaryChecked("E_imag", 2), pmesh, lod, E_imag_legacy,
+                                rtol, atol));
+
+  mfem::Vector unused_x0;
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_real_legacy(
+      &E.Real(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  BdrSurfaceFluxCoefficient<SurfaceFlux::ELECTRIC> Q_imag_legacy(
+      &E.Imag(), nullptr, mat_op, true, unused_x0, eps_scaling);
+  CheckStats("Q_s_real boundary 2D",
+             CompareScalarField(ReadBoundaryChecked("Q_s_real", 1), pmesh, lod,
+                                Q_real_legacy, rtol, atol));
+  CheckStats("Q_s_imag boundary 2D",
+             CompareScalarField(ReadBoundaryChecked("Q_s_imag", 1), pmesh, lod,
+                                Q_imag_legacy, rtol, atol));
+
+  EnergyDensityCoefficient<EnergyDensityType::ELECTRIC> Ue_legacy(E, mat_op, eps_scaling);
+  EnergyDensityCoefficient<EnergyDensityType::MAGNETIC> Um_legacy(B, mat_op, invmu_scaling);
+  PoyntingVectorCoefficient S_legacy(E, B, mat_op, invmu_scaling);
+  CheckStats("U_e boundary 2D", CompareScalarField(ReadBoundaryChecked("U_e", 1), pmesh,
+                                                   lod, Ue_legacy, rtol, atol));
+  CheckStats("U_m boundary 2D", CompareScalarField(ReadBoundaryChecked("U_m", 1), pmesh,
+                                                   lod, Um_legacy, rtol, atol));
+  CheckStats("S boundary 2D", CompareVectorField(ReadBoundaryChecked("S", 2), pmesh, lod,
+                                                 S_legacy, rtol, atol));
+
+  mfem::VectorGridFunctionCoefficient E_real_domain(&E.Real());
+  mfem::VectorGridFunctionCoefficient E_imag_domain(&E.Imag());
+  mfem::GridFunctionCoefficient B_real_domain(&B.Real());
+  mfem::GridFunctionCoefficient B_imag_domain(&B.Imag());
+  CheckStats("E_real domain 2D",
+             CompareVectorDomainField(ReadDomainChecked("E_real", 2), pmesh, lod,
+                                      E_real_domain, rtol, atol));
+  CheckStats("E_imag domain 2D",
+             CompareVectorDomainField(ReadDomainChecked("E_imag", 2), pmesh, lod,
+                                      E_imag_domain, rtol, atol));
+  CheckStats("B_real domain 2D",
+             CompareScalarDomainField(ReadDomainChecked("B_real", 1), pmesh, lod,
+                                      B_real_domain, rtol, atol));
+  CheckStats("B_imag domain 2D",
+             CompareScalarDomainField(ReadDomainChecked("B_imag", 1), pmesh, lod,
+                                      B_imag_domain, rtol, atol));
+  CheckStats("U_e domain 2D", CompareScalarDomainField(ReadDomainChecked("U_e", 1), pmesh,
+                                                       lod, Ue_legacy, rtol, atol));
+  CheckStats("U_m domain 2D", CompareScalarDomainField(ReadDomainChecked("U_m", 1), pmesh,
+                                                       lod, Um_legacy, rtol, atol));
+  CheckStats("S domain 2D", CompareVectorDomainField(ReadDomainChecked("S", 2), pmesh, lod,
+                                                     S_legacy, rtol, atol));
+}
+
+TEST_CASE_METHOD(test::SharedTempDir,
+                 "2D magnetostatic ParaView fields match the mesh point lattice",
+                 "[postoperator][boundary-viz][Serial][GPU]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  REQUIRE(Mpi::Size(comm) == 1);
+
+  constexpr int order = 2;
+  auto serial_mesh = MakeSmallTriInterfaceSerialMesh();
+  IoData iodata(Units(1.0e-4, 2.5e-4));
+  iodata.problem.type = ProblemType::MAGNETOSTATIC;
+  iodata.problem.verbose = 0;
+  iodata.problem.output = temp_dir.string();
+  iodata.problem.output_formats.paraview = true;
+  iodata.problem.output_formats.gridfunction = false;
+  iodata.model.L0 = 1.0e-4;
+  iodata.model.Lc = 2.5;
+  iodata.domains.materials = MakeTwoMaterials();
+  iodata.boundaries.pec.attributes = {1, 2, 3, 4};
+  iodata.solver.order = order;
+  iodata.solver.magnetostatic.n_post = 1;
+  iodata.CheckConfiguration();
+  iodata.NondimensionalizeInputs(serial_mesh);
+
+  auto par_mesh = std::make_unique<mfem::ParMesh>(comm, *serial_mesh);
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(std::move(par_mesh)));
+  auto &pmesh = mesh.front()->Get();
+
+  CurlCurlOperator curlcurl_op(iodata, mesh);
+  PostOperator<ProblemType::MAGNETOSTATIC> post_op(iodata, curlcurl_op);
+  const auto &Curl = curlcurl_op.GetCurlMatrix();
+  Vector A(Curl.Width()), B(Curl.Height());
+  A = 0.0;
+  B = 0.0;
+  post_op.MeasureAndPrintAll(0, A, B, 0);
+
+  const auto domain_vtu = ReadFile(fs::path(iodata.problem.output) / "paraview" /
+                                   "magnetostatic" / "Cycle000000" / "proc000000.vtu");
+  const int num_points = CountDomainVisualizationPoints(pmesh, order);
+  CHECK(ReadPointsDataArray(domain_vtu).size() == static_cast<std::size_t>(3 * num_points));
+  CHECK(ReadFloatDataArray(domain_vtu, "A").size() ==
+        static_cast<std::size_t>(2 * num_points));
+  CHECK(ReadFloatDataArray(domain_vtu, "B").size() == static_cast<std::size_t>(num_points));
+  CHECK(ReadFloatDataArray(domain_vtu, "U_m").size() ==
+        static_cast<std::size_t>(num_points));
+}
+
+}  // namespace palace


### PR DESCRIPTION
This is **9/10** in the stacked replacement for #824/#825 and depends on [#857](https://github.com/awslabs/palace/pull/857). Please review only the diff against that PR.

This connects domain and boundary point-field evaluators to `PostOperator`, ParaView output, and supported GridFunction export. The guide documents the resulting FE spaces and boundary semantics.

**Reviewer guidance:** Review this as integration rather than new numerics. Check field registration, names, units, component counts, 2D/3D behavior, and preservation of the GridFunction path. Setup remains eager here so lifecycle policy stays separate.

**Deferred:** Delayed setup and solver-memory release are isolated in the final PR.

**Validation:** Boundary visualization passes 665 assertions; GridFunction export passes with 53 serial and 103 MPI-2 assertions.
