### PR TITLE
Reduce weighted CGS and CPU multigrid operator costs

### DIFF
--- a/palace/linalg/orthog.hpp
+++ b/palace/linalg/orthog.hpp
@@ -53,21 +53,20 @@ inline void OrthogonalizeColumnMGS(MPI_Comm comm, const std::vector<VecType> &V,
   }
 }
 
-template <typename VecType, typename ScalarType,
-          typename InnerProductW = IdentityInnerProduct>
+namespace internal
+{
+
+template <typename VecType, typename ScalarType, typename Project>
 inline void OrthogonalizeColumnCGS(MPI_Comm comm, const std::vector<VecType> &V, VecType &w,
-                                   ScalarType *H, std::size_t m, bool refine = false,
-                                   const InnerProductW &dot_op = {})
+                                   ScalarType *H, std::size_t m, bool refine,
+                                   const Project &project)
 {
   MFEM_ASSERT(m <= V.size(), "Out of bounds number of columns for CGS orthogonalization!");
   if (m == 0)
   {
     return;
   }
-  for (std::size_t j = 0; j < m; j++)
-  {
-    H[j] = dot_op(w, V[j]);  // Local inner product
-  }
+  project(w, H);
   Mpi::GlobalSum(m, H, comm);
   for (std::size_t j = 0; j < m; j++)
   {
@@ -76,10 +75,7 @@ inline void OrthogonalizeColumnCGS(MPI_Comm comm, const std::vector<VecType> &V,
   if (refine)
   {
     std::vector<ScalarType> dH(m);
-    for (int j = 0; j < m; j++)
-    {
-      dH[j] = dot_op(w, V[j]);  // Local inner product
-    }
+    project(w, dH.data());
     Mpi::GlobalSum(m, dH.data(), comm);
     for (std::size_t j = 0; j < m; j++)
     {
@@ -87,6 +83,46 @@ inline void OrthogonalizeColumnCGS(MPI_Comm comm, const std::vector<VecType> &V,
       w.Add(-dH[j], V[j]);
     }
   }
+}
+
+}  // namespace internal
+
+template <typename VecType, typename ScalarType,
+          typename InnerProductW = IdentityInnerProduct>
+inline void OrthogonalizeColumnCGS(MPI_Comm comm, const std::vector<VecType> &V, VecType &w,
+                                   ScalarType *H, std::size_t m, bool refine = false,
+                                   const InnerProductW &dot_op = {})
+{
+  internal::OrthogonalizeColumnCGS(comm, V, w, H, m, refine,
+                                   [&V, m, &dot_op](const VecType &x, ScalarType *h)
+                                   {
+                                     for (std::size_t j = 0; j < m; j++)
+                                     {
+                                       h[j] = dot_op(x, V[j]);  // Local inner product
+                                     }
+                                   });
+}
+
+// Operator-weighted CGS needs only one application of W per pass because w is unchanged
+// while computing its projections. Reapply W after the first update when refining.
+// The caller owns the workspace, which must not alias w or any basis vector.
+template <typename VecType, typename ScalarType, typename WeightOperator>
+inline void OrthogonalizeColumnWeightedCGS(MPI_Comm comm, const std::vector<VecType> &V,
+                                           VecType &w, ScalarType *H, std::size_t m,
+                                           const WeightOperator &W, VecType &work,
+                                           bool refine = false)
+{
+  internal::OrthogonalizeColumnCGS(comm, V, w, H, m, refine,
+                                   [&V, m, &W, &work](const VecType &x, ScalarType *h)
+                                   {
+                                     work.SetSize(x.Size());
+                                     work.UseDevice(x.UseDevice());
+                                     W.Mult(x, work);
+                                     for (std::size_t j = 0; j < m; j++)
+                                     {
+                                       h[j] = LocalDot(work, V[j]);
+                                     }
+                                   });
 }
 
 template <typename VecType, typename ScalarType,

--- a/palace/models/romoperator.cpp
+++ b/palace/models/romoperator.cpp
@@ -889,10 +889,19 @@ void RomOperator::UpdatePROM(const ComplexVector &u, std::string_view node_label
     {
       auto pre_norm_sq = weight_op_W->InnerProduct(space_op.GetComm(), v, v, r.Real());
       pre_norm = std::sqrt(std::abs(pre_norm_sq));
-      linalg::OrthogonalizeColumn(
-          orthog_type, space_op.GetComm(), V, v, orth_R.col(dim_V).data(), dim_V,
-          [&W = *(this->weight_op_W), &r = this->r](const Vector &x, const Vector &y)
-          { return W.InnerProduct(x, y, r.Real()); });
+      if (orthog_type == Orthogonalization::MGS)
+      {
+        linalg::OrthogonalizeColumnMGS(
+            space_op.GetComm(), V, v, orth_R.col(dim_V).data(), dim_V,
+            [&W = *weight_op_W, &r = this->r](const Vector &x, const Vector &y)
+            { return W.InnerProduct(x, y, r.Real()); });
+      }
+      else
+      {
+        linalg::OrthogonalizeColumnWeightedCGS(
+            space_op.GetComm(), V, v, orth_R.col(dim_V).data(), dim_V, *weight_op_W,
+            r.Real(), orthog_type == Orthogonalization::CGS2);
+      }
       auto norm_sq = weight_op_W->InnerProduct(space_op.GetComm(), v, v, r.Real());
       orth_R(dim_V, dim_V) = std::sqrt(std::abs(norm_sq));
     }

--- a/palace/models/spaceoperator.cpp
+++ b/palace/models/spaceoperator.cpp
@@ -399,7 +399,7 @@ auto AssembleOperators(const FiniteElementSpaceHierarchy &fespaces,
   // independent of the chosen sparse-solver representation. Fine partial-assembly levels
   // have no symbolic structure to preserve, so exact-zero terms are omitted there.
   BilinearForm coarse(fespaces.GetFESpaceAtLevel(0));
-  AddConfiguredIntegrators(coarse, df, f, dfb, fb, fp, assemble_q_data);
+  AddConfiguredIntegrators(coarse, df, f, dfb, fb, fp);
   std::vector<std::unique_ptr<Operator>> ops;
   ops.reserve(fespaces.GetNumLevels());
   ops.push_back(coarse.Assemble(skip_zeros));
@@ -423,7 +423,7 @@ auto AssembleAuxOperators(const FiniteElementSpaceHierarchy &fespaces,
 {
   // Match the configured coarse-support policy of the primary hierarchy above.
   BilinearForm coarse(fespaces.GetFESpaceAtLevel(0));
-  AddConfiguredAuxIntegrators(coarse, f, fb, assemble_q_data);
+  AddConfiguredAuxIntegrators(coarse, f, fb);
   std::vector<std::unique_ptr<Operator>> ops;
   ops.reserve(fespaces.GetNumLevels());
   ops.push_back(coarse.Assemble(skip_zeros));
@@ -1024,7 +1024,10 @@ void SpaceOperator::AssemblePreconditioner(
     std::vector<std::unique_ptr<Operator>> &bi_vec,
     std::vector<std::unique_ptr<Operator>> &bi_aux_vec)
 {
-  constexpr bool skip_zeros = false, assemble_q_data = false;
+  constexpr bool skip_zeros = false;
+  // Cache geometry/material tensors for repeated CPU smoother applications. Only the
+  // fine hierarchy uses this data; the coarse sparse operator is assembled separately.
+  const bool assemble_q_data = !mfem::Device::Allows(mfem::Backend::DEVICE_MASK);
   MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()),
       dfi(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
       fi(mat_op.MaxCeedAttribute()), dfbr(mat_op.MaxCeedBdrAttribute()),
@@ -1087,7 +1090,8 @@ void SpaceOperator::AssemblePreconditioner(
     std::vector<std::unique_ptr<Operator>> &br_vec,
     std::vector<std::unique_ptr<Operator>> &br_aux_vec)
 {
-  constexpr bool skip_zeros = false, assemble_q_data = false;
+  constexpr bool skip_zeros = false;
+  const bool assemble_q_data = !mfem::Device::Allows(mfem::Backend::DEVICE_MASK);
   MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
       dfbr(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute());
   AddStiffnessCoefficients(a0.real(), dfr, fr);
@@ -1121,7 +1125,8 @@ void SpaceOperator::AssemblePreconditioner(
     std::vector<std::unique_ptr<Operator>> &br_vec,
     std::vector<std::unique_ptr<Operator>> &br_aux_vec)
 {
-  constexpr bool skip_zeros = false, assemble_q_data = false;
+  constexpr bool skip_zeros = false;
+  const bool assemble_q_data = !mfem::Device::Allows(mfem::Backend::DEVICE_MASK);
   MaterialPropertyCoefficient dfr(mat_op.MaxCeedAttribute()), fr(mat_op.MaxCeedAttribute()),
       dfbr(mat_op.MaxCeedBdrAttribute()), fbr(mat_op.MaxCeedBdrAttribute());
   AddStiffnessCoefficients(a0, dfr, fr);

--- a/scripts/measure-test-coverage
+++ b/scripts/measure-test-coverage
@@ -182,14 +182,15 @@ detect_compiler_type() {
     fi
 }
 
-# Return "--ignore-errors inconsistent" if the installed lcov supports it (>= 2.0),
-# or empty string otherwise. The "inconsistent" error type was added in lcov 2.0.
+# Return coverage inconsistency flags for lcov >= 2.0, or empty string otherwise.
+# Catch2 template-test macros can produce conflicting function end lines, which
+# lcov 2.0 reports as "mismatch". The "inconsistent" error type was added in lcov 2.0.
 lcov_ignore_inconsistent() {
     local version
     version=$(lcov --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
     local major="${version%%.*}"
     if [[ "$major" -ge 2 ]] 2>/dev/null; then
-        echo "--ignore-errors inconsistent"
+        echo "--ignore-errors inconsistent,mismatch"
     fi
 }
 
@@ -293,7 +294,7 @@ generate_gcc_coverage() {
     # compiled functions. This can lead to minor inconsistencies in the coverage
     # files. These are not fatal, and ignoring them still produces good reports.
     # For this reason, most `lcov` commands have the `--ignore-errors
-    # inconsistent` flag (lcov >= 2.0).
+    # inconsistent,mismatch` flag (lcov >= 2.0).
 
     lcov --capture --directory . $(lcov_ignore_inconsistent) --output-file "$BUILD_DIR/coverage.info"
 }

--- a/test/unit/test-orthog.cpp
+++ b/test/unit/test-orthog.cpp
@@ -3,7 +3,9 @@
 
 #include <complex>
 #include <memory>
+#include <type_traits>
 #include <vector>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -17,6 +19,105 @@
 using namespace palace;
 using namespace Catch::Matchers;
 using namespace Catch;
+
+namespace
+{
+
+struct CountingWeightOperator
+{
+  mfem::DenseMatrix matrix;
+  mutable int applications = 0;
+
+  explicit CountingWeightOperator(int n) : matrix(n)
+  {
+    matrix = 0.0;
+    for (int i = 0; i < n; i++)
+    {
+      matrix(i, i) = 2.0 + i;
+      if (i > 0)
+      {
+        matrix(i, i - 1) = matrix(i - 1, i) = 0.25;
+      }
+    }
+  }
+
+  void Mult(const Vector &x, Vector &y) const
+  {
+    applications++;
+    matrix.Mult(x, y);
+  }
+
+  void Mult(const ComplexVector &x, ComplexVector &y) const
+  {
+    applications++;
+    matrix.Mult(x.Real(), y.Real());
+    matrix.Mult(x.Imag(), y.Imag());
+  }
+};
+
+}  // namespace
+
+TEMPLATE_TEST_CASE("Weighted CGS reuses the weight application within each pass",
+                   "[orthog][Serial][Parallel]", Vector, ComplexVector)
+{
+  using VecType = TestType;
+  using ScalarType =
+      std::conditional_t<std::is_same_v<VecType, Vector>, double, std::complex<double>>;
+  const auto m = GENERATE(std::size_t{0}, std::size_t{1}, std::size_t{4});
+  const bool refine = GENERATE(false, true);
+  const auto comm = Mpi::World();
+  constexpr int n = 6;
+  CountingWeightOperator W(n);
+  VecType reference_work(n), work;
+  auto dot = [&W, &reference_work](const VecType &x, const VecType &y)
+  {
+    W.Mult(x, reference_work);
+    return linalg::LocalDot(reference_work, y);
+  };
+
+  std::vector<VecType> V;
+  V.reserve(m + 1);
+  std::vector<ScalarType> H(m), H_ref(m);
+  for (std::size_t j = 0; j <= m; j++)
+  {
+    auto &v = V.emplace_back(n);
+    const auto seed = 314159 + 17 * Mpi::Rank(comm) + 2 * j;
+    if constexpr (std::is_same_v<VecType, Vector>)
+    {
+      v.Randomize(seed);
+    }
+    else
+    {
+      v.Real().Randomize(seed);
+      v.Imag().Randomize(seed + 1);
+    }
+    if (j < m)
+    {
+      linalg::OrthogonalizeColumnMGS(comm, V, v, H.data(), j, dot);
+      auto norm_sq = dot(v, v);
+      Mpi::GlobalSum(1, &norm_sq, comm);
+      v *= 1.0 / std::sqrt(std::abs(norm_sq));
+    }
+  }
+
+  // Match the PROM use case, where the vector being orthogonalized is V.back().
+  auto &w = V.back();
+  VecType expected(w);
+  linalg::OrthogonalizeColumnCGS(comm, V, expected, H_ref.data(), m, refine, dot);
+  W.applications = 0;
+  linalg::OrthogonalizeColumnWeightedCGS(comm, V, w, H.data(), m, W, work, refine);
+  CHECK(W.applications == (m == 0 ? 0 : (refine ? 2 : 1)));
+
+  for (std::size_t j = 0; j < m; j++)
+  {
+    CHECK_THAT(std::abs(H[j] - H_ref[j]), WithinAbs(0.0, 1.0e-13));
+    auto projection = dot(w, V[j]);
+    Mpi::GlobalSum(1, &projection, comm);
+    CHECK_THAT(std::abs(projection), WithinAbs(0.0, 1.0e-12));
+  }
+  expected.Add(-1.0, w);
+  CHECK_THAT(linalg::Norml2(comm, expected), WithinAbs(0.0, 1.0e-13));
+}
 
 class RealWeightedInnerProduct
 {

--- a/test/unit/test-spaceoperator.cpp
+++ b/test/unit/test-spaceoperator.cpp
@@ -6,6 +6,8 @@
 #include <limits>
 #include <vector>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "fem/bilinearform.hpp"
 #include "fem/integrator.hpp"
@@ -148,6 +150,90 @@ TEST_CASE("SpaceOperator retains coarse support while omitting fine exact zeros"
                     [](double value) { return value != 0.0; }));
   CHECK(zero_data.fine_suboperators == 0);
   CHECK(tiny_data.fine_suboperators > 0);
+}
+
+TEST_CASE("CPU preconditioner quadrature data preserves the multigrid operators",
+          "[spaceoperator][Serial][Parallel]")
+{
+  const auto element = GENERATE(mfem::Element::TETRAHEDRON, mfem::Element::HEXAHEDRON);
+  const auto comm = Mpi::World();
+  auto serial_mesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, element);
+  serial_mesh.SetCurvature(2);
+  serial_mesh.Transform(
+      [](const mfem::Vector &x, mfem::Vector &y)
+      {
+        y = x;
+        y(0) += 0.05 * x(1) * x(2);
+        y(1) += 0.03 * x(0) * x(0);
+      });
+  std::vector<std::unique_ptr<Mesh>> mesh;
+  mesh.push_back(std::make_unique<Mesh>(comm, serial_mesh));
+
+  IntegrationSettingsGuard settings_guard;
+  config::SolverData solver;
+  solver.order = 3;
+  solver.pa_order_threshold = 2;
+  solver.linear.mg_max_levels = 3;
+  solver.linear.mg_coarsening = MultigridCoarsening::LINEAR;
+  solver.linear.pc_mat_shifted = 0;
+  BilinearForm::pa_order_threshold = solver.pa_order_threshold;
+  fem::DefaultIntegrationOrder::p_trial = solver.order;
+  fem::DefaultIntegrationOrder::q_order_jac = solver.q_order_jac;
+  fem::DefaultIntegrationOrder::q_order_extra_pk = solver.q_order_extra;
+  fem::DefaultIntegrationOrder::q_order_extra_qk = solver.q_order_extra;
+
+  config::MaterialData material;
+  material.attributes = {1};
+  material.mu_r.s = {1.0, 2.0, 3.0};
+  material.epsilon_r.s = {2.0, 4.0, 5.0};
+  config::DomainData domains;
+  domains.attributes = {1};
+  domains.materials = {material};
+  config::BoundaryData boundaries;
+  Units units(1.0, 1.0);
+  SpaceOperator space_op(solver, domains, boundaries, ProblemType::EIGENMODE, units, mesh);
+  auto pc = space_op.GetPreconditionerMatrix<Operator>(1.5, 0.0, 2.0, 0.0);
+  const auto *mg = dynamic_cast<const MultigridOperator *>(pc.get());
+  REQUIRE(mg);
+  REQUIRE(mg->GetNumLevels() == 3);
+
+  const auto &mat = space_op.GetMaterialOp();
+  MaterialPropertyCoefficient curl(mat.GetAttributeToMaterial(),
+                                   mat.GetCurlCurlInvPermeability(), 1.5);
+  MaterialPropertyCoefficient mass(mat.GetAttributeToMaterial(), mat.GetPermittivityAbs(),
+                                   2.0);
+  for (bool auxiliary : {false, true})
+  {
+    const auto &spaces = auxiliary ? space_op.GetH1Spaces() : space_op.GetNDSpaces();
+    for (std::size_t l = 0; l < mg->GetNumLevels(); l++)
+    {
+      const auto &space = spaces.GetFESpaceAtLevel(l);
+      // Independently assemble each level without cached quadrature data. This also
+      // checks reuse of the cached tensors between polynomial levels.
+      BilinearForm form(space);
+      if (auxiliary)
+      {
+        form.AddDomainIntegrator<DiffusionIntegrator>(mass);
+      }
+      else
+      {
+        form.AddDomainIntegrator<CurlCurlMassIntegrator>(curl, mass);
+      }
+      ParOperator reference(form.Assemble(false), space);
+      const auto &actual =
+          auxiliary ? mg->GetAuxiliaryOperatorAtLevel(l) : mg->GetOperatorAtLevel(l);
+      Vector x(space.GetTrueVSize()), expected(x.Size()), result(x.Size());
+      for (int seed : {42, 314159})
+      {
+        x.Randomize(seed + Mpi::Rank(comm));
+        reference.Mult(x, expected);
+        actual.Mult(x, result);
+        result.Add(-1.0, expected);
+        CHECK_THAT(linalg::Norml2(comm, result) / linalg::Norml2(comm, expected),
+                   Catch::Matchers::WithinAbs(0.0, 2.0e-13));
+      }
+    }
+  }
 }
 
 }  // namespace palace


### PR DESCRIPTION
Applies two optimizations:

First, `RomOperator::UpdatePROM` orthogonalizes against a `W`-weighted inner product. It passed a dot functor to `linalg::OrthogonalizeColumn`, which applied `W` once per basis vector (`m` applications per pass). Since `w` is unchanged while its projections are computed, one application suffices: `OrthogonalizeColumnWeightedCGS`
computes `W·w` into a caller-owned workspace and then takes plain `LocalDot` against each basis vector. `W` is reapplied after the first update when refining (CGS2), so the cost is `m` → 1 per pass. This accelerates PROM constructions by a factor of 2 in the cases considered (PROM construction is typically not dominant, so the overall effect is relatively modest). 

Second, `SpaceOperator::AssemblePreconditioner` hard-wired `assemble_q_data = false`. Caching the geometry/material tensors pays off for the repeated smoother applications on CPU, so it is now enabled whenever no device backend is active. This speeds up the single transmon case by 10 % at the cost of a small amount of extra memory.
