### PR TITLE
Use Palace naming for local constants

### DIFF
--- a/palace/utils/jsonschema.cpp
+++ b/palace/utils/jsonschema.cpp
@@ -29,15 +29,15 @@ namespace
 void FindAllSchemasByKey(const json &schema, const std::string &key, const json &root_defs,
                          std::vector<json> &results, int depth = 0)
 {
-  constexpr int kMaxDepth = 32;
-  if (depth > kMaxDepth)
+  constexpr int max_depth = 32;
+  if (depth > max_depth)
   {
     // Hitting the cap means a self-referential $defs cycle in the schema, which
     // is a developer error rather than bad user input. Warn so it surfaces
     // instead of silently truncating the search.
     Mpi::Warning("Schema search for key '{}' exceeded max depth {}; check for a "
                  "self-referential $defs cycle\n",
-                 key, kMaxDepth);
+                 key, max_depth);
     return;
   }
   if (!schema.is_object())

--- a/palace/utils/memoryreporting.cpp
+++ b/palace/utils/memoryreporting.cpp
@@ -52,7 +52,7 @@ long GetCurrentMemory()
   {
     if (line.compare(0, 6, "VmRSS:") == 0)
     {
-      // Value is in kB.
+      // Value is in kilobytes.
       return std::stol(line.substr(6)) * 1024;
     }
   }
@@ -76,7 +76,7 @@ long GetPeakMemory()
     // macOS reports ru_maxrss in bytes.
     return usage.ru_maxrss;
 #else
-    // Linux reports ru_maxrss in kB.
+    // Linux reports ru_maxrss in kilobytes.
     return usage.ru_maxrss * 1024;
 #endif
   }
@@ -85,23 +85,23 @@ long GetPeakMemory()
 
 std::string FormatBytes(double bytes)
 {
-  constexpr double kB = 1024.0;
-  constexpr double MB = kB * 1024.0;
-  constexpr double GB = MB * 1024.0;
-  constexpr double TB = GB * 1024.0;
-  if (bytes >= TB)
+  constexpr double kilobyte = 1024.0;
+  constexpr double megabyte = kilobyte * 1024.0;
+  constexpr double gigabyte = megabyte * 1024.0;
+  constexpr double terabyte = gigabyte * 1024.0;
+  if (bytes >= terabyte)
   {
-    return fmt::format("{:.1f}T", bytes / TB);
+    return fmt::format("{:.1f}T", bytes / terabyte);
   }
-  if (bytes >= GB)
+  if (bytes >= gigabyte)
   {
-    return fmt::format("{:.1f}G", bytes / GB);
+    return fmt::format("{:.1f}G", bytes / gigabyte);
   }
-  if (bytes >= MB)
+  if (bytes >= megabyte)
   {
-    return fmt::format("{:.1f}M", bytes / MB);
+    return fmt::format("{:.1f}M", bytes / megabyte);
   }
-  return fmt::format("{:.1f}K", bytes / kB);
+  return fmt::format("{:.1f}K", bytes / kilobyte);
 }
 
 namespace

--- a/test/unit/regression/cases.cpp
+++ b/test/unit/regression/cases.cpp
@@ -142,9 +142,9 @@ palace::test::CustomCheck CompareComplexMagnitudes(double rtol, double atol)
 }
 
 // Standard "drop per-element extrema + eigenmode error columns" list.
-const std::vector<std::string> kEigenExcluded = {"Maximum", "Minimum", "Mean",
+const std::vector<std::string> eigen_excluded = {"Maximum", "Minimum", "Mean",
                                                  "Error (Bkwd.)", "Error (Abs.)"};
-constexpr auto kForceDefaultSolver = palace::test::SolverOverridePolicy::ForceDefault;
+constexpr auto force_default_solver = palace::test::SolverOverridePolicy::ForceDefault;
 
 // Floquet-port S-parameters: compare only the |S[...]| (dB) magnitude columns
 // (phase isn't reproducible). NaN entries (evanescent modes) and signals below
@@ -200,7 +200,7 @@ TEST_CASE("rings", "[Serial][Parallel][GPU][Regression]")
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
   opts.excluded_columns = {"Maximum", "Minimum"};
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("rings", "rings.json", "", opts);
 }
 
@@ -210,7 +210,7 @@ TEST_CASE("circular_hole_flux_loop", "[Serial][Parallel][GPU][Regression]")
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
   opts.excluded_columns = {"Maximum", "Minimum", "Mean"};
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("circular_hole", "circular_hole.json", "", opts);
 }
 
@@ -221,9 +221,9 @@ TEST_CASE("cylinder_cavity_pec", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cylinder", "cavity_pec.json", "cavity_pec", opts);
 }
 
@@ -232,7 +232,7 @@ TEST_CASE("cylinder_cavity_impedance", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   palace::test::RunRegressionCase("cylinder", "cavity_impedance.json", "cavity_impedance",
                                   opts);
@@ -243,7 +243,7 @@ TEST_CASE("cylinder_waveguide", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   palace::test::RunRegressionCase("cylinder", "waveguide.json", "waveguide", opts);
 }
@@ -253,7 +253,7 @@ TEST_CASE("cylinder_floquet", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   palace::test::RunRegressionCase("cylinder", "floquet.json", "floquet", opts);
 }
@@ -392,7 +392,7 @@ TEST_CASE("rational_impedance_eigen", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 2.0e-2;
   opts.atol = 1.0e-11;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   opts.paraview_fields = false;
   palace::test::RunRegressionCase("rational_impedance", "series_rlc18_rational_eigen.json",
@@ -459,7 +459,7 @@ TEST_CASE("cpw_wave_eigen", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 2.0e-2;
   opts.atol = 1.0e-11;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   palace::test::RunRegressionCase("cpw", "cpw_wave_eigen.json", "wave_eigen", opts);
 }
@@ -471,7 +471,7 @@ TEST_CASE("adapter_hybrid", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 2.0e-2;
   opts.atol = 1.0e-11;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
   palace::test::RunRegressionCase("adapter", "hybrid.json", "hybrid", opts);
 }
@@ -533,8 +533,8 @@ TEST_CASE("transmon_coarse", "[Serial][Parallel][GPU][Regression][Long]")
   opts.abs_columns = {"\u03ba_ext"};
   opts.skip_rowcount = true;
   opts.gridfunction_fields = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
-  opts.eigen_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
+  opts.eigen_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("transmon", "transmon_coarse.json", "transmon_coarse",
                                   opts);
 }
@@ -549,8 +549,8 @@ TEST_CASE("transmon_amr", "[Serial][Parallel][GPU][Regression][Long]")
   opts.abs_columns = {"\u03ba_ext"};
   opts.skip_rowcount = true;
   opts.gridfunction_fields = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
-  opts.eigen_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
+  opts.eigen_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("transmon", "transmon_amr.json", "transmon_amr", opts);
 }
 
@@ -569,9 +569,9 @@ TEST_CASE("cavity2d_eigenmode", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-16;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cavity2d", "cavity2d.json", "eigenmode", opts);
 }
 
@@ -582,7 +582,7 @@ TEST_CASE("cavity2d_driven", "[Serial][Parallel][GPU][Regression]")
   opts.rtol = 2.0e-2;
   opts.atol = 1.0e-8;
   opts.excluded_columns = {"Maximum", "Minimum"};
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cavity2d", "cavity2d_driven.json", "driven", opts);
 }
 
@@ -602,7 +602,7 @@ TEST_CASE("cavity2d_magnetostatic", "[Serial][Parallel][GPU][Regression]")
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-10;
   opts.excluded_columns = {"Maximum", "Minimum"};
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cavity2d", "cavity2d_magnetostatic.json",
                                   "magnetostatic", opts);
 }
@@ -613,7 +613,7 @@ TEST_CASE("cavity2d_transient", "[Serial][Parallel][GPU][Regression]")
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-10;
   opts.excluded_columns = {"Maximum", "Minimum"};
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cavity2d", "cavity2d_transient.json", "transient", opts);
 }
 
@@ -627,7 +627,7 @@ TEST_CASE("cpw2d_thin", "[Serial][Parallel][GPU][Regression]")
   opts.excluded_columns = {"Maximum",      "Minimum",      "Mean",     "Error (Bkwd.)",
                            "Error (Abs.)", "Im{kn} (1/m)", "Im{n_eff}"};
   opts.skip_rowcount = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   opts.custom_checks["mode-V.csv"] = CompareComplexMagnitudes(opts.rtol, opts.atol);
   palace::test::RunRegressionCase("cpw2d", "cpw2d_thin.json", "thin", opts);
 }
@@ -640,7 +640,7 @@ TEST_CASE("cpw2d_thick_impedance", "[Serial][Parallel][GPU][Regression]")
   opts.excluded_columns = {"Maximum",      "Minimum",      "Mean",     "Error (Bkwd.)",
                            "Error (Abs.)", "Im{kn} (1/m)", "Im{n_eff}"};
   opts.skip_rowcount = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cpw2d", "cpw2d_thick_impedance.json", "thick_impedance",
                                   opts);
 }
@@ -651,8 +651,8 @@ TEST_CASE("cpw_wave_2dmode", "[Serial][Parallel][GPU][Regression]")
   palace::test::RegressionOptions opts;
   opts.rtol = 1.0e-4;
   opts.atol = 1.0e-10;
-  opts.excluded_columns = kEigenExcluded;
+  opts.excluded_columns = eigen_excluded;
   opts.skip_rowcount = true;
-  opts.linear_solver_policy = kForceDefaultSolver;
+  opts.linear_solver_policy = force_default_solver;
   palace::test::RunRegressionCase("cpw", "cpw_wave_2dmode.json", "wave_2dmode", opts);
 }


### PR DESCRIPTION
## Summary

- Rename the remaining Google-style `kCamelCase` constants to ordinary Palace variable names.
- Use descriptive lowercase names for local memory-size constants.

No behavior changes.
