### PR TITLE
Avoid assembling exact-zero operator terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     quantities referenced to the internal unit impedance, not physical incident waves.
     [PR 841](https://github.com/awslabs/palace/pull/841).
 
+#### Performance Improvements
+
+  - Omit material terms with mathematically exact-zero coefficients from fine-level partial
+    assembly while retaining the configured coarse sparse structure for symbolic reuse.
+    [PR 876](https://github.com/awslabs/palace/pull/876).
+
 #### Bug Fixes
 
   - Reject all-zero numerator or denominator polynomial coefficients in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     quantities referenced to the internal unit impedance, not physical incident waves.
     [PR 841](https://github.com/awslabs/palace/pull/841).
 
+#### Performance Improvements
+
+  - Omit material terms with mathematically exact-zero coefficients from fine-level partial
+    assembly while retaining the configured coarse sparse structure for symbolic reuse.
+    [PR 876](https://github.com/awslabs/palace/pull/876).
+
 #### Bug Fixes
 
   - Fixed adaptive iteration output archiving overwriting earlier meshes and made its

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -596,6 +596,19 @@ MaterialPropertyCoefficient::MaterialPropertyCoefficient(
   *this *= a;
 }
 
+bool MaterialPropertyCoefficient::IsExactlyZero() const
+{
+  const auto *data = mat_coeff.Data();
+  for (int i = 0; i < mat_coeff.TotalSize(); i++)
+  {
+    if (data[i] != 0.0)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 namespace
 {
 

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -591,6 +591,19 @@ MaterialPropertyCoefficient::MaterialPropertyCoefficient(
   *this *= a;
 }
 
+bool MaterialPropertyCoefficient::IsExactlyZero() const
+{
+  const auto *data = mat_coeff.Data();
+  for (int i = 0; i < mat_coeff.TotalSize(); i++)
+  {
+    if (data[i] != 0.0)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 namespace
 {
 

--- a/palace/models/materialoperator.hpp
+++ b/palace/models/materialoperator.hpp
@@ -192,6 +192,10 @@ public:
 
   bool empty() const { return mat_coeff.TotalSize() == 0; }
 
+  // Mathematically exact zero: empty storage is zero, otherwise every stored scalar must
+  // compare exactly equal to zero. This deliberately has no tolerance.
+  bool IsExactlyZero() const;
+
   const auto &GetAttributeToMaterial() const { return attr_mat; }
   const auto &GetMaterialProperties() const { return mat_coeff; }
 

--- a/palace/models/modeeigensolver.cpp
+++ b/palace/models/modeeigensolver.cpp
@@ -1025,9 +1025,8 @@ ModeEigenSolver::AssembleAttPreconditioner(double omega, double sigma) const
   surf_sigma_op.AddExtraSystemBdrCoefficients(omega, fbr, fbr);
   surf_rz_op.AddExtraSystemBdrCoefficients(omega, fbr, fbr);
 
-  // Assemble ND operators at all levels using the hierarchy-aware assembly pattern
-  // (matching SpaceOperator::AssembleOperators). Creates a BilinearForm on the finest
-  // space and uses Assemble(fespaces) to produce operators at all levels.
+  // Assemble ND operators at all levels from one BilinearForm. Unlike SpaceOperator's
+  // configured-coarse/active-fine split, these domain coefficients are always nonzero.
   constexpr bool assemble_q_data = false;
   {
     BilinearForm att(bmo->GetNDSpaceHierarchy().GetFinestFESpace());
@@ -1038,8 +1037,8 @@ ModeEigenSolver::AssembleAttPreconditioner(double omega, double sigma) const
     }
     auto att_ops = att.Assemble(bmo->GetNDSpaceHierarchy(), skip_zeros);
 
-    // Auxiliary H1 operators for Hiptmair smoothing (matching SpaceOperator::
-    // AssembleAuxOperators — uses DiffusionIntegrator with the mass coefficient).
+    // Assemble the auxiliary H1 operators for Hiptmair smoothing from the same always-
+    // nonzero mass coefficient.
     BilinearForm att_aux(bmo->GetH1AuxSpaceHierarchy().GetFinestFESpace());
     att_aux.AddDomainIntegrator<DiffusionIntegrator>(eps_shifted_pc);
     if (!fbr.empty())

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -266,38 +266,59 @@ void PrintHeader(const mfem::ParFiniteElementSpace &h1_fespace,
   print_hdr = false;
 }
 
-void AddIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *df,
-                    const MaterialPropertyCoefficient *f,
-                    const MaterialPropertyCoefficient *dfb,
-                    const MaterialPropertyCoefficient *fb,
-                    const MaterialPropertyCoefficient *fp, bool assemble_q_data = false)
+const MaterialPropertyCoefficient *
+ActiveCoefficient(const MaterialPropertyCoefficient *coeff)
 {
-  if (df && !df->empty() && f && !f->empty())
+  return (coeff && !coeff->IsExactlyZero()) ? coeff : nullptr;
+}
+
+template <typename... CoeffType>
+bool AreExactlyZero(const CoeffType &...coeff)
+{
+  return (... && coeff.IsExactlyZero());
+}
+
+// Add every configured (non-empty) term, including terms whose current value is exactly
+// zero. This storage-based selection is used only for coarse preconditioner assembly below;
+// normal operator assembly uses AddIntegrators and filters exact zeros.
+void AddConfiguredIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *df,
+                              const MaterialPropertyCoefficient *f,
+                              const MaterialPropertyCoefficient *dfb,
+                              const MaterialPropertyCoefficient *fb,
+                              const MaterialPropertyCoefficient *fp,
+                              bool assemble_q_data = false)
+{
+  const bool has_df = df && !df->empty();
+  const bool has_f = f && !f->empty();
+  if (has_df && has_f)
   {
     a.AddDomainIntegrator<CurlCurlMassIntegrator>(*df, *f);
   }
   else
   {
-    if (df && !df->empty())
+    if (has_df)
     {
       a.AddDomainIntegrator<CurlCurlIntegrator>(*df);
     }
-    if (f && !f->empty())
+    if (has_f)
     {
       a.AddDomainIntegrator<VectorFEMassIntegrator>(*f);
     }
   }
-  if (dfb && !dfb->empty() && fb && !fb->empty())
+
+  const bool has_dfb = dfb && !dfb->empty();
+  const bool has_fb = fb && !fb->empty();
+  if (has_dfb && has_fb)
   {
     a.AddBoundaryIntegrator<CurlCurlMassIntegrator>(*dfb, *fb);
   }
   else
   {
-    if (dfb && !dfb->empty())
+    if (has_dfb)
     {
       a.AddBoundaryIntegrator<CurlCurlIntegrator>(*dfb);
     }
-    if (fb && !fb->empty())
+    if (has_fb)
     {
       a.AddBoundaryIntegrator<VectorFEMassIntegrator>(*fb);
     }
@@ -313,8 +334,20 @@ void AddIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *df,
   }
 }
 
-void AddAuxIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *f,
-                       const MaterialPropertyCoefficient *fb, bool assemble_q_data = false)
+void AddIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *df,
+                    const MaterialPropertyCoefficient *f,
+                    const MaterialPropertyCoefficient *dfb,
+                    const MaterialPropertyCoefficient *fb,
+                    const MaterialPropertyCoefficient *fp, bool assemble_q_data = false)
+{
+  AddConfiguredIntegrators(a, ActiveCoefficient(df), ActiveCoefficient(f),
+                           ActiveCoefficient(dfb), ActiveCoefficient(fb),
+                           ActiveCoefficient(fp), assemble_q_data);
+}
+
+void AddConfiguredAuxIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *f,
+                                 const MaterialPropertyCoefficient *fb,
+                                 bool assemble_q_data = false)
 {
   if (f && !f->empty())
   {
@@ -328,6 +361,13 @@ void AddAuxIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *f,
   {
     a.AssembleQuadratureData();
   }
+}
+
+void AddAuxIntegrators(BilinearForm &a, const MaterialPropertyCoefficient *f,
+                       const MaterialPropertyCoefficient *fb, bool assemble_q_data = false)
+{
+  AddConfiguredAuxIntegrators(a, ActiveCoefficient(f), ActiveCoefficient(fb),
+                              assemble_q_data);
 }
 
 auto AssembleOperator(const FiniteElementSpace &fespace,
@@ -349,21 +389,55 @@ auto AssembleOperators(const FiniteElementSpaceHierarchy &fespaces,
                        const MaterialPropertyCoefficient *dfb,
                        const MaterialPropertyCoefficient *fb,
                        const MaterialPropertyCoefficient *fp, bool skip_zeros = false,
-                       bool assemble_q_data = false, std::size_t l0 = 0)
+                       bool assemble_q_data = false)
 {
-  BilinearForm a(fespaces.GetFinestFESpace());
-  AddIntegrators(a, df, f, dfb, fb, fp, assemble_q_data);
-  return a.Assemble(fespaces, skip_zeros, l0);
+  // Keep configured coefficient support on the coarse sparse level. This is required for
+  // an exact-complex coarse solve: a nonlinear eigenvalue seed λ = iω has Im(λ²) = 0, but
+  // the corresponding full-domain imaginary mass term becomes nonzero once Re(λ) != 0.
+  // Its off-diagonal block graph must exist before the first symbolic factorization. Use
+  // the same rule for real-approximate coarse solves to keep this hierarchy assembly
+  // independent of the chosen sparse-solver representation. Fine partial-assembly levels
+  // have no symbolic structure to preserve, so exact-zero terms are omitted there.
+  BilinearForm coarse(fespaces.GetFESpaceAtLevel(0));
+  AddConfiguredIntegrators(coarse, df, f, dfb, fb, fp, assemble_q_data);
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.reserve(fespaces.GetNumLevels());
+  ops.push_back(coarse.Assemble(skip_zeros));
+  if (fespaces.GetNumLevels() > 1)
+  {
+    BilinearForm fine(fespaces.GetFinestFESpace());
+    AddIntegrators(fine, df, f, dfb, fb, fp, assemble_q_data);
+    auto fine_ops = fine.Assemble(fespaces, skip_zeros, 1);
+    for (auto &op : fine_ops)
+    {
+      ops.push_back(std::move(op));
+    }
+  }
+  return ops;
 }
 
 auto AssembleAuxOperators(const FiniteElementSpaceHierarchy &fespaces,
                           const MaterialPropertyCoefficient *f,
                           const MaterialPropertyCoefficient *fb, bool skip_zeros = false,
-                          bool assemble_q_data = false, std::size_t l0 = 0)
+                          bool assemble_q_data = false)
 {
-  BilinearForm a(fespaces.GetFinestFESpace());
-  AddAuxIntegrators(a, f, fb, assemble_q_data);
-  return a.Assemble(fespaces, skip_zeros, l0);
+  // Match the configured coarse-support policy of the primary hierarchy above.
+  BilinearForm coarse(fespaces.GetFESpaceAtLevel(0));
+  AddConfiguredAuxIntegrators(coarse, f, fb, assemble_q_data);
+  std::vector<std::unique_ptr<Operator>> ops;
+  ops.reserve(fespaces.GetNumLevels());
+  ops.push_back(coarse.Assemble(skip_zeros));
+  if (fespaces.GetNumLevels() > 1)
+  {
+    BilinearForm fine(fespaces.GetFinestFESpace());
+    AddAuxIntegrators(fine, f, fb, assemble_q_data);
+    auto fine_ops = fine.Assemble(fespaces, skip_zeros, 1);
+    for (auto &op : fine_ops)
+    {
+      ops.push_back(std::move(op));
+    }
+  }
+  return ops;
 }
 
 }  // namespace
@@ -382,7 +456,7 @@ SpaceOperator::GetStiffnessMatrix(Operator::DiagonalPolicy diag_policy)
     AddRealPeriodicCoefficients(1.0, f);
     AddImagPeriodicCoefficients(1.0, fc);
   }
-  int empty[2] = {(df.empty() && f.empty() && fb.empty()), (fc.empty())};
+  int empty[2] = {AreExactlyZero(df, f, fb), fc.IsExactlyZero()};
   Mpi::GlobalMin(2, empty, GetComm());
   if (empty[0] && empty[1])
   {
@@ -429,7 +503,7 @@ SpaceOperator::GetDampingMatrix(Operator::DiagonalPolicy diag_policy)
   {
     AddImagPeriodicCoefficients(1.0, fp);
   }
-  int empty = (f.empty() && fb.empty() && fp.empty());
+  int empty = AreExactlyZero(f, fb, fp);
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -467,7 +541,7 @@ std::unique_ptr<OperType> SpaceOperator::GetMassMatrix(Operator::DiagonalPolicy 
   {
     AddImagMassCoefficients(1.0, fi);
   }
-  int empty[2] = {(fr.empty() && fbr.empty()), (fi.empty() && fbi.empty())};
+  int empty[2] = {AreExactlyZero(fr, fbr), AreExactlyZero(fi, fbi)};
   Mpi::GlobalMin(2, empty, GetComm());
   if (empty[0] && empty[1])
   {
@@ -515,7 +589,7 @@ SpaceOperator::GetExtraSystemMatrix(double omega, Operator::DiagonalPolicy diag_
       dfbi(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
       fbi(mat_op.MaxCeedBdrAttribute());
   AddExtraSystemBdrCoefficients(omega, dfbr, dfbi, fbr, fbi, include_wave_ports);
-  int empty[2] = {(dfbr.empty() && fbr.empty()), (dfbi.empty() && fbi.empty())};
+  int empty[2] = {AreExactlyZero(dfbr, fbr), AreExactlyZero(dfbi, fbi)};
   Mpi::GlobalMin(2, empty, GetComm());
   if (empty[0] && empty[1])
   {
@@ -561,7 +635,7 @@ SpaceOperator::GetExtraSystemMatrix(std::complex<double> omega,
       dfbi(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute()),
       fbi(mat_op.MaxCeedBdrAttribute());
   AddExtraSystemBdrCoefficients(omega, dfbr, dfbi, fbr, fbi);
-  int empty[2] = {(dfbr.empty() && fbr.empty()), (dfbi.empty() && fbi.empty())};
+  int empty[2] = {AreExactlyZero(dfbr, fbr), AreExactlyZero(dfbi, fbi)};
   Mpi::GlobalMin(2, empty, GetComm());
   if (empty[0] && empty[1])
   {
@@ -593,7 +667,7 @@ SpaceOperator::GetWavePortBoundaryMassMatrix(int port_idx,
   PrintHeader(GetH1Space(), GetNDSpace(), GetRTSpace(), print_hdr);
   MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
   wave_port_op.AddBoundaryMassBdrCoefficients(port_idx, fb);
-  int empty = fb.empty();
+  int empty = fb.IsExactlyZero();
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -632,7 +706,7 @@ SpaceOperator::GetFarfieldBoundaryCurlCurlMatrix(Operator::DiagonalPolicy diag_p
   PrintHeader(GetH1Space(), GetNDSpace(), GetRTSpace(), print_hdr);
   MaterialPropertyCoefficient df(mat_op.MaxCeedBdrAttribute());
   farfield_op.AddExtraSystemBoundaryCurlCurlBdrCoefficients(1.0, df);
-  int empty = df.empty();
+  int empty = df.IsExactlyZero();
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -674,7 +748,7 @@ SpaceOperator::GetSurfaceConductivityBoundaryMatrix(int group_idx,
   PrintHeader(GetH1Space(), GetNDSpace(), GetRTSpace(), print_hdr);
   MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
   surf_sigma_op.AddBoundaryMassBdrCoefficients(static_cast<std::size_t>(group_idx), fb);
-  int empty = fb.empty();
+  int empty = fb.IsExactlyZero();
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -713,7 +787,7 @@ std::unique_ptr<OperType> SpaceOperator::GetRationalImpedanceBoundaryMassMatrix(
   PrintHeader(GetH1Space(), GetNDSpace(), GetRTSpace(), print_hdr);
   MaterialPropertyCoefficient fb(mat_op.MaxCeedBdrAttribute());
   surf_rz_op.AddUnitBdrCoefficients(idx, fb);
-  int empty = fb.empty();
+  int empty = fb.IsExactlyZero();
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -760,7 +834,7 @@ SpaceOperator::GetFloquetRobinBoundaryMassMatrix(int port_idx,
   muinv_func.RestrictCoefficient(mat_op.GetCeedBdrAttributes(port.GetAttrList()));
   fb.AddCoefficient(muinv_func.GetAttributeToMaterial(), muinv_func.GetMaterialProperties(),
                     1.0);
-  int empty = fb.empty();
+  int empty = fb.IsExactlyZero();
   Mpi::GlobalMin(1, &empty, GetComm());
   if (empty)
   {
@@ -884,7 +958,7 @@ void ProjectBdrCoefficientViaMassSolve(SumVectorCoefficient &fb, const LumpedPor
     fb_mass.AddMaterialProperty(mat_op.GetCeedBdrAttributes(elem->GetAttrList()), 1.0);
   }
   BilinearForm m_bdr(nd_fespace);
-  if (!fb_mass.empty())
+  if (!fb_mass.IsExactlyZero())
   {
     m_bdr.AddBoundaryIntegrator<VectorFEMassIntegrator>(fb_mass);
   }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-rap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-romoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-schema.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-spaceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-strattonchu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfaceimpedanceoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-surfacerationalimpedanceoperator.cpp

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits>
 #include <vector>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -82,6 +83,66 @@ TEST_CASE("MaterialOperator IsIsotropic", "[materialoperator][Serial]")
                               palace_mesh);
       REQUIRE(mat_op.IsIsotropic(1) == false);
     }
+  }
+}
+
+TEST_CASE("MaterialPropertyCoefficient exact-zero predicate", "[materialoperator][Serial]")
+{
+  mfem::Array<int> attr_mat(2);
+  attr_mat = 0;
+
+  SECTION("Empty storage is mathematically zero")
+  {
+    MaterialPropertyCoefficient coeff(2);
+    CHECK(coeff.empty());
+    CHECK(coeff.IsExactlyZero());
+  }
+
+  SECTION("Allocated scalar and tensor zeros are exactly zero")
+  {
+    mfem::DenseTensor scalar(1, 1, 1);
+    scalar = 0.0;
+    MaterialPropertyCoefficient scalar_coeff(attr_mat, scalar);
+    CHECK_FALSE(scalar_coeff.empty());
+    CHECK(scalar_coeff.IsExactlyZero());
+
+    mfem::DenseTensor tensor(2, 2, 1);
+    tensor = 0.0;
+    MaterialPropertyCoefficient tensor_coeff(attr_mat, tensor);
+    CHECK_FALSE(tensor_coeff.empty());
+    CHECK(tensor_coeff.IsExactlyZero());
+  }
+
+  SECTION("Zero-scaled coefficient additions retain exact-zero storage")
+  {
+    mfem::DenseTensor tensor(2, 2, 1);
+    tensor = 0.0;
+    tensor(0, 0, 0) = 3.0;
+    tensor(1, 1, 0) = -2.0;
+
+    MaterialPropertyCoefficient from_coefficient(2);
+    from_coefficient.AddCoefficient(attr_mat, tensor, 0.0);
+    CHECK_FALSE(from_coefficient.empty());
+    CHECK(from_coefficient.IsExactlyZero());
+
+    MaterialPropertyCoefficient from_property(2);
+    from_property.AddMaterialProperty(1, 7.0, 0.0);
+    CHECK_FALSE(from_property.empty());
+    CHECK(from_property.IsExactlyZero());
+  }
+
+  SECTION("Mixed and tiny nonzero values are not exactly zero")
+  {
+    mfem::DenseTensor mixed(2, 2, 1);
+    mixed = 0.0;
+    mixed(0, 1, 0) = -4.0;
+    MaterialPropertyCoefficient mixed_coeff(attr_mat, mixed);
+    CHECK_FALSE(mixed_coeff.IsExactlyZero());
+
+    mfem::DenseTensor tiny(1, 1, 1);
+    tiny = std::numeric_limits<double>::min();
+    MaterialPropertyCoefficient tiny_coeff(attr_mat, tiny);
+    CHECK_FALSE(tiny_coeff.IsExactlyZero());
   }
 }
 

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits>
 #include <vector>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -83,6 +84,66 @@ TEST_CASE("MaterialOperator IsIsotropic", "[materialoperator][Serial]")
                               palace_mesh);
       REQUIRE(mat_op.IsIsotropic(1) == false);
     }
+  }
+}
+
+TEST_CASE("MaterialPropertyCoefficient exact-zero predicate", "[materialoperator][Serial]")
+{
+  mfem::Array<int> attr_mat(2);
+  attr_mat = 0;
+
+  SECTION("Empty storage is mathematically zero")
+  {
+    MaterialPropertyCoefficient coeff(2);
+    CHECK(coeff.empty());
+    CHECK(coeff.IsExactlyZero());
+  }
+
+  SECTION("Allocated scalar and tensor zeros are exactly zero")
+  {
+    mfem::DenseTensor scalar(1, 1, 1);
+    scalar = 0.0;
+    MaterialPropertyCoefficient scalar_coeff(attr_mat, scalar);
+    CHECK_FALSE(scalar_coeff.empty());
+    CHECK(scalar_coeff.IsExactlyZero());
+
+    mfem::DenseTensor tensor(2, 2, 1);
+    tensor = 0.0;
+    MaterialPropertyCoefficient tensor_coeff(attr_mat, tensor);
+    CHECK_FALSE(tensor_coeff.empty());
+    CHECK(tensor_coeff.IsExactlyZero());
+  }
+
+  SECTION("Zero-scaled coefficient additions retain exact-zero storage")
+  {
+    mfem::DenseTensor tensor(2, 2, 1);
+    tensor = 0.0;
+    tensor(0, 0, 0) = 3.0;
+    tensor(1, 1, 0) = -2.0;
+
+    MaterialPropertyCoefficient from_coefficient(2);
+    from_coefficient.AddCoefficient(attr_mat, tensor, 0.0);
+    CHECK_FALSE(from_coefficient.empty());
+    CHECK(from_coefficient.IsExactlyZero());
+
+    MaterialPropertyCoefficient from_property(2);
+    from_property.AddMaterialProperty(1, 7.0, 0.0);
+    CHECK_FALSE(from_property.empty());
+    CHECK(from_property.IsExactlyZero());
+  }
+
+  SECTION("Mixed and tiny nonzero values are not exactly zero")
+  {
+    mfem::DenseTensor mixed(2, 2, 1);
+    mixed = 0.0;
+    mixed(0, 1, 0) = -4.0;
+    MaterialPropertyCoefficient mixed_coeff(attr_mat, mixed);
+    CHECK_FALSE(mixed_coeff.IsExactlyZero());
+
+    mfem::DenseTensor tiny(1, 1, 1);
+    tiny = std::numeric_limits<double>::min();
+    MaterialPropertyCoefficient tiny_coeff(attr_mat, tiny);
+    CHECK_FALSE(tiny_coeff.IsExactlyZero());
   }
 }
 

--- a/test/unit/test-spaceoperator.cpp
+++ b/test/unit/test-spaceoperator.cpp
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <complex>
+#include <limits>
+#include <vector>
+#include <catch2/catch_test_macros.hpp>
+
+#include "fem/bilinearform.hpp"
+#include "fem/integrator.hpp"
+#include "fem/libceed/operator.hpp"
+#include "fem/mesh.hpp"
+#include "linalg/hypre.hpp"
+#include "linalg/rap.hpp"
+#include "models/spaceoperator.hpp"
+#include "utils/communication.hpp"
+#include "utils/configfile.hpp"
+#include "utils/labels.hpp"
+#include "utils/units.hpp"
+
+namespace palace
+{
+namespace
+{
+
+struct IntegrationSettingsGuard
+{
+  int pa_order_threshold = BilinearForm::pa_order_threshold;
+  int p_trial = fem::DefaultIntegrationOrder::p_trial;
+  bool q_order_jac = fem::DefaultIntegrationOrder::q_order_jac;
+  int q_order_extra_pk = fem::DefaultIntegrationOrder::q_order_extra_pk;
+  int q_order_extra_qk = fem::DefaultIntegrationOrder::q_order_extra_qk;
+
+  ~IntegrationSettingsGuard()
+  {
+    BilinearForm::pa_order_threshold = pa_order_threshold;
+    fem::DefaultIntegrationOrder::p_trial = p_trial;
+    fem::DefaultIntegrationOrder::q_order_jac = q_order_jac;
+    fem::DefaultIntegrationOrder::q_order_extra_pk = q_order_extra_pk;
+    fem::DefaultIntegrationOrder::q_order_extra_qk = q_order_extra_qk;
+  }
+};
+
+struct ImaginaryHierarchyData
+{
+  std::vector<HYPRE_Int> coarse_row_offsets;
+  std::vector<HYPRE_Int> coarse_columns;
+  std::vector<double> coarse_values;
+  CeedInt fine_suboperators = 0;
+};
+
+ImaginaryHierarchyData InspectImaginaryHierarchy(const ComplexOperator &op)
+{
+  const auto *mg_op = dynamic_cast<const ComplexMultigridOperator *>(&op);
+  REQUIRE(mg_op);
+  REQUIRE(mg_op->GetNumLevels() == 2);
+
+  const auto *coarse_op =
+      dynamic_cast<const ComplexParOperator *>(&mg_op->GetOperatorAtLevel(0));
+  REQUIRE(coarse_op);
+  const auto *coarse_imag =
+      dynamic_cast<const hypre::HypreCSRMatrix *>(coarse_op->LocalOperator().Imag());
+  REQUIRE(coarse_imag);
+  hypre_CSRMatrixMigrate(*coarse_imag, HYPRE_MEMORY_HOST);
+
+  ImaginaryHierarchyData data;
+  data.coarse_row_offsets.assign(coarse_imag->GetI(),
+                                 coarse_imag->GetI() + coarse_imag->Height() + 1);
+  data.coarse_columns.assign(coarse_imag->GetJ(), coarse_imag->GetJ() + coarse_imag->NNZ());
+  data.coarse_values.assign(coarse_imag->GetData(),
+                            coarse_imag->GetData() + coarse_imag->NNZ());
+
+  const auto *fine_op =
+      dynamic_cast<const ComplexParOperator *>(&mg_op->GetOperatorAtLevel(1));
+  REQUIRE(fine_op);
+  const auto *fine_imag =
+      dynamic_cast<const ceed::Operator *>(fine_op->LocalOperator().Imag());
+  REQUIRE(fine_imag);
+  for (std::size_t i = 0; i < fine_imag->Size(); i++)
+  {
+    CeedInt num_suboperators = 0;
+    REQUIRE(CeedOperatorCompositeGetNumSub((*fine_imag)[i], &num_suboperators) == 0);
+    data.fine_suboperators += num_suboperators;
+  }
+  return data;
+}
+
+}  // namespace
+
+TEST_CASE("SpaceOperator retains coarse support while omitting fine exact zeros",
+          "[spaceoperator][Serial][Parallel]")
+{
+  using namespace std::complex_literals;
+
+  MPI_Comm comm = Mpi::World();
+  mfem::Mesh serial_mesh = mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::TETRAHEDRON);
+  while (serial_mesh.GetNE() < Mpi::Size(comm))
+  {
+    serial_mesh.UniformRefinement();
+  }
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(comm, serial_mesh));
+
+  IntegrationSettingsGuard settings_guard;
+  config::SolverData solver;
+  solver.order = 2;
+  solver.pa_order_threshold = 2;
+  solver.linear.mg_max_levels = 2;
+  solver.linear.mg_coarsening = MultigridCoarsening::LINEAR;
+  solver.linear.pc_mat_real = false;
+  solver.linear.pc_mat_shifted = 0;
+  BilinearForm::pa_order_threshold = solver.pa_order_threshold;
+  fem::DefaultIntegrationOrder::p_trial = solver.order;
+  fem::DefaultIntegrationOrder::q_order_jac = solver.q_order_jac;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = solver.q_order_extra;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = solver.q_order_extra;
+
+  config::MaterialData material;
+  material.attributes = {1};
+  config::DomainData domains;
+  domains.attributes = {1};
+  domains.materials = {material};
+  config::BoundaryData boundaries;
+  Units units(1.0, 1.0);
+  SpaceOperator space_op(solver, domains, boundaries, ProblemType::EIGENMODE, units, mesh);
+
+  constexpr double omega = 2.0;
+  const std::complex<double> lambda_zero = 1i * omega;
+  const double epsilon = std::numeric_limits<double>::epsilon();
+  const std::complex<double> lambda_tiny = epsilon + 1i * omega;
+  auto Assemble = [&space_op](std::complex<double> lambda)
+  {
+    return space_op.GetPreconditionerMatrix<ComplexOperator>(1.0 + 0.0i, lambda,
+                                                             lambda * lambda, lambda / 1i);
+  };
+
+  auto zero_pc = Assemble(lambda_zero);
+  auto zero_data = InspectImaginaryHierarchy(*zero_pc);
+  auto tiny_pc = Assemble(lambda_tiny);
+  auto tiny_data = InspectImaginaryHierarchy(*tiny_pc);
+
+  CHECK(zero_data.coarse_row_offsets == tiny_data.coarse_row_offsets);
+  CHECK(zero_data.coarse_columns == tiny_data.coarse_columns);
+  CHECK(std::all_of(zero_data.coarse_values.begin(), zero_data.coarse_values.end(),
+                    [](double value) { return value == 0.0; }));
+  CHECK(std::any_of(tiny_data.coarse_values.begin(), tiny_data.coarse_values.end(),
+                    [](double value) { return value != 0.0; }));
+  CHECK(zero_data.fine_suboperators == 0);
+  CHECK(tiny_data.fine_suboperators > 0);
+}
+
+}  // namespace palace


### PR DESCRIPTION
Palace currently treats a coefficient as present when it has allocated storage, even if every stored value is zero. This can repeatedly apply fine-level libCEED terms that contribute nothing mathematically.

This PR omits exactly zero terms before assembling multigrid smoothing levels. Tiny nonzero values are unaffected.

The configured coarse structure is retained for symbolic reuse. This matters for `ComplexCoarseSolve`: a nonlinear seed with `λ = iω` has `Im(λ²) = 0`, but that full-domain imaginary mass term becomes nonzero once `Re(λ) != 0`, adding off-diagonal block structure. The same coarse assembly rule is used for real-approximate solves to keep the implementation independent of the selected sparse representation.

### Performance

Matched runs used the Order-4 eigenmode stress case with no AMR (`Model.Refinement.MaxIts = 0`), 8 MPI ranks on 8 A100 GPUs, `/gpu/cuda/magma`, exact-complex cuDSS, and GPU-aware MPI disabled. Configuration, mesh, dependencies, solver tolerances, output, and precision were identical. Main is the mean of three runs; this PR is one final-design run.

| Metric | Main | This PR | Change |
|---|---:|---:|---:|
| Total time | 922.5 s | 779.6 s | **-15.5%** |
| Preconditioner | 454.8 s | 314.1 s | **-31.0%** |
| Peak GPU memory | 103,661 MiB | 99,789 MiB | **-3.7%** |

Setup time was unchanged. Every run used 661 linear iterations, 677 preconditioner applications, and 1,354 coarse solves. The final candidate passed the control-derived numeric CSV gate.

### Testing

- CPU and CUDA/cuDSS Spack builds
- Full SLEPc and ARPACK unit suites, serial and MPI-2
- 32/32 ARPACK+SuperLU regression cases passed at 5 MPI ranks
- Repeated-frequency and nonlinear eigenvalue cases passed
