### PR TITLE
Bump MFEM to v4.10 and drop patches merged upstream

### DIFF
--- a/cmake/ExternalGitTags.cmake
+++ b/cmake/ExternalGitTags.cmake
@@ -133,7 +133,7 @@ set(EXTERN_MFEM_GIT_BRANCH
   "Git branch for external MFEM build"
 )
 set(EXTERN_MFEM_GIT_TAG
-  "d9d6526cc1749980a2ba1da16e2c1ca1e07d82ec" CACHE STRING
+  "d964264cdb9a13e94a201b6c236c7721e0c8765f" CACHE STRING
   "Git tag for external MFEM build"
 )
 

--- a/cmake/ExternalMFEM.cmake
+++ b/cmake/ExternalMFEM.cmake
@@ -419,43 +419,11 @@ download_mfem_patch(
   "https://github.com/mfem/mfem/compare/2d574015756711029556c14d096ca52c15d5b663...50ead1a9a785e3273b2a72ff59ac8ed8a496b498.diff"
   e9be1a0d4b2642ed1b72f31c36065cf0aacbe342b6594d5d943782c73a6177f4
 )
-# https://github.com/mfem/mfem/commit/e4a2b9568c40f20e24612066d155cc6a9973b247
-download_mfem_patch(
-  mfem_gmsh_parser_performance.diff
-  "https://github.com/mfem/mfem/commit/e4a2b9568c40f20e24612066d155cc6a9973b247.diff"
-  6ced66f487780af66fb8184d329b9aad4b694e711b65830391e8c6d0c898713e
-)
-# https://github.com/mfem/mfem/pull/5246
-download_mfem_patch(
-  mfem_pr5246.diff
-  "https://raw.githubusercontent.com/awslabs/palace/b22f654ab36fe01f1f3176349c60626efed1a6a2/extern/patch/mfem/mfem_pr5246.diff"
-  d5227c18768369b8fa3a20f4457dd378a360346850329ab1970d18ed5a73b0d6
-)
 # https://github.com/mfem/mfem/pull/5353
 download_mfem_patch(
   mfem_pr5353.diff
   "https://raw.githubusercontent.com/awslabs/palace/b22f654ab36fe01f1f3176349c60626efed1a6a2/extern/patch/mfem/mfem_pr5353.diff"
   c35f584090f97c84c12fc80e6d5c068512911d192132e18f5aa4254f507c5e4f
-)
-# https://github.com/mfem/mfem/pull/4983
-download_mfem_patch(
-  mfem_pr4983.diff
-  "https://raw.githubusercontent.com/awslabs/palace/b22f654ab36fe01f1f3176349c60626efed1a6a2/extern/patch/mfem/mfem_pr4983.diff"
-  530532da3ae8815d004bb6ce19f6f08a1248c3d585503551c90d0eeae7fb3f87
-)
-if(PALACE_WITH_CUDSS)
-  # https://github.com/mfem/mfem/pull/5124
-  download_mfem_patch(
-    mfem_pr5124_cudss.diff
-    "https://raw.githubusercontent.com/awslabs/palace/b22f654ab36fe01f1f3176349c60626efed1a6a2/extern/patch/mfem/mfem_pr5124_cudss.diff"
-    d0b5893ec7925cbc8a70cc5eba2abe037754b99b5bb366c4bae90f0583d22290
-  )
-endif()
-# https://github.com/mfem/mfem/pull/5415
-download_mfem_patch(
-  mfem_pr5415.diff
-  "https://github.com/mfem/mfem/commit/9d1438d8a2502cc927c63e093cf8c855ff17918e.diff"
-  482655b6b740b880713d67bcca843571244b7d383c95e0cef3d3102b3327ff2f
 )
 
 include(ExternalProject)

--- a/palace/models/surfacecurlsolver.cpp
+++ b/palace/models/surfacecurlsolver.cpp
@@ -65,20 +65,24 @@ void SolveSurfaceCurlProblem(const SurfaceFluxData &flux_data, const IoData &iod
   int num_holes = hole_surface_attrs.Size();
 
   // Extract hole boundary DOFs
-  std::unordered_map<int, mfem::Array<int>> attr_to_elements;
+  std::vector<mfem::Array<int>> attr_to_elements;
   std::vector<std::unordered_map<int, int>> hole_dof_to_edge_maps(num_holes);
-  std::vector<mfem::Array<int>> hole_ess_tdof_lists(num_holes);
-  std::vector<mfem::Array<int>> hole_ldof_markers(num_holes);
-  std::vector<std::unordered_set<int>> hole_boundary_edge_ldofs(num_holes);
 
   const_cast<mfem::ParFiniteElementSpace *>(fespace)->GetBoundaryElementsByAttribute(
       hole_surface_attrs, attr_to_elements);
   for (int h = 0; h < num_holes; h++)
   {
-    const_cast<mfem::ParFiniteElementSpace *>(fespace)->GetBoundaryEdgeDoFs(
-        attr_to_elements[hole_surface_attrs[h]], hole_ess_tdof_lists[h],
-        hole_ldof_markers[h], hole_boundary_edge_ldofs[h], &hole_dof_to_edge_maps[h],
-        nullptr, nullptr, nullptr);
+    // Only the DoF-to-edge map is consumed downstream (by mesh::MatchBoundaryEdges,
+    // which reads its edge-id values). Rebuild it from the two parallel outputs of
+    // GetBoundaryLoopEdgeDofs; the other outputs are unused here.
+    mfem::Array<int> ess_tdof_list, boundary_edge_dofs, dof_edges;
+    const_cast<mfem::ParFiniteElementSpace *>(fespace)->GetBoundaryLoopEdgeDofs(
+        attr_to_elements[h], ess_tdof_list, boundary_edge_dofs, nullptr, &dof_edges,
+        nullptr, nullptr);
+    for (int i = 0; i < boundary_edge_dofs.Size(); i++)
+    {
+      hole_dof_to_edge_maps[h][boundary_edge_dofs[i]] = dof_edges[i];
+    }
   }
 
   // Create submesh from all metal surface attributes


### PR DESCRIPTION
## Summary

MFEM **v4.10** is released and now includes several PRs Palace was carrying as local backport patches. This bumps `EXTERN_MFEM_GIT_TAG` to v4.10 and cleans up the patch set accordingly.

## Patches dropped (now merged upstream in v4.10)

- `mfem_pr4983.diff`, `mfem_pr5246.diff`, `mfem_pr5415.diff`, `mfem_pr5124_cudss.diff`
- `mfem_gmsh_parser_performance.diff`: v4.10 rewrote the Gmsh reader into a new `mesh/gmsh.cpp` (signature changed to `ReadGmshMesh(istream&)`) and already adopts its main optimization (`unordered_map` vertex map). The patch targeted the old `mesh_readers.cpp` code that no longer exists, so it can't be rebased and is largely superseded. Only the `reserve()` preallocations are lost. 

## Patches kept (still unmerged upstream)

- `mfem_pr3847.diff`, `mfem_pr5353.diff`

## Code changes

PR 4983's public API changed between our backport and the merged version, so `palace/models/surfacecurlsolver.cpp` is updated:

- `GetBoundaryElementsByAttribute` now returns a position-indexed `std::vector<Array<int>>` (was a `std::unordered_map<int, Array<int>>` keyed by attribute value).
- `GetBoundaryEdgeDoFs` → `GetBoundaryLoopEdgeDofs`, with reordered/retyped outputs (`dof_edges` is now `Array<int>*`). The hole DoF-to-edge map is rebuilt from the two parallel output arrays; only its edge-id values are consumed downstream by `mesh::MatchBoundaryEdges`.
