### PR TITLE
Fix MatrixFunction for fully anisotropic material tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
 
 #### Bug Fixes
 
+  - Fixed `linalg::MatrixSqrt`/`MatrixPow` returning incorrect results for fully
+    anisotropic material tensors (all three off-diagonal entries nonzero, e.g. a crystal
+    with generically-rotated `MaterialAxes`). The closed-form 3x3 eigen-decomposition used
+    an incorrect invariant and eigenvector expressions that break for degenerate spectra
+    (such as rotated uniaxial tensors); this branch now uses MFEM's robust symmetric
+    eigensolver. Affected `√(μ⁻¹ε)`, `(με)^(-1/2)`, `ε·√(I + tanδ·tanδᵀ)` in the material
+    operator and the flux error-estimator weights.
   - Fixed adaptive iteration output archiving overwriting earlier meshes and made its
     filesystem updates more robust. [PR 892](https://github.com/awslabs/palace/pull/892).
   - Fixed ParaView output for multiple driven excitations deleting fields from earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ See the [developer notes on schema versioning](https://awslabs.github.io/palace/
     (such as rotated uniaxial tensors); this branch now uses MFEM's robust symmetric
     eigensolver. Affected `√(μ⁻¹ε)`, `(με)^(-1/2)`, `ε·√(I + tanδ·tanδᵀ)` in the material
     operator and the flux error-estimator weights.
+    [PR 912](https://github.com/awslabs/palace/pull/912).
   - Fixed adaptive iteration output archiving overwriting earlier meshes and made its
     filesystem updates more robust. [PR 892](https://github.com/awslabs/palace/pull/892).
   - Fixed ParaView output for multiple driven excitations deleting fields from earlier

--- a/palace/linalg/densematrix.cpp
+++ b/palace/linalg/densematrix.cpp
@@ -14,16 +14,17 @@ namespace palace
 namespace
 {
 
-// Compute matrix functions for symmetric real-valued 2x2 or 3x3 matrices. Returns the
-// matrix U * f(Λ) * U' for input U * Λ * U'.
-// Reference: Deledalle et al., Closed-form expressions of the eigen decomposition of 2x2
-//            and 3x3 Hermitian matrices, HAL hal-01501221 (2017).
+// Compute matrix functions for symmetric real-valued 1x1, 2x2, or 3x3 matrices. Returns
+// the matrix U * f(Λ) * U' for input U * Λ * U', evaluated from the eigendecomposition
+// computed by mfem::DenseMatrix::CalcEigenvalues.
 mfem::DenseMatrix MatrixFunction(const mfem::DenseMatrix &M,
                                  const std::function<double(const double &)> &functor)
 {
   MFEM_ASSERT(M.Height() == M.Width(),
               "MatrixFunction only available for square matrices!");
   const auto N = M.Height();
+  MFEM_VERIFY(1 <= N && N <= 3,
+              "MatrixFunction only supports 1x1, 2x2, or 3x3 matrices, N: " << N << "!");
   constexpr auto tol = 10.0 * std::numeric_limits<double>::epsilon();
   for (int i = 0; i < N; i++)
   {
@@ -41,175 +42,17 @@ mfem::DenseMatrix MatrixFunction(const mfem::DenseMatrix &M,
     Mout(0, 0) = functor(M(0, 0));
     return Mout;
   }
-  else if (N == 2)
+  // N is 2 or 3: evaluate f(M) = Σᵢ functor(λᵢ) vᵢ vᵢᵀ from the eigendecomposition returned
+  // by MFEM's robust symmetric eigensolver. Unlike closed-form expressions, it handles
+  // every nonzero pattern and returns an orthonormal eigenbasis even for degenerate spectra
+  // (a rotated uniaxial material tensor is a common degenerate input). The eigenvectors are
+  // stored consecutively, N doubles each; wrap each as a non-owning Vector (no allocation).
+  double lambda[3], vec[9];
+  M.CalcEigenvalues(lambda, vec);
+  for (int i = 0; i < N; i++)
   {
-    const auto &a = M(0, 0), &b = M(1, 1);
-    const auto &d = M(0, 1);
-    const bool d_non_zero = std::abs(d) > tol;
-    if (!d_non_zero)
-    {
-      // Diagonal: apply f directly to each eigenvalue.
-      for (int i = 0; i < 2; i++)
-      {
-        Mout(i, i) = functor(M(i, i));
-      }
-      return Mout;
-    }
-    // a d
-    // d b
-    const double disc = std::sqrt((a - b) * (a - b) + 4.0 * d * d);
-    const double lambda1 = (a + b - disc) / 2.0;
-    const double lambda2 = (a + b + disc) / 2.0;
-    const mfem::Vector v1{{d, lambda1 - a}};
-    const mfem::Vector v2{{d, lambda2 - a}};
-    AddMult_a_VVt(functor(lambda1) / (v1 * v1), v1, Mout);
-    AddMult_a_VVt(functor(lambda2) / (v2 * v2), v2, Mout);
-    return Mout;
-  }
-  else if (N == 3)
-  {
-    // Need to specialize based on the number of zeros and their locations.
-    const auto &a = M(0, 0), &b = M(1, 1), &c = M(2, 2);
-    const auto &d = M(0, 1), &e = M(1, 2), &f = M(0, 2);
-    const bool d_non_zero = std::abs(d) > tol;
-    const bool e_non_zero = std::abs(e) > tol;
-    const bool f_non_zero = std::abs(f) > tol;
-    if (!d_non_zero && !e_non_zero && !f_non_zero)
-    {
-      // a 0 0
-      // 0 b 0
-      // 0 0 c
-      for (int i = 0; i < 3; i++)
-      {
-        Mout(i, i) = functor(M(i, i));
-      }
-      return Mout;
-    }
-    if (d_non_zero && !e_non_zero && !f_non_zero)
-    {
-      // a d 0
-      // d b 0
-      // 0 0 c
-      const double disc = std::sqrt(a * a - 2.0 * a * b + b * b + 4.0 * d * d);
-      const double lambda1 = c;
-      const double lambda2 = (a + b - disc) / 2.0;
-      const double lambda3 = (a + b + disc) / 2.0;
-      const mfem::Vector v1{{0.0, 0.0, 1.0}};
-      const mfem::Vector v2{{-(-a + b + disc) / (2.0 * d), 1.0, 0.0}};
-      const mfem::Vector v3{{-(-a + b - disc) / (2.0 * d), 1.0, 0.0}};
-      AddMult_a_VVt(functor(lambda1) / (v1 * v1), v1, Mout);
-      AddMult_a_VVt(functor(lambda2) / (v2 * v2), v2, Mout);
-      AddMult_a_VVt(functor(lambda3) / (v3 * v3), v3, Mout);
-      return Mout;
-    }
-    if (!d_non_zero && e_non_zero && !f_non_zero)
-    {
-      // a 0 0
-      // 0 b e
-      // 0 e c
-      const double disc = std::sqrt(b * b - 2.0 * b * c + c * c + 4.0 * e * e);
-      const double lambda1 = a;
-      const double lambda2 = 0.5 * (b + c - disc);
-      const double lambda3 = 0.5 * (b + c + disc);
-      const mfem::Vector v1{{1.0, 0.0, 0.0}};
-      const mfem::Vector v2{{0.0, -(-b + c + disc) / (2.0 * e), 1.0}};
-      const mfem::Vector v3{{0.0, -(-b + c - disc) / (2.0 * e), 1.0}};
-      AddMult_a_VVt(functor(lambda1) / (v1 * v1), v1, Mout);
-      AddMult_a_VVt(functor(lambda2) / (v2 * v2), v2, Mout);
-      AddMult_a_VVt(functor(lambda3) / (v3 * v3), v3, Mout);
-      return Mout;
-    }
-    if (!d_non_zero && !e_non_zero && f_non_zero)
-    {
-      // a 0 f
-      // 0 b 0
-      // f 0 c
-      const double disc = std::sqrt(a * a - 2.0 * a * c + c * c + 4.0 * f * f);
-      const double lambda1 = b;
-      const double lambda2 = 0.5 * (a + c - disc);
-      const double lambda3 = 0.5 * (a + c + disc);
-      const mfem::Vector v1{{0.0, 1.0, 0.0}};
-      const mfem::Vector v2{{-(-a + c + disc) / (2.0 * f), 0.0, 1.0}};
-      const mfem::Vector v3{{-(-a + c - disc) / (2.0 * f), 0.0, 1.0}};
-      AddMult_a_VVt(functor(lambda1) / (v1 * v1), v1, Mout);
-      AddMult_a_VVt(functor(lambda2) / (v2 * v2), v2, Mout);
-      AddMult_a_VVt(functor(lambda3) / (v3 * v3), v3, Mout);
-      return Mout;
-    }
-    if ((!d_non_zero && e_non_zero && f_non_zero) ||
-        (d_non_zero && !e_non_zero && f_non_zero) ||
-        (d_non_zero && e_non_zero && !f_non_zero))
-    {
-      MFEM_ABORT("This nonzero pattern is not currently supported for MatrixFunction!");
-    }
-    // General case for all nonzero:
-    // a d f
-    // d b e
-    // f e c
-    const double a2 = a * a, b2 = b * b, c2 = c * c, d2 = d * d, e2 = e * e, f2 = f * f;
-    const double a2mbmc = 2.0 * a - b - c;
-    const double b2mamc = 2.0 * b - a - c;
-    const double c2mamb = 2.0 * c - a - b;
-    const double x1 = a2 + b2 + c2 - a * b - b * c + 3.0 * (d2 + e2 + f2);
-    const double x2 = -(a2mbmc * b2mamc * c2mamb) +
-                      9.0 * (c2mamb * d2 + b2mamc * f2 + a2mbmc * e2) - 54.0 * d * e * f;
-    const double phi = std::atan2(std::sqrt(4.0 * x1 * x1 * x1 - x2 * x2), x2);
-    const double lambda1 = (a + b + c - 2.0 * std::sqrt(x1) * std::cos(phi / 3.0)) / 3.0;
-    const double lambda2 =
-        (a + b + c + 2.0 * std::sqrt(x1) * std::cos((phi - M_PI) / 3.0)) / 3.0;
-    const double lambda3 =
-        (a + b + c + 2.0 * std::sqrt(x1) * std::cos((phi + M_PI) / 3.0)) / 3.0;
-
-    auto SafeDivide = [&](double x, double y)
-    {
-      if (std::abs(x) <= tol)
-      {
-        return 0.0;
-      }
-      if (std::abs(x) >= tol && std::abs(y) <= tol)
-      {
-        MFEM_ABORT("Logic error: Zero denominator with nonzero numerator!");
-        return 0.0;
-      }
-      return x / y;
-    };
-    const double m1 = SafeDivide(d * (c - lambda1) - e * f, f * (b - lambda1) - d * e);
-    const double m2 = SafeDivide(d * (c - lambda2) - e * f, f * (b - lambda2) - d * e);
-    const double m3 = SafeDivide(d * (c - lambda3) - e * f, f * (b - lambda3) - d * e);
-    const double l1mcmem1 = lambda1 - c - e * m1;
-    const double l2mcmem2 = lambda2 - c - e * m2;
-    const double l3mcmem3 = lambda3 - c - e * m3;
-    const double n1 = 1.0 + m1 * m1 + SafeDivide(std::pow(l1mcmem1, 2), f2);
-    const double n2 = 1.0 + m2 * m2 + SafeDivide(std::pow(l2mcmem2, 2), f2);
-    const double n3 = 1.0 + m3 * m3 + SafeDivide(std::pow(l3mcmem3, 2), f2);
-    const double tlambda1 = functor(lambda1) / n1;
-    const double tlambda2 = functor(lambda2) / n2;
-    const double tlambda3 = functor(lambda3) / n3;
-
-    const double at = (tlambda1 * l1mcmem1 * l1mcmem1 + tlambda2 * l2mcmem2 * l2mcmem2 +
-                       tlambda3 * l3mcmem3 * l3mcmem3) /
-                      f2;
-    const double bt = tlambda1 * m1 * m1 + tlambda2 * m2 * m2 + tlambda3 * m3 * m3;
-    const double ct = tlambda1 + tlambda2 + tlambda3;
-    const double dt =
-        (tlambda1 * m1 * l1mcmem1 + tlambda2 * m2 * l2mcmem2 + tlambda3 * m3 * l3mcmem3) /
-        f;
-    const double et = tlambda1 * m1 + tlambda2 * m2 + tlambda3 * m3;
-    const double ft = (tlambda1 * l1mcmem1 + tlambda2 * l2mcmem2 + tlambda3 * l3mcmem3) / f;
-    Mout(0, 0) = at;
-    Mout(0, 1) = dt;
-    Mout(0, 2) = ft;
-    Mout(1, 0) = dt;
-    Mout(1, 1) = bt;
-    Mout(1, 2) = et;
-    Mout(2, 0) = ft;
-    Mout(2, 1) = et;
-    Mout(2, 2) = ct;
-    return Mout;
-  }
-  else
-  {
-    MFEM_ABORT("MatrixFunction only supports 2x2 or 3x3 matrices, N: " << N << "!");
+    const mfem::Vector v(vec + N * i, N);
+    AddMult_a_VVt(functor(lambda[i]) / (v * v), v, Mout);
   }
   return Mout;
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(unit-tests
   ${CMAKE_CURRENT_SOURCE_DIR}/test-communication.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-config.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-constants.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test-densematrix.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-domainpostoperator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-floquetport.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test-geodata.cpp

--- a/test/unit/test-densematrix.cpp
+++ b/test/unit/test-densematrix.cpp
@@ -1,0 +1,152 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <mfem.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "linalg/densematrix.hpp"
+
+using namespace palace;
+using namespace Catch::Matchers;
+
+namespace
+{
+
+// Rotation matrix for a rotation by the given angle (radians) about the given axis
+// (normalized internally), via the Rodrigues formula.
+mfem::DenseMatrix RotationMatrix(double ax, double ay, double az, double angle)
+{
+  const double norm = std::sqrt(ax * ax + ay * ay + az * az);
+  const double u[3] = {ax / norm, ay / norm, az / norm};
+  const double c = std::cos(angle), s = std::sin(angle);
+  mfem::DenseMatrix R(3);
+  for (int i = 0; i < 3; i++)
+  {
+    for (int j = 0; j < 3; j++)
+    {
+      R(i, j) = (1.0 - c) * u[i] * u[j] + ((i == j) ? c : 0.0);
+    }
+  }
+  R(0, 1) -= s * u[2];
+  R(0, 2) += s * u[1];
+  R(1, 0) += s * u[2];
+  R(1, 2) -= s * u[0];
+  R(2, 0) -= s * u[1];
+  R(2, 1) += s * u[0];
+  return R;
+}
+
+// Construct R * diag(d0, d1, d2) * Rᵀ, exactly symmetric by construction.
+mfem::DenseMatrix RotatedDiagonal(const mfem::DenseMatrix &R, double d0, double d1,
+                                  double d2)
+{
+  const double d[3] = {d0, d1, d2};
+  mfem::DenseMatrix M(3);
+  for (int i = 0; i < 3; i++)
+  {
+    for (int j = i; j < 3; j++)
+    {
+      double v = 0.0;
+      for (int k = 0; k < 3; k++)
+      {
+        v += R(i, k) * d[k] * R(j, k);
+      }
+      M(i, j) = M(j, i) = v;
+    }
+  }
+  return M;
+}
+
+// Relative Frobenius-norm residual ‖A − B‖ / ‖B‖.
+double RelDiff(const mfem::DenseMatrix &A, const mfem::DenseMatrix &B)
+{
+  mfem::DenseMatrix D(A);
+  D -= B;
+  return D.FNorm() / B.FNorm();
+}
+
+}  // namespace
+
+TEST_CASE("MatrixSqrt matches the closed-form eigendecomposition", "[densematrix][Serial]")
+{
+  // We compare against exact ground truth instead: RotatedDiagonal(R, d0, d1,
+  // d2) is R · diag(d0, d1, d2) · Rᵀ, so its eigenvalues are exactly {d0, d1,
+  // d2} and its eigenvectors are the columns of R by construction. Hence the
+  // principal square root is exactly R · diag(√d0, √d1, √d2) · Rᵀ, which we
+  // build with the same helper. Matching it element-wise directly validates
+  // that the eigenvalues (magnitude and sign) and eigenvectors used inside
+  // MatrixFunction are correct.
+  constexpr double tol = 1.0e-12;
+  const auto R = RotationMatrix(1.0, 2.0, 3.0, 0.646);
+
+  SECTION("2x2")
+  {
+    // 2x2 symmetric M = Q·diag(4, 9)·Qᵀ for a 2D rotation Q(θ); its principal square root
+    // is Q·diag(2, 3)·Qᵀ. Exercises the N == 2 path (mfem CalcEigenvalues<2>).
+    const double theta = 0.7, c = std::cos(theta), s = std::sin(theta);
+    const auto rotated_2x2 = [&](double d0, double d1)
+    {
+      mfem::DenseMatrix A(2);
+      A(0, 0) = c * c * d0 + s * s * d1;
+      A(1, 1) = s * s * d0 + c * c * d1;
+      A(0, 1) = A(1, 0) = c * s * (d0 - d1);
+      return A;
+    };
+    REQUIRE_THAT(RelDiff(linalg::MatrixSqrt(rotated_2x2(4.0, 9.0)), rotated_2x2(2.0, 3.0)),
+                 WithinAbs(0.0, tol));
+  }
+
+  SECTION("distinct eigenvalues")
+  {
+    const auto M = RotatedDiagonal(R, 8.9, 9.6, 11.3);
+    const auto expected =
+        RotatedDiagonal(R, std::sqrt(8.9), std::sqrt(9.6), std::sqrt(11.3));
+    REQUIRE_THAT(RelDiff(linalg::MatrixSqrt(M), expected), WithinAbs(0.0, tol));
+  }
+
+  SECTION("repeated eigenvalue")
+  {
+    // Degenerate spectrum: the eigenvectors of the repeated pair are not unique, but the
+    // principal square root R · diag(√d) · Rᵀ still is, so the exact comparison holds.
+    const auto M = RotatedDiagonal(R, 9.27, 9.27, 11.34);
+    const auto expected =
+        RotatedDiagonal(R, std::sqrt(9.27), std::sqrt(9.27), std::sqrt(11.34));
+    REQUIRE_THAT(RelDiff(linalg::MatrixSqrt(M), expected), WithinAbs(0.0, tol));
+  }
+}
+
+TEST_CASE("MatrixPow of symmetric matrices", "[densematrix][Serial]")
+{
+  constexpr double tol = 1.0e-12;
+
+  // M^(-1/2) · M · M^(-1/2) should recover the identity. Check both a fully coupled SPD
+  // input with distinct eigenvalues and a degenerate (rotated uniaxial) one, since the
+  // general branch is what the fix targets.
+  const auto R = RotationMatrix(1.0, 2.0, 3.0, 0.646);
+  mfem::DenseMatrix I(3);
+  I = 0.0;
+  for (int i = 0; i < 3; i++)
+  {
+    I(i, i) = 1.0;
+  }
+
+  const auto check_inverse_sqrt = [&](const mfem::DenseMatrix &M)
+  {
+    const mfem::DenseMatrix P = linalg::MatrixPow(M, -0.5);
+    mfem::DenseMatrix PM(3), PMP(3);
+    mfem::Mult(P, M, PM);
+    mfem::Mult(PM, P, PMP);
+    REQUIRE_THAT(RelDiff(PMP, I), WithinAbs(0.0, tol));
+  };
+
+  SECTION("distinct eigenvalues")
+  {
+    check_inverse_sqrt(RotatedDiagonal(R, 8.9, 9.6, 11.3));
+  }
+
+  SECTION("repeated eigenvalue")
+  {
+    check_inverse_sqrt(RotatedDiagonal(R, 9.27, 9.27, 11.34));
+  }
+}


### PR DESCRIPTION
The general (all off-diagonal nonzero) branch of `linalg::MatrixFunction` used a closed-form 3x3 eigendecomposition with an incorrect first invariant (missing an a*c term) and eigenvector expressions that assume distinct eigenvalues.

As a result `MatrixSqrt`/`MatrixPow` returned silently-wrong results for fully anisotropic material tensors  and broke entirely for degenerate spectra such as rotated uniaxial tensors (e.g. sapphire). This fed wrong values into the material operator's sqrt(mu^-1 eps), (mu eps)^-1/2 and eps*sqrt(I + tand tand^T), and into the flux error-estimator weights.

This PR replaces the explicit formula with `mfem::DenseMatrix::CalcEigenvalues`. The diagonal and single-off-diagonal special-case branches are correct and left unchanged. This is a little slower than the explicit formula, but this function is never used in performance-sensitive regions.

Closes #907 
