### PR TITLE
Fix ButterflyPACK v4.1.0 build failure with MKL

### DIFF
--- a/extern/patch/ButterflyPACK/patch_build.diff
+++ b/extern/patch/ButterflyPACK/patch_build.diff
@@ -70,3 +70,16 @@ index 394e93e..f257c3c 100755
                          t_total(tid+1) = t_total(tid+1) + (t_stop - t_start)
                      enddo
  #ifdef HAVE_TOPLEVEL_OPENMP
+diff --git a/SRC/Bplus_utilities.f90 b/SRC/Bplus_utilities.f90
+index fb06388..f89e56b 100755
+--- a/SRC/Bplus_utilities.f90
++++ b/SRC/Bplus_utilities.f90
+@@ -10240,7 +10240,7 @@ contains
+                         rank = size(blocks%ButterflyU%blocks(1)%matrix, 2)
+                         index_i = blocks%ButterflyU%idx
+                         index_i_loc_s = (index_i - BFvec%vec(1)%idx_r)/BFvec%vec(1)%inc_r + 1
+-                        if(rank*num_vectors=1)then
++                        if(rank*num_vectors==1)then
+                            vtmp = BFvec%vec(1)%blocks(index_i_loc_s, 1)%matrix(1,1)
+                            call MPI_ALLREDUCE(vtmp, BFvec%vec(1)%blocks(index_i_loc_s, 1)%matrix, rank*num_vectors, MPI_DT, MPI_SUM, ptree%pgrp(pgno_sub)%Comm, ierr)
+                         else


### PR DESCRIPTION
Backports https://github.com/liuyangzhuan/ButterflyPACK/commit/757dcb2 so that we can compile with MKL.

(The patch is larger than the single line because we need to provide enough context for git to find where to apply the patch)