### PR TITLE
Add 0.18.0 release follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format of this changelog is based on
 
 See the [developer notes on schema versioning](https://awslabs.github.io/palace/dev/developer/notes/#Schema-versioning) for how versions are bumped.
 
+## In progress
+
 ## [0.18.0] - 2026-09-09
 
 #### New Features

--- a/docs/src/developer/notes.md
+++ b/docs/src/developer/notes.md
@@ -222,13 +222,14 @@ numerically to *Palace*'s release version. The coupling is one-directional:
     not bump the schema version.
 
 Because the schema is versioned independently, a single schema version generally spans
-several *Palace* releases. The table below records the first *Palace* release shipping
-each schema version; a schema version applies to that release and all later ones up to
-(but not including) the next entry. Add a row whenever the schema version is bumped.
+several *Palace* releases. The table below records the schema version shipped by each
+*Palace* release; a listed version applies from that release until the next row. Add a
+row when a release is cut, recording the schema version at that boundary.
 
-| Schema version | First *Palace* release | Notes                              |
-|:--------------:|:----------------------:|:---------------------------------- |
-| `1-0-0`        | `0.17`                 | First explicitly-versioned schema. |
+| Schema version | *Palace* release | Notes                              |
+|:--------------:|:----------------:|:---------------------------------- |
+| `1-0-0`        | `0.17`           | First explicitly-versioned schema. |
+| `1-6-0`        | `0.18`           |                                    |
 
 #### When and how to bump (PR checklist)
 

--- a/spack_repo/local/packages/palace/package.py
+++ b/spack_repo/local/packages/palace/package.py
@@ -20,6 +20,7 @@ class Palace(CMakePackage, CudaPackage, ROCmPackage):
     maintainers("hughcars", "sbozzolo", "simlap")
 
     version("develop", branch="main")
+    version("0.18.0", tag="v0.18.0", commit="b92aef83ecfe6d360c4b3d83e2122986297f6778")
     version("0.17.0", tag="v0.17.0", commit="12d8069afb5aa9e169a17e303d735e120968e9f2")
     version("0.16.1", tag="v0.16.1", commit="c13e409f255392b9d78369c386276cf9343c2205")
     version("0.16.0", tag="v0.16.0", commit="869ee5ced4850384410a7aeebc7c25f4c01be161")


### PR DESCRIPTION
Follow up the v0.18.0 release.

- Register v0.18.0 in the local Spack Palace recipe using the annotated release target.
- Record the SchemaVer versions first shipped in v0.18 in the developer compatibility table.
- Restore the top-level `In progress` changelog section for post-release work.

Validation:
- `git diff --check`
- `python3 -m py_compile spack_repo/local/packages/palace/package.py`
- `./scripts/check-changelog-schema-versions`