### PR TITLE
Fix segfault in NLEPS random-guess fallback

### DIFF
--- a/palace/linalg/nleps.cpp
+++ b/palace/linalg/nleps.cpp
@@ -455,10 +455,16 @@ int QuasiNewtonSolver::Solve()
       eig = sigma;
       if (num_init_guess < 3)
       {
-        // Set purely random vector.
+        // Set purely random vector, zeroing the essential-BC true dofs. On a
+        // partitioned mesh GetEssentialTrueDofs() returns nullptr on ranks whose
+        // local partition owns no essential (Dirichlet/PEC) dofs, in which case
+        // there is nothing to zero on this rank.
         linalg::SetRandom(GetComm(), v);
-        linalg::SetSubVector(
-            v, *dynamic_cast<const ComplexParOperator *>(opK)->GetEssentialTrueDofs(), 0.0);
+        if (const auto *ess_tdof_list =
+                dynamic_cast<const ComplexParOperator *>(opK)->GetEssentialTrueDofs())
+        {
+          linalg::SetSubVector(v, *ess_tdof_list, 0.0);
+        }
       }
       else
       {


### PR DESCRIPTION
`QuasiNewtonSolver::Solve` dereferenced `GetEssentialTrueDofs()` unconditionally when seeding a random vector after exhausting the initial guesses. That accessor returns `nullptr` on ranks whose partition owns no essential (Dirichlet/PEC) true dofs, so on a distributed mesh those ranks segfaulted. With the crash gone, an unconverged eigenmode solve now returns cleanly and the existing `num_conv` verification reports the failure instead of crashing.