### PR TITLE
Consolidate orthogonalization dispatch

### DIFF
--- a/palace/linalg/iterative.cpp
+++ b/palace/linalg/iterative.cpp
@@ -304,26 +304,6 @@ inline void ApplyBA(PreconditionerSide side, const OperType *A, const Solver<Ope
   }
 }
 
-template <typename VecType, typename ScalarType>
-inline void OrthogonalizeIteration(Orthogonalization type, MPI_Comm comm,
-                                   const std::vector<VecType> &V, VecType &w,
-                                   ScalarType *Hj, std::size_t j)
-{
-  // Orthogonalize w against the leading j + 1 columns of V.
-  switch (type)
-  {
-    case Orthogonalization::MGS:
-      linalg::OrthogonalizeColumnMGS(comm, V, w, Hj, j + 1);
-      break;
-    case Orthogonalization::CGS:
-      linalg::OrthogonalizeColumnCGS(comm, V, w, Hj, j + 1);
-      break;
-    case Orthogonalization::CGS2:
-      linalg::OrthogonalizeColumnCGS(comm, V, w, Hj, j + 1, true);
-      break;
-  }
-}
-
 }  // namespace
 
 template <typename OperType>
@@ -627,7 +607,7 @@ void GmresSolver<OperType>::Mult(const VecType &b, VecType &x) const
       ApplyBA(pc_side, A, B, V[j], w, r, this->use_timer);
 
       ScalarType *Hj = H.data() + j * (max_dim + 1);
-      OrthogonalizeIteration(gs_orthog, comm, V, w, Hj, j);
+      linalg::OrthogonalizeColumn(gs_orthog, comm, V, w, Hj, j + 1);
       Hj[j + 1] = linalg::Norml2(comm, w);
       w *= 1.0 / Hj[j + 1];
 
@@ -806,7 +786,7 @@ void FgmresSolver<OperType>::Mult(const VecType &b, VecType &x) const
       ApplyBA(PreconditionerSide::RIGHT, A, B, V[j], w, Z[j], this->use_timer);
 
       ScalarType *Hj = H.data() + j * (max_dim + 1);
-      OrthogonalizeIteration(gs_orthog, comm, V, w, Hj, j);
+      linalg::OrthogonalizeColumn(gs_orthog, comm, V, w, Hj, j + 1);
       Hj[j + 1] = linalg::Norml2(comm, w);
       w *= 1.0 / Hj[j + 1];
 

--- a/palace/linalg/orthog.hpp
+++ b/palace/linalg/orthog.hpp
@@ -11,6 +11,7 @@
 #include "linalg/operator.hpp"
 #include "linalg/vector.hpp"
 #include "utils/communication.hpp"
+#include "utils/labels.hpp"
 
 namespace palace::linalg
 {
@@ -85,6 +86,26 @@ inline void OrthogonalizeColumnCGS(MPI_Comm comm, const std::vector<VecType> &V,
       H[j] += dH[j];
       w.Add(-dH[j], V[j]);
     }
+  }
+}
+
+template <typename VecType, typename ScalarType,
+          typename InnerProductW = IdentityInnerProduct>
+inline void OrthogonalizeColumn(Orthogonalization type, MPI_Comm comm,
+                                const std::vector<VecType> &V, VecType &w, ScalarType *H,
+                                std::size_t m, const InnerProductW &dot_op = {})
+{
+  switch (type)
+  {
+    case Orthogonalization::MGS:
+      OrthogonalizeColumnMGS(comm, V, w, H, m, dot_op);
+      break;
+    case Orthogonalization::CGS:
+      OrthogonalizeColumnCGS(comm, V, w, H, m, false, dot_op);
+      break;
+    case Orthogonalization::CGS2:
+      OrthogonalizeColumnCGS(comm, V, w, H, m, true, dot_op);
+      break;
   }
 }
 

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -187,27 +187,6 @@ inline std::complex<double> EvaluatePolyPlusPoles(std::complex<double> a0,
   return val;
 }
 
-template <typename VecType, typename ScalarType,
-          typename InnerProductW = linalg::IdentityInnerProduct>
-inline void OrthogonalizeColumn(Orthogonalization type, MPI_Comm comm,
-                                const std::vector<VecType> &V, VecType &w, ScalarType *Rj,
-                                std::size_t j, const InnerProductW &dot_op = {})
-{
-  // Orthogonalize w against the leading j columns of V.
-  switch (type)
-  {
-    case Orthogonalization::MGS:
-      linalg::OrthogonalizeColumnMGS(comm, V, w, Rj, j, dot_op);
-      break;
-    case Orthogonalization::CGS:
-      linalg::OrthogonalizeColumnCGS(comm, V, w, Rj, j, false, dot_op);
-      break;
-    case Orthogonalization::CGS2:
-      linalg::OrthogonalizeColumnCGS(comm, V, w, Rj, j, true, dot_op);
-      break;
-  }
-}
-
 inline void ProjectMatInternal(MPI_Comm comm, const std::vector<Vector> &V,
                                const ComplexOperator &A, Eigen::MatrixXcd &Ar,
                                ComplexVector &r, int n0, bool symmetric)
@@ -356,7 +335,7 @@ void MinimalRationalInterpolation::AddSolutionSample(double omega, const Complex
     Q[dim_Q].UseDevice(true);
     Q[dim_Q].SetBlocks(blocks, s);
   }
-  OrthogonalizeColumn(orthog_type, comm, Q, Q[dim_Q], R.col(dim_Q).data(), dim_Q);
+  linalg::OrthogonalizeColumn(orthog_type, comm, Q, Q[dim_Q], R.col(dim_Q).data(), dim_Q);
   R(dim_Q, dim_Q) = linalg::Norml2(comm, Q[dim_Q]);
   Q[dim_Q] *= 1.0 / R(dim_Q, dim_Q);
   dim_Q++;
@@ -910,7 +889,7 @@ void RomOperator::UpdatePROM(const ComplexVector &u, std::string_view node_label
     {
       auto pre_norm_sq = weight_op_W->InnerProduct(space_op.GetComm(), v, v, r.Real());
       pre_norm = std::sqrt(std::abs(pre_norm_sq));
-      OrthogonalizeColumn(
+      linalg::OrthogonalizeColumn(
           orthog_type, space_op.GetComm(), V, v, orth_R.col(dim_V).data(), dim_V,
           [&W = *(this->weight_op_W), &r = this->r](const Vector &x, const Vector &y)
           { return W.InnerProduct(x, y, r.Real()); });
@@ -920,8 +899,8 @@ void RomOperator::UpdatePROM(const ComplexVector &u, std::string_view node_label
     else
     {
       pre_norm = linalg::Norml2(space_op.GetComm(), v);
-      OrthogonalizeColumn(orthog_type, space_op.GetComm(), V, v, orth_R.col(dim_V).data(),
-                          dim_V);
+      linalg::OrthogonalizeColumn(orthog_type, space_op.GetComm(), V, v,
+                                  orth_R.col(dim_V).data(), dim_V);
       orth_R(dim_V, dim_V) = linalg::Norml2(space_op.GetComm(), v);
     }
 

--- a/test/unit/test-orthog.cpp
+++ b/test/unit/test-orthog.cpp
@@ -68,39 +68,10 @@ public:
   }
 };
 
-// Wapper class to make iteration over orthogonalization methods easy.
-class orthogonalize_wrapper
-{
-public:
-  Orthogonalization orthgo_type;
-
-  orthogonalize_wrapper(Orthogonalization orthgo_type_) : orthgo_type(orthgo_type_) {}
-
-  template <typename VecType, typename ScalarType,
-            typename InnerProductW = linalg::IdentityInnerProduct>
-  void operator()(MPI_Comm comm, const std::vector<VecType> &V, VecType &w, ScalarType *H,
-                  std::size_t m, const InnerProductW &dot_op = {}) const
-  {
-    switch (orthgo_type)
-    {
-      case Orthogonalization::MGS:
-        linalg::OrthogonalizeColumnMGS(comm, V, w, H, m, dot_op);
-        break;
-      case Orthogonalization::CGS:
-        linalg::OrthogonalizeColumnCGS(comm, V, w, H, m, false, dot_op);
-        break;
-      case Orthogonalization::CGS2:
-        linalg::OrthogonalizeColumnCGS(comm, V, w, H, m, true, dot_op);
-        break;
-    }
-  }
-};
-
 TEST_CASE("OrthogonalizeColumn - Real Empty", "[orthog][Serial][Parallel][GPU]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   int mpi_rank = Mpi::Rank(Mpi::World());
 
@@ -114,7 +85,7 @@ TEST_CASE("OrthogonalizeColumn - Real Empty", "[orthog][Serial][Parallel][GPU]")
   Vector w_orig = w;  // Copy for comparison
 
   double H[1];  // Not used when m = 0
-  orthogonalize_fn(Mpi::World(), V, w, H, 0);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H, 0);
 
   // Vector should remain unchanged
   CHECK_THAT(w, RangeEquals(w_orig));
@@ -122,9 +93,8 @@ TEST_CASE("OrthogonalizeColumn - Real Empty", "[orthog][Serial][Parallel][GPU]")
 
 TEST_CASE("OrthogonalizeColumn Parameterized - Real 1", "[orthog][Serial][Parallel]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   int mpi_rank = Mpi::Rank(Mpi::World());
   int mpi_size = Mpi::Size(Mpi::World());
@@ -146,7 +116,7 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Real 1", "[orthog][Serial][Parall
   auto &w = V.at(mpi_size);
   w.Randomize();
 
-  orthogonalize_fn(Mpi::World(), V, w, H.data(), mpi_size);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H.data(), mpi_size);
 
   // We should have zeroed out the value at "mpi_rank"
   CHECK_THAT(w[mpi_rank], WithinAbs(0.0, 1e-12));
@@ -163,9 +133,8 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Real 1", "[orthog][Serial][Parall
 // incorrect host syncing in set-up.
 TEST_CASE("OrthogonalizeColumn Parameterized - Real 2", "[orthog][Serial][Parallel]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   int mpi_rank = Mpi::Rank(Mpi::World());
   int mpi_size = Mpi::Size(Mpi::World());
@@ -196,7 +165,7 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Real 2", "[orthog][Serial][Parall
 
   // [0, 1, 0, 0] on all ranks
   V[1][1] = 1.0;
-  orthogonalize_fn(Mpi::World(), V, V[1], H.data(), 1);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, V[1], H.data(), 1);
 
   // Should be exact in double as multiply by zero. OrthogonalizeColumn does not
   // normalize.
@@ -213,7 +182,7 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Real 2", "[orthog][Serial][Parall
   auto d_v = w.Write();
   mfem::forall(w.Size(), [=] MFEM_HOST_DEVICE(int i) { d_v[i] = mpi_rank + i; });
 
-  orthogonalize_fn(Mpi::World(), V, w, H.data(), 2);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H.data(), 2);
 
   // Check orthogonality
   auto dot0 = linalg::Dot(Mpi::World(), w, V[0]);
@@ -233,9 +202,8 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Real 2", "[orthog][Serial][Parall
 
 TEST_CASE("OrthogonalizeColumn Parameterized - Complex 1", "[orthog][Serial][Parallel]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   int mpi_rank = Mpi::Rank(Mpi::World());
   int mpi_size = Mpi::Size(Mpi::World());
@@ -259,7 +227,7 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Complex 1", "[orthog][Serial][Par
   w.Real().Randomize();
   w.Imag().Randomize();
 
-  orthogonalize_fn(Mpi::World(), V, w, H.data(), mpi_size);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H.data(), mpi_size);
 
   // We should have zeroed out the value at "mpi_rank"
   CHECK_THAT(w.Real()[mpi_rank], WithinAbs(0.0, 1e-12));
@@ -275,9 +243,8 @@ TEST_CASE("OrthogonalizeColumn Parameterized - Complex 1", "[orthog][Serial][Par
 
 TEST_CASE("OrthogonalizeColumn Weighted - Real 1", "[orthog][Serial]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   mfem::DenseMatrix W(3, 3);
   W = 0.0;
@@ -307,7 +274,7 @@ TEST_CASE("OrthogonalizeColumn Weighted - Real 1", "[orthog][Serial]")
   std::vector<double> H(2, 0.0);
 
   RealWeightedInnerProduct weight_op{std::make_shared<mfem::DenseMatrix>(W)};
-  orthogonalize_fn(Mpi::World(), V, w, H.data(), 2, weight_op);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H.data(), 2, weight_op);
 
   // Check orthogonality with respect to weight matrix
   Vector WVj(3);  // Temporary workspace
@@ -322,9 +289,8 @@ TEST_CASE("OrthogonalizeColumn Weighted - Real 1", "[orthog][Serial]")
 
 TEST_CASE("OrthogonalizeColumn Weighted - Complex 1", "[orthog][Serial]")
 {
-  auto orthogonalize_fn = GENERATE(orthogonalize_wrapper(Orthogonalization::MGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS),
-                                   orthogonalize_wrapper(Orthogonalization::CGS2));
+  auto orthog_type =
+      GENERATE(Orthogonalization::MGS, Orthogonalization::CGS, Orthogonalization::CGS2);
 
   mfem::DenseMatrix W(3, 3);
   W = 0.0;
@@ -355,7 +321,7 @@ TEST_CASE("OrthogonalizeColumn Weighted - Complex 1", "[orthog][Serial]")
   std::vector<std::complex<double>> H(2, 0.0);
 
   RealWeightedInnerProduct weight_op{std::make_shared<mfem::DenseMatrix>(W)};
-  orthogonalize_fn(Mpi::World(), V, w, H.data(), 2, weight_op);
+  linalg::OrthogonalizeColumn(orthog_type, Mpi::World(), V, w, H.data(), 2, weight_op);
 
   auto W_wrap = ComplexWrapperOperator(&W, nullptr);
 


### PR DESCRIPTION
## Description

Centralize the selection of modified and classical Gram-Schmidt algorithms in a shared `linalg::OrthogonalizeColumn` dispatcher.

This removes the duplicate dispatch logic from the iterative solvers and ROM operator while preserving their existing basis-size semantics. The orthogonalization unit tests now call the production dispatcher directly instead of maintaining a separate test-only copy of the same switch.

## Testing

- Ran the project C++ formatter with clang-format 19
- Ran `git diff --check`
- Updated the existing serial, parallel, real, complex, weighted, and unweighted orthogonalization tests to exercise the shared dispatcher

Closes #617

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.