### PR TITLE
Fix false-positive material-coverage abort on wave-port submeshes under NC AMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Fixed a false-positive in the domain material-coverage validation that aborted numeric
+    wave-port simulations under nonconformal AMR on multiple MPI ranks with `Mesh domain attribute <n> has no corresponding entry in config["Domains"]["Materials"]!`. On a
+    partitioned, remapped port boundary submesh, ghost/shared-face neighbor entries can carry
+    the port's own boundary tag, which the check validated as if it were a retained domain.
+    The check now scans only attributes owned by a local volume element, so genuinely
+    material-less domains are still rejected while these ghost bookkeeping attributes are
+    ignored. [PR 888](https://github.com/awslabs/palace/pull/888).
   - Reject all-zero numerator or denominator polynomial coefficients in
     `config["Boundaries"]["RationalImpedance"]` during schema validation, matching the
     existing checks in the configuration parser and providing users with earlier feedback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,13 +69,10 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
-  - Fixed a false-positive in the domain material-coverage validation that aborted numeric
-    wave-port simulations under nonconformal AMR on multiple MPI ranks with `Mesh domain attribute <n> has no corresponding entry in config["Domains"]["Materials"]!`. On a
-    partitioned, remapped port boundary submesh, ghost/shared-face neighbor entries can carry
-    the port's own boundary tag, which the check validated as if it were a retained domain.
-    The check now scans only attributes owned by a local volume element, so genuinely
-    material-less domains are still rejected while these ghost bookkeeping attributes are
-    ignored. [PR 888](https://github.com/awslabs/palace/pull/888).
+  - Fixed a false-positive in the domain material-coverage check that could abort numeric
+    wave-port simulations under nonconformal AMR on multiple MPI ranks. The check now
+    validates only domains owned by a local volume element, ignoring ghost/neighbor
+    bookkeeping attributes. [PR 888](https://github.com/awslabs/palace/pull/888).
   - Reject all-zero numerator or denominator polynomial coefficients in
     `config["Boundaries"]["RationalImpedance"]` during schema validation, matching the
     existing checks in the configuration parser and providing users with earlier feedback.

--- a/palace/drivers/boundarymodesolver.cpp
+++ b/palace/drivers/boundarymodesolver.cpp
@@ -45,8 +45,8 @@ ExtractBoundary2DSubmesh(mfem::Mesh &parent, const mfem::Array<int> &surface_att
   auto sub = std::make_unique<mfem::SubMesh>(
       mfem::SubMesh::CreateFromBoundary(parent, surface_attrs));
   // Project to 2D before remapping element attributes: ProjectSubmeshTo2D's call to
-  // GetSurfaceNormal walks the mesh's unique-attribute list, which RemapSubMeshAttributes
-  // leaves stale relative to the per-element attributes it just rewrote.
+  // GetSurfaceNormal walks the unique-attribute list, which the remap rewrites from the
+  // surface tags to the neighboring domain materials.
   frame.normal = mesh::ProjectSubmeshTo2D(*sub, frame.centroid, frame.e1, frame.e2);
   mesh::RemapSubMeshAttributes(*sub);
   mesh::RemapSubMeshBdrAttributes(*sub, surface_attrs);

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -375,22 +375,23 @@ void MaterialOperator::SetUpMaterialProperties(
     count++;
   }
 
-  // Every domain retained in the mesh needs a material definition. This is normally
-  // guaranteed by unused-element cleaning, but must also hold when cleaning is disabled.
-  // Validate only attributes carried by a locally-owned volume element. loc_attr also holds
-  // ghost/shared-face neighbor attributes, and on a remapped boundary submesh (e.g. a wave-
-  // port cross-section) under nonconformal partitioning those can include the boundary tag
-  // itself, which has no material entry -- that is neighbor bookkeeping, not a retained
-  // domain. The rank owning the neighbor element validates it in its own scan, so scanning
-  // only local elements loses no coverage. Attribute presence is rank-local, so report the
-  // globally smallest missing attribute only after every rank has participated in the
-  // reduction (an element-empty rank naturally contributes nothing).
+  // Every retained domain needs a material. loc_attr also holds ghost/neighbor attributes
+  // that carry no material yet are not retained domains. Collect the material-less
+  // attributes first, usually none, then flag only those on a locally-owned volume element
+  // and reduce for the smallest globally-missing one.
+  std::unordered_set<int> unmatched_attrs;
+  for (const auto &[attr, idx] : loc_attr)
+  {
+    if (attr_mat[idx - 1] < 0)
+    {
+      unmatched_attrs.insert(attr);
+    }
+  }
   int missing_attr = std::numeric_limits<int>::max();
-  for (int i = 0; i < mesh.GetNE(); i++)
+  for (int i = 0; i < mesh.GetNE() && !unmatched_attrs.empty(); i++)
   {
     const int attr = mesh.GetAttribute(i);
-    auto it = loc_attr.find(attr);
-    if (it != loc_attr.end() && attr_mat[it->second - 1] < 0)
+    if (unmatched_attrs.find(attr) != unmatched_attrs.end())
     {
       missing_attr = std::min(missing_attr, attr);
     }

--- a/palace/models/materialoperator.cpp
+++ b/palace/models/materialoperator.cpp
@@ -377,18 +377,22 @@ void MaterialOperator::SetUpMaterialProperties(
 
   // Every domain retained in the mesh needs a material definition. This is normally
   // guaranteed by unused-element cleaning, but must also hold when cleaning is disabled.
-  // Attribute presence is rank-local, so report the globally smallest missing attribute
-  // only after every rank has participated in the reduction. Skip the local scan on an
-  // element-empty rank because BuildCeedAttributes inserts a synthetic attribute 1 there.
+  // Validate only attributes carried by a locally-owned volume element. loc_attr also holds
+  // ghost/shared-face neighbor attributes, and on a remapped boundary submesh (e.g. a wave-
+  // port cross-section) under nonconformal partitioning those can include the boundary tag
+  // itself, which has no material entry -- that is neighbor bookkeeping, not a retained
+  // domain. The rank owning the neighbor element validates it in its own scan, so scanning
+  // only local elements loses no coverage. Attribute presence is rank-local, so report the
+  // globally smallest missing attribute only after every rank has participated in the
+  // reduction (an element-empty rank naturally contributes nothing).
   int missing_attr = std::numeric_limits<int>::max();
-  if (mesh.GetNE() > 0)
+  for (int i = 0; i < mesh.GetNE(); i++)
   {
-    for (const auto &[attr, local_attr] : loc_attr)
+    const int attr = mesh.GetAttribute(i);
+    auto it = loc_attr.find(attr);
+    if (it != loc_attr.end() && attr_mat[it->second - 1] < 0)
     {
-      if (attr_mat[local_attr - 1] < 0)
-      {
-        missing_attr = std::min(missing_attr, attr);
-      }
+      missing_attr = std::min(missing_attr, attr);
     }
   }
   Mpi::GlobalMin(1, &missing_attr, mesh.GetComm());

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1499,6 +1499,9 @@ void RemapSubMeshAttributes(SubMeshT &submesh)
     }
     submesh.SetAttribute(i, nbr_attr);
   }
+  // Refresh the cached distinct-attribute array to match the rewritten per-element
+  // attributes.
+  submesh.SetAttributes();
 }
 
 template <class SubMeshT>

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -9,6 +9,7 @@
 #include "models/materialoperator.hpp"
 #include "utils/communication.hpp"
 #include "utils/configfile.hpp"
+#include "utils/geodata.hpp"
 
 namespace palace
 {
@@ -290,6 +291,62 @@ TEST_CASE("MaterialOperator utility functions", "[materialoperator][Serial]")
       REQUIRE(!internal::mat::IsIsotropic(data));
     }
   }
+}
+
+TEST_CASE("MaterialOperator ignores ghost-only submesh attributes",
+          "[materialoperator][Parallel]")
+{
+  MPI_Comm comm = Mpi::World();
+  const int rank = Mpi::Rank(comm);
+  REQUIRE(Mpi::Size(comm) >= 2);
+
+  auto serial_mesh = std::make_unique<mfem::Mesh>(
+      mfem::Mesh::MakeCartesian3D(2, 1, 1, mfem::Element::HEXAHEDRON, 2.0, 1.0, 1.0));
+  for (int i = 0; i < serial_mesh->GetNE(); i++)
+  {
+    serial_mesh->SetAttribute(i, 7);
+  }
+  serial_mesh->SetAttributes();
+  serial_mesh->EnsureNCMesh(true);
+
+  int partitioning[2] = {0, 1};
+  auto parent = std::make_unique<mfem::ParMesh>(comm, *serial_mesh, partitioning);
+  mfem::Array<mfem::Refinement> refinements;
+  if (rank == 0)
+  {
+    refinements.Append(mfem::Refinement(0));
+  }
+  parent->GeneralRefinement(refinements, -1);
+
+  mfem::Array<int> surface_attributes;
+  surface_attributes.Append(1);
+  auto submesh = std::make_unique<mfem::ParSubMesh>(
+      mfem::ParSubMesh::CreateFromBoundary(*parent, surface_attributes));
+  Mesh palace_mesh(std::move(submesh));
+  mesh::RemapSubMeshAttributes(static_cast<mfem::ParSubMesh &>(palace_mesh.Get()));
+  palace_mesh.RebuildCeedAttributes();
+
+  const bool owns_elements = rank < 2;
+  CHECK((palace_mesh.GetNE() > 0) == owns_elements);
+  for (int i = 0; i < palace_mesh.GetNE(); i++)
+  {
+    CHECK(palace_mesh.Get().GetAttribute(i) == 7);
+  }
+  const auto &local_attributes = palace_mesh.GetCeedAttributes();
+  if (owns_elements)
+  {
+    CHECK(local_attributes.find(1) != local_attributes.end());
+    CHECK(local_attributes.find(7) != local_attributes.end());
+  }
+  else
+  {
+    CHECK(local_attributes.empty());
+  }
+
+  config::MaterialData material;
+  material.attributes = {7};
+  config::PeriodicBoundaryData periodic;
+  CHECK_NOTHROW(MaterialOperator({material}, periodic, ProblemType::DRIVEN, palace_mesh));
 }
 
 }  // namespace palace

--- a/test/unit/test-materialoperator.cpp
+++ b/test/unit/test-materialoperator.cpp
@@ -337,6 +337,8 @@ TEST_CASE("MaterialOperator ignores ghost-only submesh attributes",
   {
     CHECK(local_attributes.find(1) != local_attributes.end());
     CHECK(local_attributes.find(7) != local_attributes.end());
+    // The remap must refresh the cached distinct-attribute array.
+    CHECK(palace_mesh.Get().attributes.Max() == 7);
   }
   else
   {


### PR DESCRIPTION
## Summary

The domain material-coverage validation added in #840 aborts valid numeric wave-port simulations that use nonconformal AMR on ≥2 MPI ranks, with:
`Mesh domain attribute <n> has no corresponding entry in config["Domains"]["Materials"]!`

This PR fixes the false positive while keeping the check's intended behavior.

## Root cause

The check iterated a mesh's entire libCEED attribute map (`GetCeedAttributes()`), which for a boundary submesh also contains ghost / shared-face neighbor attributes, not just locally-retained domains.

For a numeric wave port, the boundary submesh's elements are remapped from the port boundary tag to the adjacent volume material by `RemapSubMeshAttributes` (`geodata.cpp`) but that remap only touches local elements. Under
nonconformal partitioning across ranks, the ghost/face-neighbor copies keep the original port boundary tag, and `BuildCeedAttributes`' shared-face loop (`mesh.cpp`) reinjects it into the attribute map. The coverage check then treats
that boundary tag as a retained domain with no material and aborts.

This only triggers with nonconformal AMR and with >= 2 ranks:
- single rank -> no shared faces, so no ghost injection;
- conformal partition -> ghost attributes are correctly the remapped volume material;
- no local volume element ever carries the port tag.

## Fix

Validate only attributes carried by a locally-owned volume element instead of iterating the full attribute map. The rank that owns a neighbor element validates it in its own scan, and the global `Mpi::GlobalMin` reduction aggregates across ranks, so a genuinely material-less retained domain is still rejected, while ghost bookkeeping attributes are ignored.