### PR TITLE
Add mesh topology metadata to palace.json for SaveAdaptMesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     [PR 902](https://github.com/awslabs/palace/pull/902)
   - Emit a `SavedAdaptedMesh` block to `postpro/palace.json` when
     `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled, recording the true
-    (conforming) topological entity counts (vertices, edges, and faces), the element count,
-    and the sorted domain and boundary attributes of the final adapted mesh.
+    (conforming) topological entity counts of the final adapted mesh broken down by element
+    and face geometry (vertices, edges, faces per face geometry, and cells per element
+    geometry), together with the sorted domain and boundary attributes.
     [PR 911](https://github.com/awslabs/palace/pull/911).
 
 #### Interface Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     1-based index of the most recently completed adaptive mesh refinement (AMR) iteration
     (`1` for the initial solve, matching the `iterationXX` archive subdirectory).
     [PR 902](https://github.com/awslabs/palace/pull/902)
-  - Emit a `Mesh` block to `postpro/palace.json` when
+  - Emit a `SavedAdaptedMesh` block to `postpro/palace.json` when
     `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled, recording the true
     (conforming) topological entity counts (vertices, edges, and faces), the element count,
     and the sorted domain and boundary attributes of the final adapted mesh. This lets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
   - Emit a `SavedAdaptedMesh` block to `postpro/palace.json` when
     `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled, recording the true
     (conforming) topological entity counts (vertices, edges, and faces), the element count,
-    and the sorted domain and boundary attributes of the final adapted mesh. This lets
-    external tooling size a re-run from the saved mesh without re-reading it.
+    and the sorted domain and boundary attributes of the final adapted mesh.
     [PR 911](https://github.com/awslabs/palace/pull/911).
 
 #### Interface Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     (conforming) topological entity counts (vertices, edges, and faces), the element count,
     and the sorted domain and boundary attributes of the final adapted mesh. This lets
     external tooling size a re-run from the saved mesh without re-reading it.
-    [PR XXX](https://github.com/awslabs/palace/pull/XXX).
+    [PR 911](https://github.com/awslabs/palace/pull/911).
 
 #### Interface Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     1-based index of the most recently completed adaptive mesh refinement (AMR) iteration
     (`1` for the initial solve, matching the `iterationXX` archive subdirectory).
     [PR 902](https://github.com/awslabs/palace/pull/902)
+  - Emit a `Mesh` block to `postpro/palace.json` when
+    `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled, recording the true
+    (conforming) topological entity counts (vertices, edges, and faces), the element count,
+    and the sorted domain and boundary attributes of the final adapted mesh. This lets
+    external tooling size a re-run from the saved mesh without re-reading it.
+    [PR XXX](https://github.com/awslabs/palace/pull/XXX).
 
 #### Interface Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,14 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     1-based index of the most recently completed adaptive mesh refinement (AMR) iteration
     (`1` for the initial solve, matching the `iterationXX` archive subdirectory).
     [PR 902](https://github.com/awslabs/palace/pull/902)
-  - Emit a `SavedAdaptedMesh` block to `postpro/palace.json` when
-    `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled, recording the true
-    (conforming) topological entity counts of the final adapted mesh broken down by element
-    and face geometry (vertices, edges, faces per face geometry, and cells per element
-    geometry), together with the sorted domain and boundary attributes.
+  - Emit a `SavedAdaptedMesh` block to `palace.json` when
+    `config["Model"]["Refinement"]["SaveAdaptMesh"]` is enabled and adaptation was performed,
+    recording the true (conforming) topological entity counts of the adapted mesh broken down
+    by element and face geometry (vertices, edges, faces per face geometry, and cells per
+    element geometry), together with the sorted domain and boundary attributes. The block is
+    written for every adapted mesh: the top-level `palace.json` describes the final mesh, and
+    (with `SaveAdaptIterations` also enabled) each `iterationX/palace.json` describes that
+    iteration's mesh, so each saved mesh is paired with a matching block.
     [PR 911](https://github.com/awslabs/palace/pull/911).
 
 #### Interface Changes

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -170,11 +170,9 @@ solve.
 
 When [`config["Model"]["Refinement"]["SaveAdaptMesh"]`](../config/reference.md#config-model-refinement)
 is enabled and adaptation was performed, *Palace* saves the final adapted mesh to disk and
-also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology, so external
-tooling can
-size a re-run from the saved mesh without re-reading it. The block contains:
+also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology. The block contains:
 
-  - `Dimension` : Spatial dimension of the mesh.
+  - `Dimension` : Spatial dimension of the mesh (e.g., 2D, 3D).
   - `TrueVertices`, `TrueEdges`, `TrueFaces` : True (order-independent, conforming) counts of
     the mesh vertices, edges, and codimension-one faces. In 2D the codimension-one faces are
     edges, so `TrueFaces` equals `TrueEdges` there.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -173,9 +173,20 @@ is enabled and adaptation was performed, *Palace* saves the final adapted mesh t
 also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology. The block contains:
 
   - `Dimension` : Spatial dimension of the mesh (e.g., 2D, 3D).
-  - `TrueVertices`, `TrueEdges`, `TrueFaces` : True (order-independent, conforming) counts of
-    the mesh vertices, edges, and codimension-one faces. In 2D the codimension-one faces are
-    edges, so `TrueFaces` equals `TrueEdges` there.
-  - `Elements` : Total number of elements (matching `Problem`'s `MeshElements`).
+  - `TrueVertices`, `TrueEdges` : True (order-independent, conforming) counts of the mesh
+    vertices and edges.
+  - `TrueFaces` : True (conforming) counts of the codimension-one faces, broken down by face
+    geometry (`triangle`, `quadrilateral`); only the geometries with a nonzero count are
+    listed. Reported in 3D only. In 2D the codimension-one faces are edges and are already
+    given by `TrueEdges`, so this field is omitted.
+  - `Cells` : Counts of the mesh elements, broken down by element geometry (`tetrahedron`,
+    `hexahedron`, `prism`, `pyramid` in 3D; `triangle`, `quadrilateral` in 2D); only the
+    geometries with a nonzero count are listed. The sum matches `Problem`'s `MeshElements`.
   - `DomainAttributes`, `BoundaryAttributes` : Sorted lists of the unique domain (material)
     and boundary attributes present in the mesh.
+
+The face and cell counts are reported per geometry because the number of degrees of freedom
+contributed by each entity depends on its geometry at a given finite-element order. Splitting
+the counts this way lets external tooling reconstruct the exact global degree-of-freedom size
+for mixed or non-simplicial meshes, where triangle and quadrilateral faces (and tetrahedral,
+hexahedral, prism, and pyramid cells) each contribute a different per-order count.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -167,3 +167,16 @@ is enabled, the postprocessing results from the solve on the previous mesh will 
 within a subdirectory denoted `iterationX`, where `X` is the (1-based) iteration number.
 The results in the top level directory will always be those from the most recent successful
 solve.
+
+When [`config["Model"]["Refinement"]["SaveAdaptMesh"]`](../config/reference.md#config-model-refinement)
+is enabled and adaptation was performed, *Palace* saves the final adapted mesh to disk and
+also records a `Mesh` block in `palace.json` summarizing its topology, so external tooling can
+size a re-run from the saved mesh without re-reading it. The block contains:
+
+  - `Dimension` : Spatial dimension of the mesh.
+  - `TrueVertices`, `TrueEdges`, `TrueFaces` : True (order-independent, conforming) counts of
+    the mesh vertices, edges, and codimension-one faces. In 2D the codimension-one faces are
+    edges, so `TrueFaces` equals `TrueEdges` there.
+  - `Elements` : Total number of elements (matching `Problem`'s `MeshElements`).
+  - `DomainAttributes`, `BoundaryAttributes` : Sorted lists of the unique domain (material)
+    and boundary attributes present in the mesh.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -169,10 +169,14 @@ The results in the top level directory will always be those from the most recent
 solve.
 
 When [`config["Model"]["Refinement"]["SaveAdaptMesh"]`](../config/reference.md#config-model-refinement)
-is enabled and adaptation was performed, *Palace* saves the final adapted mesh to disk and
-also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology. The block contains:
+is enabled and adaptation was performed, *Palace* saves the adapted mesh to disk and also
+records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology. The block always
+describes the mesh saved next to it: the top-level `palace.json` describes the final adapted
+mesh, and (when `SaveAdaptIterations` is also enabled) each `iterationX/palace.json` describes
+that iteration's saved mesh, so a saved mesh and its block can always be paired. The block
+contains:
 
-  - `Dimension` : Spatial dimension of the mesh (e.g., 2D, 3D).
+  - `Dimension` : Spatial dimension of the mesh, as an integer (`2` or `3`).
   - `TrueVertices`, `TrueEdges` : True (order-independent, conforming) counts of the mesh
     vertices and edges.
   - `TrueFaces` : True (conforming) counts of the codimension-one faces, broken down by face

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -187,6 +187,6 @@ also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topolog
 
 The face and cell counts are reported per geometry because the number of degrees of freedom
 contributed by each entity depends on its geometry at a given finite-element order. Splitting
-the counts this way lets external tooling reconstruct the exact global degree-of-freedom size
-for mixed or non-simplicial meshes, where triangle and quadrilateral faces (and tetrahedral,
+the counts this way makes the exact global degree-of-freedom size recoverable for mixed or
+non-simplicial meshes, where triangle and quadrilateral faces (and tetrahedral,
 hexahedral, prism, and pyramid cells) each contribute a different per-order count.

--- a/docs/src/guide/postprocessing.md
+++ b/docs/src/guide/postprocessing.md
@@ -170,7 +170,8 @@ solve.
 
 When [`config["Model"]["Refinement"]["SaveAdaptMesh"]`](../config/reference.md#config-model-refinement)
 is enabled and adaptation was performed, *Palace* saves the final adapted mesh to disk and
-also records a `Mesh` block in `palace.json` summarizing its topology, so external tooling can
+also records a `SavedAdaptedMesh` block in `palace.json` summarizing its topology, so external
+tooling can
 size a re-run from the saved mesh without re-reading it. The block contains:
 
   - `Dimension` : Spatial dimension of the mesh.

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -231,6 +231,10 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
     return ret;
   };
 
+  // True topological entity counts of the final adapted mesh, filled by RebalanceMesh on
+  // the root rank whenever an adapted mesh is written (Model.Refinement.SaveAdaptMesh).
+  mesh::MeshEntityCounts mesh_counts;
+
   // Main AMR loop.
   int it = 0;
   while (use_amr && !ExhaustedResources(it, ntdof) && err >= refinement.tol)
@@ -292,7 +296,7 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
 
     // Optionally rebalance and write the adapted mesh to file.
     {
-      const auto ratio_pre = mesh::RebalanceMesh(iodata, *mesh.back());
+      const auto ratio_pre = mesh::RebalanceMesh(iodata, *mesh.back(), &mesh_counts);
       if (ratio_pre > refinement.maximum_imbalance)
       {
         int min_elem, max_elem;
@@ -321,6 +325,13 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
     // iteration 1) matches the "iterationXX" archive subdirectory and signals completion
     // via palace.json without parsing the log.
     SaveAdaptationIteration(it + 1);
+  }
+
+  // Record the final adapted mesh's true topological entity counts (only populated on the
+  // root rank when SaveAdaptMesh wrote a mesh; otherwise left invalid and skipped).
+  if (mesh_counts.valid)
+  {
+    SaveMetadata(mesh_counts);
   }
   Mpi::Print("\nCompleted {:d} iteration{} of adaptive mesh refinement (AMR):\n"
              " Indicator norm = {:.3e}, global unknowns = {:d}\n"
@@ -357,6 +368,25 @@ void BaseSolver::SaveAdaptationIteration(int iteration) const
   {
     json meta = LoadMetadata(post_dir);
     meta["Problem"]["Iteration"] = iteration;
+    WriteMetadata(post_dir, meta);
+  }
+}
+
+void BaseSolver::SaveMetadata(const mesh::MeshEntityCounts &counts) const
+{
+  // Unlike the other SaveMetadata overloads (called on every rank, some running MPI
+  // collectives before writing), this one is invoked on the root rank only, since
+  // MeshEntityCounts::valid is set only on root. It must contain no MPI-collective calls.
+  if (root)
+  {
+    json meta = LoadMetadata(post_dir);
+    meta["Mesh"]["Dimension"] = counts.dim;
+    meta["Mesh"]["TrueVertices"] = counts.true_vertices;
+    meta["Mesh"]["TrueEdges"] = counts.true_edges;
+    meta["Mesh"]["TrueFaces"] = counts.true_faces;
+    meta["Mesh"]["Elements"] = counts.elements;
+    meta["Mesh"]["DomainAttributes"] = counts.domain_attributes;
+    meta["Mesh"]["BoundaryAttributes"] = counts.boundary_attributes;
     WriteMetadata(post_dir, meta);
   }
 }

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -332,6 +332,16 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
       mesh.back()->Update();
     }
 
+    // Record the adapted mesh's true topology into palace.json.
+    if (refinement.save_adapt_mesh)
+    {
+      mesh::CompleteMeshEntityCounts(*mesh.back(), mesh_counts);
+      if (mesh_counts.valid)
+      {
+        SaveMetadata(mesh_counts);
+      }
+    }
+
     // Print statistics (element counts, size h, and shape regularity kappa) for the
     // newly-refined mesh so the evolution of mesh quality under AMR is visible.
     mesh::PrintMeshInfo(*mesh.back(), iodata, /*full=*/false);
@@ -348,16 +358,6 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
     SaveAdaptationIteration(it + 1);
   }
 
-  // Complete nonconforming vertex and edge counts collectively on the final distributed
-  // mesh. RebalanceMesh already populated the remaining counts while writing the mesh.
-  if (it > 0 && refinement.save_adapt_mesh)
-  {
-    mesh::CompleteMeshEntityCounts(*mesh.back(), mesh_counts);
-  }
-  if (mesh_counts.valid)
-  {
-    SaveMetadata(mesh_counts);
-  }
   Mpi::Print("\nCompleted {:d} iteration{} of adaptive mesh refinement (AMR):\n"
              " Indicator norm = {:.3e}, global unknowns = {:d}\n"
              " Max. iterations = {:d}, tol. = {:.3e}{}\n",

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -141,6 +141,28 @@ void WriteMetadata(const fs::path &post_dir, const json &meta)
   fs::rename(tmp_path, path);
 }
 
+// Map an MFEM geometry type to its lowercase JSON key used in the SavedAdaptedMesh block.
+const char *GeometryKey(mfem::Geometry::Type geom)
+{
+  switch (geom)
+  {
+    case mfem::Geometry::TRIANGLE:
+      return "triangle";
+    case mfem::Geometry::SQUARE:
+      return "quadrilateral";
+    case mfem::Geometry::TETRAHEDRON:
+      return "tetrahedron";
+    case mfem::Geometry::CUBE:
+      return "hexahedron";
+    case mfem::Geometry::PRISM:
+      return "prism";
+    case mfem::Geometry::PYRAMID:
+      return "pyramid";
+    default:
+      return "unknown";
+  }
+}
+
 // Returns an array of indices corresponding to marked elements.
 mfem::Array<int> MarkedElements(const Vector &e, double threshold)
 {
@@ -380,13 +402,29 @@ void BaseSolver::SaveMetadata(const mesh::MeshEntityCounts &counts) const
   if (root)
   {
     json meta = LoadMetadata(post_dir);
-    meta["SavedAdaptedMesh"]["Dimension"] = counts.dim;
-    meta["SavedAdaptedMesh"]["TrueVertices"] = counts.true_vertices;
-    meta["SavedAdaptedMesh"]["TrueEdges"] = counts.true_edges;
-    meta["SavedAdaptedMesh"]["TrueFaces"] = counts.true_faces;
-    meta["SavedAdaptedMesh"]["Elements"] = counts.elements;
-    meta["SavedAdaptedMesh"]["DomainAttributes"] = counts.domain_attributes;
-    meta["SavedAdaptedMesh"]["BoundaryAttributes"] = counts.boundary_attributes;
+    json &saved = meta["SavedAdaptedMesh"];
+    saved["Dimension"] = counts.dim;
+    saved["TrueVertices"] = counts.true_vertices;
+    saved["TrueEdges"] = counts.true_edges;
+    // Per-geometry counts emit only the geometries that are present; a missing key means
+    // zero by contract. TrueFaces is omitted entirely in 2D (the map is empty there).
+    if (!counts.true_faces.empty())
+    {
+      json faces = json::object();
+      for (const auto &[geom, count] : counts.true_faces)
+      {
+        faces[GeometryKey(geom)] = count;
+      }
+      saved["TrueFaces"] = faces;
+    }
+    json cells = json::object();
+    for (const auto &[geom, count] : counts.cells)
+    {
+      cells[GeometryKey(geom)] = count;
+    }
+    saved["Cells"] = cells;
+    saved["DomainAttributes"] = counts.domain_attributes;
+    saved["BoundaryAttributes"] = counts.boundary_attributes;
     WriteMetadata(post_dir, meta);
   }
 }

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -380,13 +380,13 @@ void BaseSolver::SaveMetadata(const mesh::MeshEntityCounts &counts) const
   if (root)
   {
     json meta = LoadMetadata(post_dir);
-    meta["Mesh"]["Dimension"] = counts.dim;
-    meta["Mesh"]["TrueVertices"] = counts.true_vertices;
-    meta["Mesh"]["TrueEdges"] = counts.true_edges;
-    meta["Mesh"]["TrueFaces"] = counts.true_faces;
-    meta["Mesh"]["Elements"] = counts.elements;
-    meta["Mesh"]["DomainAttributes"] = counts.domain_attributes;
-    meta["Mesh"]["BoundaryAttributes"] = counts.boundary_attributes;
+    meta["SavedAdaptedMesh"]["Dimension"] = counts.dim;
+    meta["SavedAdaptedMesh"]["TrueVertices"] = counts.true_vertices;
+    meta["SavedAdaptedMesh"]["TrueEdges"] = counts.true_edges;
+    meta["SavedAdaptedMesh"]["TrueFaces"] = counts.true_faces;
+    meta["SavedAdaptedMesh"]["Elements"] = counts.elements;
+    meta["SavedAdaptedMesh"]["DomainAttributes"] = counts.domain_attributes;
+    meta["SavedAdaptedMesh"]["BoundaryAttributes"] = counts.boundary_attributes;
     WriteMetadata(post_dir, meta);
   }
 }

--- a/palace/drivers/basesolver.cpp
+++ b/palace/drivers/basesolver.cpp
@@ -253,8 +253,7 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
     return ret;
   };
 
-  // True topological entity counts of the final adapted mesh, filled by RebalanceMesh on
-  // the root rank whenever an adapted mesh is written (Model.Refinement.SaveAdaptMesh).
+  // True topological entity counts of the final adapted mesh.
   mesh::MeshEntityCounts mesh_counts;
 
   // Main AMR loop.
@@ -349,8 +348,12 @@ void BaseSolver::SolveEstimateMarkRefine(std::vector<std::unique_ptr<Mesh>> &mes
     SaveAdaptationIteration(it + 1);
   }
 
-  // Record the final adapted mesh's true topological entity counts (only populated on the
-  // root rank when SaveAdaptMesh wrote a mesh; otherwise left invalid and skipped).
+  // Complete nonconforming vertex and edge counts collectively on the final distributed
+  // mesh. RebalanceMesh already populated the remaining counts while writing the mesh.
+  if (it > 0 && refinement.save_adapt_mesh)
+  {
+    mesh::CompleteMeshEntityCounts(*mesh.back(), mesh_counts);
+  }
   if (mesh_counts.valid)
   {
     SaveMetadata(mesh_counts);

--- a/palace/drivers/basesolver.hpp
+++ b/palace/drivers/basesolver.hpp
@@ -9,6 +9,7 @@
 #include <fmt/os.h>
 #include "fem/errorindicator.hpp"
 #include "utils/filesystem.hpp"
+#include "utils/geodata.hpp"
 #include "utils/memoryreporting.hpp"
 
 namespace mfem
@@ -69,6 +70,7 @@ public:
   void SaveMetadata(const Timer &timer) const;
   void SaveMetadata(const memory_reporting::MemoryStats &peak_memory) const;
   void SaveMetadata(const PortExcitations &excitation_helper) const;
+  void SaveMetadata(const mesh::MeshEntityCounts &counts) const;
 };
 
 // Archive the current postprocessing output for an AMR iteration. Creates a subfolder

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1965,16 +1965,27 @@ namespace
 
 // Fill the per-geometry topological entity counts from a serial mesh. On a serial mesh the
 // true DOF size of a lowest-order FE space equals the global entity count, so no reduction
-// is needed. The counting method depends on whether the mesh is nonconforming:
+// is needed. The counts are reset on entry, so the routine is safe to call repeatedly with
+// the same struct (each AMR iteration reuses one MeshEntityCounts). The counting method
+// depends on whether the mesh is nonconforming:
 //
-//   Nonconforming: NC-list bucketing is wrong in 3D (it over-counts edges via codim-2
-//     face-interior constraints and under-counts faces), so the true counts come from FE
-//     space true sizes. Vertices from H1(1), edges from ND(1). The tri/quad TRUE-face
-//     split is recovered by solving the 2x2 system built from the RT(0) and RT(1) true
-//     sizes after subtracting the exact raw-cell RT contributions (no NC list needed):
-//       F_tri + F_quad     = RT0_true - K0       (t0 == s0 == 1)
-//       t1*F_tri + s1*F_quad = RT1_true - K1
-//     where K0/K1 are the sums over raw cells of RT(p).DofForGeometry(cell_geom).
+//   Nonconforming:
+//     - vertices: H1(1) true size. Hanging vertices are constrained through the master
+//       edges/faces they lie on and are NOT flagged in the NC vertex list (which lists
+//       every leaf vertex as "conforming"), so the FE-space true size is the reliable
+//       count -- an NC-vertex-list count would return the raw leaf vertex count.
+//     - edges: ND(1) true size. Edges interior to a master face are constrained by that
+//       face (not by an edge master), so they are NOT slave edges in the NC edge list; the
+//       FE-space true size accounts for them, a raw NC-edge-list count would over-count.
+//     - faces (3D): DIRECT per-geometry count from the NC face list. Every leaf face is a
+//       TRUE face unless it is a hanging SLAVE constrained by a master, so classifying each
+//       leaf face with NCList::GetMeshIdType and dropping only SLAVE faces gives exactly
+//       GetNFaces() - (#constrained faces) == the RT(0) true size, and bucketing by
+//       GetFaceGeometry recovers the exact tri/quad split. CONFORMING and MASTER faces are
+//       true; boundary faces are UNRECOGNIZED (absent from the list) but still true. This
+//       replaces a prior RT(0)/RT(1) 2x2 GetTrueVSize solve that was invalid on
+//       nonconforming meshes (GetTrueVSize does not distribute per face there) and emitted
+//       negative face counts on mixed meshes.
 //
 //   Conforming: true == leaf, so raw per-geometry counts are used directly (no FE spaces):
 //     vertices GetNV(), edges GetNEdges(), faces bucketed via GetFaceGeometry() (3D only),
@@ -1983,8 +1994,26 @@ namespace
 // FE spaces are each scoped in their own block so at most one is alive at a time (built,
 // read, and destroyed before the next), keeping peak memory low. Attributes are already
 // sorted and unique on mfem::Mesh.
+//
+// MPI INVARIANT (root-only, non-collective): when called from RebalanceMesh on a
+// nonconforming mesh, `smesh` is a ParMesh whose ncmesh is a ParNCMesh holding every
+// element on the root rank, and this routine runs on the root rank ONLY. The H1(1) and
+// ND(1) GetTrueVSize() calls and the ncmesh->GetFaceList() call all reach
+// ParNCMesh::Build{Vertex,Edge,Face}List. Those overrides perform NO MPI communication
+// (verified against MFEM commit 66dbe60cb1, mesh/pncmesh.cpp: they compute only local
+// ownership and shared-entity metadata, and CalcFaceOrientations is documented "done
+// locally, without communication"), which is the ONLY reason this root-only routine cannot
+// deadlock. The prior RT/H1/ND FE spaces already relied on this same invariant via
+// GetFaceList(), so switching faces to a direct GetFaceList() adds no new collective risk.
+// If a future MFEM makes any Build*List collective, the [Parallel] RebalanceMesh count test
+// will hang -- fix by moving this whole routine to a collective call site, not by silencing.
 void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 {
+  // Reset first: the accumulating members (cells, and true_faces below) must never sum
+  // across AMR iterations that reuse the same struct. Scalars are re-set below and `valid`
+  // is re-set at the end.
+  counts = MeshEntityCounts{};
+
   const int dim = smesh.Dimension();
   counts.dim = dim;
 
@@ -1996,6 +2025,9 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 
   if (smesh.Nonconforming())
   {
+    // Root-only, non-collective: see the "MPI INVARIANT" note in the block comment above.
+    // Every GetTrueVSize()/GetFaceList() call below reaches a ParNCMesh::Build*List that
+    // does no MPI communication (pinned to MFEM commit 66dbe60cb1).
     {
       mfem::H1_FECollection h1_fec(1, dim);
       mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
@@ -2008,76 +2040,21 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
     }
     if (dim == 3)
     {
-      // Solve the tri/quad TRUE-face split from the RT(0) and RT(1) true sizes.
-      long long rt0_true = 0, t0 = 0, s0 = 0, k0 = 0;
+      // DIRECT per-geometry TRUE-face count from the NC face list (see the block comment
+      // above for why this is exact and why it replaced the RT(0)/RT(1) solve). Every leaf
+      // face is a TRUE face unless it is a hanging SLAVE constrained by a master; CONFORMING
+      // and MASTER faces are true, and boundary faces are UNRECOGNIZED (absent from the
+      // list) but still true. Counting non-SLAVE faces therefore yields exactly
+      // GetNFaces() - (#constrained faces) == the RT(0) true size, and bucketing each by
+      // GetFaceGeometry (the same source the conforming path uses) recovers the tri/quad
+      // split with no linear solve and no clamp.
+      const mfem::NCMesh::NCList &face_list = smesh.ncmesh->GetFaceList();
+      for (int f = 0; f < smesh.GetNFaces(); f++)
       {
-        mfem::RT_FECollection rt0_fec(0, dim);
-        mfem::FiniteElementSpace rt0_fespace(&smesh, &rt0_fec);
-        rt0_true = rt0_fespace.GetTrueVSize();
-        t0 = rt0_fec.DofForGeometry(mfem::Geometry::TRIANGLE);
-        s0 = rt0_fec.DofForGeometry(mfem::Geometry::SQUARE);
-        for (const auto &[geom, count] : counts.cells)
+        if (face_list.GetMeshIdType(f) != mfem::NCMesh::NCList::MeshIdType::SLAVE)
         {
-          k0 += count * rt0_fec.DofForGeometry(geom);
+          counts.true_faces[smesh.GetFaceGeometry(f)]++;
         }
-      }
-      long long rt1_true = 0, t1 = 0, s1 = 0, k1 = 0;
-      {
-        mfem::RT_FECollection rt1_fec(1, dim);
-        mfem::FiniteElementSpace rt1_fespace(&smesh, &rt1_fec);
-        rt1_true = rt1_fespace.GetTrueVSize();
-        t1 = rt1_fec.DofForGeometry(mfem::Geometry::TRIANGLE);
-        s1 = rt1_fec.DofForGeometry(mfem::Geometry::SQUARE);
-        for (const auto &[geom, count] : counts.cells)
-        {
-          k1 += count * rt1_fec.DofForGeometry(geom);
-        }
-      }
-      const long long b0 = rt0_true - k0;  // == F_tri + F_quad (t0 == s0 == 1)
-      const long long b1 = rt1_true - k1;
-      // The tri/quad split is fixed FIRST by which cell geometries are present: a face
-      // geometry can only occur if some cell bears it. Tetrahedra bear only triangular
-      // faces, hexahedra only quadrilateral, prisms and pyramids both. Keying off the
-      // (exact, raw==true) cell counts sidesteps the RT true-size solve in the common
-      // pure-tet / pure-hex cases, where that solve is UNRELIABLE on nonconforming
-      // meshes: GetTrueVSize does not distribute cleanly per face there, so b1 != t1*b0
-      // even for a pure-tet mesh and the solve emits a spurious negative count.
-      const bool tri_faced = counts.cells.count(mfem::Geometry::TETRAHEDRON) ||
-                             counts.cells.count(mfem::Geometry::PRISM) ||
-                             counts.cells.count(mfem::Geometry::PYRAMID);
-      const bool quad_faced = counts.cells.count(mfem::Geometry::CUBE) ||
-                              counts.cells.count(mfem::Geometry::PRISM) ||
-                              counts.cells.count(mfem::Geometry::PYRAMID);
-      long long f_tri = 0, f_quad = 0;
-      if (!quad_faced)
-      {
-        f_tri = b0;  // only triangular faces are possible (or no faces at all)
-      }
-      else if (!tri_faced)
-      {
-        f_quad = b0;  // only quadrilateral faces are possible
-      }
-      else if (t0 == 1 && s0 == 1 && (s1 - t1) != 0)
-      {
-        // Genuinely mixed tri+quad faces (prism/pyramid, or tet+hex). Recover the split
-        // from the RT(0)/RT(1) true sizes, clamped to [0, b0] so an imperfect
-        // nonconforming decomposition can never produce a negative or overlarge count.
-        f_quad = (b1 - t1 * b0) / (s1 - t1);
-        f_quad = std::max<long long>(0, std::min<long long>(f_quad, b0));
-        f_tri = b0 - f_quad;
-      }
-      else
-      {
-        // Fallback (should not happen for RT on standard geometries).
-        f_tri = b0;
-      }
-      if (f_tri != 0)
-      {
-        counts.true_faces[mfem::Geometry::TRIANGLE] = f_tri;
-      }
-      if (f_quad != 0)
-      {
-        counts.true_faces[mfem::Geometry::SQUARE] = f_quad;
       }
     }
   }

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1963,43 +1963,15 @@ std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
 namespace
 {
 
-// Fill the per-geometry topological entity counts from a gathered serial mesh. On a serial
-// mesh the true DOF size of a lowest-order FE space equals the global entity count, so no
-// MPI reduction is needed. `counts` is reset on entry, so this is safe to call repeatedly
-// with the same struct (each AMR iteration reuses one MeshEntityCounts).
+// Fill geometry-resolved topological entity counts from a gathered serial mesh. `counts` is
+// reset on entry, so this is safe to call repeatedly with the same struct.
 //
 // Cells are a raw per-geometry count (interior DOFs are never constrained, so raw == true).
-// The remaining entities depend on whether the mesh is nonconforming:
-//
-//   Conforming: true == leaf, so raw per-geometry counts are exact (no FE spaces): vertices
-//   GetNV(), edges GetNEdges(), faces bucketed by GetFaceGeometry() (3D only).
-//
-//   Nonconforming:
-//     - vertices: H1(1) true size. The NC vertex list flags every leaf vertex as conforming
-//       (no masters/slaves), so a list count would return the raw leaf count and over-count
-//       hanging vertices; the FE-space true size is the reliable count.
-//     - edges: ND(1) true size. Edges interior to a master face are face-constrained
-//       (they have no edge-master), so they are NOT slave edges in the NC edge list; a list
-//       count would over-count them, while the FE-space true size accounts for them.
-//     - faces (3D): a direct per-geometry count of non-SLAVE leaf faces from the NC face
-//       list. Every leaf face is TRUE unless it is a hanging SLAVE (CONFORMING and MASTER
-//       faces are true; boundary faces are UNRECOGNIZED (not in the list) but still true),
-//       so dropping only SLAVE faces yields exactly the RT(0) true size, and
-//       bucketing by GetFaceGeometry recovers the tri/quad split with no linear solve. This
-//       replaces a prior RT(0)/RT(1) 2x2 GetTrueVSize solve that was invalid on
-//       nonconforming meshes and emitted negative face counts on mixed meshes.
-//
-// The two FE spaces are each scoped so at most one is alive at a time, keeping peak memory
-// low. Attributes are already sorted and unique on mfem::Mesh.
-//
-// MPI INVARIANT (root-only, non-collective): when called from RebalanceMesh on a
-// nonconforming mesh, `smesh` is a ParMesh whose ParNCMesh holds every element on the root
-// rank, and this runs on the root rank ONLY. The H1(1)/ND(1) GetTrueVSize() and the
-// GetFaceList() calls all reach ParNCMesh::Build{Vertex,Edge,Face}List, which do NO MPI
-// communication (verified against MFEM commit 66dbe60cb1) -- the ONLY reason this root-only
-// routine cannot deadlock. If a future MFEM makes any Build*List collective, the [Parallel]
-// RebalanceMesh count test will hang; fix by moving this routine to a collective call site,
-// not by silencing.
+// On a conforming mesh, raw vertex, edge, and face counts are also true counts. On a
+// nonconforming mesh, CompleteMeshEntityCounts supplies true vertices and edges
+// collectively from distributed H1(1) and ND(1) spaces. True faces are counted here by
+// dropping hanging SLAVE faces from the NC face list; this list construction is
+// non-collective in MFEM.
 void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 {
   // Reset first so the accumulating members (cells, true_faces) never sum across AMR
@@ -2014,21 +1986,8 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
     counts.cells[smesh.GetElementBaseGeometry(i)]++;
   }
 
-  if (smesh.Nonconforming())
-  {
-    // Root-only, non-collective: see the MPI INVARIANT note in the block comment above.
-    {
-      mfem::H1_FECollection h1_fec(1, dim);
-      mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
-      counts.true_vertices = h1_fespace.GetTrueVSize();
-    }
-    {
-      mfem::ND_FECollection nd_fec(1, dim);
-      mfem::FiniteElementSpace nd_fespace(&smesh, &nd_fec);
-      counts.true_edges = nd_fespace.GetTrueVSize();
-    }
-  }
-  else
+  const bool nonconforming = smesh.Nonconforming();
+  if (!nonconforming)
   {
     counts.true_vertices = smesh.GetNV();
     counts.true_edges = (dim >= 2) ? smesh.GetNEdges() : 0;
@@ -2040,7 +1999,7 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
     // true. Nonconforming: count non-SLAVE leaf faces from the NC face list (== RT(0) true
     // size; see the block comment above). Bucketed by GetFaceGeometry either way.
     const mfem::NCMesh::NCList *face_list =
-        smesh.Nonconforming() ? &smesh.ncmesh->GetFaceList() : nullptr;
+        nonconforming ? &smesh.ncmesh->GetFaceList() : nullptr;
     for (int f = 0; f < smesh.GetNFaces(); f++)
     {
       if (face_list == nullptr ||
@@ -2055,10 +2014,41 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
       std::vector<int>(smesh.attributes.begin(), smesh.attributes.end());
   counts.boundary_attributes =
       std::vector<int>(smesh.bdr_attributes.begin(), smesh.bdr_attributes.end());
-  counts.valid = true;
+  counts.valid = !nonconforming;
 }
 
 }  // namespace
+
+void CompleteMeshEntityCounts(mfem::ParMesh &mesh, MeshEntityCounts &counts)
+{
+  if (!mesh.Nonconforming())
+  {
+    return;
+  }
+
+  const int dim = mesh.Dimension();
+  HYPRE_BigInt true_vertices;
+  {
+    mfem::H1_FECollection h1_fec(1, dim);
+    mfem::ParFiniteElementSpace h1_fespace(&mesh, &h1_fec);
+    true_vertices = h1_fespace.GlobalTrueVSize();
+  }
+  HYPRE_BigInt true_edges;
+  {
+    mfem::ND_FECollection nd_fec(1, dim);
+    mfem::ParFiniteElementSpace nd_fespace(&mesh, &nd_fec);
+    true_edges = nd_fespace.GlobalTrueVSize();
+  }
+
+  if (Mpi::Root(mesh.GetComm()))
+  {
+    MFEM_VERIFY(counts.dim == dim && !counts.cells.empty(),
+                "Missing gathered mesh entity counts!");
+    counts.true_vertices = static_cast<long long>(true_vertices);
+    counts.true_edges = static_cast<long long>(true_edges);
+    counts.valid = true;
+  }
+}
 
 double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
                      MeshEntityCounts *out_counts)

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1963,27 +1963,115 @@ std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
 namespace
 {
 
-// Fill the (order-independent) topological entity counts from a serial mesh using
-// lowest-order finite-element spaces: H1(1) -> true vertices, ND(1) -> true edges,
-// RT(0) -> true faces, L2(0) -> elements. On a serial mesh the true DOF size equals the
-// global entity count, so no reduction is needed. Mirrors the serial FE space pattern in
-// postoperator.cpp. Attributes are already sorted and unique on mfem::Mesh.
+// Fill the per-geometry topological entity counts from a serial mesh. On a serial mesh the
+// true DOF size of a lowest-order FE space equals the global entity count, so no reduction
+// is needed. The counting method depends on whether the mesh is nonconforming:
+//
+//   Nonconforming: NC-list bucketing is wrong in 3D (it over-counts edges via codim-2
+//     face-interior constraints and under-counts faces), so the true counts come from FE
+//     space true sizes. Vertices from H1(1), edges from ND(1). The tri/quad TRUE-face
+//     split is recovered by solving the 2x2 system built from the RT(0) and RT(1) true
+//     sizes after subtracting the exact raw-cell RT contributions (no NC list needed):
+//       F_tri + F_quad     = RT0_true - K0       (t0 == s0 == 1)
+//       t1*F_tri + s1*F_quad = RT1_true - K1
+//     where K0/K1 are the sums over raw cells of RT(p).DofForGeometry(cell_geom).
+//
+//   Conforming: true == leaf, so raw per-geometry counts are used directly (no FE spaces):
+//     vertices GetNV(), edges GetNEdges(), faces bucketed via GetFaceGeometry() (3D only),
+//     cells via GetElementBaseGeometry().
+//
+// FE spaces are each scoped in their own block so at most one is alive at a time (built,
+// read, and destroyed before the next), keeping peak memory low. Attributes are already
+// sorted and unique on mfem::Mesh.
 void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 {
   const int dim = smesh.Dimension();
-  mfem::H1_FECollection h1_fec(1, dim);
-  mfem::ND_FECollection nd_fec(1, dim);
-  mfem::RT_FECollection rt_fec(0, dim);
-  mfem::L2_FECollection l2_fec(0, dim);
-  mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
-  mfem::FiniteElementSpace nd_fespace(&smesh, &nd_fec);
-  mfem::FiniteElementSpace rt_fespace(&smesh, &rt_fec);
-  mfem::FiniteElementSpace l2_fespace(&smesh, &l2_fec);
   counts.dim = dim;
-  counts.true_vertices = h1_fespace.GetTrueVSize();
-  counts.true_edges = nd_fespace.GetTrueVSize();
-  counts.true_faces = rt_fespace.GetTrueVSize();
-  counts.elements = l2_fespace.GetTrueVSize();
+
+  // Raw per-geometry cell counts (interior DOFs are never constrained, so raw == true).
+  for (int i = 0; i < smesh.GetNE(); i++)
+  {
+    counts.cells[smesh.GetElementBaseGeometry(i)]++;
+  }
+
+  if (smesh.Nonconforming())
+  {
+    {
+      mfem::H1_FECollection h1_fec(1, dim);
+      mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
+      counts.true_vertices = h1_fespace.GetTrueVSize();
+    }
+    {
+      mfem::ND_FECollection nd_fec(1, dim);
+      mfem::FiniteElementSpace nd_fespace(&smesh, &nd_fec);
+      counts.true_edges = nd_fespace.GetTrueVSize();
+    }
+    if (dim == 3)
+    {
+      // Solve the tri/quad TRUE-face split from the RT(0) and RT(1) true sizes.
+      long long rt0_true = 0, t0 = 0, s0 = 0, k0 = 0;
+      {
+        mfem::RT_FECollection rt0_fec(0, dim);
+        mfem::FiniteElementSpace rt0_fespace(&smesh, &rt0_fec);
+        rt0_true = rt0_fespace.GetTrueVSize();
+        t0 = rt0_fec.DofForGeometry(mfem::Geometry::TRIANGLE);
+        s0 = rt0_fec.DofForGeometry(mfem::Geometry::SQUARE);
+        for (const auto &[geom, count] : counts.cells)
+        {
+          k0 += count * rt0_fec.DofForGeometry(geom);
+        }
+      }
+      long long rt1_true = 0, t1 = 0, s1 = 0, k1 = 0;
+      {
+        mfem::RT_FECollection rt1_fec(1, dim);
+        mfem::FiniteElementSpace rt1_fespace(&smesh, &rt1_fec);
+        rt1_true = rt1_fespace.GetTrueVSize();
+        t1 = rt1_fec.DofForGeometry(mfem::Geometry::TRIANGLE);
+        s1 = rt1_fec.DofForGeometry(mfem::Geometry::SQUARE);
+        for (const auto &[geom, count] : counts.cells)
+        {
+          k1 += count * rt1_fec.DofForGeometry(geom);
+        }
+      }
+      const long long b0 = rt0_true - k0;  // == F_tri + F_quad (t0 == s0 == 1)
+      const long long b1 = rt1_true - k1;
+      long long f_tri = 0, f_quad = 0;
+      if (t0 == 1 && s0 == 1 && (s1 - t1) != 0)
+      {
+        f_quad = (b1 - t1 * b0) / (s1 - t1);
+        f_tri = b0 - f_quad;
+      }
+      else
+      {
+        // Fallback (should not happen for RT on standard geometries).
+        f_tri = b0;
+        f_quad = 0;
+      }
+      if (f_tri != 0)
+      {
+        counts.true_faces[mfem::Geometry::TRIANGLE] = f_tri;
+      }
+      if (f_quad != 0)
+      {
+        counts.true_faces[mfem::Geometry::SQUARE] = f_quad;
+      }
+    }
+  }
+  else
+  {
+    // Conforming: true == leaf, so use raw per-geometry counts (no FE spaces needed).
+    counts.true_vertices = smesh.GetNV();
+    counts.true_edges = (dim >= 2) ? smesh.GetNEdges() : 0;
+    if (dim == 3)
+    {
+      // In 2D GetNFaces() == 0, so this loop is guarded to 3D.
+      for (int f = 0; f < smesh.GetNFaces(); f++)
+      {
+        counts.true_faces[smesh.GetFaceGeometry(f)]++;
+      }
+    }
+  }
+
   counts.domain_attributes =
       std::vector<int>(smesh.attributes.begin(), smesh.attributes.end());
   counts.boundary_attributes =

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -2035,17 +2035,41 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
       }
       const long long b0 = rt0_true - k0;  // == F_tri + F_quad (t0 == s0 == 1)
       const long long b1 = rt1_true - k1;
+      // The tri/quad split is fixed FIRST by which cell geometries are present: a face
+      // geometry can only occur if some cell bears it. Tetrahedra bear only triangular
+      // faces, hexahedra only quadrilateral, prisms and pyramids both. Keying off the
+      // (exact, raw==true) cell counts sidesteps the RT true-size solve in the common
+      // pure-tet / pure-hex cases, where that solve is UNRELIABLE on nonconforming
+      // meshes: GetTrueVSize does not distribute cleanly per face there, so b1 != t1*b0
+      // even for a pure-tet mesh and the solve emits a spurious negative count.
+      const bool tri_faced = counts.cells.count(mfem::Geometry::TETRAHEDRON) ||
+                             counts.cells.count(mfem::Geometry::PRISM) ||
+                             counts.cells.count(mfem::Geometry::PYRAMID);
+      const bool quad_faced = counts.cells.count(mfem::Geometry::CUBE) ||
+                              counts.cells.count(mfem::Geometry::PRISM) ||
+                              counts.cells.count(mfem::Geometry::PYRAMID);
       long long f_tri = 0, f_quad = 0;
-      if (t0 == 1 && s0 == 1 && (s1 - t1) != 0)
+      if (!quad_faced)
       {
+        f_tri = b0;  // only triangular faces are possible (or no faces at all)
+      }
+      else if (!tri_faced)
+      {
+        f_quad = b0;  // only quadrilateral faces are possible
+      }
+      else if (t0 == 1 && s0 == 1 && (s1 - t1) != 0)
+      {
+        // Genuinely mixed tri+quad faces (prism/pyramid, or tet+hex). Recover the split
+        // from the RT(0)/RT(1) true sizes, clamped to [0, b0] so an imperfect
+        // nonconforming decomposition can never produce a negative or overlarge count.
         f_quad = (b1 - t1 * b0) / (s1 - t1);
+        f_quad = std::max<long long>(0, std::min<long long>(f_quad, b0));
         f_tri = b0 - f_quad;
       }
       else
       {
         // Fallback (should not happen for RT on standard geometries).
         f_tri = b0;
-        f_quad = 0;
       }
       if (f_tri != 0)
       {

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1960,7 +1960,41 @@ std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
   return DistributeMesh(comm, smesh, partitioning.get());
 }
 
-double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh)
+namespace
+{
+
+// Fill the (order-independent) topological entity counts from a serial mesh using
+// lowest-order finite-element spaces: H1(1) -> true vertices, ND(1) -> true edges,
+// RT(0) -> true faces, L2(0) -> elements. On a serial mesh the true DOF size equals the
+// global entity count, so no reduction is needed. Mirrors the serial FE space pattern in
+// postoperator.cpp. Attributes are already sorted and unique on mfem::Mesh.
+void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
+{
+  const int dim = smesh.Dimension();
+  mfem::H1_FECollection h1_fec(1, dim);
+  mfem::ND_FECollection nd_fec(1, dim);
+  mfem::RT_FECollection rt_fec(0, dim);
+  mfem::L2_FECollection l2_fec(0, dim);
+  mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
+  mfem::FiniteElementSpace nd_fespace(&smesh, &nd_fec);
+  mfem::FiniteElementSpace rt_fespace(&smesh, &rt_fec);
+  mfem::FiniteElementSpace l2_fespace(&smesh, &l2_fec);
+  counts.dim = dim;
+  counts.true_vertices = h1_fespace.GetTrueVSize();
+  counts.true_edges = nd_fespace.GetTrueVSize();
+  counts.true_faces = rt_fespace.GetTrueVSize();
+  counts.elements = l2_fespace.GetTrueVSize();
+  counts.domain_attributes =
+      std::vector<int>(smesh.attributes.begin(), smesh.attributes.end());
+  counts.boundary_attributes =
+      std::vector<int>(smesh.bdr_attributes.begin(), smesh.bdr_attributes.end());
+  counts.valid = true;
+}
+
+}  // namespace
+
+double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
+                     MeshEntityCounts *out_counts)
 {
   BlockTimer bt0(Timer::REBALANCE);
   MPI_Comm comm = mesh->GetComm();
@@ -1972,6 +2006,13 @@ double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh)
 
     auto PrintSerial = [&](mfem::Mesh &smesh)
     {
+      // The gathered serial mesh holds all elements on the root rank, so its lowest-order
+      // FE spaces give the exact global topological counts. Compute before writing (the
+      // counts are scale-invariant, so dimensionalization inside the write is irrelevant).
+      if (out_counts != nullptr && Mpi::Root(comm))
+      {
+        FillMeshEntityCounts(smesh, *out_counts);
+      }
       WriteRootOutputFile(
           sfile, comm,
           [&](std::ostream &stream)

--- a/palace/utils/geodata.cpp
+++ b/palace/utils/geodata.cpp
@@ -1963,61 +1963,52 @@ std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
 namespace
 {
 
-// Fill the per-geometry topological entity counts from a serial mesh. On a serial mesh the
-// true DOF size of a lowest-order FE space equals the global entity count, so no reduction
-// is needed. The counts are reset on entry, so the routine is safe to call repeatedly with
-// the same struct (each AMR iteration reuses one MeshEntityCounts). The counting method
-// depends on whether the mesh is nonconforming:
+// Fill the per-geometry topological entity counts from a gathered serial mesh. On a serial
+// mesh the true DOF size of a lowest-order FE space equals the global entity count, so no
+// MPI reduction is needed. `counts` is reset on entry, so this is safe to call repeatedly
+// with the same struct (each AMR iteration reuses one MeshEntityCounts).
+//
+// Cells are a raw per-geometry count (interior DOFs are never constrained, so raw == true).
+// The remaining entities depend on whether the mesh is nonconforming:
+//
+//   Conforming: true == leaf, so raw per-geometry counts are exact (no FE spaces): vertices
+//   GetNV(), edges GetNEdges(), faces bucketed by GetFaceGeometry() (3D only).
 //
 //   Nonconforming:
-//     - vertices: H1(1) true size. Hanging vertices are constrained through the master
-//       edges/faces they lie on and are NOT flagged in the NC vertex list (which lists
-//       every leaf vertex as "conforming"), so the FE-space true size is the reliable
-//       count -- an NC-vertex-list count would return the raw leaf vertex count.
-//     - edges: ND(1) true size. Edges interior to a master face are constrained by that
-//       face (not by an edge master), so they are NOT slave edges in the NC edge list; the
-//       FE-space true size accounts for them, a raw NC-edge-list count would over-count.
-//     - faces (3D): DIRECT per-geometry count from the NC face list. Every leaf face is a
-//       TRUE face unless it is a hanging SLAVE constrained by a master, so classifying each
-//       leaf face with NCList::GetMeshIdType and dropping only SLAVE faces gives exactly
-//       GetNFaces() - (#constrained faces) == the RT(0) true size, and bucketing by
-//       GetFaceGeometry recovers the exact tri/quad split. CONFORMING and MASTER faces are
-//       true; boundary faces are UNRECOGNIZED (absent from the list) but still true. This
+//     - vertices: H1(1) true size. The NC vertex list flags every leaf vertex as conforming
+//       (no masters/slaves), so a list count would return the raw leaf count and over-count
+//       hanging vertices; the FE-space true size is the reliable count.
+//     - edges: ND(1) true size. Edges interior to a master face are face-constrained
+//       (they have no edge-master), so they are NOT slave edges in the NC edge list; a list
+//       count would over-count them, while the FE-space true size accounts for them.
+//     - faces (3D): a direct per-geometry count of non-SLAVE leaf faces from the NC face
+//       list. Every leaf face is TRUE unless it is a hanging SLAVE (CONFORMING and MASTER
+//       faces are true; boundary faces are UNRECOGNIZED (not in the list) but still true),
+//       so dropping only SLAVE faces yields exactly the RT(0) true size, and
+//       bucketing by GetFaceGeometry recovers the tri/quad split with no linear solve. This
 //       replaces a prior RT(0)/RT(1) 2x2 GetTrueVSize solve that was invalid on
-//       nonconforming meshes (GetTrueVSize does not distribute per face there) and emitted
-//       negative face counts on mixed meshes.
+//       nonconforming meshes and emitted negative face counts on mixed meshes.
 //
-//   Conforming: true == leaf, so raw per-geometry counts are used directly (no FE spaces):
-//     vertices GetNV(), edges GetNEdges(), faces bucketed via GetFaceGeometry() (3D only),
-//     cells via GetElementBaseGeometry().
-//
-// FE spaces are each scoped in their own block so at most one is alive at a time (built,
-// read, and destroyed before the next), keeping peak memory low. Attributes are already
-// sorted and unique on mfem::Mesh.
+// The two FE spaces are each scoped so at most one is alive at a time, keeping peak memory
+// low. Attributes are already sorted and unique on mfem::Mesh.
 //
 // MPI INVARIANT (root-only, non-collective): when called from RebalanceMesh on a
-// nonconforming mesh, `smesh` is a ParMesh whose ncmesh is a ParNCMesh holding every
-// element on the root rank, and this routine runs on the root rank ONLY. The H1(1) and
-// ND(1) GetTrueVSize() calls and the ncmesh->GetFaceList() call all reach
-// ParNCMesh::Build{Vertex,Edge,Face}List. Those overrides perform NO MPI communication
-// (verified against MFEM commit 66dbe60cb1, mesh/pncmesh.cpp: they compute only local
-// ownership and shared-entity metadata, and CalcFaceOrientations is documented "done
-// locally, without communication"), which is the ONLY reason this root-only routine cannot
-// deadlock. The prior RT/H1/ND FE spaces already relied on this same invariant via
-// GetFaceList(), so switching faces to a direct GetFaceList() adds no new collective risk.
-// If a future MFEM makes any Build*List collective, the [Parallel] RebalanceMesh count test
-// will hang -- fix by moving this whole routine to a collective call site, not by silencing.
+// nonconforming mesh, `smesh` is a ParMesh whose ParNCMesh holds every element on the root
+// rank, and this runs on the root rank ONLY. The H1(1)/ND(1) GetTrueVSize() and the
+// GetFaceList() calls all reach ParNCMesh::Build{Vertex,Edge,Face}List, which do NO MPI
+// communication (verified against MFEM commit 66dbe60cb1) -- the ONLY reason this root-only
+// routine cannot deadlock. If a future MFEM makes any Build*List collective, the [Parallel]
+// RebalanceMesh count test will hang; fix by moving this routine to a collective call site,
+// not by silencing.
 void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 {
-  // Reset first: the accumulating members (cells, and true_faces below) must never sum
-  // across AMR iterations that reuse the same struct. Scalars are re-set below and `valid`
-  // is re-set at the end.
+  // Reset first so the accumulating members (cells, true_faces) never sum across AMR
+  // iterations that reuse the same struct.
   counts = MeshEntityCounts{};
 
   const int dim = smesh.Dimension();
   counts.dim = dim;
 
-  // Raw per-geometry cell counts (interior DOFs are never constrained, so raw == true).
   for (int i = 0; i < smesh.GetNE(); i++)
   {
     counts.cells[smesh.GetElementBaseGeometry(i)]++;
@@ -2025,9 +2016,7 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
 
   if (smesh.Nonconforming())
   {
-    // Root-only, non-collective: see the "MPI INVARIANT" note in the block comment above.
-    // Every GetTrueVSize()/GetFaceList() call below reaches a ParNCMesh::Build*List that
-    // does no MPI communication (pinned to MFEM commit 66dbe60cb1).
+    // Root-only, non-collective: see the MPI INVARIANT note in the block comment above.
     {
       mfem::H1_FECollection h1_fec(1, dim);
       mfem::FiniteElementSpace h1_fespace(&smesh, &h1_fec);
@@ -2038,35 +2027,24 @@ void FillMeshEntityCounts(mfem::Mesh &smesh, MeshEntityCounts &counts)
       mfem::FiniteElementSpace nd_fespace(&smesh, &nd_fec);
       counts.true_edges = nd_fespace.GetTrueVSize();
     }
-    if (dim == 3)
-    {
-      // DIRECT per-geometry TRUE-face count from the NC face list (see the block comment
-      // above for why this is exact and why it replaced the RT(0)/RT(1) solve). Every leaf
-      // face is a TRUE face unless it is a hanging SLAVE constrained by a master; CONFORMING
-      // and MASTER faces are true, and boundary faces are UNRECOGNIZED (absent from the
-      // list) but still true. Counting non-SLAVE faces therefore yields exactly
-      // GetNFaces() - (#constrained faces) == the RT(0) true size, and bucketing each by
-      // GetFaceGeometry (the same source the conforming path uses) recovers the tri/quad
-      // split with no linear solve and no clamp.
-      const mfem::NCMesh::NCList &face_list = smesh.ncmesh->GetFaceList();
-      for (int f = 0; f < smesh.GetNFaces(); f++)
-      {
-        if (face_list.GetMeshIdType(f) != mfem::NCMesh::NCList::MeshIdType::SLAVE)
-        {
-          counts.true_faces[smesh.GetFaceGeometry(f)]++;
-        }
-      }
-    }
   }
   else
   {
-    // Conforming: true == leaf, so use raw per-geometry counts (no FE spaces needed).
     counts.true_vertices = smesh.GetNV();
     counts.true_edges = (dim >= 2) ? smesh.GetNEdges() : 0;
-    if (dim == 3)
+  }
+
+  if (dim == 3)
+  {
+    // Per-geometry TRUE-face count (GetNFaces() == 0 in 2D). Conforming: every leaf face is
+    // true. Nonconforming: count non-SLAVE leaf faces from the NC face list (== RT(0) true
+    // size; see the block comment above). Bucketed by GetFaceGeometry either way.
+    const mfem::NCMesh::NCList *face_list =
+        smesh.Nonconforming() ? &smesh.ncmesh->GetFaceList() : nullptr;
+    for (int f = 0; f < smesh.GetNFaces(); f++)
     {
-      // In 2D GetNFaces() == 0, so this loop is guarded to 3D.
-      for (int f = 0; f < smesh.GetNFaces(); f++)
+      if (face_list == nullptr ||
+          face_list->GetMeshIdType(f) != mfem::NCMesh::NCList::MeshIdType::SLAVE)
       {
         counts.true_faces[smesh.GetFaceGeometry(f)]++;
       }
@@ -2095,9 +2073,9 @@ double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
 
     auto PrintSerial = [&](mfem::Mesh &smesh)
     {
-      // The gathered serial mesh holds all elements on the root rank, so its lowest-order
-      // FE spaces give the exact global topological counts. Compute before writing (the
-      // counts are scale-invariant, so dimensionalization inside the write is irrelevant).
+      // The gathered serial mesh holds all elements on the root rank, so the counts are
+      // exact global topological counts. Compute before writing (the counts are
+      // scale-invariant, so dimensionalization inside the write is irrelevant).
       if (out_counts != nullptr && Mpi::Root(comm))
       {
         FillMeshEntityCounts(smesh, *out_counts);

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -345,9 +345,25 @@ inline double GetVolume(const mfem::ParMesh &mesh, int attr)
 std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
                                                     std::unique_ptr<mfem::Mesh> &smesh);
 
+// Order-independent (conforming) topological entity counts for a mesh, obtained from
+// lowest-order finite-element spaces on the gathered serial mesh. On a serial mesh the
+// true DOF sizes of these spaces equal the global entity counts, so these are the exact
+// counts needed to size a solver re-run without parsing the mesh. Populated only on the
+// root rank when an adapted mesh is written (see RebalanceMesh).
+struct MeshEntityCounts
+{
+  int dim = 0;
+  long long true_vertices = 0, true_edges = 0, true_faces = 0, elements = 0;
+  std::vector<int> domain_attributes, boundary_attributes;
+  bool valid = false;  // set true only when populated (root, save happened)
+};
+
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from
-// the intermediate stages to disk. Returns the imbalance ratio before rebalancing.
-double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh);
+// the intermediate stages to disk. Returns the imbalance ratio before rebalancing. When
+// `out_counts` is non-null and the adapted mesh is written, the mesh's true topological
+// entity counts are filled into it on the root rank.
+double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
+                     MeshEntityCounts *out_counts = nullptr);
 
 // Helper for creating a hexahedral mesh from a tetrahedral mesh.
 mfem::Mesh MeshTetToHex(const mfem::Mesh &orig_mesh);

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -349,10 +349,10 @@ std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
 // Order-independent (conforming) topological entity counts for a mesh, broken down
 // per geometry, obtained from the gathered serial mesh. These are the true (constrained)
 // global entity counts needed to size a solver re-run without parsing the mesh. On a
-// nonconforming mesh the true counts come from lowest-order finite-element space true
-// sizes (NC-list bucketing is wrong in 3D); on a conforming mesh true == leaf, so raw
-// per-geometry counts are used. Populated only on the root rank when an adapted mesh is
-// written (see RebalanceMesh).
+// nonconforming mesh true vertices/edges come from lowest-order finite-element space true
+// sizes (H1(1)/ND(1)) and true faces from a direct NC face-list count (dropping hanging
+// slave faces); on a conforming mesh true == leaf, so raw per-geometry counts are used.
+// Populated only on the root rank when an adapted mesh is written (see RebalanceMesh).
 struct MeshEntityCounts
 {
   int dim = 0;

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -346,13 +346,9 @@ inline double GetVolume(const mfem::ParMesh &mesh, int attr)
 std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
                                                     std::unique_ptr<mfem::Mesh> &smesh);
 
-// Order-independent (conforming) topological entity counts for a mesh, broken down
-// per geometry, obtained from the gathered serial mesh. These are the true (constrained)
-// global entity counts needed to size a solver re-run without parsing the mesh. On a
-// nonconforming mesh true vertices/edges come from lowest-order finite-element space true
-// sizes (H1(1)/ND(1)) and true faces from a direct NC face-list count (dropping hanging
-// slave faces); on a conforming mesh true == leaf, so raw per-geometry counts are used.
-// Populated only on the root rank when an adapted mesh is written (see RebalanceMesh).
+// Order-independent (conforming) topological entity counts for a mesh, broken down per
+// geometry. Populated only on the root rank when an adapted mesh is written (see
+// RebalanceMesh and CompleteMeshEntityCounts).
 struct MeshEntityCounts
 {
   int dim = 0;
@@ -368,10 +364,16 @@ struct MeshEntityCounts
 
 // Helper function responsible for rebalancing the mesh, and optionally writing meshes from
 // the intermediate stages to disk. Returns the imbalance ratio before rebalancing. When
-// `out_counts` is non-null and the adapted mesh is written, the mesh's true topological
-// entity counts are filled into it on the root rank.
+// `out_counts` is non-null and the adapted mesh is written, geometry-resolved counts are
+// filled on the root rank. Nonconforming vertex and edge counts must then be completed
+// collectively with CompleteMeshEntityCounts.
 double RebalanceMesh(const IoData &iodata, std::unique_ptr<mfem::ParMesh> &mesh,
                      MeshEntityCounts *out_counts = nullptr);
+
+// Complete true vertex and edge counts for a nonconforming mesh using distributed
+// lowest-order H1 and ND spaces. This is collective over the mesh communicator and must be
+// called on every rank after RebalanceMesh has populated out_counts for the final mesh.
+void CompleteMeshEntityCounts(mfem::ParMesh &mesh, MeshEntityCounts &counts);
 
 // Helper for creating a hexahedral mesh from a tetrahedral mesh.
 mfem::Mesh MeshTetToHex(const mfem::Mesh &orig_mesh);

--- a/palace/utils/geodata.hpp
+++ b/palace/utils/geodata.hpp
@@ -5,6 +5,7 @@
 #define PALACE_UTILS_GEODATA_HPP
 
 #include <cmath>
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -345,15 +346,22 @@ inline double GetVolume(const mfem::ParMesh &mesh, int attr)
 std::unique_ptr<mfem::ParMesh> DistributeSerialMesh(MPI_Comm comm,
                                                     std::unique_ptr<mfem::Mesh> &smesh);
 
-// Order-independent (conforming) topological entity counts for a mesh, obtained from
-// lowest-order finite-element spaces on the gathered serial mesh. On a serial mesh the
-// true DOF sizes of these spaces equal the global entity counts, so these are the exact
-// counts needed to size a solver re-run without parsing the mesh. Populated only on the
-// root rank when an adapted mesh is written (see RebalanceMesh).
+// Order-independent (conforming) topological entity counts for a mesh, broken down
+// per geometry, obtained from the gathered serial mesh. These are the true (constrained)
+// global entity counts needed to size a solver re-run without parsing the mesh. On a
+// nonconforming mesh the true counts come from lowest-order finite-element space true
+// sizes (NC-list bucketing is wrong in 3D); on a conforming mesh true == leaf, so raw
+// per-geometry counts are used. Populated only on the root rank when an adapted mesh is
+// written (see RebalanceMesh).
 struct MeshEntityCounts
 {
   int dim = 0;
-  long long true_vertices = 0, true_edges = 0, true_faces = 0, elements = 0;
+  long long true_vertices = 0;
+  long long true_edges = 0;
+  // TRUE codim-1 faces by geometry (3D only; empty in 2D). Keys are TRIANGLE, SQUARE.
+  std::map<mfem::Geometry::Type, long long> true_faces;
+  // Raw cells by geometry (2D: TRIANGLE, SQUARE; 3D: TETRAHEDRON, CUBE, PRISM, PYRAMID).
+  std::map<mfem::Geometry::Type, long long> cells;
   std::vector<int> domain_attributes, boundary_attributes;
   bool valid = false;  // set true only when populated (root, save happened)
 };

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -45,12 +45,9 @@ public:
   }
 };
 
-// Reconstruct the exact conforming DOF count (GetTrueVSize) of an FE space from the
-// per-geometry true entity counts: each true entity contributes fec.DofForGeometry(geom)
-// dofs of its geometry. This is the reconstruction oracle used by the nonconforming test
-// below -- an earlier NC-list bucketing method silently mis-counted (over-counted edges,
-// mis-split faces) in 3D, and reproducing GetTrueVSize this way catches that whole class
-// of bug. Mirrors the DofForGeometry usage validated exact in the mfem_dofcheck_nc harness.
+// Reconstruct the exact conforming DOF count (`GetTrueVSize`) from the per-geometry
+// true entity counts. Agreement with `GetTrueVSize` verifies that constrained entities
+// are excluded and face geometries are classified correctly on nonconforming meshes.
 long long Reconstruct(const mesh::MeshEntityCounts &c, mfem::FiniteElementCollection &fec)
 {
   long long n = c.true_vertices * fec.DofForGeometry(mfem::Geometry::POINT) +

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -359,6 +359,20 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) < leaf_faces);
     // Cells are never constrained, so the raw per-geometry cell count is not discounted.
     CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == leaf_elements);
+    // No entity count may ever be negative. Guards the class of bug where the
+    // nonconforming true-size solve underflows into a negative face count (a real AMR
+    // run produced TrueFaces.quadrilateral = -3447 on a pure-tet mesh before the
+    // cell-geometry guard in FillMeshEntityCounts).
+    for (const auto &[g, c] : counts.true_faces)
+    {
+      CHECK(c >= 0);
+    }
+    for (const auto &[g, c] : counts.cells)
+    {
+      CHECK(c >= 0);
+    }
+    CHECK(counts.true_vertices >= 0);
+    CHECK(counts.true_edges >= 0);
     // Reconstruction-vs-GetTrueVSize oracle: the per-geometry true counts must reproduce
     // the EXACT conforming DOF count of the H1 and ND spaces Palace solves with, across
     // orders, on this nonconforming mesh. This is the regression guard -- an earlier

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <memory>
 #include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
 #include "drivers/basesolver.hpp"
 #include "fixtures.hpp"
 #include "test-helpers.hpp"
@@ -29,6 +30,47 @@ std::string ReadFile(const fs::path &path)
 {
   std::ifstream f(path);
   return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+// Minimal concrete BaseSolver so BaseSolver::SaveMetadata can be exercised directly; the
+// Solve override is never invoked by these tests.
+class TestSolver : public BaseSolver
+{
+public:
+  using BaseSolver::BaseSolver;
+  std::pair<ErrorIndicator, long long int>
+  Solve(const std::vector<std::unique_ptr<Mesh>> &) const override
+  {
+    return {};
+  }
+};
+
+// Verify the emitted true entity counts reproduce the EXACT conforming DOF count of the
+// H1 and ND spaces (used by Palace's solvers) across orders, via the standard per-entity
+// decomposition on tetrahedra. This is what lets the counts size a re-run at any order --
+// a stronger check than true < leaf (it also catches an edge/face swap).
+void CheckDofDecomposition(mfem::Mesh &mesh, const mesh::MeshEntityCounts &counts)
+{
+  const long long V = counts.true_vertices, E = counts.true_edges, F = counts.true_faces,
+                  T = counts.elements;
+  const int dim = mesh.Dimension();
+  // H1 order p on tets: V + E(p-1) + F(p-1)(p-2)/2 + T(p-1)(p-2)(p-3)/6. Order 4 exercises
+  // the tetrahedron-interior term.
+  for (int p = 1; p <= 4; p++)
+  {
+    const long long expected = V + E * (p - 1) + F * ((p - 1) * (p - 2) / 2) +
+                               T * ((p - 1) * (p - 2) * (p - 3) / 6);
+    mfem::H1_FECollection fec(p, dim);
+    CHECK(mfem::FiniteElementSpace(&mesh, &fec).GetTrueVSize() == expected);
+  }
+  // ND (Nedelec, first kind) order p on tets: E*p + F*p(p-1) + T*p(p-1)(p-2)/2. Order 3
+  // exercises the tetrahedron-interior term.
+  for (int p = 1; p <= 3; p++)
+  {
+    const long long expected = E * p + F * (p * (p - 1)) + T * (p * (p - 1) * (p - 2) / 2);
+    mfem::ND_FECollection fec(p, dim);
+    CHECK(mfem::FiniteElementSpace(&mesh, &fec).GetTrueVSize() == expected);
+  }
 }
 
 }  // namespace
@@ -316,13 +358,11 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(counts.true_faces < leaf_faces);
     // Elements are never constrained, so the element count is not discounted.
     CHECK(counts.elements == leaf_elements);
-    // The true entity counts must compose into a higher-order true size: an order-2 H1
-    // space on tetrahedra has one dof per (true) vertex and edge, so on this nonconforming
-    // mesh its true size equals true_vertices + true_edges -- validating the counts against
-    // their downstream (DOF-sizing) use, not just the leaf-count inequalities.
-    mfem::H1_FECollection h1_p2(2, 3);
-    mfem::FiniteElementSpace fes_p2(&serial_mesh, &h1_p2);
-    CHECK(fes_p2.GetTrueVSize() == counts.true_vertices + counts.true_edges);
+    // The true entity counts must reproduce the exact conforming DOF count of the H1/ND
+    // spaces Palace solves with, across orders, on this nonconforming mesh -- the property
+    // that lets them size a re-run at any order (stronger than the leaf-count
+    // inequalities).
+    CheckDofDecomposition(serial_mesh, counts);
   }
 }
 
@@ -349,6 +389,48 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   // than merely to the struct's default.
   CHECK_FALSE(counts.valid);
   CHECK_FALSE(fs::exists(temp_dir / "model.mesh"));
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveAdaptMesh writes the Mesh block to palace.json",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  // The BaseSolver constructor writes the initial palace.json (root only); SaveMetadata
+  // then reads it, adds the "Mesh" block, and writes it back -- exactly the production
+  // path.
+  TestSolver solver(iodata, Mpi::Root(comm));
+  if (counts.valid)
+  {
+    solver.SaveMetadata(counts);
+  }
+
+  if (Mpi::Root(comm))
+  {
+    const auto meta = nlohmann::json::parse(ReadFile(temp_dir / "palace.json"));
+    REQUIRE(meta.contains("Mesh"));
+    const auto &m = meta.at("Mesh");
+    CHECK(m.at("Dimension").get<int>() == 3);
+    CHECK(m.at("TrueVertices").get<long long>() == 4);
+    CHECK(m.at("TrueEdges").get<long long>() == 6);
+    CHECK(m.at("TrueFaces").get<long long>() == 4);
+    CHECK(m.at("Elements").get<long long>() == 1);
+    CHECK(m.at("DomainAttributes").get<std::vector<int>>() == std::vector<int>{1});
+    CHECK(m.at("BoundaryAttributes").get<std::vector<int>>() ==
+          std::vector<int>{1, 2, 3, 4});
+  }
 }
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -392,7 +392,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
 }
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,
-                 "SaveAdaptMesh writes the Mesh block to palace.json",
+                 "SaveAdaptMesh writes a SavedAdaptedMesh block to palace.json",
                  "[basesolver][Serial]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
@@ -409,7 +409,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
 
   // The BaseSolver constructor writes the initial palace.json (root only); SaveMetadata
-  // then reads it, adds the "Mesh" block, and writes it back -- exactly the production
+  // then reads it, adds the "SavedAdaptedMesh" block, and writes it back -- exactly the
   // path.
   TestSolver solver(iodata, Mpi::Root(comm));
   if (counts.valid)
@@ -420,8 +420,8 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   if (Mpi::Root(comm))
   {
     const auto meta = nlohmann::json::parse(ReadFile(temp_dir / "palace.json"));
-    REQUIRE(meta.contains("Mesh"));
-    const auto &m = meta.at("Mesh");
+    REQUIRE(meta.contains("SavedAdaptedMesh"));
+    const auto &m = meta.at("SavedAdaptedMesh");
     CHECK(m.at("Dimension").get<int>() == 3);
     CHECK(m.at("TrueVertices").get<long long>() == 4);
     CHECK(m.at("TrueEdges").get<long long>() == 6);

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -66,6 +66,73 @@ long long Reconstruct(const mesh::MeshEntityCounts &c, mfem::FiniteElementCollec
   return n;
 }
 
+// Assert the per-geometry true counts reproduce the EXACT conforming true DOF size of the
+// H1, ND, and RT spaces Palace sizes with, across orders, on `serial_mesh`. RT (p=0..2) is
+// the ONLY space with FACE dofs, so its match directly validates the tri/quad TRUE-face
+// split -- the quantity a prior RT-solve corrupted. `counts` come from a gathered serial
+// copy whose topology is identical to `serial_mesh`, so the true sizes must match exactly.
+// Runs on the caller's rank; call inside a root guard (counts are valid only on root).
+void CheckReconstructionOracle(const mesh::MeshEntityCounts &counts, mfem::Mesh &serial_mesh)
+{
+  const int dim = serial_mesh.Dimension();
+  for (int p = 1; p <= 3; p++)
+  {
+    mfem::H1_FECollection fec(p, dim);
+    CHECK(Reconstruct(counts, fec) ==
+          mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+  }
+  for (int p = 1; p <= 3; p++)
+  {
+    mfem::ND_FECollection fec(p, dim);
+    CHECK(Reconstruct(counts, fec) ==
+          mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+  }
+  if (dim == 3)
+  {
+    for (int p = 0; p <= 2; p++)
+    {
+      mfem::RT_FECollection fec(p, dim);
+      CHECK(Reconstruct(counts, fec) ==
+            mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+    }
+  }
+}
+
+// Distribute `serial_mesh`, run RebalanceMesh with SaveAdaptMesh enabled (which fills the
+// counts on the root rank), and return the counts. Writes model.mesh into `out`.
+mesh::MeshEntityCounts ComputeCounts(MPI_Comm comm, const fs::path &out,
+                                     mfem::Mesh &serial_mesh)
+{
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = out.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+  return counts;
+}
+
+// Build a nonconforming prism (WEDGE) mesh: extrude a 2D triangular mesh into wedges, mark
+// it nonconforming, and refine a subset so hanging nodes appear. A prism carries BOTH
+// triangular (top/bottom) and quadrilateral (side) faces, so it exercises the mixed
+// tri/quad TRUE-face split with a genuinely nonzero answer for both geometries.
+mfem::Mesh BuildNCPrismMesh()
+{
+  auto base2d = mfem::Mesh::MakeCartesian2D(3, 3, mfem::Element::TRIANGLE);
+  std::unique_ptr<mfem::Mesh> extruded(mfem::Extrude2D(&base2d, 3, 1.0));
+  mfem::Mesh serial_mesh(*extruded);
+  serial_mesh.EnsureNCMesh(true);
+  mfem::Array<int> refs;
+  for (int i = 0; i < serial_mesh.GetNE(); i += 3)
+  {
+    refs.Append(i);
+  }
+  serial_mesh.GeneralRefinement(refs, 1);  // 1 => nonconforming
+  return serial_mesh;
+}
+
 }  // namespace
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,
@@ -359,10 +426,10 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) < leaf_faces);
     // Cells are never constrained, so the raw per-geometry cell count is not discounted.
     CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == leaf_elements);
-    // No entity count may ever be negative. Guards the class of bug where the
-    // nonconforming true-size solve underflows into a negative face count (a real AMR
-    // run produced TrueFaces.quadrilateral = -3447 on a pure-tet mesh before the
-    // cell-geometry guard in FillMeshEntityCounts).
+    // No entity count may ever be negative. Guards the class of bug where the prior
+    // nonconforming RT true-size solve underflowed into a negative face count (a real AMR
+    // run produced TrueFaces.quadrilateral = -3447 on a pure-tet mesh). The direct NC
+    // face-list count that replaced the solve cannot go negative by construction.
     for (const auto &[g, c] : counts.true_faces)
     {
       CHECK(c >= 0);
@@ -373,25 +440,208 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     }
     CHECK(counts.true_vertices >= 0);
     CHECK(counts.true_edges >= 0);
-    // Reconstruction-vs-GetTrueVSize oracle: the per-geometry true counts must reproduce
-    // the EXACT conforming DOF count of the H1 and ND spaces Palace solves with, across
-    // orders, on this nonconforming mesh. This is the regression guard -- an earlier
-    // NC-list counting method silently mis-counted (over-counted edges, mis-split faces)
-    // in 3D, and this reproduction catches that whole class of bug. counts came from the
-    // gathered serial copy, whose topology is identical to serial_mesh, so the true sizes
-    // computed on serial_mesh must match Reconstruct(counts, ...) exactly.
-    for (int p = 1; p <= 3; p++)
+    // Reconstruction-vs-GetTrueVSize oracle across H1, ND, and RT (RT validates the tri/quad
+    // TRUE-face split that the old solve corrupted). See CheckReconstructionOracle.
+    CheckReconstructionOracle(counts, serial_mesh);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh reports exact true counts on a nonconforming prism mesh",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // A refined nonconforming prism (wedge) mesh carries BOTH triangular and quadrilateral
+  // faces, so it exercises the mixed tri/quad TRUE-face split with a nonzero answer for
+  // both geometries -- the case the removed RT(0)/RT(1) solve got wrong.
+  auto serial_mesh = BuildNCPrismMesh();
+  REQUIRE(serial_mesh.Nonconforming());
+
+  const auto counts = ComputeCounts(comm, temp_dir, serial_mesh);
+
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    CHECK(counts.dim == 3);
+    // Prisms bear both triangular and quadrilateral faces; both must be present and > 0.
+    CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) > 0);
+    CHECK(counts.true_faces.at(mfem::Geometry::SQUARE) > 0);
+    // Cells are all prisms.
+    CHECK(counts.cells.count(mfem::Geometry::PRISM) == 1);
+    for (const auto &[g, c] : counts.true_faces)
     {
-      mfem::H1_FECollection fec(p, 3);
-      CHECK(Reconstruct(counts, fec) ==
-            mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+      CHECK(c >= 0);
     }
-    for (int p = 1; p <= 3; p++)
+    // The full H1/ND/RT sweep. RT directly validates the tri/quad split on a mixed mesh.
+    CheckReconstructionOracle(counts, serial_mesh);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh reports exact true counts on a nonconforming hex mesh",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // Pure-hexahedral nonconforming mesh: only quadrilateral faces, so this is the !tri_faced
+  // path (SQUARE present, TRIANGLE absent).
+  auto serial_mesh = mfem::Mesh::MakeCartesian3D(3, 3, 3, mfem::Element::HEXAHEDRON);
+  serial_mesh.EnsureNCMesh();
+  mfem::Array<int> refs;
+  for (int i = 0; i < serial_mesh.GetNE(); i += 3)
+  {
+    refs.Append(i);
+  }
+  serial_mesh.GeneralRefinement(refs, 1);  // 1 => nonconforming
+  REQUIRE(serial_mesh.Nonconforming());
+
+  const auto counts = ComputeCounts(comm, temp_dir, serial_mesh);
+
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    CHECK(counts.dim == 3);
+    // A hex mesh has only quadrilateral faces: SQUARE present-positive, TRIANGLE absent.
+    CHECK(counts.true_faces.at(mfem::Geometry::SQUARE) > 0);
+    CHECK(counts.true_faces.count(mfem::Geometry::TRIANGLE) == 0);
+    CHECK(counts.cells.count(mfem::Geometry::CUBE) == 1);
+    CheckReconstructionOracle(counts, serial_mesh);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh counts match between a conforming mesh and its unrefined "
+                 "nonconforming twin",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  // For each element geometry: compute counts on the conforming mesh (raw-count path), then
+  // flag the same mesh nonconforming WITHOUT refining (topologically identical, routed
+  // through the NC FE-space + NC-face-list path) and compute again. The two must agree
+  // exactly -- the robust guard that the NC counting reduces to the conforming answer when
+  // there are no hanging entities. Each geometry uses its own subdirectory so the written
+  // model.mesh files do not collide.
+  auto check_twin = [&](const std::string &name, const mfem::Mesh &base)
+  {
+    const auto conf_dir = temp_dir / (name + "-conf");
+    const auto nc_dir = temp_dir / (name + "-nc");
+    fs::create_directories(conf_dir);
+    fs::create_directories(nc_dir);
+
+    mfem::Mesh conf_mesh(base);
+    const auto conf = ComputeCounts(comm, conf_dir, conf_mesh);
+
+    mfem::Mesh nc_mesh(base);
+    nc_mesh.EnsureNCMesh(true);
+    REQUIRE(nc_mesh.Nonconforming());
+    const auto nc = ComputeCounts(comm, nc_dir, nc_mesh);
+
+    if (Mpi::Root(comm))
     {
-      mfem::ND_FECollection fec(p, 3);
-      CHECK(Reconstruct(counts, fec) ==
-            mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+      INFO("geometry: " << name);
+      REQUIRE(conf.valid);
+      REQUIRE(nc.valid);
+      CHECK(conf.dim == nc.dim);
+      CHECK(conf.true_vertices == nc.true_vertices);
+      CHECK(conf.true_edges == nc.true_edges);
+      CHECK(conf.true_faces == nc.true_faces);
+      CHECK(conf.cells == nc.cells);
     }
+  };
+
+  check_twin("tet", mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON));
+  check_twin("hex", mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::HEXAHEDRON));
+  {
+    auto base2d = mfem::Mesh::MakeCartesian2D(2, 2, mfem::Element::TRIANGLE);
+    std::unique_ptr<mfem::Mesh> prism(mfem::Extrude2D(&base2d, 2, 1.0));
+    check_twin("prism", *prism);
+  }
+  check_twin("tri2d", mfem::Mesh::MakeCartesian2D(3, 3, mfem::Element::TRIANGLE));
+  check_twin("quad2d", mfem::Mesh::MakeCartesian2D(3, 3, mfem::Element::QUADRILATERAL));
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh entity counts reflect only the final mesh across iterations",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  // Regression for the accumulation bug: one MeshEntityCounts reused across AMR iterations
+  // must be reset each call, so the accumulating members (cells, true_faces) reflect ONLY
+  // the last mesh, never the sum over iterations.
+  auto serial_mesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON);
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+
+  mesh::MeshEntityCounts counts;
+
+  // Iteration 1.
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+  const long long ne1 = parallel_mesh->GetGlobalNE();
+
+  // Iteration 2: refine (still conforming) so the mesh genuinely changes, reusing `counts`.
+  parallel_mesh->UniformRefinement();
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+  const long long ne2 = parallel_mesh->GetGlobalNE();
+
+  // Build the expected final serial mesh (same single uniform refinement) for the oracle.
+  serial_mesh.UniformRefinement();
+
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    REQUIRE(ne2 > ne1);
+    // Cells must equal ONLY the final element count, not ne1 + ne2. Without the per-call
+    // reset this would be inflated to the running sum.
+    CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == ne2);
+    long long total_cells = 0;
+    for (const auto &[g, c] : counts.cells)
+    {
+      total_cells += c;
+    }
+    CHECK(total_cells == ne2);
+    // The reconstruction oracle on the final mesh also fails if true_faces (or any true
+    // count) had accumulated across the two iterations.
+    CheckReconstructionOracle(counts, serial_mesh);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "SaveMetadata writes no SavedAdaptedMesh block when counts are invalid",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = false;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  // With SaveAdaptMesh disabled (a zero-AMR-iteration run also lands here), counts are
+  // invalid and the driver skips the block; palace.json must contain no SavedAdaptedMesh.
+  TestSolver solver(iodata, Mpi::Root(comm));
+  if (counts.valid)
+  {
+    solver.SaveMetadata(counts);
+  }
+  if (Mpi::Root(comm))
+  {
+    CHECK_FALSE(counts.valid);
+    const auto meta = nlohmann::json::parse(ReadFile(temp_dir / "palace.json"));
+    CHECK_FALSE(meta.contains("SavedAdaptedMesh"));
   }
 }
 
@@ -462,6 +712,54 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(m.at("DomainAttributes").get<std::vector<int>>() == std::vector<int>{1});
     CHECK(m.at("BoundaryAttributes").get<std::vector<int>>() ==
           std::vector<int>{1, 2, 3, 4});
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh reports the true topological entity counts in parallel",
+                 "[basesolver][Parallel]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  // Build a nonconforming tet mesh identically on every rank, distribute it across the
+  // ranks, then RebalanceMesh gathers it back to the root rank to fill the counts. The
+  // reported counts must equal the single-rank answer (validated by the reconstruction
+  // oracle on the identical serial mesh) regardless of how the mesh was partitioned, and
+  // non-root ranks must be left unpopulated (valid == false, since FillMeshEntityCounts
+  // runs on root only and must contain no MPI-collective call).
+  auto serial_mesh = mfem::Mesh::MakeCartesian3D(4, 4, 4, mfem::Element::TETRAHEDRON);
+  serial_mesh.EnsureNCMesh(true);
+  mfem::Array<int> refs;
+  for (int i = 0; i < serial_mesh.GetNE(); i += 3)
+  {
+    refs.Append(i);
+  }
+  serial_mesh.GeneralRefinement(refs, 1);  // 1 => nonconforming
+  REQUIRE(serial_mesh.Nonconforming());
+
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    CHECK(counts.dim == 3);
+    CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) > 0);
+    CHECK(counts.true_faces.count(mfem::Geometry::SQUARE) == 0);
+    // Partition-invariant: the gathered root counts reproduce the serial true DOF sizes.
+    CheckReconstructionOracle(counts, serial_mesh);
+  }
+  else
+  {
+    // FillMeshEntityCounts runs on the root rank only; other ranks stay unpopulated.
+    CHECK_FALSE(counts.valid);
   }
 }
 

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -224,6 +224,134 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
 }
 
 TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh reports the true topological entity counts",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  // The counts are computed on the root rank, where the gathered serial mesh is complete.
+  const long long global_ne = parallel_mesh->GetGlobalNE();
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    CHECK(counts.dim == 3);
+    // A single tetrahedron has 4 vertices, 6 edges, 4 faces, and 1 element. These are the
+    // order-independent conforming entity counts (H1(1)/ND(1)/RT(0)/L2(0) true sizes).
+    CHECK(counts.true_vertices == 4);
+    CHECK(counts.true_edges == 6);
+    CHECK(counts.true_faces == 4);
+    CHECK(counts.elements == 1);
+    // The element count must agree with the mesh's own global element count.
+    CHECK(counts.elements == global_ne);
+    // SingleTetMesh tags its one domain 1 and its four boundary faces 1..4.
+    CHECK(counts.domain_attributes == std::vector<int>{1});
+    CHECK(counts.boundary_attributes == std::vector<int>{1, 2, 3, 4});
+    // The counts compose into higher-order true sizes: an order-2 (P2) H1 space on a
+    // tetrahedron has one dof per vertex and one per edge (no face/interior dofs at p=2),
+    // so its true size must equal true_vertices + true_edges.
+    mfem::H1_FECollection h1_p2(2, 3);
+    mfem::FiniteElementSpace fes_p2(&serial_mesh, &h1_p2);
+    CHECK(fes_p2.GetTrueVSize() == counts.true_vertices + counts.true_edges);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh discounts hanging entities on a nonconforming mesh",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = true;
+
+  // Build a multi-element tetrahedral mesh and refine a subset nonconformally so that
+  // hanging nodes appear at the refined/unrefined interfaces.
+  auto serial_mesh = mfem::Mesh::MakeCartesian3D(4, 4, 4, mfem::Element::TETRAHEDRON);
+  serial_mesh.EnsureNCMesh(true);
+  mfem::Array<int> refs;
+  for (int i = 0; i < serial_mesh.GetNE(); i += 3)
+  {
+    refs.Append(i);
+  }
+  serial_mesh.GeneralRefinement(refs, 1);  // 1 => nonconforming
+  REQUIRE(serial_mesh.Nonconforming());
+
+  // Raw leaf entity counts of the (global) serial mesh, before distribution.
+  const long long leaf_vertices = serial_mesh.GetNV();
+  const long long leaf_edges = serial_mesh.GetNEdges();
+  const long long leaf_faces = serial_mesh.GetNFaces();
+  const long long leaf_elements = serial_mesh.GetNE();
+
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  if (Mpi::Root(comm))
+  {
+    REQUIRE(counts.valid);
+    CHECK(counts.dim == 3);
+    // The true (conforming) counts discount the constrained hanging vertices, edges, and
+    // faces, so they are strictly smaller than the raw leaf counts. This is the whole
+    // reason leaf counts cannot be used directly for sizing a nonconforming mesh.
+    CHECK(counts.true_vertices > 0);
+    CHECK(counts.true_edges > 0);
+    CHECK(counts.true_faces > 0);
+    CHECK(counts.true_vertices < leaf_vertices);
+    CHECK(counts.true_edges < leaf_edges);
+    CHECK(counts.true_faces < leaf_faces);
+    // Elements are never constrained, so the element count is not discounted.
+    CHECK(counts.elements == leaf_elements);
+    // The true entity counts must compose into a higher-order true size: an order-2 H1
+    // space on tetrahedra has one dof per (true) vertex and edge, so on this nonconforming
+    // mesh its true size equals true_vertices + true_edges -- validating the counts against
+    // their downstream (DOF-sizing) use, not just the leaf-count inequalities.
+    mfem::H1_FECollection h1_p2(2, 3);
+    mfem::FiniteElementSpace fes_p2(&serial_mesh, &h1_p2);
+    CHECK(fes_p2.GetTrueVSize() == counts.true_vertices + counts.true_edges);
+  }
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
+                 "RebalanceMesh leaves entity counts unset without SaveAdaptMesh",
+                 "[basesolver][Serial]")
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  Units units(1.0, 1.0);
+  IoData iodata(units);
+  iodata.problem.output = temp_dir.string();
+  iodata.model.mesh = "model.msh";
+  iodata.model.refinement.save_adapt_mesh = false;
+
+  auto serial_mesh = SingleTetMesh();
+  auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
+
+  mesh::MeshEntityCounts counts;
+  mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+
+  // With SaveAdaptMesh disabled no mesh is written, so no counts are produced. Also assert
+  // the save side-effect did not happen, tying valid == false to its actual cause rather
+  // than merely to the struct's default.
+  CHECK_FALSE(counts.valid);
+  CHECK_FALSE(fs::exists(temp_dir / "model.mesh"));
+}
+
+TEST_CASE_METHOD(palace::test::SharedTempDir,
                  "SaveIteration handles dirty output directory from previous run",
                  "[basesolver][Serial]")
 {

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -45,32 +45,25 @@ public:
   }
 };
 
-// Verify the emitted true entity counts reproduce the EXACT conforming DOF count of the
-// H1 and ND spaces (used by Palace's solvers) across orders, via the standard per-entity
-// decomposition on tetrahedra. This is what lets the counts size a re-run at any order --
-// a stronger check than true < leaf (it also catches an edge/face swap).
-void CheckDofDecomposition(mfem::Mesh &mesh, const mesh::MeshEntityCounts &counts)
+// Reconstruct the exact conforming DOF count (GetTrueVSize) of an FE space from the
+// per-geometry true entity counts: each true entity contributes fec.DofForGeometry(geom)
+// dofs of its geometry. This is the reconstruction oracle used by the nonconforming test
+// below -- an earlier NC-list bucketing method silently mis-counted (over-counted edges,
+// mis-split faces) in 3D, and reproducing GetTrueVSize this way catches that whole class
+// of bug. Mirrors the DofForGeometry usage validated exact in the mfem_dofcheck_nc harness.
+long long Reconstruct(const mesh::MeshEntityCounts &c, mfem::FiniteElementCollection &fec)
 {
-  const long long V = counts.true_vertices, E = counts.true_edges, F = counts.true_faces,
-                  T = counts.elements;
-  const int dim = mesh.Dimension();
-  // H1 order p on tets: V + E(p-1) + F(p-1)(p-2)/2 + T(p-1)(p-2)(p-3)/6. Order 4 exercises
-  // the tetrahedron-interior term.
-  for (int p = 1; p <= 4; p++)
+  long long n = c.true_vertices * fec.DofForGeometry(mfem::Geometry::POINT) +
+                c.true_edges * fec.DofForGeometry(mfem::Geometry::SEGMENT);
+  for (const auto &[g, cnt] : c.true_faces)
   {
-    const long long expected = V + E * (p - 1) + F * ((p - 1) * (p - 2) / 2) +
-                               T * ((p - 1) * (p - 2) * (p - 3) / 6);
-    mfem::H1_FECollection fec(p, dim);
-    CHECK(mfem::FiniteElementSpace(&mesh, &fec).GetTrueVSize() == expected);
+    n += cnt * fec.DofForGeometry(g);
   }
-  // ND (Nedelec, first kind) order p on tets: E*p + F*p(p-1) + T*p(p-1)(p-2)/2. Order 3
-  // exercises the tetrahedron-interior term.
-  for (int p = 1; p <= 3; p++)
+  for (const auto &[g, cnt] : c.cells)
   {
-    const long long expected = E * p + F * (p * (p - 1)) + T * (p * (p - 1) * (p - 2) / 2);
-    mfem::ND_FECollection fec(p, dim);
-    CHECK(mfem::FiniteElementSpace(&mesh, &fec).GetTrueVSize() == expected);
+    n += cnt * fec.DofForGeometry(g);
   }
+  return n;
 }
 
 }  // namespace
@@ -289,14 +282,19 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   {
     REQUIRE(counts.valid);
     CHECK(counts.dim == 3);
-    // A single tetrahedron has 4 vertices, 6 edges, 4 faces, and 1 element. These are the
-    // order-independent conforming entity counts (H1(1)/ND(1)/RT(0)/L2(0) true sizes).
+    // A single tetrahedron has 4 vertices, 6 edges, 4 triangular faces, and is one
+    // TETRAHEDRON cell. These are the order-independent conforming entity counts
+    // (H1(1)/ND(1)/RT(0)/L2(0) true sizes), reported per geometry.
     CHECK(counts.true_vertices == 4);
     CHECK(counts.true_edges == 6);
-    CHECK(counts.true_faces == 4);
-    CHECK(counts.elements == 1);
-    // The element count must agree with the mesh's own global element count.
-    CHECK(counts.elements == global_ne);
+    CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) == 4);
+    // A tet has no quadrilateral faces, so the SQUARE key must be absent (not
+    // present-zero).
+    CHECK(counts.true_faces.count(mfem::Geometry::SQUARE) == 0);
+    CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == 1);
+    CHECK(counts.cells.size() == 1);
+    // The (single) cell count must agree with the mesh's own global element count.
+    CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == global_ne);
     // SingleTetMesh tags its one domain 1 and its four boundary faces 1..4.
     CHECK(counts.domain_attributes == std::vector<int>{1});
     CHECK(counts.boundary_attributes == std::vector<int>{1, 2, 3, 4});
@@ -349,20 +347,37 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(counts.dim == 3);
     // The true (conforming) counts discount the constrained hanging vertices, edges, and
     // faces, so they are strictly smaller than the raw leaf counts. This is the whole
-    // reason leaf counts cannot be used directly for sizing a nonconforming mesh.
+    // reason leaf counts cannot be used directly for sizing a nonconforming mesh. This
+    // all-tet mesh has only triangular faces, so the SQUARE key must be absent.
     CHECK(counts.true_vertices > 0);
     CHECK(counts.true_edges > 0);
-    CHECK(counts.true_faces > 0);
+    CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) > 0);
+    CHECK(counts.true_faces.count(mfem::Geometry::SQUARE) == 0);
     CHECK(counts.true_vertices < leaf_vertices);
     CHECK(counts.true_edges < leaf_edges);
-    CHECK(counts.true_faces < leaf_faces);
-    // Elements are never constrained, so the element count is not discounted.
-    CHECK(counts.elements == leaf_elements);
-    // The true entity counts must reproduce the exact conforming DOF count of the H1/ND
-    // spaces Palace solves with, across orders, on this nonconforming mesh -- the property
-    // that lets them size a re-run at any order (stronger than the leaf-count
-    // inequalities).
-    CheckDofDecomposition(serial_mesh, counts);
+    // Cheap sanity check that the face discount happened.
+    CHECK(counts.true_faces.at(mfem::Geometry::TRIANGLE) < leaf_faces);
+    // Cells are never constrained, so the raw per-geometry cell count is not discounted.
+    CHECK(counts.cells.at(mfem::Geometry::TETRAHEDRON) == leaf_elements);
+    // Reconstruction-vs-GetTrueVSize oracle: the per-geometry true counts must reproduce
+    // the EXACT conforming DOF count of the H1 and ND spaces Palace solves with, across
+    // orders, on this nonconforming mesh. This is the regression guard -- an earlier
+    // NC-list counting method silently mis-counted (over-counted edges, mis-split faces)
+    // in 3D, and this reproduction catches that whole class of bug. counts came from the
+    // gathered serial copy, whose topology is identical to serial_mesh, so the true sizes
+    // computed on serial_mesh must match Reconstruct(counts, ...) exactly.
+    for (int p = 1; p <= 3; p++)
+    {
+      mfem::H1_FECollection fec(p, 3);
+      CHECK(Reconstruct(counts, fec) ==
+            mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+    }
+    for (int p = 1; p <= 3; p++)
+    {
+      mfem::ND_FECollection fec(p, 3);
+      CHECK(Reconstruct(counts, fec) ==
+            mfem::FiniteElementSpace(&serial_mesh, &fec).GetTrueVSize());
+    }
   }
 }
 
@@ -425,8 +440,11 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     CHECK(m.at("Dimension").get<int>() == 3);
     CHECK(m.at("TrueVertices").get<long long>() == 4);
     CHECK(m.at("TrueEdges").get<long long>() == 6);
-    CHECK(m.at("TrueFaces").get<long long>() == 4);
-    CHECK(m.at("Elements").get<long long>() == 1);
+    // Per-geometry blocks: a single tet has four triangular faces and is one tetrahedron.
+    CHECK(m.at("TrueFaces").at("triangle").get<long long>() == 4);
+    // A tet has no quadrilateral faces, so that key must be absent (not present-zero).
+    CHECK_FALSE(m.at("TrueFaces").contains("quadrilateral"));
+    CHECK(m.at("Cells").at("tetrahedron").get<long long>() == 1);
     CHECK(m.at("DomainAttributes").get<std::vector<int>>() == std::vector<int>{1});
     CHECK(m.at("BoundaryAttributes").get<std::vector<int>>() ==
           std::vector<int>{1, 2, 3, 4});

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -492,8 +492,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
 {
   MPI_Comm comm = MPI_COMM_WORLD;
 
-  // Pure-hexahedral nonconforming mesh: only quadrilateral faces, so this is the !tri_faced
-  // path (SQUARE present, TRIANGLE absent).
+  // A pure-hexahedral nonconforming mesh must report quadrilateral true faces only.
   auto serial_mesh = mfem::Mesh::MakeCartesian3D(3, 3, 3, mfem::Element::HEXAHEDRON);
   serial_mesh.EnsureNCMesh();
   mfem::Array<int> refs;

--- a/test/unit/test-basesolver.cpp
+++ b/test/unit/test-basesolver.cpp
@@ -72,7 +72,8 @@ long long Reconstruct(const mesh::MeshEntityCounts &c, mfem::FiniteElementCollec
 // split -- the quantity a prior RT-solve corrupted. `counts` come from a gathered serial
 // copy whose topology is identical to `serial_mesh`, so the true sizes must match exactly.
 // Runs on the caller's rank; call inside a root guard (counts are valid only on root).
-void CheckReconstructionOracle(const mesh::MeshEntityCounts &counts, mfem::Mesh &serial_mesh)
+void CheckReconstructionOracle(const mesh::MeshEntityCounts &counts,
+                               mfem::Mesh &serial_mesh)
 {
   const int dim = serial_mesh.Dimension();
   for (int p = 1; p <= 3; p++)
@@ -98,8 +99,8 @@ void CheckReconstructionOracle(const mesh::MeshEntityCounts &counts, mfem::Mesh 
   }
 }
 
-// Distribute `serial_mesh`, run RebalanceMesh with SaveAdaptMesh enabled (which fills the
-// counts on the root rank), and return the counts. Writes model.mesh into `out`.
+// Distribute `serial_mesh`, gather geometry-resolved counts while writing model.mesh, then
+// collectively complete nonconforming true vertex and edge counts.
 mesh::MeshEntityCounts ComputeCounts(MPI_Comm comm, const fs::path &out,
                                      mfem::Mesh &serial_mesh)
 {
@@ -111,6 +112,7 @@ mesh::MeshEntityCounts ComputeCounts(MPI_Comm comm, const fs::path &out,
   auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
   mesh::MeshEntityCounts counts;
   mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+  mesh::CompleteMeshEntityCounts(*parallel_mesh, counts);
   return counts;
 }
 
@@ -410,6 +412,14 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
 
   if (Mpi::Root(comm))
   {
+    CHECK_FALSE(counts.valid);
+    CHECK(counts.true_vertices == 0);
+    CHECK(counts.true_edges == 0);
+  }
+  mesh::CompleteMeshEntityCounts(*parallel_mesh, counts);
+
+  if (Mpi::Root(comm))
+  {
     REQUIRE(counts.valid);
     CHECK(counts.dim == 3);
     // The true (conforming) counts discount the constrained hanging vertices, edges, and
@@ -440,8 +450,9 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
     }
     CHECK(counts.true_vertices >= 0);
     CHECK(counts.true_edges >= 0);
-    // Reconstruction-vs-GetTrueVSize oracle across H1, ND, and RT (RT validates the tri/quad
-    // TRUE-face split that the old solve corrupted). See CheckReconstructionOracle.
+    // Reconstruction-vs-GetTrueVSize oracle across H1, ND, and RT (RT validates the
+    // tri/quad TRUE-face split that the old solve corrupted). See
+    // CheckReconstructionOracle.
     CheckReconstructionOracle(counts, serial_mesh);
   }
 }
@@ -562,9 +573,10 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   check_twin("quad2d", mfem::Mesh::MakeCartesian2D(3, 3, mfem::Element::QUADRILATERAL));
 }
 
-TEST_CASE_METHOD(palace::test::SharedTempDir,
-                 "RebalanceMesh entity counts reflect only the final mesh across iterations",
-                 "[basesolver][Serial]")
+TEST_CASE_METHOD(
+    palace::test::SharedTempDir,
+    "RebalanceMesh entity counts reflect only the final mesh across iterations",
+    "[basesolver][Serial]")
 {
   MPI_Comm comm = MPI_COMM_WORLD;
 
@@ -728,11 +740,10 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   iodata.model.refinement.save_adapt_mesh = true;
 
   // Build a nonconforming tet mesh identically on every rank, distribute it across the
-  // ranks, then RebalanceMesh gathers it back to the root rank to fill the counts. The
-  // reported counts must equal the single-rank answer (validated by the reconstruction
-  // oracle on the identical serial mesh) regardless of how the mesh was partitioned, and
-  // non-root ranks must be left unpopulated (valid == false, since FillMeshEntityCounts
-  // runs on root only and must contain no MPI-collective call).
+  // ranks, then RebalanceMesh gathers geometry-resolved counts on root and the collective
+  // completion step obtains true vertex and edge totals from distributed spaces. The
+  // reported counts must equal the single-rank answer regardless of partitioning, while
+  // non-root count records remain invalid.
   auto serial_mesh = mfem::Mesh::MakeCartesian3D(4, 4, 4, mfem::Element::TETRAHEDRON);
   serial_mesh.EnsureNCMesh(true);
   mfem::Array<int> refs;
@@ -746,6 +757,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   auto parallel_mesh = std::make_unique<mfem::ParMesh>(comm, serial_mesh);
   mesh::MeshEntityCounts counts;
   mesh::RebalanceMesh(iodata, parallel_mesh, &counts);
+  mesh::CompleteMeshEntityCounts(*parallel_mesh, counts);
 
   if (Mpi::Root(comm))
   {
@@ -758,7 +770,7 @@ TEST_CASE_METHOD(palace::test::SharedTempDir,
   }
   else
   {
-    // FillMeshEntityCounts runs on the root rank only; other ranks stay unpopulated.
+    // Only root owns the gathered geometry-resolved count record.
     CHECK_FALSE(counts.valid);
   }
 }


### PR DESCRIPTION
When Model.Refinement.SaveAdaptMesh is enabled, emit a `"SaveAdaptedMesh"` block to `postpro/palace.json `recording the true (conforming) topological entity counts (vertices, edges, faces), the element count, and the sorted domain and boundary attributes of the final adapted mesh. This lets external tooling size a re-run from the saved mesh without re-reading it.