### PR TITLE
Delay visualization setup and reuse staging memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Delayed visualization setup until after the first solve, reused output staging
+    storage, and added an optional CUDA profiling range to reduce peak device memory.
   - Routed ParaView and GridFunction output through device-backed point-field
     evaluators while preserving field names, units, and layouts.
   - Added lazy ParaView VTU serialization for device-evaluated point and cell

--- a/palace/drivers/drivensolver.cpp
+++ b/palace/drivers/drivensolver.cpp
@@ -162,13 +162,11 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &space_op) const
       Mpi::Print("\nSweeping excitation index {:d} ({:d}/{:d}):\n", excitation_idx,
                  excitation_counter, port_excitations.Size());
     }
-    // Switch paraview subfolders: one for each excitation, if nr_excitations > 1.
-    post_op.InitializeParaviewDataCollection(excitation_idx);
-
-    // Frequency loop.
-    for (std::size_t omega_i =
-             ((excitation_counter == excitation_restart_counter) ? freq_restart_idx : 0);
-         omega_i < omega_sample.size(); omega_i++)
+    // Frequency loop. Delay the potentially large visualization operators until the
+    // first solution is ready, so they do not increase the solve/preconditioner peak.
+    const std::size_t omega_start =
+        (excitation_counter == excitation_restart_counter) ? freq_restart_idx : 0;
+    for (std::size_t omega_i = omega_start; omega_i < omega_sample.size(); omega_i++)
     {
       auto omega = omega_sample[omega_i];
       // Assemble frequency dependent matrices and initialize operators in linear
@@ -216,6 +214,11 @@ ErrorIndicator DrivenSolver::SweepUniform(SpaceOperator &space_op) const
             space_op.GetMaterialOp().HasFloquetFrequencyScaling() ? 1.0 : 1.0 / omega);
       }
 
+      if (omega_i == omega_start)
+      {
+        // Switch ParaView subfolders once per excitation, after the first solve.
+        post_op.InitializeParaviewDataCollection(excitation_idx);
+      }
       auto total_domain_energy =
           post_op.MeasureAndPrintAll(excitation_idx, int(omega_i), E, B, omega);
 
@@ -445,10 +448,7 @@ ErrorIndicator DrivenSolver::SweepAdaptive(SpaceOperator &space_op) const
       Mpi::Print("\nSweeping excitation index {:d} ({:d}/{:d}):\n", excitation_idx,
                  ++excitation_counter, port_excitations.Size());
     }
-    // Switch paraview subfolders: one for each excitation, if nr_excitations > 1.
-    post_op.InitializeParaviewDataCollection(excitation_idx);
-
-    // Frequency loop.
+    // Frequency loop. Delay visualization setup until the first online solution is ready.
     for (std::size_t omega_i = 0; omega_i < omega_sample.size(); omega_i++)
     {
       auto omega = omega_sample[omega_i];
@@ -477,6 +477,11 @@ ErrorIndicator DrivenSolver::SweepAdaptive(SpaceOperator &space_op) const
         floquet_corr->AddMult(
             E, B,
             space_op.GetMaterialOp().HasFloquetFrequencyScaling() ? 1.0 : 1.0 / omega);
+      }
+      if (omega_i == 0)
+      {
+        // Switch ParaView subfolders once per excitation, after the first solve.
+        post_op.InitializeParaviewDataCollection(excitation_idx);
       }
       post_op.MeasureAndPrintAll(excitation_idx, int(omega_i), E, B, omega);
     }

--- a/palace/drivers/eigensolver.cpp
+++ b/palace/drivers/eigensolver.cpp
@@ -40,6 +40,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
   SpaceOperator space_op(iodata, mesh);
   auto K = space_op.GetStiffnessMatrix<ComplexOperator>(Operator::DIAG_ONE);
   auto C = space_op.GetDampingMatrix<ComplexOperator>(Operator::DIAG_ZERO);
+  const bool has_C = (C != nullptr);
   auto M = space_op.GetMassMatrix<ComplexOperator>(Operator::DIAG_ZERO);
 
   // Check if there are nonlinear terms and, if so, setup interpolation operator.
@@ -127,8 +128,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
   // Configure objects for postprocessing.
   PostOperator<ProblemType::EIGENMODE> post_op(iodata, space_op);
-  ComplexVector E(Curl.Width()), B(Curl.Height());
-  E.UseDevice(true);
+  ComplexVector B(Curl.Height());
   B.UseDevice(true);
 
   // Define and configure the eigensolver to solve the eigenvalue problem:
@@ -447,15 +447,54 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
     eigen->SetBMat(*KM);
     eigen->RescaleEigenvectors(num_conv);
   }
+  std::vector<std::complex<double>> eigenvalues(num_conv);
+  std::vector<double> errors_bkwd(num_conv), errors_abs(num_conv);
+  // Stage finalized eigenvectors in host memory so extracting all converged modes does
+  // not overlap the eigensolver basis with num_conv additional full device vectors. One
+  // device work vector is reused for extraction and later postprocessing.
+  std::vector<std::vector<std::complex<double>>> eigenvectors(
+      num_conv, std::vector<std::complex<double>>(Curl.Width()));
+  ComplexVector E(Curl.Width());
+  E.UseDevice(true);
+  for (int i = 0; i < num_conv; i++)
+  {
+    eigenvalues[i] = eigen->GetEigenvalue(i);
+    errors_bkwd[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
+    errors_abs[i] = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
+    eigen->GetEigenvector(i, E);
+    E.Get(eigenvectors[i].data(), E.Size(), false);
+  }
+
+  // The shifted linear system, eigenvalue solver, and assembled matrices are only needed
+  // through eigenvector extraction. Release their device allocations before error
+  // estimation and field-output postprocessing, where large libCEED visualization
+  // operators may need additional GPU memory on refined meshes.
+  eigen.reset();
+  KM.reset();
+  ksp.reset();
+  P.reset();
+  A.reset();
+  divfree.reset();
+  Kp.reset();
+  Cp.reset();
+  Mp.reset();
+  A2_0.reset();
+  A2_1.reset();
+  A2_2.reset();
+  A2.reset();
+  interp_op.reset();
+  K.reset();
+  C.reset();
+  M.reset();
   Mpi::Print("\n");
 
   for (int i = 0; i < num_conv; i++)
   {
     // Get the eigenvalue and relative error.
-    std::complex<double> omega = eigen->GetEigenvalue(i);
-    double error_bkwd = eigen->GetError(i, EigenvalueSolver::ErrorType::BACKWARD);
-    double error_abs = eigen->GetError(i, EigenvalueSolver::ErrorType::ABSOLUTE);
-    if (!C && !has_A2)
+    std::complex<double> omega = eigenvalues[i];
+    double error_bkwd = errors_bkwd[i];
+    double error_abs = errors_abs[i];
+    if (!has_C && !has_A2)
     {
       // Linear EVP has eigenvalue μ = -λ² = ω².
       omega = std::sqrt(omega);
@@ -468,8 +507,7 @@ EigenSolver::Solve(const std::vector<std::unique_ptr<Mesh>> &mesh) const
 
     // Compute B = -1/(iω) ∇ x E on the true dofs, and set the internal GridFunctions in
     // PostOperator for all postprocessing operations.
-    eigen->GetEigenvector(i, E);
-
+    E.Set(eigenvectors[i].data(), E.Size(), false);
     linalg::NormalizePhase(space_op.GetComm(), E);
 
     Curl.Mult(E.Real(), B.Real());

--- a/palace/linalg/slepc.cpp
+++ b/palace/linalg/slepc.cpp
@@ -119,8 +119,7 @@ inline PetscErrorCode ConfigurePetscDevice()
                                    mfem::Device::GetGPUAwareMPI() ? "1" : "0"));
     PetscCall(PetscOptionsSetValue(NULL, "-device_select_cuda",
                                    std::to_string(mfem::Device::GetId()).c_str()));
-    // PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
-    // PetscCall(PetscOptionsSetValue(NULL, "-vec_type", "cuda"));
+    PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
   }
   if (mfem::Device::Allows(mfem::Backend::HIP_MASK))
   {
@@ -128,8 +127,7 @@ inline PetscErrorCode ConfigurePetscDevice()
                                    mfem::Device::GetGPUAwareMPI() ? "1" : "0"));
     PetscCall(PetscOptionsSetValue(NULL, "-device_select_hip",
                                    std::to_string(mfem::Device::GetId()).c_str()));
-    // PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
-    // PetscCall(PetscOptionsSetValue(NULL, "-vec_type", "hip"));
+    PetscCall(PetscOptionsSetValue(NULL, "-bv_type", "svec"));
   }
   return PETSC_SUCCESS;
 }

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -270,9 +270,6 @@ PostOperator<solver_t>::PostOperator(const config::ProblemData &problem,
   RemovePreviousOutput(gridfunction_root, fem_op->GetComm());
   gridfunction_output_dir = (gridfunction_root / OutputFolderName(solver_t)).string();
 
-  SetupFieldCoefficients();
-  InitializeParaviewDataCollection();
-
   // Initialize CSV files for measurements.
   post_op_csv.InitializeCSVDataCollection(*this);
 }
@@ -308,6 +305,10 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
   {
     return;
   }
+  MFEM_VERIFY(!field_coefficients_initialized,
+              "Field coefficients should only be initialized once!");
+  field_coefficients_initialized = true;
+
   // Initialize the (interpolatory L2) output spaces for the libCEED-evaluated
   // visualization fields. The order matches the ParaView output sampling lattice
   // (SetLevelsOfDetail below), preserving the existing VTU point layout.
@@ -614,9 +615,29 @@ void PostOperator<solver_t>::SetupFieldCoefficients()
 }
 
 template <ProblemType solver_t>
+void PostOperator<solver_t>::EnsureFieldCoefficientsSetup()
+{
+  if (!field_coefficients_initialized)
+  {
+    SetupFieldCoefficients();
+  }
+}
+
+template <ProblemType solver_t>
+void PostOperator<solver_t>::EnsureParaviewDataCollection()
+{
+  EnsureFieldCoefficientsSetup();
+  if (ShouldWriteParaviewFields() && !paraview)
+  {
+    InitializeParaviewDataCollection();
+  }
+}
+
+template <ProblemType solver_t>
 void PostOperator<solver_t>::InitializeParaviewDataCollection(
     const fs::path &sub_folder_name)
 {
+  EnsureFieldCoefficientsSetup();
   if (!ShouldWriteParaviewFields())
   {
     return;
@@ -966,6 +987,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
 {
   BlockTimer bt(Timer::POSTPRO_PARAVIEW);
+  EnsureParaviewDataCollection();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 
@@ -1027,6 +1049,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteParaviewFieldsFinal(const ErrorIndicator *indicator)
 {
   BlockTimer bt(Timer::POSTPRO_PARAVIEW);
+  EnsureParaviewDataCollection();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 
@@ -1103,6 +1126,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteMFEMGridFunctions(double time, int step)
 {
   BlockTimer bt(Timer::POSTPRO_GRIDFUNCTION);
+  EnsureFieldCoefficientsSetup();
 
   // Create output directory if it doesn't exist (node-local filesystem aware).
   EnsureDirectory(fs::path(gridfunction_output_dir), fem_op->GetComm());
@@ -1292,6 +1316,7 @@ template <ProblemType solver_t>
 void PostOperator<solver_t>::WriteMFEMGridFunctionsFinal(const ErrorIndicator *indicator)
 {
   BlockTimer bt(Timer::POSTPRO_GRIDFUNCTION);
+  EnsureFieldCoefficientsSetup();
 
   auto mesh_Lc0 = units.GetMeshLengthRelativeScale();
 

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <complex>
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <set>
@@ -32,6 +33,10 @@
 #include "utils/timer.hpp"
 
 #include <mfem/config/config.hpp>
+#if defined(MFEM_USE_CUDA)
+#include <cuda_profiler_api.h>
+#endif
+
 namespace palace
 {
 
@@ -66,6 +71,31 @@ void RequireCeedPointFieldEvaluator(const PointFieldEvaluator *eval,
 {
   MFEM_VERIFY(eval && eval->IsValid(), "libCEED postprocessing was expected for " + what +
                                            ", but PointFieldEvaluator could not assemble!");
+}
+
+bool UseCudaProfilerParaviewRange()
+{
+  return std::getenv("PALACE_PROFILE_PARAVIEW_RANGE") != nullptr;
+}
+
+void StartCudaProfilerParaviewRange()
+{
+#if defined(MFEM_USE_CUDA)
+  if (UseCudaProfilerParaviewRange())
+  {
+    cudaProfilerStart();
+  }
+#endif
+}
+
+void StopCudaProfilerParaviewRange()
+{
+#if defined(MFEM_USE_CUDA)
+  if (UseCudaProfilerParaviewRange())
+  {
+    cudaProfilerStop();
+  }
+#endif
 }
 
 std::string OutputFolderName(const ProblemType solver_t)
@@ -1025,8 +1055,10 @@ void PostOperator<solver_t>::WriteParaviewFields(double time, int step)
   paraview->SetTime(paraview_time);
   paraview_bdr->SetCycle(step);
   paraview_bdr->SetTime(paraview_time);
+  StartCudaProfilerParaviewRange();
   paraview->Save();
   paraview_bdr->Save();
+  StopCudaProfilerParaviewRange();
   mesh::NondimensionalizeMesh(mesh, mesh_Lc0);
   ScaleGridFunctions(1.0 / mesh_Lc0, mesh.Dimension(), E, B, V, A);
   NondimensionalizeGridFunctions(units, E, B, V, A);
@@ -1100,7 +1132,9 @@ void PostOperator<solver_t>::WriteParaviewFieldsFinal(const ErrorIndicator *indi
   {
     paraview->DeregisterDomainPointField(name);
   }
+  StartCudaProfilerParaviewRange();
   paraview->Save();
+  StopCudaProfilerParaviewRange();
   paraview->DeregisterDomainCellField("Rank");
   if (indicator)
   {

--- a/palace/models/postoperator.hpp
+++ b/palace/models/postoperator.hpp
@@ -132,6 +132,7 @@ protected:
   // Field output format control flags.
   bool enable_paraview_output = false;
   bool enable_gridfunction_output = false;
+  bool field_coefficients_initialized = false;
 
   // How many / which fields to output.
   int output_delta_post = 0;                          // printing rate (TRANSIENT)
@@ -226,9 +227,11 @@ protected:
   // Construction-only FE staging is detached and freed immediately; assembled libCEED
   // operators remain cached for later writes in a frequency or mode sweep.
   void SetupFieldCoefficients();
+  void EnsureFieldCoefficientsSetup();
 
   // Initialize Paraview, register all fields to write.
   void InitializeParaviewDataCollection(const fs::path &sub_folder_name = "");
+  void EnsureParaviewDataCollection();
 
 public:
   // Public overload for the driven solver only, that takes in an excitation index and


### PR DESCRIPTION
This is **10/10** in the stacked replacement for #824/#825 and depends on [#858](https://github.com/awslabs/palace/pull/858). Please review only the diff against that PR.

This delays visualization construction until after the first solve, releases solver storage before output where possible, reuses host staging for eigenvectors, and adds an optional CUDA profiling range around ParaView output.

**Reviewer guidance:** The output values are unchanged; review only lifecycle and ownership. The commits separately cover lazy setup, solver-memory/staging policy, and profiling so each concern can be reviewed in isolation.

**Stack result:** Apart from the ten slice-specific changelog entries, this final tree is byte-identical to the current #825 head.

**Validation:** Full exact-head suite passes: 162,091 serial assertions and 54,718 MPI-2 assertions.
