### PR TITLE
Fix output archiving and symlink handling on shared filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 #### Bug Fixes
 
   - Fixed adaptive iteration output archiving overwriting earlier meshes and made its
-    filesystem updates more robust.
+    filesystem updates more robust. [PR 892](https://github.com/awslabs/palace/pull/892).
   - Fixed ParaView output for multiple driven excitations deleting fields from earlier
-    excitations.
+    excitations. [PR 892](https://github.com/awslabs/palace/pull/892).
   - Fixed a false-positive in the domain material-coverage check that could abort numeric
     wave-port simulations under nonconformal AMR on multiple MPI ranks. The check now
     validates only domains owned by a local volume element, ignoring ghost/neighbor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Fixed adaptive iteration output archiving overwriting earlier meshes and made its
+    filesystem updates more robust.
+  - Fixed ParaView output for multiple driven excitations deleting fields from earlier
+    excitations.
   - Fixed a false-positive in the domain material-coverage check that could abort numeric
     wave-port simulations under nonconformal AMR on multiple MPI ranks. The check now
     validates only domains owned by a local volume element, ignoring ghost/neighbor

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -37,6 +37,9 @@ void SaveIteration(MPI_Comm comm, const fs::path &output_dir, int step, int widt
   auto rel_step = step_output.filename();
   auto operation =
       fmt::format("archiving adaptive iteration output in \"{}\"", step_output.string());
+  ApplyOnEachNodeFilesystem(
+      comm, fmt::format("Creating adaptive iteration output \"{}\"", step_output.string()),
+      [&]() { fs::create_directories(step_output); });
   ApplyOnceOnEachNodeFilesystem(
       comm, step_output / ".palace-archive-claim", operation,
       [&]()

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -35,36 +35,55 @@ void SaveIteration(MPI_Comm comm, const fs::path &output_dir, int step, int widt
   Mpi::Barrier(comm);  // Wait for all processes to write postprocessing files
   auto step_output = output_dir / fmt::format("iteration{:0{}d}", step, width);
   auto rel_step = step_output.filename();
-  ApplyOnEachNodeFilesystem(
-      comm,
-      fmt::format("Archiving adaptive iteration output in \"{}\"", step_output.string()),
+  auto operation =
+      fmt::format("archiving adaptive iteration output in \"{}\"", step_output.string());
+  ApplyOnceOnEachNodeFilesystem(
+      comm, step_output / ".palace-archive-claim", operation,
       [&]()
       {
-        // On a shared filesystem, the global root moves the output before the other node
-        // roots inspect it, so they see symlinks and have nothing left to move. On a
-        // node-local filesystem, each node root archives that node's rank files.
-        fs::create_directories(step_output);
-        for (const auto &f : fs::directory_iterator(output_dir))
+        // Snapshot the directory before changing it. Mutating a directory while iterating
+        // it has filesystem-dependent behavior, especially when directory entries are
+        // cached by a network filesystem.
+        std::vector<fs::path> entries;
+        for (const auto &entry : fs::directory_iterator(output_dir))
         {
-          const auto &fname = f.path().filename().string();
+          entries.push_back(entry.path());
+        }
+
+        for (const auto &path : entries)
+        {
+          const auto &fname = path.filename().string();
           if (fname.rfind("iteration") == 0)
           {
             continue;
           }
-          auto dest = step_output / f.path().filename();
-          if (f.is_symlink())
+
+          // A path can disappear after the snapshot, and existing archive symlinks have
+          // already been moved. Neither case leaves anything to archive.
+          std::error_code ec;
+          auto status = fs::symlink_status(path, ec);
+          if (ec == std::errc::no_such_file_or_directory)
           {
-            // Skip symlinks left from a previous iteration's save. They still point
-            // to valid data and will be overwritten by the next solve.
             continue;
           }
-          else if (fname == "palace.json")
+          if (ec)
+          {
+            throw fs::filesystem_error("Could not inspect adaptive iteration output", path,
+                                       ec);
+          }
+          if (!fs::exists(status) || fs::is_symlink(status))
+          {
+            continue;
+          }
+
+          auto dest = step_output / path.filename();
+          if (fname == "palace.json")
           {
             // Metadata is written only by the global root. Copy it only there to avoid
             // concurrent copies when the output directory is shared.
             if (Mpi::Root(comm))
             {
-              fs::copy(f, dest, fs::copy_options::overwrite_existing);
+              fs::copy(path, dest, fs::copy_options::overwrite_existing);
             }
           }
           else if (fname.size() >= 14 &&
@@ -81,8 +100,8 @@ void SaveIteration(MPI_Comm comm, const fs::path &output_dir, int step, int widt
             // so that the output directory always has accessible results. Remove
             // any existing destination first (e.g. from a previous run).
             fs::remove_all(dest);
-            fs::rename(f, dest);
-            fs::create_symlink(rel_step / f.path().filename(), f.path());
+            fs::rename(path, dest);
+            fs::create_symlink(rel_step / path.filename(), path);
           }
         }
       });

--- a/palace/models/postoperator.cpp
+++ b/palace/models/postoperator.cpp
@@ -237,6 +237,13 @@ PostOperator<solver_t>::PostOperator(const config::ProblemData &problem,
   RemovePreviousOutput(gridfunction_root, fem_op->GetComm());
   gridfunction_output_dir = (gridfunction_root / OutputFolderName(solver_t)).string();
 
+  // Clear previous ParaView output once per solve. Switching driven excitations only
+  // changes subdirectories and must preserve output from earlier excitations.
+  if (ShouldWriteParaviewFields())
+  {
+    RemovePreviousOutput(post_dir / "paraview", fem_op->GetComm());
+  }
+
   SetupFieldCoefficients();
   InitializeParaviewDataCollection();
 
@@ -380,11 +387,11 @@ void PostOperator<solver_t>::InitializeParaviewDataCollection(
   {
     return;
   }
-  // Remove previous symlink/directory before writing (node-local filesystem aware, so
-  // stale artifacts are cleared on every node rather than only where the global root
-  // lives). Removing directory only happens when the output folder is dirty.
+  // Close any files held by the previous collection before switching output paths.
+  paraview.reset();
+  paraview_bdr.reset();
+
   auto paraview_root = post_dir / "paraview";
-  RemovePreviousOutput(paraview_root, fem_op->GetComm());
   fs::path paraview_dir_v = paraview_root / OutputFolderName(solver_t);
   fs::path paraview_dir_b =
       paraview_root / fmt::format("{}_boundary", OutputFolderName(solver_t));

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -25,6 +25,7 @@
 #include "utils/filesystem.hpp"
 #include "utils/meshio.hpp"
 #include "utils/omp.hpp"
+#include "utils/outputdir.hpp"
 #include "utils/prettyprint.hpp"
 #include "utils/timer.hpp"
 #include "utils/units.hpp"
@@ -1971,21 +1972,18 @@ double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh)
 
     auto PrintSerial = [&](mfem::Mesh &smesh)
     {
-      BlockTimer bt1(Timer::IO);
-      if (Mpi::Root(comm))
-      {
-        // Remove the symlink left by SaveIteration to avoid overwriting the archived mesh
-        // from the previous AMR iteration.
-        fs::remove(sfile);
-        std::ofstream fo(sfile);
-        // mfem::ofgzstream fo(sfile, true);  // Use zlib compression if available
-        // fo << std::fixed;
-        fo << std::scientific;
-        fo.precision(MSH_FLT_PRECISION);
-        mesh::DimensionalizeMesh(smesh, iodata.units.GetMeshLengthRelativeScale());
-        smesh.Mesh::Print(fo);  // Do not need to nondimensionalize the temporary mesh
-      }
-      Mpi::Barrier(comm);
+      WriteRootOutputFile(
+          sfile, comm,
+          [&](std::ostream &stream)
+          {
+            // mfem::ofgzstream stream(sfile, true);  // Use zlib compression if available
+            // stream << std::fixed;
+            stream << std::scientific;
+            stream.precision(MSH_FLT_PRECISION);
+            mesh::DimensionalizeMesh(smesh, iodata.units.GetMeshLengthRelativeScale());
+            smesh.Mesh::Print(
+                stream);  // Do not need to nondimensionalize the temporary mesh
+          });
     };
 
     if (mesh->Nonconforming())

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1974,6 +1974,9 @@ double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh)
       BlockTimer bt1(Timer::IO);
       if (Mpi::Root(comm))
       {
+        // Remove the symlink left by SaveIteration to avoid overwriting the archived mesh
+        // from the previous AMR iteration.
+        fs::remove(sfile);
         std::ofstream fo(sfile);
         // mfem::ofgzstream fo(sfile, true);  // Use zlib compression if available
         // fo << std::fixed;

--- a/palace/utils/outputdir.hpp
+++ b/palace/utils/outputdir.hpp
@@ -43,6 +43,30 @@ inline void AbortOnNodeFilesystemError(MPI_Comm comm, const std::string &operati
 
 }  // namespace internal
 
+// Apply a filesystem operation on the global root and propagate any error collectively so
+// other ranks do not continue into a mismatched MPI control path.
+template <typename Func>
+inline void ApplyOnRootFilesystem(MPI_Comm comm, const std::string &operation, Func &&func)
+{
+  std::string local_error;
+  if (Mpi::Root(comm))
+  {
+    try
+    {
+      func();
+    }
+    catch (const std::exception &e)
+    {
+      local_error = e.what();
+    }
+    catch (...)
+    {
+      local_error = "Unknown filesystem error";
+    }
+  }
+  internal::AbortOnNodeFilesystemError(comm, operation, local_error);
+}
+
 // Apply an operation once to each node's view of the filesystem. The global root runs
 // first so that shared filesystems are updated before the remaining node roots inspect
 // them. Filesystem exceptions are reported only after every rank has completed the same
@@ -86,6 +110,62 @@ inline void ApplyOnEachNodeFilesystem(MPI_Comm comm, const std::string &operatio
   internal::AbortOnNodeFilesystemError(comm, operation, local_error);
 }
 
+// Apply a non-idempotent operation exactly once to each distinct filesystem view. An
+// atomic directory claim makes all node roots sharing an NFS/SMB mount agree on one
+// writer, while roots with node-local storage each acquire their own claim.
+template <typename Func>
+inline void ApplyOnceOnEachNodeFilesystem(MPI_Comm comm, const fs::path &claim,
+                                          const std::string &operation, Func &&func)
+{
+  ApplyOnEachNodeFilesystem(comm,
+                            fmt::format("Preparing filesystem operation: {}", operation),
+                            [&]()
+                            {
+                              fs::create_directories(claim.parent_path());
+                              fs::remove_all(claim);
+                            });
+
+  std::string local_error;
+  auto apply_here = [&]()
+  {
+    try
+    {
+      if (fs::create_directory(claim))
+      {
+        func();
+      }
+    }
+    catch (const std::exception &e)
+    {
+      local_error = e.what();
+    }
+    catch (...)
+    {
+      local_error = "Unknown filesystem error";
+    }
+  };
+
+  if (Mpi::Root(comm))
+  {
+    apply_here();
+  }
+  Mpi::Barrier(comm);
+
+  MPI_Comm node_comm = MPI_COMM_NULL;
+  MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, Mpi::Rank(comm), MPI_INFO_NULL,
+                      &node_comm);
+  if (Mpi::Root(node_comm) && !Mpi::Root(comm))
+  {
+    apply_here();
+  }
+  MPI_Comm_free(&node_comm);
+
+  internal::AbortOnNodeFilesystemError(comm, operation, local_error);
+  ApplyOnEachNodeFilesystem(comm,
+                            fmt::format("Cleaning up filesystem operation: {}", operation),
+                            [&]() { fs::remove_all(claim); });
+}
+
 // Ensure an output directory exists on every node's filesystem. This is
 // node-local-filesystem aware: on a shared filesystem only the global root creates the
 // directory (all other creations hit an already-existing directory harmlessly), while on
@@ -121,6 +201,35 @@ inline void RemovePreviousOutput(const fs::path &dir, MPI_Comm comm)
   ApplyOnEachNodeFilesystem(comm,
                             fmt::format("Removing previous output \"{}\"", dir.string()),
                             [&]() { fs::remove_all(dir); });
+}
+
+// Replace a root-written output file without following a symlink left by SaveIteration.
+// The postprocessing directory is Palace-owned, so any existing file, directory, or
+// symlink at the path can be removed. Open and write failures are propagated collectively
+// to keep all ranks on the same MPI control path.
+template <typename Func>
+inline void WriteRootOutputFile(const fs::path &path, MPI_Comm comm, Func &&write)
+{
+  BlockTimer bt(Timer::IO);
+  ApplyOnRootFilesystem(
+      comm, fmt::format("Writing output file \"{}\"", path.string()),
+      [&]()
+      {
+        fs::remove_all(path);
+        std::ofstream stream(path);
+        if (!stream.is_open())
+        {
+          throw fs::filesystem_error("Could not open output file", path,
+                                     std::make_error_code(std::errc::io_error));
+        }
+        write(stream);
+        stream.close();
+        if (stream.fail())
+        {
+          throw fs::filesystem_error("Could not write output file", path,
+                                     std::make_error_code(std::errc::io_error));
+        }
+      });
 }
 
 inline void MakeOutputFolder(IoData &iodata, MPI_Comm &comm)

--- a/palace/utils/outputdir.hpp
+++ b/palace/utils/outputdir.hpp
@@ -110,60 +110,32 @@ inline void ApplyOnEachNodeFilesystem(MPI_Comm comm, const std::string &operatio
   internal::AbortOnNodeFilesystemError(comm, operation, local_error);
 }
 
-// Apply a non-idempotent operation exactly once to each distinct filesystem view. An
-// atomic directory claim makes all node roots sharing an NFS/SMB mount agree on one
-// writer, while roots with node-local storage each acquire their own claim.
+// Apply a non-idempotent operation exactly once to each distinct filesystem view. The
+// global root attempts the claim first; later node roots sharing its NFS/SMB mount observe
+// the claim and skip the operation, while roots with node-local storage each acquire their
+// own claim. Directory creation is a portable atomic create-if-absent operation, avoiding
+// platform-specific file-lock APIs. The caller must first create the claim's parent
+// directory on every filesystem view.
 template <typename Func>
-inline void ApplyOnceOnEachNodeFilesystem(MPI_Comm comm, const fs::path &claim,
-                                          const std::string &operation, Func &&func)
+inline void ApplyOnceOnEachNodeFilesystem(MPI_Comm comm, const fs::path &claim_path,
+                                          const std::string &operation,
+                                          Func &&operation_func)
 {
-  ApplyOnEachNodeFilesystem(comm,
-                            fmt::format("Preparing filesystem operation: {}", operation),
+  ApplyOnEachNodeFilesystem(comm, "Removing stale claims for " + operation,
+                            [&]() { fs::remove_all(claim_path); });
+
+  ApplyOnEachNodeFilesystem(comm, operation,
                             [&]()
                             {
-                              fs::create_directories(claim.parent_path());
-                              fs::remove_all(claim);
+                              const bool acquired_claim = fs::create_directory(claim_path);
+                              if (acquired_claim)
+                              {
+                                operation_func();
+                              }
                             });
 
-  std::string local_error;
-  auto apply_here = [&]()
-  {
-    try
-    {
-      if (fs::create_directory(claim))
-      {
-        func();
-      }
-    }
-    catch (const std::exception &e)
-    {
-      local_error = e.what();
-    }
-    catch (...)
-    {
-      local_error = "Unknown filesystem error";
-    }
-  };
-
-  if (Mpi::Root(comm))
-  {
-    apply_here();
-  }
-  Mpi::Barrier(comm);
-
-  MPI_Comm node_comm = MPI_COMM_NULL;
-  MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, Mpi::Rank(comm), MPI_INFO_NULL,
-                      &node_comm);
-  if (Mpi::Root(node_comm) && !Mpi::Root(comm))
-  {
-    apply_here();
-  }
-  MPI_Comm_free(&node_comm);
-
-  internal::AbortOnNodeFilesystemError(comm, operation, local_error);
-  ApplyOnEachNodeFilesystem(comm,
-                            fmt::format("Cleaning up filesystem operation: {}", operation),
-                            [&]() { fs::remove_all(claim); });
+  ApplyOnEachNodeFilesystem(comm, "Cleaning up " + operation,
+                            [&]() { fs::remove_all(claim_path); });
 }
 
 // Ensure an output directory exists on every node's filesystem. This is
@@ -208,7 +180,7 @@ inline void RemovePreviousOutput(const fs::path &dir, MPI_Comm comm)
 // symlink at the path can be removed. Open and write failures are propagated collectively
 // to keep all ranks on the same MPI control path.
 template <typename Func>
-inline void WriteRootOutputFile(const fs::path &path, MPI_Comm comm, Func &&write)
+inline void WriteRootOutputFile(const fs::path &path, MPI_Comm comm, Func &&write_func)
 {
   BlockTimer bt(Timer::IO);
   ApplyOnRootFilesystem(
@@ -222,7 +194,7 @@ inline void WriteRootOutputFile(const fs::path &path, MPI_Comm comm, Func &&writ
           throw fs::filesystem_error("Could not open output file", path,
                                      std::make_error_code(std::errc::io_error));
         }
-        write(stream);
+        write_func(stream);
         stream.close();
         if (stream.fail())
         {

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fstream>
+#include <memory>
 #include <catch2/catch_test_macros.hpp>
 #include "drivers/basesolver.hpp"
 #include "fixtures.hpp"
+#include "test-helpers.hpp"
 #include "utils/communication.hpp"
 #include "utils/filesystem.hpp"
+#include "utils/geodata.hpp"
+#include "utils/iodata.hpp"
 
 using namespace palace;
 
@@ -181,6 +185,42 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   {
     CHECK(ReadFile(temp_dir / "iteration2" / "domain-E.csv") == "iter2");
   }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveAdaptMesh preserves an archived mesh between iterations",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::RebalanceMesh(iodata, parallel_mesh);
+
+  // Save the first adapted mesh contents for comparison.
+  auto mesh_file = temp_dir / "model.mesh";
+  auto first_mesh = ReadFile(mesh_file);
+  REQUIRE_FALSE(first_mesh.empty());
+
+  // Archive the first mesh, leaving a top-level symlink to it.
+  SaveIteration(comm, temp_dir, 1, 1);
+  REQUIRE(fs::is_symlink(mesh_file));
+  REQUIRE(ReadFile(temp_dir / "iteration1" / "model.mesh") == first_mesh);
+
+  // Simulate the next AMR iteration with a changed mesh.
+  parallel_mesh->GetVertex(0)[0] = -1.0;
+  mesh::RebalanceMesh(iodata, parallel_mesh);
+
+  // The new mesh replaces the symlink without changing the archived mesh.
+  CHECK_FALSE(fs::is_symlink(mesh_file));
+  CHECK(ReadFile(mesh_file) != first_mesh);
+  CHECK(ReadFile(temp_dir / "iteration1" / "model.mesh") == first_mesh);
 }
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -234,6 +234,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   fs::create_directories(temp_dir / "iteration1" / "paraview" / "driven");
   CreateFile(temp_dir / "iteration1" / "paraview" / "driven" / "old.vtu", "old");
   CreateFile(temp_dir / "iteration1" / "domain-E.csv", "old_data");
+  fs::create_directories(temp_dir / "iteration1" / ".palace-archive-claim");
 
   // New run produces fresh output.
   CreateFile(temp_dir / "domain-E.csv", "new_data");
@@ -254,6 +255,11 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   {
     CHECK(fs::is_symlink(temp_dir / "domain-E.csv"));
     CHECK(ReadFile(temp_dir / "domain-E.csv") == "new_data");
+  }
+
+  SECTION("Stale archive claims are removed")
+  {
+    CHECK_FALSE(fs::exists(temp_dir / "iteration1" / ".palace-archive-claim"));
   }
 }
 

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -490,6 +490,47 @@ TEST_CASE_METHOD(test::SharedTempDir, "GridFunction export",
     CHECK_THAT(pvd_time, Catch::Matchers::WithinRel(expected_freq, 1.0e-5));
   }
 
+  SECTION("Driven multiple excitations")
+  {
+    // Create operator with two excitations.
+    iodata.problem.type = ProblemType::DRIVEN;
+    iodata.solver.driven.save_indices = {0};
+    iodata.solver.driven.sample_f = {1.0};
+    json multi_port_boundaries = {{"LumpedPort",
+                                   {{{"Attributes", {2}},
+                                     {"Index", 1},
+                                     {"R", 50.0},
+                                     {"Direction", "+X"},
+                                     {"Excitation", 1}},
+                                    {{"Attributes", {3}},
+                                     {"Index", 2},
+                                     {"R", 50.0},
+                                     {"Direction", "+Y"},
+                                     {"Excitation", 2}}}}};
+    config::BoundaryData multi_port(multi_port_boundaries);
+    iodata.boundaries.lumpedport = multi_port.lumpedport;
+    SpaceOperator space_op(iodata, mesh);
+    PostOperator<ProblemType::DRIVEN> post_op(iodata, space_op);
+
+    ComplexVector E(space_op.GetNDSpace().GetTrueVSize()),
+        B(space_op.GetRTSpace().GetTrueVSize());
+    E = 0.0;
+    B = 0.0;
+    post_op.InitializeParaviewDataCollection(1);
+    post_op.MeasureAndPrintAll(1, 0, E, B, 1.0);
+    post_op.InitializeParaviewDataCollection(2);
+    post_op.MeasureAndPrintAll(2, 0, E, B, 1.0);
+
+    // Switching excitations must preserve both collections.
+    auto root = fs::path(iodata.problem.output) / "paraview";
+    for (int excitation : {1, 2})
+    {
+      auto folder = fmt::format("excitation_{}", excitation);
+      CHECK(fs::is_regular_file(root / "driven" / folder / (folder + ".pvd")));
+      CHECK(fs::is_regular_file(root / "driven_boundary" / folder / (folder + ".pvd")));
+    }
+  }
+
   SECTION("Eigenmode")
   {
     // Create operator.

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -346,8 +346,8 @@ TEST_CASE("PostOperator", "[idempotent][Serial]")
   }
 }
 
-TEST_CASE_METHOD(test::SharedTempDir, "GridFunction export",
-                 "[gridfunction][Serial][Parallel]")
+TEST_CASE_METHOD(test::SharedTempDir, "Field export",
+                 "[gridfunction][paraview][Serial][Parallel]")
 {
   // Create iodata.
   Units units(0.496, 1.453);


### PR DESCRIPTION
Fixes #887. Supersedes #889.

This PR builds on #889 from @alexhad6 and preserves that commit and authorship.

It fixes three related output-filesystem problems:

- Prevent `SaveAdaptMesh` from following a top-level symlink and overwriting a mesh archived by `SaveAdaptIterations`.
- Preserve ParaView output from earlier driven excitations instead of deleting the entire ParaView root when switching excitations.
- Make adaptive iteration archiving safe for shared NFS/SMB filesystems by snapshotting directory entries before modifying them and using an atomic claim so only one node archives each shared filesystem view.

The ParaView fix closes the previous MFEM data collection before switching paths, avoiding deletion of files that may still be open on SMB.

This addresses the filesystem failure discussed in #860, but not the separate field-visualization issue reported there.

Closes #889