### PR TITLE
Reject all-zero rational impedance polynomials in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 #### Bug Fixes
 
   - Reject all-zero numerator or denominator polynomial coefficients in
-    `config["Boundaries"]["RationalImpedance"]` during schema validation, instead of
-    accepting the configuration only to reject it when parsing the solve. SchemaVer 1-5-1
-    [PR 874](https://github.com/awslabs/palace/pull/874).
+    `config["Boundaries"]["RationalImpedance"]` during schema validation, matching the
+    existing checks in the configuration parser and providing users with earlier feedback.
+    SchemaVer 1-5-1 [PR 874](https://github.com/awslabs/palace/pull/874).
   - Fixed validation of domain material coverage so postprocessing and retained mesh
     attributes without a corresponding `config["Domains"]["Materials"]` entry are rejected
     instead of silently assigning zero material coefficients to retained volumes. [PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Reject all-zero numerator or denominator polynomial coefficients in
+    `config["Boundaries"]["RationalImpedance"]` during schema validation, instead of
+    accepting the configuration only to reject it when parsing the solve. SchemaVer 1-5-1
+    [PR 874](https://github.com/awslabs/palace/pull/874).
   - Fixed validation of domain material coverage so postprocessing and retained mesh
     attributes without a corresponding `config["Domains"]["Materials"]` entry are rejected
     instead of silently assigning zero material coefficients to retained volumes. [PR

--- a/scripts/schema/config-schema.json
+++ b/scripts/schema/config-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:palace:schema:1-5-0",
+  "$id": "urn:palace:schema:1-5-1",
   "title": "Configuration File Schema",
   "description": "Palace configuration file schema for 3D electromagnetic simulations.",
   "type": "object",
@@ -942,14 +942,16 @@
           "type": "array",
           "items": { "type": "number" },
           "minItems": 1,
-          "description": "Real polynomial coefficients of the numerator N(s) of the rational surface impedance per square Zs(s) = N(s)/D(s), with s = iω, ordered from highest to lowest degree. The roots of N are the zeros of Zs. SI units (s in rad/s, Zs in Ω/sq); only the ratio N/D is physical."
+          "contains": { "not": { "const": 0 } },
+          "description": "Real polynomial coefficients of the numerator N(s) of the rational surface impedance per square Zs(s) = N(s)/D(s), with s = iω, ordered from highest to lowest degree. At least one coefficient must be nonzero. The roots of N are the zeros of Zs. SI units (s in rad/s, Zs in Ω/sq); only the ratio N/D is physical."
         },
         "Denominator":
         {
           "type": "array",
           "items": { "type": "number" },
           "minItems": 1,
-          "description": "Real polynomial coefficients of the denominator D(s), ordered from highest to lowest degree. The roots of D are the poles of Zs."
+          "contains": { "not": { "const": 0 } },
+          "description": "Real polynomial coefficients of the denominator D(s), ordered from highest to lowest degree. At least one coefficient must be nonzero. The roots of D are the poles of Zs."
         }
       }
     },

--- a/test/unit/test-schema.cpp
+++ b/test/unit/test-schema.cpp
@@ -260,6 +260,25 @@ TEST_CASE("Schema Validation - Sub-schema by Key", "[schema][Serial]")
     CHECK(!err.empty());
   }
 
+  SECTION("RationalImpedance polynomials require a nonzero coefficient")
+  {
+    json impedance = {
+        {"Attributes", {1}}, {"Numerator", {1.0, 0.0}}, {"Denominator", {0.0, 2.0}}};
+    CHECK(ValidateConfig(impedance, "RationalImpedance").empty());
+
+    for (const char *polynomial : {"Numerator", "Denominator"})
+    {
+      CAPTURE(polynomial);
+      for (const json &zeros : {json{0, 0}, json{0.0, 0.0}})
+      {
+        CAPTURE(zeros);
+        impedance[polynomial] = zeros;
+        CHECK(!ValidateConfig(impedance, "RationalImpedance").empty());
+        impedance[polynomial] = {1.0};
+      }
+    }
+  }
+
   SECTION("Invalid Direction strings")
   {
     std::vector<std::string> invalid_dirs = {"a",  "+a", "-a",  "xx", "~x",


### PR DESCRIPTION
## Description

Reject all-zero `Numerator` and `Denominator` arrays for `RationalImpedance` during JSON schema validation. This aligns early configuration validation with the existing runtime checks and gives users feedback before a solve starts.

The schema version is bumped from `1-5-0` to `1-5-1`, and the schema descriptions now state that each polynomial requires at least one nonzero coefficient.

## Testing

- Added schema unit coverage for:
  - a valid polynomial containing internal zero coefficients
  - all-zero integer and floating-point numerator arrays
  - all-zero integer and floating-point denominator arrays
- Validated all 45 example configurations against the updated Draft-07 schema
- Ran `check-schema-version`, `check-changelog-schema-versions`, `check-test-tags`, and `git diff --check`

The compiled C++ suite was not run locally because this checkout has no configured Palace build; CI will run the authoritative unit test.

Closes #834

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.