### PR TITLE
Accept configuration enum values case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Configuration enum values (e.g. solver names such as `"SuperLU"`) are now matched
+    case-insensitively, so any capitalization (`"superlu"`, `"SUPERLU"`, ...) is accepted
+    both during schema validation and parsing, and is normalized to the canonical spelling.
+    Previously an incorrect case caused validation to abort.
+    [Issue 586](https://github.com/awslabs/palace/issues/586).
   - Reject all-zero numerator or denominator polynomial coefficients in
     `config["Boundaries"]["RationalImpedance"]` during schema validation, matching the
     existing checks in the configuration parser and providing users with earlier feedback.

--- a/palace/utils/enum_string.cpp
+++ b/palace/utils/enum_string.cpp
@@ -4,7 +4,9 @@
 #include "utils/enum_string.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <iterator>
+#include <string_view>
 #include <utility>
 #include <mfem.hpp>
 
@@ -15,6 +17,24 @@
 
 namespace palace
 {
+
+namespace
+{
+
+// Case-insensitive ASCII string comparison. Configuration enum spellings are plain ASCII,
+// so FromString accepts any capitalization (e.g. "superlu", "SUPERLU", or "SuperLU" all
+// resolve to LinearSolver::SUPERLU) rather than forcing users to remember the exact case.
+// Enum spellings are unique when compared case-insensitively, so this cannot introduce an
+// ambiguous match. See https://github.com/awslabs/palace/issues/586.
+bool EqualsIgnoreCase(std::string_view a, std::string_view b)
+{
+  return a.size() == b.size() &&
+         std::equal(a.begin(), a.end(), b.begin(),
+                    [](unsigned char c1, unsigned char c2)
+                    { return std::tolower(c1) == std::tolower(c2); });
+}
+
+}  // namespace
 
 #define PALACE_ENUM_STRING_DEFINE(ENUM_TYPE, ...)                               \
   std::string ToString(ENUM_TYPE e)                                             \
@@ -32,7 +52,7 @@ namespace palace
     static const std::pair<ENUM_TYPE, const char *> m[] = __VA_ARGS__;          \
     auto it = std::find_if(std::begin(m), std::end(m),                          \
                            [s](const std::pair<ENUM_TYPE, const char *> &p)     \
-                           { return s == p.second; });                          \
+                           { return EqualsIgnoreCase(s, p.second); });          \
     MFEM_VERIFY(it != std::end(m), "Invalid value ("                            \
                                        << s << ") for " #ENUM_TYPE              \
                                        << " given in the configuration file!"); \

--- a/palace/utils/enum_string.cpp
+++ b/palace/utils/enum_string.cpp
@@ -29,8 +29,7 @@ namespace
 bool EqualsIgnoreCase(std::string_view a, std::string_view b)
 {
   return a.size() == b.size() &&
-         std::equal(a.begin(), a.end(), b.begin(),
-                    [](unsigned char c1, unsigned char c2)
+         std::equal(a.begin(), a.end(), b.begin(), [](unsigned char c1, unsigned char c2)
                     { return std::tolower(c1) == std::tolower(c2); });
 }
 

--- a/palace/utils/iodata.cpp
+++ b/palace/utils/iodata.cpp
@@ -201,6 +201,11 @@ json IoData::ParseAndValidate(const char *filename)
     MFEM_ABORT("Error parsing configuration file!\n  " << e.what());
   }
 
+  // Normalize enum-valued strings to their canonical spelling (e.g. "superlu" ->
+  // "SuperLU") so users are not forced to remember exact capitalization. This must run
+  // before schema validation, which matches enum values case-sensitively.
+  CanonicalizeEnumCase(config);
+
   // Validate against JSON schema.
   {
     std::string err = ValidateConfig(config);

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -263,8 +263,7 @@ json FindEnumInSchema(const json &schema, const std::string &ptr)
 bool EqualsIgnoreCase(std::string_view a, std::string_view b)
 {
   return a.size() == b.size() &&
-         std::equal(a.begin(), a.end(), b.begin(),
-                    [](unsigned char c1, unsigned char c2)
+         std::equal(a.begin(), a.end(), b.begin(), [](unsigned char c1, unsigned char c2)
                     { return std::tolower(c1) == std::tolower(c2); });
 }
 

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -4,7 +4,9 @@
 #include "jsonschema.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <nlohmann/json-schema.hpp>
 #include "communication.hpp"
@@ -256,6 +258,67 @@ json FindEnumInSchema(const json &schema, const std::string &ptr)
   return json();
 }
 
+// Case-insensitive ASCII string comparison, used to match a user-provided enum spelling
+// against the allowed values declared in the schema.
+bool EqualsIgnoreCase(std::string_view a, std::string_view b)
+{
+  return a.size() == b.size() &&
+         std::equal(a.begin(), a.end(), b.begin(),
+                    [](unsigned char c1, unsigned char c2)
+                    { return std::tolower(c1) == std::tolower(c2); });
+}
+
+// Recursively walk the config, tracking the JSON pointer to each node, and rewrite string
+// leaves whose schema location declares an enum to the canonical (schema-declared) spelling
+// when they match only case-insensitively. Array indices are included in the pointer;
+// FindEnumInSchema skips them when navigating the schema.
+void CanonicalizeEnumCaseImpl(json &node, const json &schema, const std::string &ptr)
+{
+  if (node.is_object())
+  {
+    for (auto &[key, val] : node.items())
+    {
+      CanonicalizeEnumCaseImpl(val, schema, ptr + "/" + key);
+    }
+    return;
+  }
+  if (node.is_array())
+  {
+    for (std::size_t i = 0; i < node.size(); i++)
+    {
+      CanonicalizeEnumCaseImpl(node[i], schema, ptr + "/" + std::to_string(i));
+    }
+    return;
+  }
+  if (!node.is_string())
+  {
+    return;
+  }
+
+  json allowed = FindEnumInSchema(schema, ptr);
+  if (!allowed.is_array() || allowed.empty())
+  {
+    return;
+  }
+  const std::string value = node.get<std::string>();
+  // Leave exact matches (already canonical) and genuinely invalid values (so validation
+  // still reports them) untouched; only rewrite a unique case-insensitive match.
+  bool exact = std::any_of(allowed.begin(), allowed.end(), [&value](const json &a)
+                           { return a.is_string() && a.get<std::string>() == value; });
+  if (exact)
+  {
+    return;
+  }
+  for (const auto &a : allowed)
+  {
+    if (a.is_string() && EqualsIgnoreCase(value, a.get<std::string>()))
+    {
+      node = a;
+      return;
+    }
+  }
+}
+
 }  // namespace
 
 // Custom error handler that formats errors with documentation-style paths.
@@ -371,6 +434,29 @@ std::string GetSchemaVersion()
     }
   }
   return "unknown";
+}
+
+void CanonicalizeEnumCase(nlohmann::json &config)
+{
+  const auto &schema_map = schema::GetSchemaMap();
+  auto it = schema_map.find(root_schema_file);
+  if (it == schema_map.end())
+  {
+    // No schema to canonicalize against; ValidateConfig reports the missing schema.
+    return;
+  }
+  json schema;
+  try
+  {
+    schema = json::parse(it->second);
+  }
+  catch (json::parse_error &)
+  {
+    // A malformed schema is a developer error surfaced by ValidateConfig; leave the
+    // config unchanged here.
+    return;
+  }
+  CanonicalizeEnumCaseImpl(config, schema, "");
 }
 
 std::string ValidateConfig(const nlohmann::json &config)

--- a/palace/utils/jsonschema.hpp
+++ b/palace/utils/jsonschema.hpp
@@ -13,6 +13,13 @@ namespace palace
 // Return the schema version extracted from the "$id" URN (e.g. "1-0-0").
 std::string GetSchemaVersion();
 
+// Rewrite enum-valued strings in the config to the canonical spelling declared in the
+// schema, matching case-insensitively (e.g. "superlu" -> "SuperLU"). Values that already
+// match exactly, or that do not match any allowed spelling, are left untouched so that
+// schema validation still reports genuinely invalid values. Run this before ValidateConfig,
+// which matches enum values case-sensitively.
+void CanonicalizeEnumCase(nlohmann::json &config);
+
 // Validate a full JSON config against the embedded root schema.
 // Returns empty string on success, error message on failure.
 std::string ValidateConfig(const nlohmann::json &config);

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -1649,6 +1649,61 @@ TEST_CASE("ConcretizeDefaults", "[config][Serial]")
   }
 }
 
+TEST_CASE("Enum values accept any capitalization", "[config][Serial]")
+{
+  // Regression test for https://github.com/awslabs/palace/issues/586: configuration enum
+  // spellings should not be case-sensitive, so users do not have to remember the exact
+  // capitalization of e.g. solver names.
+  SECTION("FromString resolves values case-insensitively")
+  {
+    json config = {
+        {"Problem", {{"Type", "Electrostatic"}, {"Output", "test_output"}}},
+        {"Model", {{"Mesh", "test.msh"}}},
+        {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+        {"Boundaries", json::object()},
+        {"Solver", {{"Linear", {{"Type", "boomeramg"}, {"KSPType", "gmres"}}}}}};
+
+    IoData iodata(config, false);
+    CHECK(iodata.solver.linear.type == LinearSolver::BOOMER_AMG);
+    CHECK(iodata.solver.linear.krylov_solver == KrylovSolver::GMRES);
+  }
+
+  SECTION("CanonicalizeEnumCase rewrites to the schema spelling and validates")
+  {
+    json config = {
+        {"Problem", {{"Type", "electrostatic"}, {"Output", "test_output"}}},
+        {"Model", {{"Mesh", "test.msh"}}},
+        {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+        {"Boundaries", json::object()},
+        {"Solver", {{"Linear", {{"Type", "BOOMERAMG"}, {"KSPType", "GmRes"}}}}}};
+
+    CanonicalizeEnumCase(config);
+    CHECK(config["Problem"]["Type"].get<std::string>() == "Electrostatic");
+    CHECK(config["Solver"]["Linear"]["Type"].get<std::string>() == "BoomerAMG");
+    CHECK(config["Solver"]["Linear"]["KSPType"].get<std::string>() == "GMRES");
+
+    // The canonicalized enum values now pass case-sensitive schema validation, so a
+    // file-based run (which validates before parsing) no longer aborts on casing.
+    IoData iodata(config, false);
+    config = IoData::ConcretizeDefaults(iodata, config);
+    std::string err = ValidateConfig(config);
+    INFO("schema validation error: " << err);
+    CHECK(err.empty());
+  }
+
+  SECTION("CanonicalizeEnumCase leaves exact and invalid values untouched")
+  {
+    // An already-canonical value is preserved, and a value that matches no allowed
+    // spelling (even case-insensitively) is left as-is so schema validation still
+    // reports it as invalid.
+    json config = {{"Problem", {{"Type", "Electrostatic"}}},
+                   {"Solver", {{"Linear", {{"Type", "NotASolver"}}}}}};
+    CanonicalizeEnumCase(config);
+    CHECK(config["Problem"]["Type"].get<std::string>() == "Electrostatic");
+    CHECK(config["Solver"]["Linear"]["Type"].get<std::string>() == "NotASolver");
+  }
+}
+
 #if defined(MFEM_USE_CUDSS)
 TEST_CASE("Linear solver Type cuDSS parses when built with cuDSS", "[config][Serial]")
 {

--- a/test/unit/test-config.cpp
+++ b/test/unit/test-config.cpp
@@ -1656,12 +1656,11 @@ TEST_CASE("Enum values accept any capitalization", "[config][Serial]")
   // capitalization of e.g. solver names.
   SECTION("FromString resolves values case-insensitively")
   {
-    json config = {
-        {"Problem", {{"Type", "Electrostatic"}, {"Output", "test_output"}}},
-        {"Model", {{"Mesh", "test.msh"}}},
-        {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
-        {"Boundaries", json::object()},
-        {"Solver", {{"Linear", {{"Type", "boomeramg"}, {"KSPType", "gmres"}}}}}};
+    json config = {{"Problem", {{"Type", "Electrostatic"}, {"Output", "test_output"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver", {{"Linear", {{"Type", "boomeramg"}, {"KSPType", "gmres"}}}}}};
 
     IoData iodata(config, false);
     CHECK(iodata.solver.linear.type == LinearSolver::BOOMER_AMG);
@@ -1670,12 +1669,11 @@ TEST_CASE("Enum values accept any capitalization", "[config][Serial]")
 
   SECTION("CanonicalizeEnumCase rewrites to the schema spelling and validates")
   {
-    json config = {
-        {"Problem", {{"Type", "electrostatic"}, {"Output", "test_output"}}},
-        {"Model", {{"Mesh", "test.msh"}}},
-        {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
-        {"Boundaries", json::object()},
-        {"Solver", {{"Linear", {{"Type", "BOOMERAMG"}, {"KSPType", "GmRes"}}}}}};
+    json config = {{"Problem", {{"Type", "electrostatic"}, {"Output", "test_output"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver", {{"Linear", {{"Type", "BOOMERAMG"}, {"KSPType", "GmRes"}}}}}};
 
     CanonicalizeEnumCase(config);
     CHECK(config["Problem"]["Type"].get<std::string>() == "Electrostatic");


### PR DESCRIPTION
Palace required exact capitalization for configuration enum values (e.g. "SuperLU", not "superlu"). Since the user intent is unambiguous, accept any capitalization for these values.

Two layers enforced the exact case, so both are addressed:
- FromString (utils/enum_string.cpp) now compares case-insensitively, so the enum <-> string mapping resolves any capitalization. Enum spellings are unique when compared case-insensitively, so this cannot be ambiguous.
- Schema validation (utils/jsonschema.cpp) matches enum values case-sensitively and aborts before parsing on a mismatch. A new CanonicalizeEnumCase pass rewrites enum-valued strings to their canonical schema spelling before validation, reusing the existing schema walk. It leaves exact matches and genuinely invalid values untouched so validation still reports real errors.

Wired into IoData::ParseAndValidate before validation, added unit tests, and a changelog entry.

Fixes #586

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
