### PR TITLE
Prevent SaveAdaptMesh from overwriting archived meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Fixed `SaveAdaptMesh` overwriting the archived mesh from an earlier adaptive iteration
+    when `SaveAdaptIterations` is also enabled.
   - Reject all-zero numerator or denominator polynomial coefficients in
     `config["Boundaries"]["RationalImpedance"]` during schema validation, matching the
     existing checks in the configuration parser and providing users with earlier feedback.

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1971,6 +1971,9 @@ double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh)
       BlockTimer bt1(Timer::IO);
       if (Mpi::Root(comm))
       {
+        // Remove the symlink left by SaveIteration to avoid overwriting the archived mesh
+        // from the previous AMR iteration.
+        fs::remove(sfile);
         std::ofstream fo(sfile);
         // mfem::ofgzstream fo(sfile, true);  // Use zlib compression if available
         // fo << std::fixed;

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fstream>
+#include <memory>
 #include <catch2/catch_test_macros.hpp>
 #include "drivers/basesolver.hpp"
 #include "fixtures.hpp"
+#include "test-helpers.hpp"
 #include "utils/communication.hpp"
 #include "utils/filesystem.hpp"
+#include "utils/geodata.hpp"
+#include "utils/iodata.hpp"
 
 using namespace palace;
 
@@ -181,6 +185,42 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   {
     CHECK(ReadFile(temp_dir / "iteration2" / "domain-E.csv") == "iter2");
   }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveAdaptMesh preserves an archived mesh between iterations",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::RebalanceMesh(iodata, parallel_mesh);
+
+  // Save the first adapted mesh contents for comparison.
+  auto mesh_file = temp_dir / "model.mesh";
+  auto first_mesh = ReadFile(mesh_file);
+  REQUIRE_FALSE(first_mesh.empty());
+
+  // Archive the first mesh, leaving a top-level symlink to it.
+  SaveIteration(comm, temp_dir, 1, 1);
+  REQUIRE(fs::is_symlink(mesh_file));
+  REQUIRE(ReadFile(temp_dir / "iteration1" / "model.mesh") == first_mesh);
+
+  // Simulate the next AMR iteration with a changed mesh.
+  parallel_mesh->GetVertex(0)[0] = -1.0;
+  mesh::RebalanceMesh(iodata, parallel_mesh);
+
+  // The new mesh replaces the symlink without changing the archived mesh.
+  CHECK_FALSE(fs::is_symlink(mesh_file));
+  CHECK(ReadFile(mesh_file) != first_mesh);
+  CHECK(ReadFile(temp_dir / "iteration1" / "model.mesh") == first_mesh);
 }
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,


### PR DESCRIPTION
Fixes #887.

This removes the top-level mesh symlink left by `SaveIteration` before writing the next adapted mesh, preventing `SaveAdaptMesh` from overwriting a mesh archived by `SaveAdaptIterations`. It also adds regression coverage for consecutive adapted mesh writes.

TODO: Verify that tests pass and run a Palace simulation from this dev branch.