### PR TITLE
Fix parenthesis in test

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -75,15 +75,7 @@ jobs:
   # build-containers-release below, so this job is gated off for them.
   build-containers:
     needs: filter
-    if: >-
-      ${{
-        !startsWith(github.ref, 'refs/tags/v') &&
-        (
-          needs.filter.outputs.test == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/main'
-        )
-      }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +102,9 @@ jobs:
       # (Release tags are handled by build-containers-release, which has no
       # filter.)
       - uses: actions/checkout@v6
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
       - uses: ./.github/actions/build-container
+        if: needs.filter.outputs.test == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
         with:
           target: ${{ matrix.target }}
 

--- a/test/unit/test-postoperator.cpp
+++ b/test/unit/test-postoperator.cpp
@@ -139,7 +139,7 @@ auto RandomMeasurement(int ndomain = 5)
   {
     cache.interface_eps_i.emplace_back(
         Measurement::InterfaceData{i, 1 + randd(100), (1 + randd(9999)) / 10000,
-                                   (1 + randd(9999) / 10000), 1e9 / (1 + randd(9999))});
+                                   (1 + randd(9999)) / 10000, 1e9 / (1 + randd(9999))});
   }
 
   return cache;


### PR DESCRIPTION
The `energy_participation` argument uses `(1 + randd(9999) / 10000)`, giving values always larger than 1.

<!--
*Description of changes:*

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.
-->
