### PR TITLE
Retry transient PPA setup in container CI

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -29,10 +29,20 @@ runs:
         source /tmp/timing_functions.sh
         start_timer
 
-        sudo add-apt-repository -y ppa:apptainer/ppa
-        sudo apt update
-
-        sudo apt install -y podman apptainer
+        for attempt in 1 2 3 4; do
+          if sudo add-apt-repository -y ppa:apptainer/ppa && \
+             sudo apt update && \
+             sudo apt install -y podman apptainer; then
+            break
+          fi
+          if [ "$attempt" -eq 4 ]; then
+            echo "Apptainer PPA setup failed after ${attempt} attempts" >&2
+            exit 1
+          fi
+          delay=$((15 * attempt))
+          echo "Apptainer PPA setup attempt ${attempt} failed; retrying in ${delay}s" >&2
+          sleep "$delay"
+        done
 
         # Configure podman to resolve short image names from Docker Hub
         echo 'unqualified-search-registries = ["docker.io"]' | sudo tee /etc/containers/registries.conf.d/docker.conf

--- a/.github/actions/build-container/spack_env/PalaceDockerfile
+++ b/.github/actions/build-container/spack_env/PalaceDockerfile
@@ -14,8 +14,20 @@ ARG GITHUB_TOKEN=""
 # ubuntu-toolchain-r/test PPA.
 RUN apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get -yqq install --no-install-recommends gcc-16 g++-16 gfortran-16 && \
+    for attempt in 1 2 3 4; do \
+      if add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+         apt-get -yqq update && \
+         apt-get -yqq install --no-install-recommends gcc-16 g++-16 gfortran-16; then \
+        break; \
+      fi; \
+      if [ "$attempt" -eq 4 ]; then \
+        echo "Ubuntu toolchain PPA setup failed after ${attempt} attempts" >&2; \
+        exit 1; \
+      fi; \
+      delay=$((15 * attempt)); \
+      echo "Ubuntu toolchain PPA setup attempt ${attempt} failed; retrying in ${delay}s" >&2; \
+      sleep "$delay"; \
+    done && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy the Palace source tree
@@ -119,8 +131,20 @@ RUN cd {{ paths.environment }} && \
 # against. Remove with the spack.yaml `compilers` group fix.
 RUN apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get -yqq install --no-install-recommends libstdc++6 && \
+    for attempt in 1 2 3 4; do \
+      if add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+         apt-get -yqq update && \
+         apt-get -yqq install --no-install-recommends libstdc++6; then \
+        break; \
+      fi; \
+      if [ "$attempt" -eq 4 ]; then \
+        echo "Ubuntu toolchain PPA setup failed after ${attempt} attempts" >&2; \
+        exit 1; \
+      fi; \
+      delay=$((15 * attempt)); \
+      echo "Ubuntu toolchain PPA setup attempt ${attempt} failed; retrying in ${delay}s" >&2; \
+      sleep "$delay"; \
+    done && \
     apt-get -yqq purge --auto-remove -y software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 {% endblock %}


### PR DESCRIPTION
Fixes #899.

Container builds currently fail before reaching Palace when Launchpad transiently returns `GPGKeyTemporarilyNotFoundError` from `add-apt-repository`.

This adds bounded retry with backoff around the Apptainer and Ubuntu toolchain PPA setup. Transient repository, update, and package-install failures retry in place; permanent failures still terminate after four attempts with the final command output intact.
