### PR TITLE
Limit MFEM #4983 patch to version 4.9

### DIFF
--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -243,6 +243,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
                     "b22f654ab36fe01f1f3176349c60626efed1a6a2/extern/patch/mfem/"
                     "mfem_pr4983.diff",
                     sha256="530532da3ae8815d004bb6ce19f6f08a1248c3d585503551c90d0eeae7fb3f87",
+                    when="@:4.9",
                 ),
                 # https://github.com/mfem/mfem/pull/5124
                 patch(


### PR DESCRIPTION
MFEM #4983 is now part of MFEM develop. Applying Palace's backport to that version causes the x64 and GPU lookahead jobs to fail before Palace builds.

Limit the Spack dependency patch to MFEM 4.9, where it still applies and is still needed. The CMake superbuild stays unchanged because its pinned MFEM commit predates the upstream merge.

Testing:

- `python3 -m py_compile spack_repo/local/packages/palace/package.py`
- `git diff --check`
- Verified that the backport applies cleanly to MFEM 4.9
- Verified that the backport is rejected by current MFEM master

Closes #894