### PR TITLE
Fix validate-config script name in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Documentation
 
+  - Corrected the configuration validation script name in the docs
+    (`validate-config`).
   - Clarified how to interpret the elapsed time report: indented rows are exclusive
     sub-categories, parent rows are remainders, and Min/Max/Avg are over MPI ranks.
     [PR 885](https://github.com/awslabs/palace/pull/885).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,8 +122,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 #### Documentation
 
   - Corrected the configuration validation script name in the docs
-    (`validate-config`).
-    [PR 891](https://github.com/awslabs/palace/pull/891).
+    (`validate-config`). [PR 891](https://github.com/awslabs/palace/pull/891).
   - Clarified how to interpret the elapsed time report: indented rows are exclusive
     sub-categories, parent rows are remainders, and Min/Max/Avg are over MPI ranks.
     [PR 885](https://github.com/awslabs/palace/pull/885).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
   - Corrected the configuration validation script name in the docs
     (`validate-config`).
+    [PR 891](https://github.com/awslabs/palace/pull/891).
   - Clarified how to interpret the elapsed time report: indented rows are exclusive
     sub-categories, parent rows are remainders, and Min/Max/Avg are over MPI ranks.
     [PR 885](https://github.com/awslabs/palace/pull/885).

--- a/docs/src/config/config.md
+++ b/docs/src/config/config.md
@@ -46,7 +46,7 @@ Schema](https://json-schema.org/draft-07/schema) before the solver starts. The s
 used independently to check your configuration before running *Palace* by running:
 
 ```bash
-./scripts/validate_config config.json
+./scripts/validate-config config.json
 ```
 
 Note that there are constraints on the configuration that cannot be expressed in a JSON Schema.

--- a/docs/src/developer/notes.md
+++ b/docs/src/developer/notes.md
@@ -145,10 +145,10 @@ A JSON format [configuration file](../config/config.md), for example named
 `config.json`, can be validated against the provided Schema using:
 
 ```bash
-./scripts/validate_config config.json
+./scripts/validate-config config.json
 ```
 
-[This script](https://github.com/awslabs/palace/blob/main/scripts/validate_config) uses
+[This script](https://github.com/awslabs/palace/blob/main/scripts/validate-config) uses
 Julia's [`JSONSchema.jl`](https://github.com/fredo-dedup/JSONSchema.jl) and the Schema
 provided in [`scripts/schema/`](https://github.com/awslabs/palace/blob/main/scripts/schema)
 to parse the configuration file and check that the fields are correctly specified. This


### PR DESCRIPTION
The validation script is `scripts/validate-config`, but the docs still say `validate_config` (and the GitHub link 404s).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.