### PR TITLE
Improve diagnostics for invalid configuration enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 #### New Features
 
   - Improved configuration schema validation errors to list valid enum values through nested
-    schema alternatives and suggest the canonical capitalization for case-only mismatches.
+    schema alternatives and suggest the canonical capitalization for case-only mismatches
+    [PR 890](https://github.com/awslabs/palace/pull/890).
   - Added a `RationalImpedance` boundary condition: a surface (Robin) impedance boundary
     whose per-square impedance is an arbitrary rational function of frequency,
     `Zs(s) = N(s)/D(s)` with `s = iω`, given by numerator and denominator polynomial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### New Features
 
+  - Improved configuration schema validation errors to list valid enum values through nested
+    schema alternatives and suggest the canonical capitalization for case-only mismatches.
   - Added a `RationalImpedance` boundary condition: a surface (Robin) impedance boundary
     whose per-square impedance is an arbitrary rational function of frequency,
     `Zs(s) = N(s)/D(s)` with `s = iω`, given by numerator and denominator polynomial

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -261,11 +261,9 @@ json FindEnumInSchema(const json &schema, const std::string &ptr)
   return values.empty() ? json() : values;
 }
 
-// Find a unique allowed string which differs from the input only by ASCII case. Returns
-// null when there is no match or when multiple spellings match case-insensitively.
+// Find an allowed string which differs from the input only by ASCII case.
 const json *FindCaseInsensitiveMatch(const json &allowed, std::string_view input)
 {
-  const json *match = nullptr;
   for (const auto &candidate : allowed)
   {
     if (!candidate.is_string())
@@ -279,14 +277,10 @@ const json *FindCaseInsensitiveMatch(const json &allowed, std::string_view input
                               { return std::tolower(a) == std::tolower(b); });
     if (matches)
     {
-      if (match != nullptr)
-      {
-        return nullptr;
-      }
-      match = &candidate;
+      return &candidate;
     }
   }
-  return match;
+  return nullptr;
 }
 
 }  // namespace

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -333,6 +333,8 @@ public:
              const std::string &message) override
   {
     const std::string path = ptr.to_string();
+    // These message strings are implementation details of json-schema-validator 2.4.0;
+    // update them when upgrading the dependency.
     const bool is_enum_failure =
         message.find("instance not found in required enum") != std::string::npos ||
         message.find("instance not const") != std::string::npos ||
@@ -351,9 +353,8 @@ public:
     }
 
     errors << "At " << FormatPath(path) << ": " << message;
-    // Enhance type mismatch errors with actual type. These message strings are
-    // implementation details of json-schema-validator 2.4.0; update if upgrading.
-    // Use find() so the enhancement also fires for oneOf/anyOf-wrapped messages
+    // Enhance type mismatch errors with actual type. Use find() so the enhancement also
+    // fires for oneOf/anyOf-wrapped messages
     // like "[combination: oneOf / case#0] unexpected instance type".
     if (message.find("unexpected instance type") != std::string::npos)
     {

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -158,8 +158,8 @@ void CollectEnumValues(const json &schema, const json &defs,
                        const std::vector<std::string> &tokens, std::size_t token_index,
                        json &values, int depth = 0)
 {
-  constexpr int kMaxDepth = 32;
-  if (!schema.is_object() || depth > kMaxDepth)
+  constexpr int max_depth = 32;
+  if (!schema.is_object() || depth > max_depth)
   {
     return;
   }

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -5,9 +5,9 @@
 
 #include <algorithm>
 #include <cctype>
-#include <sstream>
 #include <string_view>
 #include <unordered_set>
+#include <fmt/format.h>
 #include <nlohmann/json-schema.hpp>
 #include "communication.hpp"
 #include "embedded_schema.hpp"
@@ -295,7 +295,7 @@ const json *FindCaseInsensitiveMatch(const json &allowed, std::string_view input
 // Custom error handler that formats errors with documentation-style paths.
 class SchemaErrorHandler : public error_handler
 {
-  std::ostringstream errors;
+  fmt::memory_buffer errors;
   bool has_error = false;
   const json *schema;
   std::unordered_set<std::string> reported_enum_paths;
@@ -307,7 +307,8 @@ class SchemaErrorHandler : public error_handler
     {
       return "config";
     }
-    std::ostringstream result;
+    fmt::memory_buffer result;
+    auto out = fmt::appender{result};
     std::size_t pos = 0;
     while (pos < ptr.size())
     {
@@ -322,15 +323,15 @@ class SchemaErrorHandler : public error_handler
       bool is_index = !token.empty() && std::all_of(token.begin(), token.end(), ::isdigit);
       if (is_index)
       {
-        result << "[" << token << "]";
+        fmt::format_to(out, "[{}]", token);
       }
       else
       {
-        result << "[\"" << token << "\"]";
+        fmt::format_to(out, "[\"{}\"]", token);
       }
       pos = next;
     }
-    return result.str();
+    return fmt::to_string(result);
   }
 
 public:
@@ -362,48 +363,49 @@ public:
       }
     }
 
-    errors << "At " << FormatPath(path) << ": ";
+    auto out = fmt::appender{errors};
+    fmt::format_to(out, "At {}: ", FormatPath(path));
     if (has_enum_values)
     {
-      errors << "invalid value " << instance.dump();
+      fmt::format_to(out, "invalid value {}", instance.dump());
     }
     else
     {
-      errors << message;
+      fmt::format_to(out, "{}", message);
     }
     // Enhance type mismatch errors with actual type. Use find() so the enhancement also
     // fires for oneOf/anyOf-wrapped messages
     // like "[combination: oneOf / case#0] unexpected instance type".
     if (message.find("unexpected instance type") != std::string::npos)
     {
-      errors << " (got " << instance.type_name() << ")";
+      fmt::format_to(out, " (got {})", instance.type_name());
     }
     else if (has_enum_values)
     {
-      errors << "; valid values: ";
+      fmt::format_to(out, "; valid values: ");
       for (std::size_t i = 0; i < enum_values.size(); i++)
       {
         if (i > 0)
         {
-          errors << ", ";
+          fmt::format_to(out, ", ");
         }
-        errors << enum_values[i].dump();
+        fmt::format_to(out, "{}", enum_values[i].dump());
       }
       if (instance.is_string())
       {
         const auto &input = instance.get_ref<const std::string &>();
         if (const json *suggestion = FindCaseInsensitiveMatch(enum_values, input))
         {
-          errors << ". Did you mean " << suggestion->dump() << "?";
+          fmt::format_to(out, ". Did you mean {}?", suggestion->dump());
         }
       }
     }
-    errors << "\n";
+    fmt::format_to(out, "\n");
     has_error = true;
   }
 
   explicit operator bool() const { return has_error; }
-  std::string get_errors() const { return errors.str(); }
+  std::string get_errors() const { return fmt::to_string(errors); }
 };
 
 std::string GetSchemaVersion()

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 #include <nlohmann/json-schema.hpp>
 #include "communication.hpp"
 #include "embedded_schema.hpp"
@@ -141,15 +142,102 @@ json ResolveRef(const json &node, const json &defs)
   return json();
 }
 
-// Find enum values in schema by following a JSON pointer path.
-json FindEnumInSchema(const json &schema, const std::string &ptr)
+void AppendUnique(json &values, const json &candidate)
 {
-  if (ptr.empty() || ptr == "/")
+  if (std::none_of(values.begin(), values.end(),
+                   [&candidate](const json &value) { return value == candidate; }))
   {
-    return json();
+    values.push_back(candidate);
+  }
+}
+
+// Collect enum-like values at an exact instance path. Composition branches are searched
+// with the same unconsumed path, so a property is never matched merely because it has the
+// same name elsewhere in the schema.
+void CollectEnumValues(const json &schema, const json &defs,
+                       const std::vector<std::string> &tokens, std::size_t token_index,
+                       json &values, int depth = 0)
+{
+  constexpr int kMaxDepth = 32;
+  if (!schema.is_object() || depth > kMaxDepth)
+  {
+    return;
   }
 
-  // Parse path into tokens (skip numeric indices for arrays).
+  const json &local_defs = schema.contains("$defs") ? schema["$defs"] : defs;
+  if (schema.contains("$ref"))
+  {
+    json resolved = ResolveRef(schema, local_defs);
+    if (!resolved.is_null())
+    {
+      CollectEnumValues(resolved, local_defs, tokens, token_index, values, depth + 1);
+    }
+    return;
+  }
+
+  if (token_index == tokens.size())
+  {
+    if (auto enum_it = schema.find("enum"); enum_it != schema.end() && enum_it->is_array())
+    {
+      for (const auto &value : *enum_it)
+      {
+        AppendUnique(values, value);
+      }
+    }
+    if (auto const_it = schema.find("const"); const_it != schema.end())
+    {
+      AppendUnique(values, *const_it);
+    }
+  }
+  else
+  {
+    const std::string &token = tokens[token_index];
+    bool is_index =
+        !token.empty() && std::all_of(token.begin(), token.end(),
+                                      [](unsigned char c) { return std::isdigit(c); });
+    if (is_index)
+    {
+      if (auto items_it = schema.find("items"); items_it != schema.end())
+      {
+        CollectEnumValues(*items_it, local_defs, tokens, token_index + 1, values,
+                          depth + 1);
+      }
+    }
+    else if (auto properties_it = schema.find("properties");
+             properties_it != schema.end() && properties_it->contains(token))
+    {
+      CollectEnumValues((*properties_it)[token], local_defs, tokens, token_index + 1,
+                        values, depth + 1);
+    }
+  }
+
+  // Composition can occur either at the enum itself or at an object/array containing the
+  // property. Preserve the current path position while exploring each possible branch.
+  for (const char *keyword : {"oneOf", "anyOf", "allOf"})
+  {
+    if (auto branches_it = schema.find(keyword);
+        branches_it != schema.end() && branches_it->is_array())
+    {
+      for (const auto &branch : *branches_it)
+      {
+        CollectEnumValues(branch, local_defs, tokens, token_index, values, depth + 1);
+      }
+    }
+  }
+  // A conditional predicate does not itself constrain the instance; either result branch
+  // can contribute a spelling. Schema validation remains responsible for applicability.
+  for (const char *keyword : {"then", "else"})
+  {
+    if (auto branch_it = schema.find(keyword); branch_it != schema.end())
+    {
+      CollectEnumValues(*branch_it, local_defs, tokens, token_index, values, depth + 1);
+    }
+  }
+}
+
+// Find enum values in schema by following an exact JSON pointer path.
+json FindEnumInSchema(const json &schema, const std::string &ptr)
+{
   std::vector<std::string> tokens;
   std::size_t pos = 0;
   while (pos < ptr.size())
@@ -161,100 +249,16 @@ json FindEnumInSchema(const json &schema, const std::string &ptr)
     }
     std::size_t next = ptr.find('/', pos);
     std::string token = ptr.substr(pos, next - pos);
-    // Skip array indices.
-    if (token.empty() || !std::all_of(token.begin(), token.end(), ::isdigit))
+    if (!token.empty())
     {
-      tokens.push_back(token);
+      tokens.push_back(std::move(token));
     }
     pos = next;
   }
 
-  // Get $defs from root schema for resolving internal refs.
-  json defs = schema.value("$defs", json::object());
-
-  // Navigate schema following the path.
-  json current = schema;
-  for (const auto &token : tokens)
-  {
-    // Resolve $ref chain.
-    while (current.contains("$ref"))
-    {
-      json resolved = ResolveRef(current, defs);
-      if (resolved.is_null())
-      {
-        return json();
-      }
-      // Pick up $defs from resolved schema.
-      if (resolved.contains("$defs"))
-      {
-        defs = resolved["$defs"];
-      }
-      current = resolved;
-    }
-
-    // Look in properties.
-    if (current.contains("properties") && current["properties"].contains(token))
-    {
-      current = current["properties"][token];
-      // Follow into array items.
-      if (current.contains("items"))
-      {
-        current = current["items"];
-      }
-    }
-    else
-    {
-      return json();
-    }
-  }
-
-  // Final $ref resolution.
-  while (current.contains("$ref"))
-  {
-    json resolved = ResolveRef(current, defs);
-    if (resolved.is_null())
-    {
-      break;
-    }
-    current = resolved;
-  }
-
-  // Extract enum values (handle anyOf).
-  if (current.contains("enum"))
-  {
-    return current["enum"];
-  }
-  if (current.contains("anyOf"))
-  {
-    for (const auto &opt : current["anyOf"])
-    {
-      if (opt.contains("enum"))
-      {
-        return opt["enum"];
-      }
-    }
-  }
-  // oneOf is used in two ways: the "usual" way to constrain types and as an emum
-  // replacement using the oneOf+const pattern, which allows us to add documentation fields
-  // to enum entries. For oneOf+const we want to collect all values into an array for
-  // consistent error formatting.
-  if (current.contains("oneOf"))
-  {
-    const auto &branches = current["oneOf"];
-    // Check if oneOf + const enum: all items in oneOf have "const" and no "properties"
-    if (!branches.empty() &&
-        std::all_of(branches.begin(), branches.end(), [](const json &b)
-                    { return b.contains("const") && !b.contains("properties"); }))
-    {
-      json consts = json::array();
-      for (const auto &branch : branches)
-      {
-        consts.push_back(branch["const"]);
-      }
-      return consts;
-    }
-  }
-  return json();
+  json values = json::array();
+  CollectEnumValues(schema, schema.value("$defs", json::object()), tokens, 0, values);
+  return values.empty() ? json() : values;
 }
 
 // Find a unique allowed string which differs from the input only by ASCII case. Returns
@@ -293,6 +297,7 @@ class SchemaErrorHandler : public error_handler
   std::ostringstream errors;
   bool has_error = false;
   const json *schema;
+  std::unordered_set<std::string> reported_enum_paths;
 
   // Convert JSON pointer "/Boundaries/LumpedPort/0" to ["Boundaries"]["LumpedPort"][0]
   static std::string FormatPath(const std::string &ptr)
@@ -333,18 +338,25 @@ public:
   void error(const json::json_pointer &ptr, const json &instance,
              const std::string &message) override
   {
-    // If a oneOf+const enum, we only want to print the top-level path, since that already
-    // contains all information. Individual schema mismatch of items has no new information.
-    if ((schema != nullptr) && message.find("[combination: oneOf") != std::string::npos)
+    const std::string path = ptr.to_string();
+    const bool is_enum_failure =
+        message.find("instance not found in required enum") != std::string::npos ||
+        message.find("instance not const") != std::string::npos ||
+        message.find("no subschema has succeeded") != std::string::npos;
+    json enum_values;
+    if ((schema != nullptr) && is_enum_failure)
     {
-      json enum_values = FindEnumInSchema(*schema, ptr.to_string());
-      if (!enum_values.is_null() && !enum_values.empty())
+      enum_values = FindEnumInSchema(*schema, path);
+      if (!enum_values.is_null() && enum_values.is_array() && !enum_values.empty() &&
+          !reported_enum_paths.insert(path).second)
       {
+        // Logical combinations can report the same enum failure once per branch. The first
+        // message already contains the union of values at this exact instance path.
         return;
       }
     }
 
-    errors << "At " << FormatPath(ptr.to_string()) << ": " << message;
+    errors << "At " << FormatPath(path) << ": " << message;
     // Enhance type mismatch errors with actual type. These message strings are
     // implementation details of json-schema-validator 2.4.0; update if upgrading.
     // Use find() so the enhancement also fires for oneOf/anyOf-wrapped messages
@@ -353,32 +365,23 @@ public:
     {
       errors << " (got " << instance.type_name() << ")";
     }
-    // Enhance enum errors with valid values — handles flat "enum" arrays (including
-    // oneOf/anyOf-wrapped messages) and oneOf+const enum patterns (both resolve to a list
-    // of valid values via FindEnumInSchema).
-    else if ((schema != nullptr) &&
-             (message.find("instance not found in required enum") != std::string::npos ||
-              message.rfind("no subschema has succeeded", 0) == 0))
+    else if (!enum_values.is_null() && enum_values.is_array() && !enum_values.empty())
     {
-      json enum_values = FindEnumInSchema(*schema, ptr.to_string());
-      if (!enum_values.is_null() && enum_values.is_array() && !enum_values.empty())
+      errors << "; valid values: ";
+      for (std::size_t i = 0; i < enum_values.size(); i++)
       {
-        errors << "; valid values: ";
-        for (std::size_t i = 0; i < enum_values.size(); i++)
+        if (i > 0)
         {
-          if (i > 0)
-          {
-            errors << ", ";
-          }
-          errors << enum_values[i].dump();
+          errors << ", ";
         }
-        if (instance.is_string())
+        errors << enum_values[i].dump();
+      }
+      if (instance.is_string())
+      {
+        const auto &input = instance.get_ref<const std::string &>();
+        if (const json *suggestion = FindCaseInsensitiveMatch(enum_values, input))
         {
-          const auto &input = instance.get_ref<const std::string &>();
-          if (const json *suggestion = FindCaseInsensitiveMatch(enum_values, input))
-          {
-            errors << ". Did you mean " << suggestion->dump() << "?";
-          }
+          errors << ". Did you mean " << suggestion->dump() << "?";
         }
       }
     }

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -4,6 +4,7 @@
 #include "jsonschema.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <sstream>
 #include <string_view>
 #include <nlohmann/json-schema.hpp>
@@ -256,6 +257,34 @@ json FindEnumInSchema(const json &schema, const std::string &ptr)
   return json();
 }
 
+// Find a unique allowed string which differs from the input only by ASCII case. Returns
+// null when there is no match or when multiple spellings match case-insensitively.
+const json *FindCaseInsensitiveMatch(const json &allowed, std::string_view input)
+{
+  const json *match = nullptr;
+  for (const auto &candidate : allowed)
+  {
+    if (!candidate.is_string())
+    {
+      continue;
+    }
+    const auto &value = candidate.get_ref<const std::string &>();
+    bool matches = input != value && input.size() == value.size() &&
+                   std::equal(input.begin(), input.end(), value.begin(),
+                              [](unsigned char a, unsigned char b)
+                              { return std::tolower(a) == std::tolower(b); });
+    if (matches)
+    {
+      if (match != nullptr)
+      {
+        return nullptr;
+      }
+      match = &candidate;
+    }
+  }
+  return match;
+}
+
 }  // namespace
 
 // Custom error handler that formats errors with documentation-style paths.
@@ -342,6 +371,14 @@ public:
             errors << ", ";
           }
           errors << enum_values[i].dump();
+        }
+        if (instance.is_string())
+        {
+          const auto &input = instance.get_ref<const std::string &>();
+          if (const json *suggestion = FindCaseInsensitiveMatch(enum_values, input))
+          {
+            errors << ". Did you mean " << suggestion->dump() << "?";
+          }
         }
       }
     }

--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -159,7 +159,14 @@ void CollectEnumValues(const json &schema, const json &defs,
                        json &values, int depth = 0)
 {
   constexpr int max_depth = 32;
-  if (!schema.is_object() || depth > max_depth)
+  if (depth > max_depth)
+  {
+    Mpi::Warning("Schema enum search exceeded max depth {}; check for a self-referential "
+                 "$defs cycle\n",
+                 max_depth);
+    return;
+  }
+  if (!schema.is_object())
   {
     return;
   }
@@ -340,19 +347,30 @@ public:
         message.find("instance not const") != std::string::npos ||
         message.find("no subschema has succeeded") != std::string::npos;
     json enum_values;
+    bool has_enum_values = false;
     if ((schema != nullptr) && is_enum_failure)
     {
       enum_values = FindEnumInSchema(*schema, path);
-      if (!enum_values.is_null() && enum_values.is_array() && !enum_values.empty() &&
-          !reported_enum_paths.insert(path).second)
+      has_enum_values =
+          !enum_values.is_null() && enum_values.is_array() && !enum_values.empty();
+      if (has_enum_values && !reported_enum_paths.insert(path).second)
       {
-        // Logical combinations can report the same enum failure once per branch. The first
-        // message already contains the union of values at this exact instance path.
+        // Logical combinations can report the same enum failure once per branch. Every
+        // enriched line uses the same user-facing message, so the first report is useful
+        // regardless of the validator's error emission order.
         return;
       }
     }
 
-    errors << "At " << FormatPath(path) << ": " << message;
+    errors << "At " << FormatPath(path) << ": ";
+    if (has_enum_values)
+    {
+      errors << "invalid value " << instance.dump();
+    }
+    else
+    {
+      errors << message;
+    }
     // Enhance type mismatch errors with actual type. Use find() so the enhancement also
     // fires for oneOf/anyOf-wrapped messages
     // like "[combination: oneOf / case#0] unexpected instance type".
@@ -360,7 +378,7 @@ public:
     {
       errors << " (got " << instance.type_name() << ")";
     }
-    else if (!enum_values.is_null() && enum_values.is_array() && !enum_values.empty())
+    else if (has_enum_values)
     {
       errors << "; valid values: ";
       for (std::size_t i = 0; i < enum_values.size(); i++)

--- a/test/unit/test-schema.cpp
+++ b/test/unit/test-schema.cpp
@@ -659,6 +659,75 @@ TEST_CASE("Schema Validation - Error Message Format", "[schema][Serial]")
                    "\"cuDSS\"") != std::string::npos);
   }
 
+  SECTION("Enum lookup follows object alternatives at the exact instance path")
+  {
+    json config = {{"Problem", {{"Type", "Driven"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver",
+                    {{"Driven",
+                      {{"Samples",
+                        {{{"Type", "linear"},
+                          {"MinFreq", 1.0},
+                          {"MaxFreq", 2.0},
+                          {"NSample", 2}}}}}}}}};
+
+    std::string err = ValidateConfig(config);
+    INFO(err);
+    CHECK(err.find("[\"Solver\"][\"Driven\"][\"Samples\"][0][\"Type\"]") !=
+          std::string::npos);
+    CHECK(err.find("valid values: \"Point\", \"Linear\", \"Log\"") != std::string::npos);
+    CHECK(err.find("Did you mean \"Linear\"?") != std::string::npos);
+    CHECK(err.find("\"SuperLU\"") == std::string::npos);
+  }
+
+  SECTION("Enum lookup recurses through nested arrays and references")
+  {
+    json config = {{"Problem", {{"Type", "Electrostatic"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries",
+                    {{"LumpedPort",
+                      {{{"Index", 1},
+                        {"Elements",
+                         {{{"Attributes", {1}},
+                           {"Direction", {1.0, 0.0, 0.0}},
+                           {"CoordinateSystem", "cylindrical"}}}}}}}}},
+                   {"Solver", json::object()}};
+
+    std::string err = ValidateConfig(config);
+    INFO(err);
+    CHECK(err.find("[\"Boundaries\"][\"LumpedPort\"][0][\"Elements\"][0]"
+                   "[\"CoordinateSystem\"]") != std::string::npos);
+    CHECK(err.find("valid values: \"Cartesian\", \"Cylindrical\"") != std::string::npos);
+    CHECK(err.find("Did you mean \"Cylindrical\"?") != std::string::npos);
+    CHECK(err.find("\"Open\"") == std::string::npos);
+  }
+
+  SECTION("Enum lookup resolves references within anyOf")
+  {
+    json config = {{"Problem", {{"Type", "Electrostatic"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains",
+                    {{"Materials", {{{"Attributes", {1}}}}},
+                     {"CurrentDipole",
+                      {{{"Index", 1},
+                        {"Moment", 1.0},
+                        {"Center", {0.0, 0.0, 0.0}},
+                        {"Direction", "BadDir"}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver", json::object()}};
+
+    std::string err = ValidateConfig(config);
+    INFO(err);
+    CHECK(err.find("[\"Domains\"][\"CurrentDipole\"][0][\"Direction\"]") !=
+          std::string::npos);
+    CHECK(err.find("valid values: \"X\", \"Y\", \"Z\"") != std::string::npos);
+    CHECK(err.find("\"-z\"") != std::string::npos);
+    CHECK(err.find("Did you mean") == std::string::npos);
+  }
+
   SECTION("Invalid enum in nested array")
   {
     json config = {

--- a/test/unit/test-schema.cpp
+++ b/test/unit/test-schema.cpp
@@ -654,6 +654,7 @@ TEST_CASE("Schema Validation - Error Message Format", "[schema][Serial]")
     INFO(err);
     CHECK(err.find("[\"Solver\"][\"Linear\"][\"Type\"]") != std::string::npos);
     CHECK(err.find("Did you mean \"SuperLU\"?") != std::string::npos);
+    CHECK(err.find("case#") == std::string::npos);
     CHECK(err.find("valid values: \"Default\", \"AMS\", \"BoomerAMG\", \"MUMPS\", "
                    "\"SuperLU\", \"STRUMPACK\", \"STRUMPACK-MP\", \"Jacobi\", "
                    "\"cuDSS\"") != std::string::npos);

--- a/test/unit/test-schema.cpp
+++ b/test/unit/test-schema.cpp
@@ -639,6 +639,24 @@ TEST_CASE("Schema Validation - Error Message Format", "[schema][Serial]")
     CHECK(err.find("valid values: \"Eigenmode\", \"Driven\", \"Transient\", "
                    "\"Electrostatic\", \"Magnetostatic\", \"BoundaryMode\"") !=
           std::string::npos);
+    CHECK(err.find("Did you mean") == std::string::npos);
+  }
+
+  SECTION("Enum value with incorrect case suggests canonical spelling")
+  {
+    json config = {{"Problem", {{"Type", "Electrostatic"}}},
+                   {"Model", {{"Mesh", "test.msh"}}},
+                   {"Domains", {{"Materials", {{{"Attributes", {1}}}}}}},
+                   {"Boundaries", json::object()},
+                   {"Solver", {{"Linear", {{"Type", "superlu"}}}}}};
+
+    std::string err = ValidateConfig(config);
+    INFO(err);
+    CHECK(err.find("[\"Solver\"][\"Linear\"][\"Type\"]") != std::string::npos);
+    CHECK(err.find("Did you mean \"SuperLU\"?") != std::string::npos);
+    CHECK(err.find("valid values: \"Default\", \"AMS\", \"BoomerAMG\", \"MUMPS\", "
+                   "\"SuperLU\", \"STRUMPACK\", \"STRUMPACK-MP\", \"Jacobi\", "
+                   "\"cuDSS\"") != std::string::npos);
   }
 
   SECTION("Invalid enum in nested array")

--- a/test/unit/test-schema.cpp
+++ b/test/unit/test-schema.cpp
@@ -652,7 +652,8 @@ TEST_CASE("Schema Validation - Error Message Format", "[schema][Serial]")
 
     std::string err = ValidateConfig(config);
     INFO(err);
-    CHECK(err.find("[\"Solver\"][\"Linear\"][\"Type\"]") != std::string::npos);
+    CHECK(err.find("At [\"Solver\"][\"Linear\"][\"Type\"]: invalid value \"superlu\"") !=
+          std::string::npos);
     CHECK(err.find("Did you mean \"SuperLU\"?") != std::string::npos);
     CHECK(err.find("case#") == std::string::npos);
     CHECK(err.find("valid values: \"Default\", \"AMS\", \"BoomerAMG\", \"MUMPS\", "
@@ -676,10 +677,13 @@ TEST_CASE("Schema Validation - Error Message Format", "[schema][Serial]")
 
     std::string err = ValidateConfig(config);
     INFO(err);
-    CHECK(err.find("[\"Solver\"][\"Driven\"][\"Samples\"][0][\"Type\"]") !=
-          std::string::npos);
-    CHECK(err.find("valid values: \"Point\", \"Linear\", \"Log\"") != std::string::npos);
-    CHECK(err.find("Did you mean \"Linear\"?") != std::string::npos);
+    const std::string enum_error =
+        "At [\"Solver\"][\"Driven\"][\"Samples\"][0][\"Type\"]: invalid value "
+        "\"linear\"; valid values: \"Point\", \"Linear\", \"Log\". Did you mean "
+        "\"Linear\"?";
+    const auto enum_error_pos = err.find(enum_error);
+    REQUIRE(enum_error_pos != std::string::npos);
+    CHECK(err.find(enum_error, enum_error_pos + enum_error.size()) == std::string::npos);
     CHECK(err.find("\"SuperLU\"") == std::string::npos);
   }
 


### PR DESCRIPTION
## Summary

- Recursively recover valid enum values at the exact failing configuration path through arrays, `$ref`, `oneOf`, `anyOf`, and other schema composition.
- List the valid values when schema validation rejects an enum-like entry.
- Suggest the canonical capitalization for case-only mismatches.
- Preserve the canonical, case-sensitive configuration contract.

## Motivation

Addresses #586.

This is intended to supersede #883 with a diagnostics-only approach. Rather than canonicalizing configuration values before validation and making runtime acceptance differ from the published schema, Palace reports the canonical options and a targeted correction:

```text
valid values: ..., "SuperLU", ... Did you mean "SuperLU"?
```

The input configuration and embedded schema remain unchanged. Thanks to @SpookyJumpyBeans for the work in #883 that prompted and informed this alternative.

## Implementation

Enum lookup follows the exact JSON instance path and recursively traverses arrays, internal references, and schema composition. Values are collected only from the corresponding sub-schema path, deduplicated in schema order, and used solely to enrich validation errors.

The current Palace schema's 33 enum-like paths are covered, including nested forms such as:

- `Solver.Driven.Samples[].Type`
- `Boundaries.LumpedPort[].Elements[].CoordinateSystem`
- `Boundaries.SurfaceCurrent[].InactiveMode`
- direction enums referenced inside `anyOf`
